### PR TITLE
*: introduce continuation stack for return address saving

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -245,11 +245,9 @@ eval(struct VM *vm, Obj exp) {
 }
 
 
-extern void saveCC(struct VM *vm);
-
 static Obj
 call(struct VM *vm, int nargs, ...) {
-  saveCC(vm);
+  vmSaveCont(vm, vm->pos, NULL, NULL);
 
   /* printf("before call...%d %d\n", vm->base, vm->pos); */
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -12,7 +12,6 @@ extern Instr makeInstrClosureRef(int m, int n, Instr cont);
 extern Instr makeInstrGlobalRef(Obj exp, Instr cont);
 extern Instr makeInstrIf(Instr then, Instr cont);
 extern Instr makeInstrMakeClosure(Instr code, int narg, Instr cont, int *closed, int nclosed);
-extern Instr makeInstrPrepareCall(Instr code);
 extern Instr makeInstrCall(int sz, Instr code);
 extern Instr makeInstrPush(Instr remain);
 extern Instr makeInstrPrimitive(int size, Obj prim, Instr next);
@@ -171,8 +170,7 @@ compileCall(Obj exp, Obj env, Instr cont, struct posArray *pa) {
 
   int sz = listLength(exp);
   Instr call = makeInstrCall(sz, cont);
-  Instr next = compileList(exp, env, call, pa);
-  return makeInstrPrepareCall(next);
+  return compileList(exp, env, call, pa);
 }
 
 static Instr
@@ -248,9 +246,6 @@ eval(struct VM *vm, Obj exp) {
 static Obj
 call(struct VM *vm, int nargs, ...) {
   vmSaveCont(vm, vm->pos, NULL, NULL);
-
-  /* printf("before call...%d %d\n", vm->base, vm->pos); */
-
   va_list ap;
   va_start(ap, nargs);
   for (int i=0; i<nargs; i++) {
@@ -258,9 +253,6 @@ call(struct VM *vm, int nargs, ...) {
   }
   va_end(ap);
 
-  /* struct InstrCall data = {nargs, identity()}; */
-  /* vm->pc = instrCallExec; */
-  /* vm->pcData = &data; */
   Instr instr = makeInstrCall(nargs, identity()); // mem leak?
   vm->pc = getInstrFunc(instr);
   vm->pcData = instr;
@@ -268,8 +260,6 @@ call(struct VM *vm, int nargs, ...) {
   while(vm->pc != NULL) {
     vm->pc(vm);
   }
-
-  /* printf("after call...%d %d\n", vm->base, vm->pos); */
 
   return vm->val;
 }

--- a/src/types.c
+++ b/src/types.c
@@ -94,7 +94,6 @@ cdddr(Obj x) {
 
 struct scmClosure {
   scmHead head;
-  // required is the required stack size, argc = required - 1;
   int required; 
   InstrFunc code;
   void *codeData;
@@ -195,52 +194,15 @@ closureSlot(Obj o, int idx) {
   return x->value;
 }
 
-struct scmContinuation {
-  scmHead head;
-  struct stack s;
-  InstrFunc code;
-  Instr codeData;
-};
-
-Obj
-makeContinuation(struct stack s, InstrFunc code, Instr codeData) {
-  struct scmContinuation* cont = newObj(scmHeadContinuation, sizeof(struct scmContinuation));
-  cont->s = s;
-  cont->code = code;
-  cont->codeData = codeData;
-  return ((Obj)(&cont->head) | TAG_PTR);
-}
-
 static void
 continuationGCFunc(struct GC *gc, void *obj) {
-  struct scmContinuation *cont = obj;
+  struct continuation *cont = obj;
   struct stack *s = &cont->s;
   /* printf("cont gc func, stack = %d %d\n", s->base, s->pos); */
   for (int i=s->base; i<s->pos; i++) {
     gcField(gc, getScmHead(s->data[i]));
   }
   gcField(gc, &cont->codeData->head);
-}
-
-struct stack
-contStack(Obj o) {
-  struct scmContinuation* cont = ptr(o);
-  assert(cont->head.type == scmHeadContinuation);
-  return cont->s;
-}
-
-InstrFunc
-contCode(Obj o) {
-  struct scmContinuation* cont = ptr(o);
-  assert(cont->head.type == scmHeadContinuation);
-  return cont->code;
-}
-
-void*
-contCodeData(Obj o) {
-  struct scmContinuation* cont = ptr(o);
-  assert(cont->head.type == scmHeadContinuation);
-  return cont->codeData;
 }
 
 Obj

--- a/src/types.h
+++ b/src/types.h
@@ -174,9 +174,11 @@ struct stack {
   int pos;
 };
 
-Obj makeContinuation(struct stack s, InstrFunc code, Instr data);
-InstrFunc contCode(Obj o);
-void* contCodeData(Obj o);
+struct continuation {
+  struct stack s;
+  InstrFunc code;
+  Instr codeData;
+};
 
 Obj symQuote, symIf, symLambda, symDo, symMacroExpand, symDebugEval;
 /* void gcSymbols(struct GC *gc); */
@@ -185,7 +187,5 @@ Obj makeVector(int c);
 Obj vectorRef(Obj vec, int idx);
 Obj vectorSet(Obj vec, int idx, Obj val);
 bool isvector(Obj o);
-
-struct stack contStack(Obj o);
 
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -108,7 +108,6 @@ typedef enum {
   instrHeadPrimitive,
   instrHeadExit,
   instrHeadCall,
-  instrHeadPrepareCall,
   instrHeadMakeClosure,
   instrHeadMax,
 } instrHeadType;

--- a/src/vm.h
+++ b/src/vm.h
@@ -4,17 +4,28 @@
 struct VM;
 typedef void (*InstrFunc)(struct VM *vm);
 
+struct contStack {
+  struct continuation *data;
+  int size;
+  int cap;
+};
+
 struct VM {
   InstrFunc pc;
   // In bytecode mode, this field is used.
   // pc + pcData = closure, using closure for code generation.
   void *pcData; 
 
+  // Value register.
   Obj val;
 
+  // The value stack.
   Obj *data;
   int base;
   int pos;
+
+  // Continuation stack.
+  struct contStack contStack;
 
   int gcTicker;
   scmHead* gcSave[2];
@@ -29,6 +40,7 @@ Obj vmGet(struct VM* vm, int idx);
 Obj ctxGet(struct VM* vm, int idx);
 void vmSet(struct VM* vm, int idx, Obj v);
 void vmResize(struct VM* vm, int sz);
+void vmSaveCont(struct VM *vm, int end, InstrFunc code, Instr codeData);
 void nextInstr(struct VM *vm, InstrFunc code, void *data);
 void vmReturn(struct VM *vm, Obj x);
 void run(struct VM* vm, InstrFunc code);


### PR DESCRIPTION
Introduce continuation stack to the VM.
Now there are two  stacks: value stack, and continuation stack.
This change avoid put the continuation in the value stack, so as to avoid allocating continuation object.

Remove PrepareCall instruction, after this change, this instruction become useless.