### PR TITLE
*: debug the GC implementation is really a nightmare!

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -209,18 +209,23 @@ builtinLoad(struct VM *vm) {
     // TODO: exception?
     assert("wrong path");
   }
+
+  vm->gcSave = vm->pcData;
+
   int err = 0;
   Obj ast = sexpRead(in, &err);
   while(err == 0) {
-    /* printf("read == \n"); */
-    /* sexpWrite(stdout, ast); */
-    /* printf("\n"); */
+    printf("========================================= read == \n");
+    sexpWrite(stdout, ast);
+    printf("\n");
     Obj exp = macroExpand(vm, ast);
     eval(vm, exp);
     ast = sexpRead(in, &err);
   }
   fclose(in);
   vm->val = path;
+
+  vm->gcSave = NULL;
 }
 
 /* void */

--- a/src/eval.c
+++ b/src/eval.c
@@ -2,6 +2,7 @@
 #include "vm.h"
 #include <stdlib.h>
 #include <stdarg.h>
+#include <assert.h>
 
 extern Instr makeInstrConst(Obj exp, Instr cont);
 extern Instr makeInstrNOP(Instr cont);
@@ -218,6 +219,7 @@ eval(struct VM *vm, Obj exp) {
   struct posArray pa = {.ptr = NULL, .size = 0, .cap = 0};
   Instr code = compile(exp, Nil, identity(), &pa);
   vm->pcData = code;
+  /* assert(vm->pos == 0); */
   run(vm, code->fn);
   return vm->val;
 }
@@ -228,6 +230,8 @@ extern void saveCC(struct VM *vm);
 static Obj
 call(struct VM *vm, int nargs, ...) {
   saveCC(vm);
+
+  printf("before call...%d %d\n", vm->base, vm->pos);
 
   va_list ap;
   va_start(ap, nargs);
@@ -246,6 +250,9 @@ call(struct VM *vm, int nargs, ...) {
   while(vm->pc != NULL) {
     vm->pc(vm);
   }
+
+  printf("after call...%d %d\n", vm->base, vm->pos);
+
   return vm->val;
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -104,10 +104,11 @@ typedef struct _instrHead {
 
 typedef instrHead* Instr;
 
-Obj makePrimitive(InstrFunc fn, int required);
+Obj makePrimitive(InstrFunc fn, int required, char* name);
 bool isprimitive(Obj o);
 int primitiveRequired(Obj o);
 InstrFunc primitiveFn(Obj o);
+char *primitiveName(Obj o);
 
 /* Obj makeBuiltin(nativeFuncPtr fn, int required); */
 /* Obj makeNative(nativeFuncPtr fn, int required, int captured, ...); */
@@ -155,7 +156,7 @@ struct stack {
   int pos;
 };
 
-Obj makeContinuation(struct stack s, InstrFunc code, void *data);
+Obj makeContinuation(struct stack s, InstrFunc code, Instr data);
 InstrFunc contCode(Obj o);
 void* contCodeData(Obj o);
 

--- a/src/vm.h
+++ b/src/vm.h
@@ -17,6 +17,7 @@ struct VM {
   int pos;
 
   int gcTicker;
+  scmHead* gcSave;
 };
 
 struct VM* newVM();


### PR DESCRIPTION
eval -> instrPrimitiveExec -> load data -> eval,
in this order, there is no reference to the instrPrimitive object, so it's recycled later, when load data exit, and the calling stack back to the first eval, it use instrPrimitve->next and panic