### PR TITLE
*: some functions refactor use the GC-safe API

### DIFF
--- a/src/builtin.h
+++ b/src/builtin.h
@@ -39,7 +39,7 @@ Obj primGensym(Obj sym);
 Obj primIsSymbol(Obj tmp);
 Obj primNot(Obj x);
 
-void primLoad(struct VM *vm, str path, str pkg);
+void primLoad(struct VM *vm, int pos, str path, str pkg);
 /* void primLoadSo(struct VM *vm, char *path); */
 
 #endif

--- a/src/reader.h
+++ b/src/reader.h
@@ -10,10 +10,10 @@ struct SexpReader {
   char *selfPath;
 };
 
-Obj sexpRead(struct SexpReader *r, FILE *in, int *errCode);
+Obj sexpRead(struct VM *vm, int pos, struct SexpReader *r, FILE *in, int *errCode);
 void sexpWrite(FILE *out, Obj obj);
 
-Obj reverse(Obj o);
+/* Obj reverse(Obj o); */
 
 void printObj(FILE* f, Obj o);
 

--- a/src/types.c
+++ b/src/types.c
@@ -90,7 +90,7 @@ makeClosure(int required, int nfrees, void *closed, void *code, int sz) {
   return ((Obj)(&clo->head) | TAG_PTR);
 }
 
-extern void instrGCFunc(struct GC *gc, void *obj);
+/* extern void instrGCFunc(struct GC *gc, void *obj); */
 
 /* static void */
 /* closureGCFunc(struct GC *gc, void *obj) { */
@@ -491,65 +491,6 @@ eq(Obj x, Obj y) {
   }
 
   return false;
-}
-
-struct scmPrimitive {
-  scmHead head;
-  int required;
-  InstrFunc fn;
-  char *name;
-  char *fname;
-};
-
-/* Obj */
-/* makePrimitive(InstrFunc fn, int required, char *name, char *fname) { */
-/*   struct scmPrimitive* clo = newObj(scmHeadPrimitive, sizeof(struct scmPrimitive)); */
-/*   clo->fn = fn; */
-/*   clo->required = required; */
-/*   clo->name = name; */
-/*   clo->fname = fname; */
-/*   return ((Obj)(&clo->head) | TAG_PTR); */
-/* } */
-
-/* static void */
-/* primitiveGCFunc(struct GC *gc, void *obj) { */
-/*   // TODO? */
-/* } */
-
-bool
-isprimitive(Obj c) {
-  if ((c & TAG_MASK) != TAG_PTR) {
-    return false;
-  }
-  scmHead *h = ptr(c);
-  return h->type == scmHeadPrimitive;
-}
-
-int primitiveRequired(Obj o) {
-  struct scmPrimitive* c = ptr(o);
-  assert(c->head.type == scmHeadPrimitive);
-  return c->required;
-}
-
-InstrFunc
-primitiveFn(Obj o) {
-  struct scmPrimitive* c = ptr(o);
-  assert(c->head.type == scmHeadPrimitive);
-  return c->fn;
-}
-
-char *
-primitiveName(Obj o) {
-  struct scmPrimitive* c = ptr(o);
-  assert(c->head.type == scmHeadPrimitive);
-  return c->name;
-}
-
-char *
-primitiveFnName(Obj o) {
-  struct scmPrimitive* c = ptr(o);
-  assert(c->head.type == scmHeadPrimitive);
-  return c->fname;
 }
 
 void

--- a/src/types.h
+++ b/src/types.h
@@ -60,7 +60,7 @@ enum {
 
       // Seems weird, but the instructions object memory management need it.
       // Instr do not use tagged pointer, because it's not Obj.
-      scmHeadInstr,
+      /* scmHeadInstr, */
 };
 
 void typesInit();
@@ -68,8 +68,6 @@ void typesInit();
 void* newObj(scmHeadType tp, int sz);
 
 struct VM;
-typedef void (*InstrFunc)(struct VM *vm);
-
 struct scmCons {
   scmHead head;
   Obj car;
@@ -95,53 +93,6 @@ Obj caddr(Obj v);
 Obj cdddr(Obj v);
 #define car(v) (((struct scmCons*)(ptr(v)))->car)
 #define cdr(v) (((struct scmCons*)(ptr(v)))->cdr)
-
-typedef enum {
-  instrHeadConst,
-  instrHeadIf,
-  instrHeadNOP,
-  instrHeadPush,
-  instrHeadLocalRef,
-  instrHeadClosureRef,
-  instrHeadGlobalRef,
-  instrHeadPrimitive,
-  instrHeadExit,
-  instrHeadCall,
-  instrHeadMakeClosure,
-  instrHeadMax,
-} instrHeadType;
-
-typedef struct _instrHead {
-  scmHead head;
-  instrHeadType type;
-} instrHead;
-
-typedef instrHead* Instr;
-
-/* Obj makePrimitive(InstrFunc fn, int required, char* name, char *fname); */
-/* bool isprimitive(Obj o); */
-/* int primitiveRequired(Obj o); */
-/* InstrFunc primitiveFn(Obj o); */
-/* char *primitiveName(Obj o); */
-/* char *primitiveFnName(Obj o); */
-
-/* Obj makeCurry(int required, int captured, Obj *data); */
-/* int curryRequired(Obj curry); */
-/* Obj curryPrim(Obj curry); */
-/* Obj curryCaptured(Obj curry); */
-/* Obj* curryData(Obj curry); */
-/* bool iscurry(Obj o); */
-
-
-/* struct hashForObjItem { */
-/*   int key; */
-/*   Obj value; */
-/* }; */
-
-/* struct hashForObj { */
-/*   struct hashForObjItem *ptr; */
-/*   int size; */
-/* }; */
 
 typedef void (*opcode)(void *pc, Obj val, struct VM *vm, int pos);
 
@@ -176,12 +127,6 @@ struct stack {
   Obj *data;
   int base;
   int pos;
-};
-
-struct continuation {
-  struct stack s;
-  InstrFunc code;
-  Instr codeData;
 };
 
 Obj symQuote, symIf, symLambda, symDo, symMacroExpand, symDebugEval;

--- a/src/vm.h
+++ b/src/vm.h
@@ -12,12 +12,19 @@ struct VM* newVM();
 Obj vmGet(struct VM *vm, int idx);
 void vmReturn(struct VM *vm, Obj val);
 
+Obj vmRef(struct VM *vm, int ref);
+Obj vmCar(struct VM *vm, int ref);
+Obj vmCdr(struct VM *vm, int ref);
+Obj vmCons(struct VM *vm, int r1, int r2);
+void vmSet(struct VM* vm, int ref, Obj val);
+void vmPush(struct VM *vm, int *pos, Obj val);
+
 // Essentially, the VM only provide this.
 Obj run(struct VM *vm, char *pc);
 
 // High level APIs, which can be implemented using previous APIs.
-Obj macroExpand(struct VM *vm, Obj exp);
-Obj eval(struct VM *vm, Obj exp);
-int loadByteCode(struct VM *vm, str path);
+Obj macroExpand(struct VM *vm, int pos, int exp);
+Obj eval(struct VM *vm, int pos, int exp);
+int loadByteCode(struct VM *vm, int pos, str path);
 
 #endif


### PR DESCRIPTION
GC-safe API should accept the reference of the stack as the parameter. For example:
    Obj reverse(struct VM *vm, int pos, int ref)

In this way, all the temporary objects are in the stack (GC root), so they are not recycled unexpectedly by GC.