### PR TITLE
*: fix build on mac osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ clean:
 	make clean -C src
 	make clean -C lib
 
-toc.so: toc.c
-	gcc -shared -o toc.so -g -fPIC toc.c -Isrc -I.
+toc.so: toc.c libcora
+	gcc -shared -o toc.so -g -fPIC toc.c -Isrc -I. -Lsrc -lcora
 
-init.so: init.c
-	gcc -shared -o init.so -g -fPIC init.c -Isrc -I.
+init.so: init.c libcora
+	gcc -shared -o init.so -g -fPIC init.c -Isrc -I. -Lsrc -lcora
 

--- a/cora
+++ b/cora
@@ -4,8 +4,36 @@
 BASE_DIR=$(dirname "$0")
 BIN_PATH=${BASE_DIR}/cora.bin
 
-export LD_LIBRARY_PATH=${BASE_DIR}/src
-export LD_LIBRARY_PATH=${BASE_DIR}:${LD_LIBRARY_PATH}
-export CORAPATH=/home/genius/project/
+#!/bin/sh
+
+case "$(uname -sr)" in
+
+   Darwin*)
+     export DYLD_LIBRARY_PATH=${BASE_DIR}/src
+     export DYLD_LIBRARY_PATH=${BASE_DIR}:${DYLD_LIBRARY_PATH}
+     ;;
+
+   Linux*Microsoft*)
+     echo 'WSL'  # Windows Subsystem for Linux
+     ;;
+
+   Linux*)
+     export LD_LIBRARY_PATH=${BASE_DIR}/src
+     export LD_LIBRARY_PATH=${BASE_DIR}:${LD_LIBRARY_PATH}
+     ;;
+
+   CYGWIN*|MINGW*|MINGW32*|MSYS*)
+     echo 'MS Windows'
+     ;;
+
+   # Add here more strings to compare
+   # See correspondence table at the bottom of this answer
+
+   *)
+     echo 'Other OS'
+     ;;
+esac
+
+export CORAPATH=${HOME}/project/
 
 exec rlwrap ${BIN_PATH} $*

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -13,7 +13,7 @@ clean:
 	rm -rf *.o *.so
 
 %.so : %.o
-	gcc -shared -o $@ $^ -fPIC -I../src
+	gcc -shared -o $@ $^ -fPIC -I../src -L../src -lcora
 
 %.o : %.c
 %.o : %.c $(DEPDIR)/%.d | $(DEPDIR)

--- a/src/types.c
+++ b/src/types.c
@@ -494,8 +494,8 @@ eq(Obj x, Obj y) {
   return false;
 }
 
-void
-typesInit(struct GC *gc) {
+/* void */
+/* typesInit(struct GC *gc) { */
   /* gcRegistForType(gc, scmHeadCons, consGCFunc); */
   /* gcRegistForType(gc, scmHeadClosure, closureGCFunc); */
   /* gcRegistForType(gc, scmHeadCurry, curryGCFunc); */
@@ -504,4 +504,4 @@ typesInit(struct GC *gc) {
   /* gcRegistForType(gc, scmHeadVector, vectorGCFunc); */
   /* gcRegistForType(gc, scmHeadContinuation, continuationGCFunc); */
   /* gcRegistForType(gc, scmHeadInstr, instrGCFunc); */
-}
+/* } */

--- a/src/types.h
+++ b/src/types.h
@@ -63,7 +63,7 @@ enum {
       scmHeadNative,
 };
 
-void typesInit();
+/* void typesInit(); */
 
 struct VM;
 


### PR DESCRIPTION
On mac osx, LD_LIBRARY_PATH should be DYLD_LIBRARY_PATH

And there is also a minor differ that gcc does not check existance of symbol of a so
While on osx it's a build error rather than runtime error