### PR TITLE
*: get back the old stop-copy GC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ cora.bin: libcora main.o init.so toc.so
 	$(CC) main.o -Lsrc -lcora -ldl -o $@
 
 clean:
-	rm -f *.o *.so
+	rm -f *.o *.so *.bin
 	make clean -C src
 	make clean -C lib
 

--- a/init.c
+++ b/init.c
@@ -231,7 +231,7 @@ co->args[1] = Nil;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -260,7 +260,7 @@ co->args[2] = globalRef(intern("defmacro-macro"));
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -276,7 +276,7 @@ co->args[2] = makeNative(_35clofun1038, 1, 0);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -292,7 +292,7 @@ co->args[2] = makeNative(_35clofun1040, 1, 0);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -311,7 +311,7 @@ co->args[2] = makeNative(_35clofun1052, 1, 0);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -327,7 +327,7 @@ co->args[2] = makeNative(_35clofun1054, 1, 0);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -344,7 +344,7 @@ co->args[2] = makeNative(_35clofun1061, 1, 0);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -361,7 +361,7 @@ co->args[2] = makeNative(_35clofun1065, 1, 0);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -379,7 +379,7 @@ co->args[2] = makeNative(_35clofun1071, 1, 0);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -400,7 +400,7 @@ co->args[2] = makeNative(_35clofun1128, 1, 0);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -426,7 +426,7 @@ co->args[2] = makeNative(_35clofun1157, 1, 0);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -446,7 +446,7 @@ co->args[2] = makeNative(_35clofun1206, 1, 0);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -462,7 +462,7 @@ co->args[2] = makeNative(_35clofun1214, 1, 0);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -477,7 +477,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -491,7 +491,7 @@ co->args[1] = _35val1005;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -514,7 +514,7 @@ co->args[0] = _35cc34;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -547,7 +547,7 @@ co->args[0] = _35cc35;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -558,7 +558,7 @@ co->args[0] = _35cc35;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -569,7 +569,7 @@ co->args[0] = _35cc35;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -580,7 +580,7 @@ co->args[0] = _35cc35;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -604,7 +604,7 @@ co->args[2] = _35reg988;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -614,7 +614,7 @@ co->args[0] = _35cc36;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -644,7 +644,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -659,7 +659,7 @@ co->args[1] = _35reg983;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -684,7 +684,7 @@ co->args[0] = _35cc30;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -695,7 +695,7 @@ co->args[0] = _35cc30;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -730,7 +730,7 @@ co->args[0] = _35cc31;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -741,7 +741,7 @@ co->args[0] = _35cc31;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -752,7 +752,7 @@ co->args[0] = _35cc31;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -774,7 +774,7 @@ co->args[1] = y;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -784,7 +784,7 @@ co->args[0] = _35cc32;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -809,7 +809,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -824,7 +824,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -838,7 +838,7 @@ co->args[1] = _35val957;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -873,7 +873,7 @@ co->args[0] = _35cc18;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -884,7 +884,7 @@ co->args[0] = _35cc18;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -895,7 +895,7 @@ co->args[0] = _35cc18;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -906,7 +906,7 @@ co->args[0] = _35cc18;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -937,7 +937,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -947,18 +947,7 @@ co->args[0] = _35cc19;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc19;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -969,7 +958,7 @@ co->args[0] = _35cc19;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -980,7 +969,18 @@ co->args[0] = _35cc19;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc19;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -998,7 +998,7 @@ co->args[1] = _35reg943;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1028,7 +1028,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1038,18 +1038,7 @@ co->args[0] = _35cc20;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc20;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1060,7 +1049,7 @@ co->args[0] = _35cc20;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1071,7 +1060,18 @@ co->args[0] = _35cc20;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc20;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1089,7 +1089,7 @@ co->args[1] = _35reg930;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1119,7 +1119,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1129,18 +1129,7 @@ co->args[0] = _35cc21;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc21;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1151,7 +1140,7 @@ co->args[0] = _35cc21;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1162,7 +1151,18 @@ co->args[0] = _35cc21;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc21;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1180,7 +1180,7 @@ co->args[1] = _35reg917;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1219,7 +1219,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1229,18 +1229,7 @@ co->args[0] = _35cc22;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc22;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1251,7 +1240,7 @@ co->args[0] = _35cc22;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1262,7 +1251,7 @@ co->args[0] = _35cc22;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1273,7 +1262,18 @@ co->args[0] = _35cc22;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc22;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1291,7 +1291,7 @@ co->args[1] = y;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1310,7 +1310,7 @@ co->args[1] = _35reg904;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1340,7 +1340,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1350,18 +1350,7 @@ co->args[0] = _35cc23;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc23;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1372,7 +1361,7 @@ co->args[0] = _35cc23;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1383,7 +1372,18 @@ co->args[0] = _35cc23;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc23;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1401,7 +1401,7 @@ co->args[1] = _35reg882;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1431,7 +1431,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1441,18 +1441,7 @@ co->args[0] = _35cc24;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc24;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1463,7 +1452,7 @@ co->args[0] = _35cc24;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1474,7 +1463,18 @@ co->args[0] = _35cc24;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc24;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1492,7 +1492,7 @@ co->args[1] = _35reg869;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1542,7 +1542,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1552,18 +1552,7 @@ co->args[0] = _35cc25;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc25;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1574,7 +1563,7 @@ co->args[0] = _35cc25;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1585,7 +1574,7 @@ co->args[0] = _35cc25;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1596,7 +1585,7 @@ co->args[0] = _35cc25;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1607,7 +1596,18 @@ co->args[0] = _35cc25;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc25;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1626,7 +1626,7 @@ co->args[1] = y;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1644,7 +1644,7 @@ co->args[1] = z;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1665,7 +1665,7 @@ co->args[1] = _35reg856;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1704,7 +1704,7 @@ co->args[1] = body;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1714,18 +1714,7 @@ co->args[0] = _35cc26;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc26;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1736,7 +1725,7 @@ co->args[0] = _35cc26;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1747,7 +1736,7 @@ co->args[0] = _35cc26;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1758,7 +1747,18 @@ co->args[0] = _35cc26;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc26;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1792,7 +1792,7 @@ co->args[2] = _35reg802;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1802,7 +1802,7 @@ co->args[0] = _35cc27;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1824,7 +1824,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1892,7 +1892,7 @@ co->args[0] = _35cc6;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1903,7 +1903,7 @@ co->args[0] = _35cc6;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1914,7 +1914,7 @@ co->args[0] = _35cc6;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1925,7 +1925,7 @@ co->args[0] = _35cc6;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1936,7 +1936,7 @@ co->args[0] = _35cc6;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1947,7 +1947,7 @@ co->args[0] = _35cc6;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1958,7 +1958,7 @@ co->args[0] = _35cc6;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1969,7 +1969,7 @@ co->args[0] = _35cc6;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1980,7 +1980,7 @@ co->args[0] = _35cc6;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2048,7 +2048,7 @@ co->args[0] = _35cc7;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2059,7 +2059,7 @@ co->args[0] = _35cc7;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2070,7 +2070,7 @@ co->args[0] = _35cc7;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2081,7 +2081,7 @@ co->args[0] = _35cc7;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2092,7 +2092,7 @@ co->args[0] = _35cc7;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2103,7 +2103,7 @@ co->args[0] = _35cc7;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2114,7 +2114,7 @@ co->args[0] = _35cc7;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2125,7 +2125,7 @@ co->args[0] = _35cc7;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2136,7 +2136,7 @@ co->args[0] = _35cc7;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2204,7 +2204,7 @@ co->args[0] = _35cc8;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2215,7 +2215,7 @@ co->args[0] = _35cc8;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2226,7 +2226,7 @@ co->args[0] = _35cc8;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2237,7 +2237,7 @@ co->args[0] = _35cc8;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2248,7 +2248,7 @@ co->args[0] = _35cc8;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2259,7 +2259,7 @@ co->args[0] = _35cc8;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2270,7 +2270,7 @@ co->args[0] = _35cc8;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2281,7 +2281,7 @@ co->args[0] = _35cc8;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2292,7 +2292,7 @@ co->args[0] = _35cc8;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2336,7 +2336,7 @@ co->args[0] = _35cc9;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2347,7 +2347,7 @@ co->args[0] = _35cc9;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2358,7 +2358,7 @@ co->args[0] = _35cc9;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2369,7 +2369,7 @@ co->args[0] = _35cc9;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2380,7 +2380,7 @@ co->args[0] = _35cc9;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2391,7 +2391,7 @@ co->args[0] = _35cc9;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2402,7 +2402,7 @@ co->args[0] = _35cc9;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2436,7 +2436,7 @@ co->args[0] = _35cc10;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2447,7 +2447,7 @@ co->args[0] = _35cc10;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2458,7 +2458,7 @@ co->args[0] = _35cc10;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2469,7 +2469,7 @@ co->args[0] = _35cc10;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2480,7 +2480,7 @@ co->args[0] = _35cc10;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2548,7 +2548,7 @@ co->args[0] = _35cc11;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2559,7 +2559,7 @@ co->args[0] = _35cc11;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2570,7 +2570,7 @@ co->args[0] = _35cc11;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2581,7 +2581,7 @@ co->args[0] = _35cc11;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2592,7 +2592,7 @@ co->args[0] = _35cc11;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2603,7 +2603,7 @@ co->args[0] = _35cc11;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2614,7 +2614,7 @@ co->args[0] = _35cc11;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2625,7 +2625,7 @@ co->args[0] = _35cc11;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2636,7 +2636,7 @@ co->args[0] = _35cc11;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2670,7 +2670,7 @@ co->args[0] = _35cc12;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2681,7 +2681,7 @@ co->args[0] = _35cc12;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2692,7 +2692,7 @@ co->args[0] = _35cc12;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2703,7 +2703,7 @@ co->args[0] = _35cc12;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2714,7 +2714,7 @@ co->args[0] = _35cc12;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2748,7 +2748,7 @@ co->args[0] = _35cc13;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2759,7 +2759,7 @@ co->args[0] = _35cc13;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2770,7 +2770,7 @@ co->args[0] = _35cc13;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2781,7 +2781,7 @@ co->args[0] = _35cc13;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2792,7 +2792,7 @@ co->args[0] = _35cc13;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2846,7 +2846,7 @@ co->args[0] = _35cc14;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2857,7 +2857,7 @@ co->args[0] = _35cc14;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2868,7 +2868,7 @@ co->args[0] = _35cc14;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2879,7 +2879,7 @@ co->args[0] = _35cc14;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2890,7 +2890,7 @@ co->args[0] = _35cc14;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2901,7 +2901,7 @@ co->args[0] = _35cc14;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2912,7 +2912,7 @@ co->args[0] = _35cc14;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2966,7 +2966,7 @@ co->args[0] = _35cc15;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2977,7 +2977,7 @@ co->args[0] = _35cc15;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2988,7 +2988,7 @@ co->args[0] = _35cc15;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2999,7 +2999,7 @@ co->args[0] = _35cc15;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3010,7 +3010,7 @@ co->args[0] = _35cc15;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3021,7 +3021,7 @@ co->args[0] = _35cc15;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3032,7 +3032,7 @@ co->args[0] = _35cc15;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3054,7 +3054,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3069,7 +3069,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3085,7 +3085,7 @@ co->args[1] = _35val523;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3102,7 +3102,7 @@ co->args[1] = body;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3120,7 +3120,7 @@ co->args[1] = nargs;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3138,7 +3138,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3177,7 +3177,7 @@ co->args[1] = _35reg519;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3203,7 +3203,7 @@ co->args[2] = rules;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3221,7 +3221,7 @@ co->args[2] = pats;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3242,7 +3242,7 @@ co->args[2] = _35reg512;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3258,7 +3258,7 @@ co->args[1] = _35val513;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3275,7 +3275,7 @@ co->args[1] = makeString1("inconsistent func rule args count");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3304,7 +3304,7 @@ co->args[1] = _35reg507;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3329,7 +3329,7 @@ co->args[2] = l2;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3356,7 +3356,7 @@ co->args[3] = l;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3376,7 +3376,7 @@ co->args[1] = _35reg492;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3387,7 +3387,7 @@ co->args[1] = res;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3411,7 +3411,7 @@ co->args[3] = _35reg496;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3425,7 +3425,7 @@ co->args[3] = _35reg497;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3441,7 +3441,7 @@ co->args[2] = l;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3465,7 +3465,7 @@ co->args[2] = _35reg488;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3482,7 +3482,7 @@ co->args[1] = rules;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3499,7 +3499,7 @@ co->args[1] = res;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3513,7 +3513,7 @@ co->args[1] = rules;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3530,7 +3530,7 @@ co->args[2] = _35val484;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3546,7 +3546,7 @@ co->args[3] = Nil;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3565,7 +3565,7 @@ co->args[1] = result;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3575,7 +3575,7 @@ co->args[0] = _35cc1;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3626,7 +3626,7 @@ co->args[1] = closureRef(co, 1);
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3636,18 +3636,7 @@ co->args[0] = _35cc2;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc2;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3658,7 +3647,7 @@ co->args[0] = _35cc2;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3669,7 +3658,7 @@ co->args[0] = _35cc2;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3680,7 +3669,7 @@ co->args[0] = _35cc2;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3691,7 +3680,18 @@ co->args[0] = _35cc2;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc2;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3718,7 +3718,7 @@ co->args[3] = _35reg477;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3747,7 +3747,7 @@ co->args[1] = closureRef(co, 1);
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3757,18 +3757,7 @@ co->args[0] = _35cc3;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc3;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3779,7 +3768,18 @@ co->args[0] = _35cc3;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc3;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3802,7 +3802,7 @@ co->args[3] = _35reg444;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3825,7 +3825,7 @@ co->args[3] = closureRef(co, 2);
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3835,7 +3835,7 @@ co->args[0] = _35cc4;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3849,7 +3849,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3863,7 +3863,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3878,7 +3878,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3894,7 +3894,7 @@ co->args[1] = _35val401;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3911,7 +3911,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3938,7 +3938,7 @@ co->args[2] = rules;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3950,7 +3950,7 @@ co->args[2] = rules;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3967,7 +3967,7 @@ co->args[2] = rules;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3979,7 +3979,7 @@ co->args[2] = rules;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3997,7 +3997,7 @@ co->args[2] = rules;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4009,7 +4009,7 @@ co->args[2] = rules;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4066,7 +4066,7 @@ co->args[1] = rules;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4090,7 +4090,7 @@ co->args[1] = rules;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4110,7 +4110,7 @@ co->args[1] = _35reg353;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4128,7 +4128,7 @@ co->args[2] = cc;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4139,7 +4139,7 @@ co->args[1] = makeString1("no cond match");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4161,7 +4161,7 @@ co->args[1] = pat;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4183,7 +4183,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4205,7 +4205,7 @@ co->args[2] = _35reg391;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4246,7 +4246,7 @@ co->args[2] = cc;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4257,7 +4257,7 @@ co->args[1] = makeString1("no cond match");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4276,7 +4276,7 @@ co->args[2] = cc;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4287,7 +4287,7 @@ co->args[1] = makeString1("no cond match");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4309,7 +4309,7 @@ co->args[1] = pat;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4331,7 +4331,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4353,7 +4353,7 @@ co->args[2] = _35reg376;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4390,7 +4390,7 @@ co->args[1] = pat;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4412,7 +4412,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4434,7 +4434,7 @@ co->args[2] = _35reg361;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4470,7 +4470,7 @@ co->args[1] = action;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4492,7 +4492,7 @@ co->args[1] = action;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4510,7 +4510,7 @@ co->args[1] = action;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4529,7 +4529,7 @@ co->args[1] = action;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4552,7 +4552,7 @@ co->args[1] = action;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4583,7 +4583,7 @@ co->args[1] = action;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4614,7 +4614,7 @@ co->args[1] = action;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4647,7 +4647,7 @@ co->args[1] = pat;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4696,7 +4696,7 @@ co->args[1] = pat;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4738,7 +4738,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4749,7 +4749,7 @@ co->args[1] = makeString1("no cond match");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4764,7 +4764,7 @@ co->args[2] = pat;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4779,7 +4779,7 @@ co->args[1] = _35val320;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4794,7 +4794,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4834,7 +4834,7 @@ co->args[1] = pat;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4854,7 +4854,7 @@ co->args[1] = pat;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4880,7 +4880,7 @@ co->args[1] = expr;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4901,7 +4901,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4915,7 +4915,7 @@ co->args[1] = expr;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4936,7 +4936,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4951,7 +4951,7 @@ co->args[1] = expr;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4972,7 +4972,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4996,7 +4996,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5031,7 +5031,7 @@ co->args[1] = expr;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5055,7 +5055,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5075,7 +5075,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5097,7 +5097,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5132,7 +5132,7 @@ co->args[1] = expr;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5156,7 +5156,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5176,7 +5176,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5198,7 +5198,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5233,7 +5233,7 @@ co->args[1] = expr;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5257,7 +5257,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5277,7 +5277,7 @@ co->args[4] = cc;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5292,7 +5292,7 @@ co->args[1] = _35reg233;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5308,7 +5308,7 @@ co->args[1] = _35reg223;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5332,7 +5332,7 @@ co->args[1] = _35reg227;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5380,7 +5380,7 @@ co->args[1] = _35reg218;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5409,7 +5409,7 @@ co->args[1] = _35reg209;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5447,7 +5447,7 @@ co->args[1] = _35reg204;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5476,7 +5476,7 @@ co->args[1] = _35reg195;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5523,7 +5523,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5542,7 +5542,7 @@ co->args[1] = curr;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5559,7 +5559,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5588,7 +5588,7 @@ co->args[1] = _35reg176;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5604,7 +5604,7 @@ co->args[1] = _35reg164;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5627,7 +5627,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5645,7 +5645,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5662,7 +5662,7 @@ co->args[1] = _35val169;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5710,7 +5710,7 @@ co->args[2] = _35reg159;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5731,7 +5731,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5749,7 +5749,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5766,7 +5766,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5796,7 +5796,7 @@ co->args[1] = _35reg142;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5811,7 +5811,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5829,7 +5829,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5846,7 +5846,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5888,7 +5888,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5907,7 +5907,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5930,7 +5930,7 @@ co->args[1] = _35val127;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5947,7 +5947,7 @@ co->args[2] = exp1;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5958,7 +5958,7 @@ co->args[1] = exp1;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5975,7 +5975,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5991,7 +5991,7 @@ co->args[1] = _35val119;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6017,7 +6017,7 @@ co->args[2] = globalRef(intern("*macros*"));
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6039,7 +6039,7 @@ co->args[1] = _35reg109;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6062,7 +6062,7 @@ co->args[1] = closureRef(co, 0);
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6075,7 +6075,7 @@ co->args[2] = _35reg104;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6089,7 +6089,7 @@ co->args[1] = closureRef(co, 0);
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6102,7 +6102,7 @@ co->args[2] = _35reg106;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6117,7 +6117,7 @@ co->args[1] = closureRef(co, 0);
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6130,7 +6130,7 @@ co->args[2] = _35reg108;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6161,7 +6161,7 @@ return;
 void _35clofun1021(struct Cora* co) {
 Obj f = co->args[1];
 Obj l = co->args[2];
- assert(iscons(l));
+ /* assert(iscons(l)); */
 co->args[0] = globalRef(intern("map-h"));
 co->args[1] = Nil;
 co->args[2] = f;
@@ -6169,7 +6169,7 @@ co->args[3] = l;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6196,7 +6196,7 @@ co->args[1] = _35reg83;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6207,7 +6207,7 @@ co->args[1] = res;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6229,7 +6229,7 @@ co->args[3] = _35reg86;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6250,7 +6250,7 @@ co->args[2] = _35reg78;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6282,7 +6282,7 @@ co->args[1] = _35reg67;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }

--- a/init.c
+++ b/init.c
@@ -6161,7 +6161,6 @@ return;
 void _35clofun1021(struct Cora* co) {
 Obj f = co->args[1];
 Obj l = co->args[2];
- /* assert(iscons(l)); */
 co->args[0] = globalRef(intern("map-h"));
 co->args[1] = Nil;
 co->args[2] = f;
@@ -6180,17 +6179,10 @@ void _35clofun1019(struct Cora* co) {
 Obj res = co->args[1];
 Obj f = co->args[2];
 Obj l = co->args[3];
-
-scmHead* h = getScmHead(l);
- if (h) {
-   assert(h->forwarding == 0);
- }
-
 Obj _35reg82 = primIsCons(l);
 if (True == _35reg82) {
 Obj _35reg83 = primCar(l);
-/* pushCont(co, _35clofun1020, 3, res, l, f); */
-pushCont3(co, _35clofun1020, res, l, f);
+pushCont(co, _35clofun1020, 3, res, l, f);
 co->args[0] = f;
 co->args[1] = _35reg83;
 co->nargs = 2;

--- a/init.c
+++ b/init.c
@@ -2,233 +2,233 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun1018(struct Cora* co);
-void _35clofun1037(struct Cora* co);
-void _35clofun1039(struct Cora* co);
-void _35clofun1044(struct Cora* co);
-void _35clofun1053(struct Cora* co);
-void _35clofun1058(struct Cora* co);
-void _35clofun1062(struct Cora* co);
-void _35clofun1066(struct Cora* co);
-void _35clofun1072(struct Cora* co);
-void _35clofun1129(struct Cora* co);
-void _35clofun1163(struct Cora* co);
-void _35clofun1207(struct Cora* co);
-void _35clofun1214(struct Cora* co);
-void _35clofun1215(struct Cora* co);
-void _35clofun1208(struct Cora* co);
-void _35clofun1209(struct Cora* co);
-void _35clofun1210(struct Cora* co);
-void _35clofun1213(struct Cora* co);
-void _35clofun1211(struct Cora* co);
-void _35clofun1212(struct Cora* co);
-void _35clofun1206(struct Cora* co);
-void _35clofun1201(struct Cora* co);
-void _35clofun1202(struct Cora* co);
-void _35clofun1203(struct Cora* co);
-void _35clofun1205(struct Cora* co);
-void _35clofun1204(struct Cora* co);
-void _35clofun1199(struct Cora* co);
-void _35clofun1200(struct Cora* co);
-void _35clofun1176(struct Cora* co);
-void _35clofun1177(struct Cora* co);
-void _35clofun1198(struct Cora* co);
-void _35clofun1178(struct Cora* co);
-void _35clofun1197(struct Cora* co);
-void _35clofun1179(struct Cora* co);
-void _35clofun1196(struct Cora* co);
-void _35clofun1180(struct Cora* co);
-void _35clofun1194(struct Cora* co);
-void _35clofun1195(struct Cora* co);
-void _35clofun1181(struct Cora* co);
-void _35clofun1193(struct Cora* co);
-void _35clofun1182(struct Cora* co);
-void _35clofun1192(struct Cora* co);
-void _35clofun1183(struct Cora* co);
-void _35clofun1189(struct Cora* co);
-void _35clofun1190(struct Cora* co);
-void _35clofun1191(struct Cora* co);
-void _35clofun1184(struct Cora* co);
-void _35clofun1188(struct Cora* co);
-void _35clofun1185(struct Cora* co);
-void _35clofun1186(struct Cora* co);
-void _35clofun1187(struct Cora* co);
-void _35clofun1164(struct Cora* co);
-void _35clofun1165(struct Cora* co);
-void _35clofun1166(struct Cora* co);
-void _35clofun1167(struct Cora* co);
-void _35clofun1168(struct Cora* co);
-void _35clofun1169(struct Cora* co);
-void _35clofun1170(struct Cora* co);
-void _35clofun1171(struct Cora* co);
-void _35clofun1172(struct Cora* co);
-void _35clofun1173(struct Cora* co);
-void _35clofun1174(struct Cora* co);
-void _35clofun1175(struct Cora* co);
-void _35clofun1157(struct Cora* co);
-void _35clofun1158(struct Cora* co);
-void _35clofun1159(struct Cora* co);
-void _35clofun1160(struct Cora* co);
-void _35clofun1161(struct Cora* co);
-void _35clofun1162(struct Cora* co);
-void _35clofun1155(struct Cora* co);
-void _35clofun1156(struct Cora* co);
-void _35clofun1148(struct Cora* co);
-void _35clofun1149(struct Cora* co);
-void _35clofun1151(struct Cora* co);
-void _35clofun1153(struct Cora* co);
-void _35clofun1154(struct Cora* co);
-void _35clofun1152(struct Cora* co);
-void _35clofun1150(struct Cora* co);
-void _35clofun1146(struct Cora* co);
-void _35clofun1147(struct Cora* co);
-void _35clofun1145(struct Cora* co);
-void _35clofun1143(struct Cora* co);
-void _35clofun1144(struct Cora* co);
-void _35clofun1142(struct Cora* co);
-void _35clofun1141(struct Cora* co);
-void _35clofun1138(struct Cora* co);
-void _35clofun1139(struct Cora* co);
-void _35clofun1140(struct Cora* co);
-void _35clofun1137(struct Cora* co);
-void _35clofun1130(struct Cora* co);
-void _35clofun1131(struct Cora* co);
-void _35clofun1136(struct Cora* co);
-void _35clofun1132(struct Cora* co);
-void _35clofun1135(struct Cora* co);
-void _35clofun1133(struct Cora* co);
-void _35clofun1134(struct Cora* co);
-void _35clofun1128(struct Cora* co);
-void _35clofun1121(struct Cora* co);
-void _35clofun1122(struct Cora* co);
-void _35clofun1123(struct Cora* co);
-void _35clofun1124(struct Cora* co);
-void _35clofun1127(struct Cora* co);
-void _35clofun1126(struct Cora* co);
-void _35clofun1125(struct Cora* co);
-void _35clofun1105(struct Cora* co);
-void _35clofun1106(struct Cora* co);
-void _35clofun1107(struct Cora* co);
-void _35clofun1117(struct Cora* co);
-void _35clofun1118(struct Cora* co);
-void _35clofun1119(struct Cora* co);
-void _35clofun1120(struct Cora* co);
-void _35clofun1108(struct Cora* co);
-void _35clofun1113(struct Cora* co);
-void _35clofun1114(struct Cora* co);
-void _35clofun1115(struct Cora* co);
-void _35clofun1116(struct Cora* co);
-void _35clofun1109(struct Cora* co);
-void _35clofun1110(struct Cora* co);
-void _35clofun1111(struct Cora* co);
-void _35clofun1112(struct Cora* co);
-void _35clofun1097(struct Cora* co);
-void _35clofun1098(struct Cora* co);
-void _35clofun1103(struct Cora* co);
-void _35clofun1104(struct Cora* co);
-void _35clofun1101(struct Cora* co);
-void _35clofun1102(struct Cora* co);
-void _35clofun1099(struct Cora* co);
-void _35clofun1100(struct Cora* co);
-void _35clofun1091(struct Cora* co);
-void _35clofun1094(struct Cora* co);
-void _35clofun1095(struct Cora* co);
-void _35clofun1096(struct Cora* co);
-void _35clofun1092(struct Cora* co);
-void _35clofun1093(struct Cora* co);
-void _35clofun1073(struct Cora* co);
-void _35clofun1074(struct Cora* co);
-void _35clofun1075(struct Cora* co);
-void _35clofun1089(struct Cora* co);
-void _35clofun1090(struct Cora* co);
-void _35clofun1086(struct Cora* co);
-void _35clofun1087(struct Cora* co);
-void _35clofun1088(struct Cora* co);
-void _35clofun1084(struct Cora* co);
-void _35clofun1085(struct Cora* co);
-void _35clofun1081(struct Cora* co);
-void _35clofun1082(struct Cora* co);
-void _35clofun1083(struct Cora* co);
-void _35clofun1079(struct Cora* co);
-void _35clofun1080(struct Cora* co);
-void _35clofun1076(struct Cora* co);
-void _35clofun1077(struct Cora* co);
-void _35clofun1078(struct Cora* co);
-void _35clofun1071(struct Cora* co);
-void _35clofun1068(struct Cora* co);
-void _35clofun1069(struct Cora* co);
-void _35clofun1070(struct Cora* co);
-void _35clofun1067(struct Cora* co);
-void _35clofun1065(struct Cora* co);
-void _35clofun1063(struct Cora* co);
-void _35clofun1064(struct Cora* co);
-void _35clofun1061(struct Cora* co);
-void _35clofun1059(struct Cora* co);
-void _35clofun1060(struct Cora* co);
-void _35clofun1054(struct Cora* co);
-void _35clofun1055(struct Cora* co);
-void _35clofun1056(struct Cora* co);
-void _35clofun1057(struct Cora* co);
-void _35clofun1052(struct Cora* co);
-void _35clofun1047(struct Cora* co);
-void _35clofun1048(struct Cora* co);
-void _35clofun1049(struct Cora* co);
-void _35clofun1050(struct Cora* co);
-void _35clofun1051(struct Cora* co);
-void _35clofun1046(struct Cora* co);
-void _35clofun1045(struct Cora* co);
-void _35clofun1040(struct Cora* co);
-void _35clofun1041(struct Cora* co);
-void _35clofun1042(struct Cora* co);
-void _35clofun1043(struct Cora* co);
-void _35clofun1038(struct Cora* co);
-void _35clofun1033(struct Cora* co);
-void _35clofun1034(struct Cora* co);
-void _35clofun1035(struct Cora* co);
-void _35clofun1036(struct Cora* co);
-void _35clofun1027(struct Cora* co);
-void _35clofun1031(struct Cora* co);
-void _35clofun1032(struct Cora* co);
-void _35clofun1028(struct Cora* co);
-void _35clofun1029(struct Cora* co);
-void _35clofun1030(struct Cora* co);
-void _35clofun1026(struct Cora* co);
-void _35clofun1024(struct Cora* co);
-void _35clofun1025(struct Cora* co);
-void _35clofun1023(struct Cora* co);
-void _35clofun1022(struct Cora* co);
-void _35clofun1021(struct Cora* co);
-void _35clofun1019(struct Cora* co);
-void _35clofun1020(struct Cora* co);
-void _35clofun1017(struct Cora* co);
-void _35clofun1016(struct Cora* co);
-void _35clofun1014(struct Cora* co);
-void _35clofun1015(struct Cora* co);
-void _35clofun1013(struct Cora* co);
-void _35clofun1012(struct Cora* co);
-void _35clofun1011(struct Cora* co);
-void _35clofun1010(struct Cora* co);
-void _35clofun1009(struct Cora* co);
-void _35clofun1008(struct Cora* co);
-void _35clofun1007(struct Cora* co);
-void _35clofun1006(struct Cora* co);
+void _35clofun5052(struct Cora* co);
+void _35clofun5071(struct Cora* co);
+void _35clofun5073(struct Cora* co);
+void _35clofun5078(struct Cora* co);
+void _35clofun5087(struct Cora* co);
+void _35clofun5092(struct Cora* co);
+void _35clofun5096(struct Cora* co);
+void _35clofun5100(struct Cora* co);
+void _35clofun5106(struct Cora* co);
+void _35clofun5163(struct Cora* co);
+void _35clofun5197(struct Cora* co);
+void _35clofun5241(struct Cora* co);
+void _35clofun5248(struct Cora* co);
+void _35clofun5249(struct Cora* co);
+void _35clofun5242(struct Cora* co);
+void _35clofun5243(struct Cora* co);
+void _35clofun5244(struct Cora* co);
+void _35clofun5247(struct Cora* co);
+void _35clofun5245(struct Cora* co);
+void _35clofun5246(struct Cora* co);
+void _35clofun5240(struct Cora* co);
+void _35clofun5235(struct Cora* co);
+void _35clofun5236(struct Cora* co);
+void _35clofun5237(struct Cora* co);
+void _35clofun5239(struct Cora* co);
+void _35clofun5238(struct Cora* co);
+void _35clofun5233(struct Cora* co);
+void _35clofun5234(struct Cora* co);
+void _35clofun5210(struct Cora* co);
+void _35clofun5211(struct Cora* co);
+void _35clofun5232(struct Cora* co);
+void _35clofun5212(struct Cora* co);
+void _35clofun5231(struct Cora* co);
+void _35clofun5213(struct Cora* co);
+void _35clofun5230(struct Cora* co);
+void _35clofun5214(struct Cora* co);
+void _35clofun5228(struct Cora* co);
+void _35clofun5229(struct Cora* co);
+void _35clofun5215(struct Cora* co);
+void _35clofun5227(struct Cora* co);
+void _35clofun5216(struct Cora* co);
+void _35clofun5226(struct Cora* co);
+void _35clofun5217(struct Cora* co);
+void _35clofun5223(struct Cora* co);
+void _35clofun5224(struct Cora* co);
+void _35clofun5225(struct Cora* co);
+void _35clofun5218(struct Cora* co);
+void _35clofun5222(struct Cora* co);
+void _35clofun5219(struct Cora* co);
+void _35clofun5220(struct Cora* co);
+void _35clofun5221(struct Cora* co);
+void _35clofun5198(struct Cora* co);
+void _35clofun5199(struct Cora* co);
+void _35clofun5200(struct Cora* co);
+void _35clofun5201(struct Cora* co);
+void _35clofun5202(struct Cora* co);
+void _35clofun5203(struct Cora* co);
+void _35clofun5204(struct Cora* co);
+void _35clofun5205(struct Cora* co);
+void _35clofun5206(struct Cora* co);
+void _35clofun5207(struct Cora* co);
+void _35clofun5208(struct Cora* co);
+void _35clofun5209(struct Cora* co);
+void _35clofun5191(struct Cora* co);
+void _35clofun5192(struct Cora* co);
+void _35clofun5193(struct Cora* co);
+void _35clofun5194(struct Cora* co);
+void _35clofun5195(struct Cora* co);
+void _35clofun5196(struct Cora* co);
+void _35clofun5189(struct Cora* co);
+void _35clofun5190(struct Cora* co);
+void _35clofun5182(struct Cora* co);
+void _35clofun5183(struct Cora* co);
+void _35clofun5185(struct Cora* co);
+void _35clofun5187(struct Cora* co);
+void _35clofun5188(struct Cora* co);
+void _35clofun5186(struct Cora* co);
+void _35clofun5184(struct Cora* co);
+void _35clofun5180(struct Cora* co);
+void _35clofun5181(struct Cora* co);
+void _35clofun5179(struct Cora* co);
+void _35clofun5177(struct Cora* co);
+void _35clofun5178(struct Cora* co);
+void _35clofun5176(struct Cora* co);
+void _35clofun5175(struct Cora* co);
+void _35clofun5172(struct Cora* co);
+void _35clofun5173(struct Cora* co);
+void _35clofun5174(struct Cora* co);
+void _35clofun5171(struct Cora* co);
+void _35clofun5164(struct Cora* co);
+void _35clofun5165(struct Cora* co);
+void _35clofun5170(struct Cora* co);
+void _35clofun5166(struct Cora* co);
+void _35clofun5169(struct Cora* co);
+void _35clofun5167(struct Cora* co);
+void _35clofun5168(struct Cora* co);
+void _35clofun5162(struct Cora* co);
+void _35clofun5155(struct Cora* co);
+void _35clofun5156(struct Cora* co);
+void _35clofun5157(struct Cora* co);
+void _35clofun5158(struct Cora* co);
+void _35clofun5161(struct Cora* co);
+void _35clofun5160(struct Cora* co);
+void _35clofun5159(struct Cora* co);
+void _35clofun5139(struct Cora* co);
+void _35clofun5140(struct Cora* co);
+void _35clofun5141(struct Cora* co);
+void _35clofun5151(struct Cora* co);
+void _35clofun5152(struct Cora* co);
+void _35clofun5153(struct Cora* co);
+void _35clofun5154(struct Cora* co);
+void _35clofun5142(struct Cora* co);
+void _35clofun5147(struct Cora* co);
+void _35clofun5148(struct Cora* co);
+void _35clofun5149(struct Cora* co);
+void _35clofun5150(struct Cora* co);
+void _35clofun5143(struct Cora* co);
+void _35clofun5144(struct Cora* co);
+void _35clofun5145(struct Cora* co);
+void _35clofun5146(struct Cora* co);
+void _35clofun5131(struct Cora* co);
+void _35clofun5132(struct Cora* co);
+void _35clofun5137(struct Cora* co);
+void _35clofun5138(struct Cora* co);
+void _35clofun5135(struct Cora* co);
+void _35clofun5136(struct Cora* co);
+void _35clofun5133(struct Cora* co);
+void _35clofun5134(struct Cora* co);
+void _35clofun5125(struct Cora* co);
+void _35clofun5128(struct Cora* co);
+void _35clofun5129(struct Cora* co);
+void _35clofun5130(struct Cora* co);
+void _35clofun5126(struct Cora* co);
+void _35clofun5127(struct Cora* co);
+void _35clofun5107(struct Cora* co);
+void _35clofun5108(struct Cora* co);
+void _35clofun5109(struct Cora* co);
+void _35clofun5123(struct Cora* co);
+void _35clofun5124(struct Cora* co);
+void _35clofun5120(struct Cora* co);
+void _35clofun5121(struct Cora* co);
+void _35clofun5122(struct Cora* co);
+void _35clofun5118(struct Cora* co);
+void _35clofun5119(struct Cora* co);
+void _35clofun5115(struct Cora* co);
+void _35clofun5116(struct Cora* co);
+void _35clofun5117(struct Cora* co);
+void _35clofun5113(struct Cora* co);
+void _35clofun5114(struct Cora* co);
+void _35clofun5110(struct Cora* co);
+void _35clofun5111(struct Cora* co);
+void _35clofun5112(struct Cora* co);
+void _35clofun5105(struct Cora* co);
+void _35clofun5102(struct Cora* co);
+void _35clofun5103(struct Cora* co);
+void _35clofun5104(struct Cora* co);
+void _35clofun5101(struct Cora* co);
+void _35clofun5099(struct Cora* co);
+void _35clofun5097(struct Cora* co);
+void _35clofun5098(struct Cora* co);
+void _35clofun5095(struct Cora* co);
+void _35clofun5093(struct Cora* co);
+void _35clofun5094(struct Cora* co);
+void _35clofun5088(struct Cora* co);
+void _35clofun5089(struct Cora* co);
+void _35clofun5090(struct Cora* co);
+void _35clofun5091(struct Cora* co);
+void _35clofun5086(struct Cora* co);
+void _35clofun5081(struct Cora* co);
+void _35clofun5082(struct Cora* co);
+void _35clofun5083(struct Cora* co);
+void _35clofun5084(struct Cora* co);
+void _35clofun5085(struct Cora* co);
+void _35clofun5080(struct Cora* co);
+void _35clofun5079(struct Cora* co);
+void _35clofun5074(struct Cora* co);
+void _35clofun5075(struct Cora* co);
+void _35clofun5076(struct Cora* co);
+void _35clofun5077(struct Cora* co);
+void _35clofun5072(struct Cora* co);
+void _35clofun5067(struct Cora* co);
+void _35clofun5068(struct Cora* co);
+void _35clofun5069(struct Cora* co);
+void _35clofun5070(struct Cora* co);
+void _35clofun5061(struct Cora* co);
+void _35clofun5065(struct Cora* co);
+void _35clofun5066(struct Cora* co);
+void _35clofun5062(struct Cora* co);
+void _35clofun5063(struct Cora* co);
+void _35clofun5064(struct Cora* co);
+void _35clofun5060(struct Cora* co);
+void _35clofun5058(struct Cora* co);
+void _35clofun5059(struct Cora* co);
+void _35clofun5057(struct Cora* co);
+void _35clofun5056(struct Cora* co);
+void _35clofun5055(struct Cora* co);
+void _35clofun5053(struct Cora* co);
+void _35clofun5054(struct Cora* co);
+void _35clofun5051(struct Cora* co);
+void _35clofun5050(struct Cora* co);
+void _35clofun5048(struct Cora* co);
+void _35clofun5049(struct Cora* co);
+void _35clofun5047(struct Cora* co);
+void _35clofun5046(struct Cora* co);
+void _35clofun5045(struct Cora* co);
+void _35clofun5044(struct Cora* co);
+void _35clofun5043(struct Cora* co);
+void _35clofun5042(struct Cora* co);
+void _35clofun5041(struct Cora* co);
+void _35clofun5040(struct Cora* co);
 
 void entry(struct Cora* co) {
-Obj _35reg39 = primSet(intern("null?"), makeNative(_35clofun1006, 1, 0));
-Obj _35reg42 = primSet(intern("cadr"), makeNative(_35clofun1007, 1, 0));
-Obj _35reg45 = primSet(intern("caar"), makeNative(_35clofun1008, 1, 0));
-Obj _35reg48 = primSet(intern("cdar"), makeNative(_35clofun1009, 1, 0));
-Obj _35reg51 = primSet(intern("cddr"), makeNative(_35clofun1010, 1, 0));
-Obj _35reg55 = primSet(intern("caddr"), makeNative(_35clofun1011, 1, 0));
-Obj _35reg60 = primSet(intern("cadddr"), makeNative(_35clofun1012, 1, 0));
-Obj _35reg64 = primSet(intern("cdddr"), makeNative(_35clofun1013, 1, 0));
-Obj _35reg72 = primSet(intern("rcons"), makeNative(_35clofun1014, 1, 0));
-Obj _35reg74 = primSet(intern("pair?"), makeNative(_35clofun1016, 1, 0));
-Obj _35reg79 = primSet(intern("cora/init.reverse-h"), makeNative(_35clofun1017, 2, 0));
-pushCont(co, _35clofun1018, 0);
+Obj _35reg4073 = primSet(intern("null?"), makeNative(_35clofun5040, 1, 0));
+Obj _35reg4076 = primSet(intern("cadr"), makeNative(_35clofun5041, 1, 0));
+Obj _35reg4079 = primSet(intern("caar"), makeNative(_35clofun5042, 1, 0));
+Obj _35reg4082 = primSet(intern("cdar"), makeNative(_35clofun5043, 1, 0));
+Obj _35reg4085 = primSet(intern("cddr"), makeNative(_35clofun5044, 1, 0));
+Obj _35reg4089 = primSet(intern("caddr"), makeNative(_35clofun5045, 1, 0));
+Obj _35reg4094 = primSet(intern("cadddr"), makeNative(_35clofun5046, 1, 0));
+Obj _35reg4098 = primSet(intern("cdddr"), makeNative(_35clofun5047, 1, 0));
+Obj _35reg4106 = primSet(intern("rcons"), makeNative(_35clofun5048, 1, 0));
+Obj _35reg4108 = primSet(intern("pair?"), makeNative(_35clofun5050, 1, 0));
+Obj _35reg4113 = primSet(intern("cora/init.reverse-h"), makeNative(_35clofun5051, 2, 0));
+pushCont(co, _35clofun5052, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.reverse-h"));
 co->args[1] = Nil;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -238,26 +238,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1018(struct Cora* co) {
-Obj _35val80 = co->args[1];
-Obj _35reg81 = primSet(intern("reverse"), _35val80);
-Obj _35reg87 = primSet(intern("map-h"), makeNative(_35clofun1019, 3, 0));
-Obj _35reg88 = primSet(intern("map"), makeNative(_35clofun1021, 2, 0));
-Obj _35reg89 = primSet(intern("*macros*"), Nil);
-Obj _35reg90 = primGenSym(intern("protect"));
-Obj _35reg91 = primSet(intern("*protect-symbol*"), _35reg90);
-Obj _35reg93 = primSet(intern("cora/init.protect"), makeNative(_35clofun1022, 1, 0));
-Obj _35reg97 = primSet(intern("cora/init.add-to-*macros*"), makeNative(_35clofun1023, 2, 0));
-Obj _35reg110 = primSet(intern("cora/init.macroexpand1-h"), makeNative(_35clofun1024, 2, 0));
-Obj _35reg111 = primSet(intern("cora/init.macroexpand1"), makeNative(_35clofun1026, 1, 0));
-Obj _35reg128 = primSet(intern("cora/init.macroexpand-boot"), makeNative(_35clofun1027, 1, 0));
-Obj _35reg129 = primSet(intern("macroexpand"), globalRef(intern("cora/init.macroexpand-boot")));
-Obj _35reg140 = primSet(intern("defmacro-macro"), makeNative(_35clofun1033, 1, 0));
-pushCont(co, _35clofun1037, 0);
+void _35clofun5052(struct Cora* co) {
+Obj _35val4114 = co->args[1];
+Obj _35reg4115 = primSet(intern("reverse"), _35val4114);
+Obj _35reg4121 = primSet(intern("map-h"), makeNative(_35clofun5053, 3, 0));
+Obj _35reg4122 = primSet(intern("map"), makeNative(_35clofun5055, 2, 0));
+Obj _35reg4123 = primSet(intern("*macros*"), Nil);
+Obj _35reg4124 = primGenSym(intern("protect"));
+Obj _35reg4125 = primSet(intern("*protect-symbol*"), _35reg4124);
+Obj _35reg4127 = primSet(intern("cora/init.protect"), makeNative(_35clofun5056, 1, 0));
+Obj _35reg4131 = primSet(intern("cora/init.add-to-*macros*"), makeNative(_35clofun5057, 2, 0));
+Obj _35reg4144 = primSet(intern("cora/init.macroexpand1-h"), makeNative(_35clofun5058, 2, 0));
+Obj _35reg4145 = primSet(intern("cora/init.macroexpand1"), makeNative(_35clofun5060, 1, 0));
+Obj _35reg4162 = primSet(intern("cora/init.macroexpand-boot"), makeNative(_35clofun5061, 1, 0));
+Obj _35reg4163 = primSet(intern("macroexpand"), globalRef(intern("cora/init.macroexpand-boot")));
+Obj _35reg4174 = primSet(intern("defmacro-macro"), makeNative(_35clofun5067, 1, 0));
+pushCont(co, _35clofun5071, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("defmacro");
 co->args[2] = globalRef(intern("defmacro-macro"));
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -267,13 +267,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1037(struct Cora* co) {
-Obj _35val141 = co->args[1];
-pushCont(co, _35clofun1039, 0);
+void _35clofun5071(struct Cora* co) {
+Obj _35val4175 = co->args[1];
+pushCont(co, _35clofun5073, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("list");
-co->args[2] = makeNative(_35clofun1038, 1, 0);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun5072, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -283,13 +283,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1039(struct Cora* co) {
-Obj _35val143 = co->args[1];
-pushCont(co, _35clofun1044, 0);
+void _35clofun5073(struct Cora* co) {
+Obj _35val4177 = co->args[1];
+pushCont(co, _35clofun5078, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("defun");
-co->args[2] = makeNative(_35clofun1040, 1, 0);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun5074, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -299,16 +299,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1044(struct Cora* co) {
-Obj _35val155 = co->args[1];
-Obj _35reg160 = primSet(intern("elem?"), makeNative(_35clofun1045, 2, 0));
-Obj _35reg163 = primSet(intern("atom?"), makeNative(_35clofun1046, 1, 0));
-Obj _35reg175 = primSet(intern("cora/init.rewrite-let"), makeNative(_35clofun1047, 1, 0));
-pushCont(co, _35clofun1053, 0);
+void _35clofun5078(struct Cora* co) {
+Obj _35val4189 = co->args[1];
+Obj _35reg4194 = primSet(intern("elem?"), makeNative(_35clofun5079, 2, 0));
+Obj _35reg4197 = primSet(intern("atom?"), makeNative(_35clofun5080, 1, 0));
+Obj _35reg4209 = primSet(intern("cora/init.rewrite-let"), makeNative(_35clofun5081, 1, 0));
+pushCont(co, _35clofun5087, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("let");
-co->args[2] = makeNative(_35clofun1052, 1, 0);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun5086, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -318,13 +318,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1053(struct Cora* co) {
-Obj _35val177 = co->args[1];
-pushCont(co, _35clofun1058, 0);
+void _35clofun5087(struct Cora* co) {
+Obj _35val4211 = co->args[1];
+pushCont(co, _35clofun5092, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("cond");
-co->args[2] = makeNative(_35clofun1054, 1, 0);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun5088, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -334,14 +334,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1058(struct Cora* co) {
-Obj _35val191 = co->args[1];
-Obj _35reg203 = primSet(intern("cora/init.rewrite-or"), makeNative(_35clofun1059, 1, 0));
-pushCont(co, _35clofun1062, 0);
+void _35clofun5092(struct Cora* co) {
+Obj _35val4225 = co->args[1];
+Obj _35reg4237 = primSet(intern("cora/init.rewrite-or"), makeNative(_35clofun5093, 1, 0));
+pushCont(co, _35clofun5096, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("or");
-co->args[2] = makeNative(_35clofun1061, 1, 0);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun5095, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -351,14 +351,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1062(struct Cora* co) {
-Obj _35val205 = co->args[1];
-Obj _35reg217 = primSet(intern("cora/init.rewrite-and"), makeNative(_35clofun1063, 1, 0));
-pushCont(co, _35clofun1066, 0);
+void _35clofun5096(struct Cora* co) {
+Obj _35val4239 = co->args[1];
+Obj _35reg4251 = primSet(intern("cora/init.rewrite-and"), makeNative(_35clofun5097, 1, 0));
+pushCont(co, _35clofun5100, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("and");
-co->args[2] = makeNative(_35clofun1065, 1, 0);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun5099, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -368,15 +368,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1066(struct Cora* co) {
-Obj _35val219 = co->args[1];
-Obj _35reg222 = primSet(intern("boolean?"), makeNative(_35clofun1067, 1, 0));
-Obj _35reg232 = primSet(intern("cora/init.rcons1"), makeNative(_35clofun1068, 1, 0));
-pushCont(co, _35clofun1072, 0);
+void _35clofun5100(struct Cora* co) {
+Obj _35val4253 = co->args[1];
+Obj _35reg4256 = primSet(intern("boolean?"), makeNative(_35clofun5101, 1, 0));
+Obj _35reg4266 = primSet(intern("cora/init.rcons1"), makeNative(_35clofun5102, 1, 0));
+pushCont(co, _35clofun5106, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("list-rest");
-co->args[2] = makeNative(_35clofun1071, 1, 0);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun5105, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -386,18 +386,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1072(struct Cora* co) {
-Obj _35val234 = co->args[1];
-Obj _35reg288 = primSet(intern("cora/init.match-cons-expander"), makeNative(_35clofun1073, 4, 0));
-Obj _35reg321 = primSet(intern("cora/init.match1"), makeNative(_35clofun1091, 4, 0));
-Obj _35reg348 = primSet(intern("cora/init.extract-rule-action"), makeNative(_35clofun1097, 2, 0));
-Obj _35reg400 = primSet(intern("cora/init.match-helper"), makeNative(_35clofun1105, 2, 0));
-Obj _35reg426 = primSet(intern("cora/init.rewrite-match"), makeNative(_35clofun1121, 1, 0));
-pushCont(co, _35clofun1129, 0);
+void _35clofun5106(struct Cora* co) {
+Obj _35val4268 = co->args[1];
+Obj _35reg4322 = primSet(intern("cora/init.match-cons-expander"), makeNative(_35clofun5107, 4, 0));
+Obj _35reg4355 = primSet(intern("cora/init.match1"), makeNative(_35clofun5125, 4, 0));
+Obj _35reg4382 = primSet(intern("cora/init.extract-rule-action"), makeNative(_35clofun5131, 2, 0));
+Obj _35reg4434 = primSet(intern("cora/init.match-helper"), makeNative(_35clofun5139, 2, 0));
+Obj _35reg4460 = primSet(intern("cora/init.rewrite-match"), makeNative(_35clofun5155, 1, 0));
+pushCont(co, _35clofun5163, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("match");
-co->args[2] = makeNative(_35clofun1128, 1, 0);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun5162, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -407,23 +407,23 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1129(struct Cora* co) {
-Obj _35val427 = co->args[1];
-Obj _35reg479 = primSet(intern("cora/init.extract-rules1"), makeNative(_35clofun1130, 3, 0));
-Obj _35reg480 = primSet(intern("cora/init.extract-rules"), makeNative(_35clofun1137, 1, 0));
-Obj _35reg485 = primSet(intern("cora/init.rules-patterns"), makeNative(_35clofun1138, 2, 0));
-Obj _35reg489 = primSet(intern("cora/init.length-h"), makeNative(_35clofun1141, 2, 0));
-Obj _35reg490 = primSet(intern("length"), makeNative(_35clofun1142, 1, 0));
-Obj _35reg498 = primSet(intern("cora/init.filter-h"), makeNative(_35clofun1143, 3, 0));
-Obj _35reg499 = primSet(intern("filter"), makeNative(_35clofun1145, 2, 0));
-Obj _35reg505 = primSet(intern("append"), makeNative(_35clofun1146, 2, 0));
-Obj _35reg516 = primSet(intern("cora/init.rules-arg-count"), makeNative(_35clofun1148, 1, 0));
-Obj _35reg522 = primSet(intern("cora/init.gen-parameters"), makeNative(_35clofun1155, 1, 0));
-pushCont(co, _35clofun1163, 0);
+void _35clofun5163(struct Cora* co) {
+Obj _35val4461 = co->args[1];
+Obj _35reg4513 = primSet(intern("cora/init.extract-rules1"), makeNative(_35clofun5164, 3, 0));
+Obj _35reg4514 = primSet(intern("cora/init.extract-rules"), makeNative(_35clofun5171, 1, 0));
+Obj _35reg4519 = primSet(intern("cora/init.rules-patterns"), makeNative(_35clofun5172, 2, 0));
+Obj _35reg4523 = primSet(intern("cora/init.length-h"), makeNative(_35clofun5175, 2, 0));
+Obj _35reg4524 = primSet(intern("length"), makeNative(_35clofun5176, 1, 0));
+Obj _35reg4532 = primSet(intern("cora/init.filter-h"), makeNative(_35clofun5177, 3, 0));
+Obj _35reg4533 = primSet(intern("filter"), makeNative(_35clofun5179, 2, 0));
+Obj _35reg4539 = primSet(intern("append"), makeNative(_35clofun5180, 2, 0));
+Obj _35reg4550 = primSet(intern("cora/init.rules-arg-count"), makeNative(_35clofun5182, 1, 0));
+Obj _35reg4556 = primSet(intern("cora/init.gen-parameters"), makeNative(_35clofun5189, 1, 0));
+pushCont(co, _35clofun5197, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("func");
-co->args[2] = makeNative(_35clofun1157, 1, 0);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun5191, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -433,17 +433,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1163(struct Cora* co) {
-Obj _35val535 = co->args[1];
-Obj _35reg798 = primSet(intern("cora/init.propagate-boolean0"), makeNative(_35clofun1164, 1, 0));
-Obj _35reg956 = primSet(intern("cora/init.propagate-boolean"), makeNative(_35clofun1176, 1, 0));
-Obj _35reg958 = primSet(intern("macroexpand"), makeNative(_35clofun1199, 1, 0));
-Obj _35reg982 = primSet(intern("cora/init.rewrite-begin"), makeNative(_35clofun1201, 1, 0));
-pushCont(co, _35clofun1207, 0);
+void _35clofun5197(struct Cora* co) {
+Obj _35val4569 = co->args[1];
+Obj _35reg4832 = primSet(intern("cora/init.propagate-boolean0"), makeNative(_35clofun5198, 1, 0));
+Obj _35reg4990 = primSet(intern("cora/init.propagate-boolean"), makeNative(_35clofun5210, 1, 0));
+Obj _35reg4992 = primSet(intern("macroexpand"), makeNative(_35clofun5233, 1, 0));
+Obj _35reg5016 = primSet(intern("cora/init.rewrite-begin"), makeNative(_35clofun5235, 1, 0));
+pushCont(co, _35clofun5241, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("begin");
-co->args[2] = makeNative(_35clofun1206, 1, 0);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun5240, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -453,13 +453,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1207(struct Cora* co) {
-Obj _35val984 = co->args[1];
-Obj _35reg1004 = primSet(intern("cora/init.rewrite-backquote"), makeNative(_35clofun1208, 1, 0));
+void _35clofun5241(struct Cora* co) {
+Obj _35val5018 = co->args[1];
+Obj _35reg5038 = primSet(intern("cora/init.rewrite-backquote"), makeNative(_35clofun5242, 1, 0));
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("backquote");
-co->args[2] = makeNative(_35clofun1214, 1, 0);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun5248, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -469,12 +469,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1214(struct Cora* co) {
+void _35clofun5248(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun1215, 0);
+pushCont(co, _35clofun5249, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -484,11 +484,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1215(struct Cora* co) {
-Obj _35val1005 = co->args[1];
+void _35clofun5249(struct Cora* co) {
+Obj _35val5039 = co->args[1];
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-backquote"));
-co->args[1] = _35val1005;
-co->nargs = 2;
+co->args[1] = _35val5039;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -498,20 +498,21 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1208(struct Cora* co) {
-Obj _35p33 = co->args[1];
-Obj _35cc34 = makeNative(_35clofun1209, 0, 1, _35p33);
-Obj x = _35p33;
-Obj _35reg1001 = primIsSymbol(x);
-if (True == _35reg1001) {
-Obj _35reg1002 = primCons(x, Nil);
-Obj _35reg1003 = primCons(intern("quote"), _35reg1002);
-co->args[1] = _35reg1003;
+void _35clofun5242(struct Cora* co) {
+Obj _35p4067 = co->args[1];
+Obj _35cc4068 = makeNative(_35clofun5243, 0, 1, _35p4067);
+Obj x = _35p4067;
+Obj _35reg5035 = primIsSymbol(x);
+if (True == _35reg5035) {
+Obj _35reg5036 = primCons(x, Nil);
+Obj _35reg5037 = primCons(intern("quote"), _35reg5036);
+co->nargs = 2;
+co->args[1] = _35reg5037;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc34;
 co->nargs = 1;
+co->args[0] = _35cc4068;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -522,29 +523,30 @@ return;
 }
 }
 
-void _35clofun1209(struct Cora* co) {
-Obj _35cc35 = makeNative(_35clofun1210, 0, 1, closureRef(co, 0));
-Obj _35reg991 = primIsCons(closureRef(co, 0));
-if (True == _35reg991) {
-Obj _35reg992 = primCar(closureRef(co, 0));
-Obj _35reg993 = primEQ(intern("unquote"), _35reg992);
-if (True == _35reg993) {
-Obj _35reg994 = primCdr(closureRef(co, 0));
-Obj _35reg995 = primIsCons(_35reg994);
-if (True == _35reg995) {
-Obj _35reg996 = primCdr(closureRef(co, 0));
-Obj _35reg997 = primCar(_35reg996);
-Obj x = _35reg997;
-Obj _35reg998 = primCdr(closureRef(co, 0));
-Obj _35reg999 = primCdr(_35reg998);
-Obj _35reg1000 = primEQ(Nil, _35reg999);
-if (True == _35reg1000) {
+void _35clofun5243(struct Cora* co) {
+Obj _35cc4069 = makeNative(_35clofun5244, 0, 1, closureRef(co, 0));
+Obj _35reg5025 = primIsCons(closureRef(co, 0));
+if (True == _35reg5025) {
+Obj _35reg5026 = primCar(closureRef(co, 0));
+Obj _35reg5027 = primEQ(intern("unquote"), _35reg5026);
+if (True == _35reg5027) {
+Obj _35reg5028 = primCdr(closureRef(co, 0));
+Obj _35reg5029 = primIsCons(_35reg5028);
+if (True == _35reg5029) {
+Obj _35reg5030 = primCdr(closureRef(co, 0));
+Obj _35reg5031 = primCar(_35reg5030);
+Obj x = _35reg5031;
+Obj _35reg5032 = primCdr(closureRef(co, 0));
+Obj _35reg5033 = primCdr(_35reg5032);
+Obj _35reg5034 = primEQ(Nil, _35reg5033);
+if (True == _35reg5034) {
+co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc35;
 co->nargs = 1;
+co->args[0] = _35cc4069;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -554,8 +556,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc35;
 co->nargs = 1;
+co->args[0] = _35cc4069;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -565,8 +567,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc35;
 co->nargs = 1;
+co->args[0] = _35cc4069;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -576,8 +578,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc35;
 co->nargs = 1;
+co->args[0] = _35cc4069;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -588,20 +590,20 @@ return;
 }
 }
 
-void _35clofun1210(struct Cora* co) {
-Obj _35cc36 = makeNative(_35clofun1211, 0, 1, closureRef(co, 0));
-Obj _35reg985 = primIsCons(closureRef(co, 0));
-if (True == _35reg985) {
-Obj _35reg986 = primCar(closureRef(co, 0));
-Obj x = _35reg986;
-Obj _35reg987 = primCdr(closureRef(co, 0));
-Obj more = _35reg987;
-Obj _35reg988 = primCons(x, more);
-pushCont(co, _35clofun1213, 0);
+void _35clofun5244(struct Cora* co) {
+Obj _35cc4070 = makeNative(_35clofun5245, 0, 1, closureRef(co, 0));
+Obj _35reg5019 = primIsCons(closureRef(co, 0));
+if (True == _35reg5019) {
+Obj _35reg5020 = primCar(closureRef(co, 0));
+Obj x = _35reg5020;
+Obj _35reg5021 = primCdr(closureRef(co, 0));
+Obj more = _35reg5021;
+Obj _35reg5022 = primCons(x, more);
+pushCont(co, _35clofun5247, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/init.rewrite-backquote"));
-co->args[2] = _35reg988;
-co->nargs = 3;
+co->args[2] = _35reg5022;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -610,8 +612,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc36;
 co->nargs = 1;
+co->args[0] = _35cc4070;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -622,26 +624,28 @@ return;
 }
 }
 
-void _35clofun1213(struct Cora* co) {
-Obj _35val989 = co->args[1];
-Obj _35reg990 = primCons(intern("list"), _35val989);
-co->args[1] = _35reg990;
+void _35clofun5247(struct Cora* co) {
+Obj _35val5023 = co->args[1];
+Obj _35reg5024 = primCons(intern("list"), _35val5023);
+co->nargs = 2;
+co->args[1] = _35reg5024;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1211(struct Cora* co) {
-Obj _35cc37 = makeNative(_35clofun1212, 0, 0);
+void _35clofun5245(struct Cora* co) {
+Obj _35cc4071 = makeNative(_35clofun5246, 0, 0);
 Obj x = closureRef(co, 0);
+co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1212(struct Cora* co) {
+void _35clofun5246(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -651,12 +655,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1206(struct Cora* co) {
+void _35clofun5240(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg983 = primCdr(exp);
-co->args[0] = globalRef(intern("cora/init.rewrite-begin"));
-co->args[1] = _35reg983;
+Obj _35reg5017 = primCdr(exp);
 co->nargs = 2;
+co->args[0] = globalRef(intern("cora/init.rewrite-begin"));
+co->args[1] = _35reg5017;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -666,22 +670,23 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1201(struct Cora* co) {
-Obj _35p29 = co->args[1];
-Obj _35cc30 = makeNative(_35clofun1202, 0, 1, _35p29);
-Obj _35reg978 = primIsCons(_35p29);
-if (True == _35reg978) {
-Obj _35reg979 = primCar(_35p29);
-Obj x = _35reg979;
-Obj _35reg980 = primCdr(_35p29);
-Obj _35reg981 = primEQ(Nil, _35reg980);
-if (True == _35reg981) {
+void _35clofun5235(struct Cora* co) {
+Obj _35p4063 = co->args[1];
+Obj _35cc4064 = makeNative(_35clofun5236, 0, 1, _35p4063);
+Obj _35reg5012 = primIsCons(_35p4063);
+if (True == _35reg5012) {
+Obj _35reg5013 = primCar(_35p4063);
+Obj x = _35reg5013;
+Obj _35reg5014 = primCdr(_35p4063);
+Obj _35reg5015 = primEQ(Nil, _35reg5014);
+if (True == _35reg5015) {
+co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc30;
 co->nargs = 1;
+co->args[0] = _35cc4064;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -691,8 +696,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc30;
 co->nargs = 1;
+co->args[0] = _35cc4064;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -703,31 +708,32 @@ return;
 }
 }
 
-void _35clofun1202(struct Cora* co) {
-Obj _35cc31 = makeNative(_35clofun1203, 0, 1, closureRef(co, 0));
-Obj _35reg966 = primIsCons(closureRef(co, 0));
-if (True == _35reg966) {
-Obj _35reg967 = primCar(closureRef(co, 0));
-Obj x = _35reg967;
-Obj _35reg968 = primCdr(closureRef(co, 0));
-Obj _35reg969 = primIsCons(_35reg968);
-if (True == _35reg969) {
-Obj _35reg970 = primCdr(closureRef(co, 0));
-Obj _35reg971 = primCar(_35reg970);
-Obj y = _35reg971;
-Obj _35reg972 = primCdr(closureRef(co, 0));
-Obj _35reg973 = primCdr(_35reg972);
-Obj _35reg974 = primEQ(Nil, _35reg973);
-if (True == _35reg974) {
-Obj _35reg975 = primCons(y, Nil);
-Obj _35reg976 = primCons(x, _35reg975);
-Obj _35reg977 = primCons(intern("do"), _35reg976);
-co->args[1] = _35reg977;
+void _35clofun5236(struct Cora* co) {
+Obj _35cc4065 = makeNative(_35clofun5237, 0, 1, closureRef(co, 0));
+Obj _35reg5000 = primIsCons(closureRef(co, 0));
+if (True == _35reg5000) {
+Obj _35reg5001 = primCar(closureRef(co, 0));
+Obj x = _35reg5001;
+Obj _35reg5002 = primCdr(closureRef(co, 0));
+Obj _35reg5003 = primIsCons(_35reg5002);
+if (True == _35reg5003) {
+Obj _35reg5004 = primCdr(closureRef(co, 0));
+Obj _35reg5005 = primCar(_35reg5004);
+Obj y = _35reg5005;
+Obj _35reg5006 = primCdr(closureRef(co, 0));
+Obj _35reg5007 = primCdr(_35reg5006);
+Obj _35reg5008 = primEQ(Nil, _35reg5007);
+if (True == _35reg5008) {
+Obj _35reg5009 = primCons(y, Nil);
+Obj _35reg5010 = primCons(x, _35reg5009);
+Obj _35reg5011 = primCons(intern("do"), _35reg5010);
+co->nargs = 2;
+co->args[1] = _35reg5011;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc31;
 co->nargs = 1;
+co->args[0] = _35cc4065;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -737,8 +743,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc31;
 co->nargs = 1;
+co->args[0] = _35cc4065;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -748,8 +754,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc31;
 co->nargs = 1;
+co->args[0] = _35cc4065;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -760,18 +766,18 @@ return;
 }
 }
 
-void _35clofun1203(struct Cora* co) {
-Obj _35cc32 = makeNative(_35clofun1204, 0, 0);
-Obj _35reg959 = primIsCons(closureRef(co, 0));
-if (True == _35reg959) {
-Obj _35reg960 = primCar(closureRef(co, 0));
-Obj x = _35reg960;
-Obj _35reg961 = primCdr(closureRef(co, 0));
-Obj y = _35reg961;
-pushCont(co, _35clofun1205, 1, x);
+void _35clofun5237(struct Cora* co) {
+Obj _35cc4066 = makeNative(_35clofun5238, 0, 0);
+Obj _35reg4993 = primIsCons(closureRef(co, 0));
+if (True == _35reg4993) {
+Obj _35reg4994 = primCar(closureRef(co, 0));
+Obj x = _35reg4994;
+Obj _35reg4995 = primCdr(closureRef(co, 0));
+Obj y = _35reg4995;
+pushCont(co, _35clofun5239, 1, x);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-begin"));
 co->args[1] = y;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -780,8 +786,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc32;
 co->nargs = 1;
+co->args[0] = _35cc4066;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -792,21 +798,22 @@ return;
 }
 }
 
-void _35clofun1205(struct Cora* co) {
-Obj _35val962 = co->args[1];
+void _35clofun5239(struct Cora* co) {
+Obj _35val4996 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35reg963 = primCons(_35val962, Nil);
-Obj _35reg964 = primCons(x, _35reg963);
-Obj _35reg965 = primCons(intern("do"), _35reg964);
-co->args[1] = _35reg965;
+Obj _35reg4997 = primCons(_35val4996, Nil);
+Obj _35reg4998 = primCons(x, _35reg4997);
+Obj _35reg4999 = primCons(intern("do"), _35reg4998);
+co->nargs = 2;
+co->args[1] = _35reg4999;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1204(struct Cora* co) {
+void _35clofun5238(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -816,12 +823,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1199(struct Cora* co) {
+void _35clofun5233(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun1200, 0);
+pushCont(co, _35clofun5234, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.macroexpand-boot"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -831,11 +838,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1200(struct Cora* co) {
-Obj _35val957 = co->args[1];
+void _35clofun5234(struct Cora* co) {
+Obj _35val4991 = co->args[1];
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
-co->args[1] = _35val957;
-co->nargs = 2;
+co->args[1] = _35val4991;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -845,32 +852,33 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1176(struct Cora* co) {
-Obj _35p17 = co->args[1];
-Obj _35cc18 = makeNative(_35clofun1177, 0, 1, _35p17);
-Obj _35reg944 = primIsCons(_35p17);
-if (True == _35reg944) {
-Obj _35reg945 = primCar(_35p17);
-Obj _35reg946 = primEQ(intern("quote"), _35reg945);
-if (True == _35reg946) {
-Obj _35reg947 = primCdr(_35p17);
-Obj _35reg948 = primIsCons(_35reg947);
-if (True == _35reg948) {
-Obj _35reg949 = primCdr(_35p17);
-Obj _35reg950 = primCar(_35reg949);
-Obj x = _35reg950;
-Obj _35reg951 = primCdr(_35p17);
-Obj _35reg952 = primCdr(_35reg951);
-Obj _35reg953 = primEQ(Nil, _35reg952);
-if (True == _35reg953) {
-Obj _35reg954 = primCons(x, Nil);
-Obj _35reg955 = primCons(intern("quote"), _35reg954);
-co->args[1] = _35reg955;
+void _35clofun5210(struct Cora* co) {
+Obj _35p4051 = co->args[1];
+Obj _35cc4052 = makeNative(_35clofun5211, 0, 1, _35p4051);
+Obj _35reg4978 = primIsCons(_35p4051);
+if (True == _35reg4978) {
+Obj _35reg4979 = primCar(_35p4051);
+Obj _35reg4980 = primEQ(intern("quote"), _35reg4979);
+if (True == _35reg4980) {
+Obj _35reg4981 = primCdr(_35p4051);
+Obj _35reg4982 = primIsCons(_35reg4981);
+if (True == _35reg4982) {
+Obj _35reg4983 = primCdr(_35p4051);
+Obj _35reg4984 = primCar(_35reg4983);
+Obj x = _35reg4984;
+Obj _35reg4985 = primCdr(_35p4051);
+Obj _35reg4986 = primCdr(_35reg4985);
+Obj _35reg4987 = primEQ(Nil, _35reg4986);
+if (True == _35reg4987) {
+Obj _35reg4988 = primCons(x, Nil);
+Obj _35reg4989 = primCons(intern("quote"), _35reg4988);
+co->nargs = 2;
+co->args[1] = _35reg4989;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc18;
 co->nargs = 1;
+co->args[0] = _35cc4052;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -880,8 +888,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc18;
 co->nargs = 1;
+co->args[0] = _35cc4052;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -891,8 +899,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc18;
 co->nargs = 1;
+co->args[0] = _35cc4052;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -902,8 +910,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc18;
 co->nargs = 1;
+co->args[0] = _35cc4052;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -914,27 +922,27 @@ return;
 }
 }
 
-void _35clofun1177(struct Cora* co) {
-Obj _35cc19 = makeNative(_35clofun1178, 0, 1, closureRef(co, 0));
-Obj _35reg931 = primIsCons(closureRef(co, 0));
-if (True == _35reg931) {
-Obj _35reg932 = primCar(closureRef(co, 0));
-Obj _35reg933 = primEQ(intern("cons?"), _35reg932);
-if (True == _35reg933) {
-Obj _35reg934 = primCdr(closureRef(co, 0));
-Obj _35reg935 = primIsCons(_35reg934);
-if (True == _35reg935) {
-Obj _35reg936 = primCdr(closureRef(co, 0));
-Obj _35reg937 = primCar(_35reg936);
-Obj x = _35reg937;
-Obj _35reg938 = primCdr(closureRef(co, 0));
-Obj _35reg939 = primCdr(_35reg938);
-Obj _35reg940 = primEQ(Nil, _35reg939);
-if (True == _35reg940) {
-pushCont(co, _35clofun1198, 0);
+void _35clofun5211(struct Cora* co) {
+Obj _35cc4053 = makeNative(_35clofun5212, 0, 1, closureRef(co, 0));
+Obj _35reg4965 = primIsCons(closureRef(co, 0));
+if (True == _35reg4965) {
+Obj _35reg4966 = primCar(closureRef(co, 0));
+Obj _35reg4967 = primEQ(intern("cons?"), _35reg4966);
+if (True == _35reg4967) {
+Obj _35reg4968 = primCdr(closureRef(co, 0));
+Obj _35reg4969 = primIsCons(_35reg4968);
+if (True == _35reg4969) {
+Obj _35reg4970 = primCdr(closureRef(co, 0));
+Obj _35reg4971 = primCar(_35reg4970);
+Obj x = _35reg4971;
+Obj _35reg4972 = primCdr(closureRef(co, 0));
+Obj _35reg4973 = primCdr(_35reg4972);
+Obj _35reg4974 = primEQ(Nil, _35reg4973);
+if (True == _35reg4974) {
+pushCont(co, _35clofun5232, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -943,8 +951,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc19;
 co->nargs = 1;
+co->args[0] = _35cc4053;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -954,8 +962,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc19;
 co->nargs = 1;
+co->args[0] = _35cc4053;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -965,8 +973,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc19;
 co->nargs = 1;
+co->args[0] = _35cc4053;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -976,8 +984,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc19;
 co->nargs = 1;
+co->args[0] = _35cc4053;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -988,14 +996,14 @@ return;
 }
 }
 
-void _35clofun1198(struct Cora* co) {
-Obj _35val941 = co->args[1];
-Obj x1 = _35val941;
-Obj _35reg942 = primCons(x1, Nil);
-Obj _35reg943 = primCons(intern("cons?"), _35reg942);
+void _35clofun5232(struct Cora* co) {
+Obj _35val4975 = co->args[1];
+Obj x1 = _35val4975;
+Obj _35reg4976 = primCons(x1, Nil);
+Obj _35reg4977 = primCons(intern("cons?"), _35reg4976);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg943;
-co->nargs = 2;
+co->args[1] = _35reg4977;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1005,27 +1013,27 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1178(struct Cora* co) {
-Obj _35cc20 = makeNative(_35clofun1179, 0, 1, closureRef(co, 0));
-Obj _35reg918 = primIsCons(closureRef(co, 0));
-if (True == _35reg918) {
-Obj _35reg919 = primCar(closureRef(co, 0));
-Obj _35reg920 = primEQ(intern("car"), _35reg919);
-if (True == _35reg920) {
-Obj _35reg921 = primCdr(closureRef(co, 0));
-Obj _35reg922 = primIsCons(_35reg921);
-if (True == _35reg922) {
-Obj _35reg923 = primCdr(closureRef(co, 0));
-Obj _35reg924 = primCar(_35reg923);
-Obj x = _35reg924;
-Obj _35reg925 = primCdr(closureRef(co, 0));
-Obj _35reg926 = primCdr(_35reg925);
-Obj _35reg927 = primEQ(Nil, _35reg926);
-if (True == _35reg927) {
-pushCont(co, _35clofun1197, 0);
+void _35clofun5212(struct Cora* co) {
+Obj _35cc4054 = makeNative(_35clofun5213, 0, 1, closureRef(co, 0));
+Obj _35reg4952 = primIsCons(closureRef(co, 0));
+if (True == _35reg4952) {
+Obj _35reg4953 = primCar(closureRef(co, 0));
+Obj _35reg4954 = primEQ(intern("car"), _35reg4953);
+if (True == _35reg4954) {
+Obj _35reg4955 = primCdr(closureRef(co, 0));
+Obj _35reg4956 = primIsCons(_35reg4955);
+if (True == _35reg4956) {
+Obj _35reg4957 = primCdr(closureRef(co, 0));
+Obj _35reg4958 = primCar(_35reg4957);
+Obj x = _35reg4958;
+Obj _35reg4959 = primCdr(closureRef(co, 0));
+Obj _35reg4960 = primCdr(_35reg4959);
+Obj _35reg4961 = primEQ(Nil, _35reg4960);
+if (True == _35reg4961) {
+pushCont(co, _35clofun5231, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1034,8 +1042,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc20;
 co->nargs = 1;
+co->args[0] = _35cc4054;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1045,8 +1053,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc20;
 co->nargs = 1;
+co->args[0] = _35cc4054;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1056,8 +1064,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc20;
 co->nargs = 1;
+co->args[0] = _35cc4054;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1067,8 +1075,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc20;
 co->nargs = 1;
+co->args[0] = _35cc4054;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1079,14 +1087,14 @@ return;
 }
 }
 
-void _35clofun1197(struct Cora* co) {
-Obj _35val928 = co->args[1];
-Obj x1 = _35val928;
-Obj _35reg929 = primCons(x1, Nil);
-Obj _35reg930 = primCons(intern("car"), _35reg929);
+void _35clofun5231(struct Cora* co) {
+Obj _35val4962 = co->args[1];
+Obj x1 = _35val4962;
+Obj _35reg4963 = primCons(x1, Nil);
+Obj _35reg4964 = primCons(intern("car"), _35reg4963);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg930;
-co->nargs = 2;
+co->args[1] = _35reg4964;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1096,27 +1104,27 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1179(struct Cora* co) {
-Obj _35cc21 = makeNative(_35clofun1180, 0, 1, closureRef(co, 0));
-Obj _35reg905 = primIsCons(closureRef(co, 0));
-if (True == _35reg905) {
-Obj _35reg906 = primCar(closureRef(co, 0));
-Obj _35reg907 = primEQ(intern("cdr"), _35reg906);
-if (True == _35reg907) {
-Obj _35reg908 = primCdr(closureRef(co, 0));
-Obj _35reg909 = primIsCons(_35reg908);
-if (True == _35reg909) {
-Obj _35reg910 = primCdr(closureRef(co, 0));
-Obj _35reg911 = primCar(_35reg910);
-Obj x = _35reg911;
-Obj _35reg912 = primCdr(closureRef(co, 0));
-Obj _35reg913 = primCdr(_35reg912);
-Obj _35reg914 = primEQ(Nil, _35reg913);
-if (True == _35reg914) {
-pushCont(co, _35clofun1196, 0);
+void _35clofun5213(struct Cora* co) {
+Obj _35cc4055 = makeNative(_35clofun5214, 0, 1, closureRef(co, 0));
+Obj _35reg4939 = primIsCons(closureRef(co, 0));
+if (True == _35reg4939) {
+Obj _35reg4940 = primCar(closureRef(co, 0));
+Obj _35reg4941 = primEQ(intern("cdr"), _35reg4940);
+if (True == _35reg4941) {
+Obj _35reg4942 = primCdr(closureRef(co, 0));
+Obj _35reg4943 = primIsCons(_35reg4942);
+if (True == _35reg4943) {
+Obj _35reg4944 = primCdr(closureRef(co, 0));
+Obj _35reg4945 = primCar(_35reg4944);
+Obj x = _35reg4945;
+Obj _35reg4946 = primCdr(closureRef(co, 0));
+Obj _35reg4947 = primCdr(_35reg4946);
+Obj _35reg4948 = primEQ(Nil, _35reg4947);
+if (True == _35reg4948) {
+pushCont(co, _35clofun5230, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1125,8 +1133,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc21;
 co->nargs = 1;
+co->args[0] = _35cc4055;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1136,8 +1144,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc21;
 co->nargs = 1;
+co->args[0] = _35cc4055;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1147,8 +1155,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc21;
 co->nargs = 1;
+co->args[0] = _35cc4055;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1158,8 +1166,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc21;
 co->nargs = 1;
+co->args[0] = _35cc4055;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1170,14 +1178,14 @@ return;
 }
 }
 
-void _35clofun1196(struct Cora* co) {
-Obj _35val915 = co->args[1];
-Obj x1 = _35val915;
-Obj _35reg916 = primCons(x1, Nil);
-Obj _35reg917 = primCons(intern("cdr"), _35reg916);
+void _35clofun5230(struct Cora* co) {
+Obj _35val4949 = co->args[1];
+Obj x1 = _35val4949;
+Obj _35reg4950 = primCons(x1, Nil);
+Obj _35reg4951 = primCons(intern("cdr"), _35reg4950);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg917;
-co->nargs = 2;
+co->args[1] = _35reg4951;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1187,36 +1195,36 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1180(struct Cora* co) {
-Obj _35cc22 = makeNative(_35clofun1181, 0, 1, closureRef(co, 0));
-Obj _35reg883 = primIsCons(closureRef(co, 0));
-if (True == _35reg883) {
-Obj _35reg884 = primCar(closureRef(co, 0));
-Obj _35reg885 = primEQ(intern("and"), _35reg884);
-if (True == _35reg885) {
-Obj _35reg886 = primCdr(closureRef(co, 0));
-Obj _35reg887 = primIsCons(_35reg886);
-if (True == _35reg887) {
-Obj _35reg888 = primCdr(closureRef(co, 0));
-Obj _35reg889 = primCar(_35reg888);
-Obj x = _35reg889;
-Obj _35reg890 = primCdr(closureRef(co, 0));
-Obj _35reg891 = primCdr(_35reg890);
-Obj _35reg892 = primIsCons(_35reg891);
-if (True == _35reg892) {
-Obj _35reg893 = primCdr(closureRef(co, 0));
-Obj _35reg894 = primCdr(_35reg893);
-Obj _35reg895 = primCar(_35reg894);
-Obj y = _35reg895;
-Obj _35reg896 = primCdr(closureRef(co, 0));
-Obj _35reg897 = primCdr(_35reg896);
-Obj _35reg898 = primCdr(_35reg897);
-Obj _35reg899 = primEQ(Nil, _35reg898);
-if (True == _35reg899) {
-pushCont(co, _35clofun1194, 1, y);
+void _35clofun5214(struct Cora* co) {
+Obj _35cc4056 = makeNative(_35clofun5215, 0, 1, closureRef(co, 0));
+Obj _35reg4917 = primIsCons(closureRef(co, 0));
+if (True == _35reg4917) {
+Obj _35reg4918 = primCar(closureRef(co, 0));
+Obj _35reg4919 = primEQ(intern("and"), _35reg4918);
+if (True == _35reg4919) {
+Obj _35reg4920 = primCdr(closureRef(co, 0));
+Obj _35reg4921 = primIsCons(_35reg4920);
+if (True == _35reg4921) {
+Obj _35reg4922 = primCdr(closureRef(co, 0));
+Obj _35reg4923 = primCar(_35reg4922);
+Obj x = _35reg4923;
+Obj _35reg4924 = primCdr(closureRef(co, 0));
+Obj _35reg4925 = primCdr(_35reg4924);
+Obj _35reg4926 = primIsCons(_35reg4925);
+if (True == _35reg4926) {
+Obj _35reg4927 = primCdr(closureRef(co, 0));
+Obj _35reg4928 = primCdr(_35reg4927);
+Obj _35reg4929 = primCar(_35reg4928);
+Obj y = _35reg4929;
+Obj _35reg4930 = primCdr(closureRef(co, 0));
+Obj _35reg4931 = primCdr(_35reg4930);
+Obj _35reg4932 = primCdr(_35reg4931);
+Obj _35reg4933 = primEQ(Nil, _35reg4932);
+if (True == _35reg4933) {
+pushCont(co, _35clofun5228, 1, y);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1225,8 +1233,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc22;
 co->nargs = 1;
+co->args[0] = _35cc4056;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1236,8 +1244,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc22;
 co->nargs = 1;
+co->args[0] = _35cc4056;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1247,8 +1255,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc22;
 co->nargs = 1;
+co->args[0] = _35cc4056;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1258,8 +1266,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc22;
 co->nargs = 1;
+co->args[0] = _35cc4056;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1269,8 +1277,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc22;
 co->nargs = 1;
+co->args[0] = _35cc4056;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1281,14 +1289,14 @@ return;
 }
 }
 
-void _35clofun1194(struct Cora* co) {
-Obj _35val900 = co->args[1];
+void _35clofun5228(struct Cora* co) {
+Obj _35val4934 = co->args[1];
 Obj y = co->stack[co->base + 0];
-Obj x1 = _35val900;
-pushCont(co, _35clofun1195, 1, x1);
+Obj x1 = _35val4934;
+pushCont(co, _35clofun5229, 1, x1);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = y;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1298,16 +1306,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1195(struct Cora* co) {
-Obj _35val901 = co->args[1];
+void _35clofun5229(struct Cora* co) {
+Obj _35val4935 = co->args[1];
 Obj x1 = co->stack[co->base + 0];
-Obj y1 = _35val901;
-Obj _35reg902 = primCons(y1, Nil);
-Obj _35reg903 = primCons(x1, _35reg902);
-Obj _35reg904 = primCons(intern("and"), _35reg903);
-co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg904;
+Obj y1 = _35val4935;
+Obj _35reg4936 = primCons(y1, Nil);
+Obj _35reg4937 = primCons(x1, _35reg4936);
+Obj _35reg4938 = primCons(intern("and"), _35reg4937);
 co->nargs = 2;
+co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
+co->args[1] = _35reg4938;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1317,27 +1325,27 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1181(struct Cora* co) {
-Obj _35cc23 = makeNative(_35clofun1182, 0, 1, closureRef(co, 0));
-Obj _35reg870 = primIsCons(closureRef(co, 0));
-if (True == _35reg870) {
-Obj _35reg871 = primCar(closureRef(co, 0));
-Obj _35reg872 = primEQ(intern("null?"), _35reg871);
-if (True == _35reg872) {
-Obj _35reg873 = primCdr(closureRef(co, 0));
-Obj _35reg874 = primIsCons(_35reg873);
-if (True == _35reg874) {
-Obj _35reg875 = primCdr(closureRef(co, 0));
-Obj _35reg876 = primCar(_35reg875);
-Obj x = _35reg876;
-Obj _35reg877 = primCdr(closureRef(co, 0));
-Obj _35reg878 = primCdr(_35reg877);
-Obj _35reg879 = primEQ(Nil, _35reg878);
-if (True == _35reg879) {
-pushCont(co, _35clofun1193, 0);
+void _35clofun5215(struct Cora* co) {
+Obj _35cc4057 = makeNative(_35clofun5216, 0, 1, closureRef(co, 0));
+Obj _35reg4904 = primIsCons(closureRef(co, 0));
+if (True == _35reg4904) {
+Obj _35reg4905 = primCar(closureRef(co, 0));
+Obj _35reg4906 = primEQ(intern("null?"), _35reg4905);
+if (True == _35reg4906) {
+Obj _35reg4907 = primCdr(closureRef(co, 0));
+Obj _35reg4908 = primIsCons(_35reg4907);
+if (True == _35reg4908) {
+Obj _35reg4909 = primCdr(closureRef(co, 0));
+Obj _35reg4910 = primCar(_35reg4909);
+Obj x = _35reg4910;
+Obj _35reg4911 = primCdr(closureRef(co, 0));
+Obj _35reg4912 = primCdr(_35reg4911);
+Obj _35reg4913 = primEQ(Nil, _35reg4912);
+if (True == _35reg4913) {
+pushCont(co, _35clofun5227, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1346,8 +1354,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc23;
 co->nargs = 1;
+co->args[0] = _35cc4057;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1357,8 +1365,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc23;
 co->nargs = 1;
+co->args[0] = _35cc4057;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1368,8 +1376,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc23;
 co->nargs = 1;
+co->args[0] = _35cc4057;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1379,8 +1387,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc23;
 co->nargs = 1;
+co->args[0] = _35cc4057;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1391,14 +1399,14 @@ return;
 }
 }
 
-void _35clofun1193(struct Cora* co) {
-Obj _35val880 = co->args[1];
-Obj x1 = _35val880;
-Obj _35reg881 = primCons(x1, Nil);
-Obj _35reg882 = primCons(intern("null?"), _35reg881);
+void _35clofun5227(struct Cora* co) {
+Obj _35val4914 = co->args[1];
+Obj x1 = _35val4914;
+Obj _35reg4915 = primCons(x1, Nil);
+Obj _35reg4916 = primCons(intern("null?"), _35reg4915);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg882;
-co->nargs = 2;
+co->args[1] = _35reg4916;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1408,27 +1416,27 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1182(struct Cora* co) {
-Obj _35cc24 = makeNative(_35clofun1183, 0, 1, closureRef(co, 0));
-Obj _35reg857 = primIsCons(closureRef(co, 0));
-if (True == _35reg857) {
-Obj _35reg858 = primCar(closureRef(co, 0));
-Obj _35reg859 = primEQ(intern("not"), _35reg858);
-if (True == _35reg859) {
-Obj _35reg860 = primCdr(closureRef(co, 0));
-Obj _35reg861 = primIsCons(_35reg860);
-if (True == _35reg861) {
-Obj _35reg862 = primCdr(closureRef(co, 0));
-Obj _35reg863 = primCar(_35reg862);
-Obj x = _35reg863;
-Obj _35reg864 = primCdr(closureRef(co, 0));
-Obj _35reg865 = primCdr(_35reg864);
-Obj _35reg866 = primEQ(Nil, _35reg865);
-if (True == _35reg866) {
-pushCont(co, _35clofun1192, 0);
+void _35clofun5216(struct Cora* co) {
+Obj _35cc4058 = makeNative(_35clofun5217, 0, 1, closureRef(co, 0));
+Obj _35reg4891 = primIsCons(closureRef(co, 0));
+if (True == _35reg4891) {
+Obj _35reg4892 = primCar(closureRef(co, 0));
+Obj _35reg4893 = primEQ(intern("not"), _35reg4892);
+if (True == _35reg4893) {
+Obj _35reg4894 = primCdr(closureRef(co, 0));
+Obj _35reg4895 = primIsCons(_35reg4894);
+if (True == _35reg4895) {
+Obj _35reg4896 = primCdr(closureRef(co, 0));
+Obj _35reg4897 = primCar(_35reg4896);
+Obj x = _35reg4897;
+Obj _35reg4898 = primCdr(closureRef(co, 0));
+Obj _35reg4899 = primCdr(_35reg4898);
+Obj _35reg4900 = primEQ(Nil, _35reg4899);
+if (True == _35reg4900) {
+pushCont(co, _35clofun5226, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1437,8 +1445,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc24;
 co->nargs = 1;
+co->args[0] = _35cc4058;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1448,8 +1456,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc24;
 co->nargs = 1;
+co->args[0] = _35cc4058;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1459,8 +1467,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc24;
 co->nargs = 1;
+co->args[0] = _35cc4058;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1470,8 +1478,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc24;
 co->nargs = 1;
+co->args[0] = _35cc4058;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1482,14 +1490,14 @@ return;
 }
 }
 
-void _35clofun1192(struct Cora* co) {
-Obj _35val867 = co->args[1];
-Obj x1 = _35val867;
-Obj _35reg868 = primCons(x1, Nil);
-Obj _35reg869 = primCons(intern("not"), _35reg868);
+void _35clofun5226(struct Cora* co) {
+Obj _35val4901 = co->args[1];
+Obj x1 = _35val4901;
+Obj _35reg4902 = primCons(x1, Nil);
+Obj _35reg4903 = primCons(intern("not"), _35reg4902);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg869;
-co->nargs = 2;
+co->args[1] = _35reg4903;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1499,47 +1507,47 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1183(struct Cora* co) {
-Obj _35cc25 = makeNative(_35clofun1184, 0, 1, closureRef(co, 0));
-Obj _35reg824 = primIsCons(closureRef(co, 0));
-if (True == _35reg824) {
-Obj _35reg825 = primCar(closureRef(co, 0));
-Obj _35reg826 = primEQ(intern("if"), _35reg825);
-if (True == _35reg826) {
-Obj _35reg827 = primCdr(closureRef(co, 0));
-Obj _35reg828 = primIsCons(_35reg827);
-if (True == _35reg828) {
-Obj _35reg829 = primCdr(closureRef(co, 0));
-Obj _35reg830 = primCar(_35reg829);
-Obj x = _35reg830;
-Obj _35reg831 = primCdr(closureRef(co, 0));
-Obj _35reg832 = primCdr(_35reg831);
-Obj _35reg833 = primIsCons(_35reg832);
-if (True == _35reg833) {
-Obj _35reg834 = primCdr(closureRef(co, 0));
-Obj _35reg835 = primCdr(_35reg834);
-Obj _35reg836 = primCar(_35reg835);
-Obj y = _35reg836;
-Obj _35reg837 = primCdr(closureRef(co, 0));
-Obj _35reg838 = primCdr(_35reg837);
-Obj _35reg839 = primCdr(_35reg838);
-Obj _35reg840 = primIsCons(_35reg839);
-if (True == _35reg840) {
-Obj _35reg841 = primCdr(closureRef(co, 0));
-Obj _35reg842 = primCdr(_35reg841);
-Obj _35reg843 = primCdr(_35reg842);
-Obj _35reg844 = primCar(_35reg843);
-Obj z = _35reg844;
-Obj _35reg845 = primCdr(closureRef(co, 0));
-Obj _35reg846 = primCdr(_35reg845);
-Obj _35reg847 = primCdr(_35reg846);
-Obj _35reg848 = primCdr(_35reg847);
-Obj _35reg849 = primEQ(Nil, _35reg848);
-if (True == _35reg849) {
-pushCont(co, _35clofun1189, 2, y, z);
+void _35clofun5217(struct Cora* co) {
+Obj _35cc4059 = makeNative(_35clofun5218, 0, 1, closureRef(co, 0));
+Obj _35reg4858 = primIsCons(closureRef(co, 0));
+if (True == _35reg4858) {
+Obj _35reg4859 = primCar(closureRef(co, 0));
+Obj _35reg4860 = primEQ(intern("if"), _35reg4859);
+if (True == _35reg4860) {
+Obj _35reg4861 = primCdr(closureRef(co, 0));
+Obj _35reg4862 = primIsCons(_35reg4861);
+if (True == _35reg4862) {
+Obj _35reg4863 = primCdr(closureRef(co, 0));
+Obj _35reg4864 = primCar(_35reg4863);
+Obj x = _35reg4864;
+Obj _35reg4865 = primCdr(closureRef(co, 0));
+Obj _35reg4866 = primCdr(_35reg4865);
+Obj _35reg4867 = primIsCons(_35reg4866);
+if (True == _35reg4867) {
+Obj _35reg4868 = primCdr(closureRef(co, 0));
+Obj _35reg4869 = primCdr(_35reg4868);
+Obj _35reg4870 = primCar(_35reg4869);
+Obj y = _35reg4870;
+Obj _35reg4871 = primCdr(closureRef(co, 0));
+Obj _35reg4872 = primCdr(_35reg4871);
+Obj _35reg4873 = primCdr(_35reg4872);
+Obj _35reg4874 = primIsCons(_35reg4873);
+if (True == _35reg4874) {
+Obj _35reg4875 = primCdr(closureRef(co, 0));
+Obj _35reg4876 = primCdr(_35reg4875);
+Obj _35reg4877 = primCdr(_35reg4876);
+Obj _35reg4878 = primCar(_35reg4877);
+Obj z = _35reg4878;
+Obj _35reg4879 = primCdr(closureRef(co, 0));
+Obj _35reg4880 = primCdr(_35reg4879);
+Obj _35reg4881 = primCdr(_35reg4880);
+Obj _35reg4882 = primCdr(_35reg4881);
+Obj _35reg4883 = primEQ(Nil, _35reg4882);
+if (True == _35reg4883) {
+pushCont(co, _35clofun5223, 2, y, z);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1548,8 +1556,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc25;
 co->nargs = 1;
+co->args[0] = _35cc4059;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1559,8 +1567,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc25;
 co->nargs = 1;
+co->args[0] = _35cc4059;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1570,8 +1578,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc25;
 co->nargs = 1;
+co->args[0] = _35cc4059;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1581,8 +1589,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc25;
 co->nargs = 1;
+co->args[0] = _35cc4059;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1592,8 +1600,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc25;
 co->nargs = 1;
+co->args[0] = _35cc4059;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1603,8 +1611,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc25;
 co->nargs = 1;
+co->args[0] = _35cc4059;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1615,15 +1623,15 @@ return;
 }
 }
 
-void _35clofun1189(struct Cora* co) {
-Obj _35val850 = co->args[1];
+void _35clofun5223(struct Cora* co) {
+Obj _35val4884 = co->args[1];
 Obj y = co->stack[co->base + 0];
 Obj z = co->stack[co->base + 1];
-Obj x1 = _35val850;
-pushCont(co, _35clofun1190, 2, z, x1);
+Obj x1 = _35val4884;
+pushCont(co, _35clofun5224, 2, z, x1);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = y;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1633,15 +1641,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1190(struct Cora* co) {
-Obj _35val851 = co->args[1];
+void _35clofun5224(struct Cora* co) {
+Obj _35val4885 = co->args[1];
 Obj z = co->stack[co->base + 0];
 Obj x1 = co->stack[co->base + 1];
-Obj y1 = _35val851;
-pushCont(co, _35clofun1191, 2, y1, x1);
+Obj y1 = _35val4885;
+pushCont(co, _35clofun5225, 2, y1, x1);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = z;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1651,18 +1659,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1191(struct Cora* co) {
-Obj _35val852 = co->args[1];
+void _35clofun5225(struct Cora* co) {
+Obj _35val4886 = co->args[1];
 Obj y1 = co->stack[co->base + 0];
 Obj x1 = co->stack[co->base + 1];
-Obj z1 = _35val852;
-Obj _35reg853 = primCons(z1, Nil);
-Obj _35reg854 = primCons(y1, _35reg853);
-Obj _35reg855 = primCons(x1, _35reg854);
-Obj _35reg856 = primCons(intern("if"), _35reg855);
-co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg856;
+Obj z1 = _35val4886;
+Obj _35reg4887 = primCons(z1, Nil);
+Obj _35reg4888 = primCons(y1, _35reg4887);
+Obj _35reg4889 = primCons(x1, _35reg4888);
+Obj _35reg4890 = primCons(intern("if"), _35reg4889);
 co->nargs = 2;
+co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
+co->args[1] = _35reg4890;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1672,36 +1680,36 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1184(struct Cora* co) {
-Obj _35cc26 = makeNative(_35clofun1185, 0, 1, closureRef(co, 0));
-Obj _35reg803 = primIsCons(closureRef(co, 0));
-if (True == _35reg803) {
-Obj _35reg804 = primCar(closureRef(co, 0));
-Obj _35reg805 = primEQ(intern("lambda"), _35reg804);
-if (True == _35reg805) {
-Obj _35reg806 = primCdr(closureRef(co, 0));
-Obj _35reg807 = primIsCons(_35reg806);
-if (True == _35reg807) {
-Obj _35reg808 = primCdr(closureRef(co, 0));
-Obj _35reg809 = primCar(_35reg808);
-Obj args = _35reg809;
-Obj _35reg810 = primCdr(closureRef(co, 0));
-Obj _35reg811 = primCdr(_35reg810);
-Obj _35reg812 = primIsCons(_35reg811);
-if (True == _35reg812) {
-Obj _35reg813 = primCdr(closureRef(co, 0));
-Obj _35reg814 = primCdr(_35reg813);
-Obj _35reg815 = primCar(_35reg814);
-Obj body = _35reg815;
-Obj _35reg816 = primCdr(closureRef(co, 0));
-Obj _35reg817 = primCdr(_35reg816);
-Obj _35reg818 = primCdr(_35reg817);
-Obj _35reg819 = primEQ(Nil, _35reg818);
-if (True == _35reg819) {
-pushCont(co, _35clofun1188, 1, args);
+void _35clofun5218(struct Cora* co) {
+Obj _35cc4060 = makeNative(_35clofun5219, 0, 1, closureRef(co, 0));
+Obj _35reg4837 = primIsCons(closureRef(co, 0));
+if (True == _35reg4837) {
+Obj _35reg4838 = primCar(closureRef(co, 0));
+Obj _35reg4839 = primEQ(intern("lambda"), _35reg4838);
+if (True == _35reg4839) {
+Obj _35reg4840 = primCdr(closureRef(co, 0));
+Obj _35reg4841 = primIsCons(_35reg4840);
+if (True == _35reg4841) {
+Obj _35reg4842 = primCdr(closureRef(co, 0));
+Obj _35reg4843 = primCar(_35reg4842);
+Obj args = _35reg4843;
+Obj _35reg4844 = primCdr(closureRef(co, 0));
+Obj _35reg4845 = primCdr(_35reg4844);
+Obj _35reg4846 = primIsCons(_35reg4845);
+if (True == _35reg4846) {
+Obj _35reg4847 = primCdr(closureRef(co, 0));
+Obj _35reg4848 = primCdr(_35reg4847);
+Obj _35reg4849 = primCar(_35reg4848);
+Obj body = _35reg4849;
+Obj _35reg4850 = primCdr(closureRef(co, 0));
+Obj _35reg4851 = primCdr(_35reg4850);
+Obj _35reg4852 = primCdr(_35reg4851);
+Obj _35reg4853 = primEQ(Nil, _35reg4852);
+if (True == _35reg4853) {
+pushCont(co, _35clofun5222, 1, args);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = body;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1710,8 +1718,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc26;
 co->nargs = 1;
+co->args[0] = _35cc4060;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1721,8 +1729,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc26;
 co->nargs = 1;
+co->args[0] = _35cc4060;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1732,8 +1740,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc26;
 co->nargs = 1;
+co->args[0] = _35cc4060;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1743,8 +1751,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc26;
 co->nargs = 1;
+co->args[0] = _35cc4060;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1754,8 +1762,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc26;
 co->nargs = 1;
+co->args[0] = _35cc4060;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1766,30 +1774,31 @@ return;
 }
 }
 
-void _35clofun1188(struct Cora* co) {
-Obj _35val820 = co->args[1];
+void _35clofun5222(struct Cora* co) {
+Obj _35val4854 = co->args[1];
 Obj args = co->stack[co->base + 0];
-Obj _35reg821 = primCons(_35val820, Nil);
-Obj _35reg822 = primCons(args, _35reg821);
-Obj _35reg823 = primCons(intern("lambda"), _35reg822);
-co->args[1] = _35reg823;
+Obj _35reg4855 = primCons(_35val4854, Nil);
+Obj _35reg4856 = primCons(args, _35reg4855);
+Obj _35reg4857 = primCons(intern("lambda"), _35reg4856);
+co->nargs = 2;
+co->args[1] = _35reg4857;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1185(struct Cora* co) {
-Obj _35cc27 = makeNative(_35clofun1186, 0, 1, closureRef(co, 0));
-Obj _35reg799 = primIsCons(closureRef(co, 0));
-if (True == _35reg799) {
-Obj _35reg800 = primCar(closureRef(co, 0));
-Obj f = _35reg800;
-Obj _35reg801 = primCdr(closureRef(co, 0));
-Obj args = _35reg801;
-Obj _35reg802 = primCons(f, args);
+void _35clofun5219(struct Cora* co) {
+Obj _35cc4061 = makeNative(_35clofun5220, 0, 1, closureRef(co, 0));
+Obj _35reg4833 = primIsCons(closureRef(co, 0));
+if (True == _35reg4833) {
+Obj _35reg4834 = primCar(closureRef(co, 0));
+Obj f = _35reg4834;
+Obj _35reg4835 = primCdr(closureRef(co, 0));
+Obj args = _35reg4835;
+Obj _35reg4836 = primCons(f, args);
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/init.propagate-boolean"));
-co->args[2] = _35reg802;
-co->nargs = 3;
+co->args[2] = _35reg4836;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1798,8 +1807,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc27;
 co->nargs = 1;
+co->args[0] = _35cc4061;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1810,18 +1819,19 @@ return;
 }
 }
 
-void _35clofun1186(struct Cora* co) {
-Obj _35cc28 = makeNative(_35clofun1187, 0, 0);
+void _35clofun5220(struct Cora* co) {
+Obj _35cc4062 = makeNative(_35clofun5221, 0, 0);
 Obj x = closureRef(co, 0);
+co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1187(struct Cora* co) {
+void _35clofun5221(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1831,65 +1841,66 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1164(struct Cora* co) {
-Obj _35p5 = co->args[1];
-Obj _35cc6 = makeNative(_35clofun1165, 0, 1, _35p5);
-Obj _35reg759 = primIsCons(_35p5);
-if (True == _35reg759) {
-Obj _35reg760 = primCar(_35p5);
-Obj _35reg761 = primEQ(intern("car"), _35reg760);
-if (True == _35reg761) {
-Obj _35reg762 = primCdr(_35p5);
-Obj _35reg763 = primIsCons(_35reg762);
-if (True == _35reg763) {
-Obj _35reg764 = primCdr(_35p5);
-Obj _35reg765 = primCar(_35reg764);
-Obj _35reg766 = primIsCons(_35reg765);
-if (True == _35reg766) {
-Obj _35reg767 = primCdr(_35p5);
-Obj _35reg768 = primCar(_35reg767);
-Obj _35reg769 = primCar(_35reg768);
-Obj _35reg770 = primEQ(intern("cons"), _35reg769);
-if (True == _35reg770) {
-Obj _35reg771 = primCdr(_35p5);
-Obj _35reg772 = primCar(_35reg771);
-Obj _35reg773 = primCdr(_35reg772);
-Obj _35reg774 = primIsCons(_35reg773);
-if (True == _35reg774) {
-Obj _35reg775 = primCdr(_35p5);
-Obj _35reg776 = primCar(_35reg775);
-Obj _35reg777 = primCdr(_35reg776);
-Obj _35reg778 = primCar(_35reg777);
-Obj x = _35reg778;
-Obj _35reg779 = primCdr(_35p5);
-Obj _35reg780 = primCar(_35reg779);
-Obj _35reg781 = primCdr(_35reg780);
-Obj _35reg782 = primCdr(_35reg781);
-Obj _35reg783 = primIsCons(_35reg782);
-if (True == _35reg783) {
-Obj _35reg784 = primCdr(_35p5);
-Obj _35reg785 = primCar(_35reg784);
-Obj _35reg786 = primCdr(_35reg785);
-Obj _35reg787 = primCdr(_35reg786);
-Obj _35reg788 = primCar(_35reg787);
-Obj __ = _35reg788;
-Obj _35reg789 = primCdr(_35p5);
-Obj _35reg790 = primCar(_35reg789);
-Obj _35reg791 = primCdr(_35reg790);
-Obj _35reg792 = primCdr(_35reg791);
-Obj _35reg793 = primCdr(_35reg792);
-Obj _35reg794 = primEQ(Nil, _35reg793);
-if (True == _35reg794) {
-Obj _35reg795 = primCdr(_35p5);
-Obj _35reg796 = primCdr(_35reg795);
-Obj _35reg797 = primEQ(Nil, _35reg796);
-if (True == _35reg797) {
+void _35clofun5198(struct Cora* co) {
+Obj _35p4039 = co->args[1];
+Obj _35cc4040 = makeNative(_35clofun5199, 0, 1, _35p4039);
+Obj _35reg4793 = primIsCons(_35p4039);
+if (True == _35reg4793) {
+Obj _35reg4794 = primCar(_35p4039);
+Obj _35reg4795 = primEQ(intern("car"), _35reg4794);
+if (True == _35reg4795) {
+Obj _35reg4796 = primCdr(_35p4039);
+Obj _35reg4797 = primIsCons(_35reg4796);
+if (True == _35reg4797) {
+Obj _35reg4798 = primCdr(_35p4039);
+Obj _35reg4799 = primCar(_35reg4798);
+Obj _35reg4800 = primIsCons(_35reg4799);
+if (True == _35reg4800) {
+Obj _35reg4801 = primCdr(_35p4039);
+Obj _35reg4802 = primCar(_35reg4801);
+Obj _35reg4803 = primCar(_35reg4802);
+Obj _35reg4804 = primEQ(intern("cons"), _35reg4803);
+if (True == _35reg4804) {
+Obj _35reg4805 = primCdr(_35p4039);
+Obj _35reg4806 = primCar(_35reg4805);
+Obj _35reg4807 = primCdr(_35reg4806);
+Obj _35reg4808 = primIsCons(_35reg4807);
+if (True == _35reg4808) {
+Obj _35reg4809 = primCdr(_35p4039);
+Obj _35reg4810 = primCar(_35reg4809);
+Obj _35reg4811 = primCdr(_35reg4810);
+Obj _35reg4812 = primCar(_35reg4811);
+Obj x = _35reg4812;
+Obj _35reg4813 = primCdr(_35p4039);
+Obj _35reg4814 = primCar(_35reg4813);
+Obj _35reg4815 = primCdr(_35reg4814);
+Obj _35reg4816 = primCdr(_35reg4815);
+Obj _35reg4817 = primIsCons(_35reg4816);
+if (True == _35reg4817) {
+Obj _35reg4818 = primCdr(_35p4039);
+Obj _35reg4819 = primCar(_35reg4818);
+Obj _35reg4820 = primCdr(_35reg4819);
+Obj _35reg4821 = primCdr(_35reg4820);
+Obj _35reg4822 = primCar(_35reg4821);
+Obj __ = _35reg4822;
+Obj _35reg4823 = primCdr(_35p4039);
+Obj _35reg4824 = primCar(_35reg4823);
+Obj _35reg4825 = primCdr(_35reg4824);
+Obj _35reg4826 = primCdr(_35reg4825);
+Obj _35reg4827 = primCdr(_35reg4826);
+Obj _35reg4828 = primEQ(Nil, _35reg4827);
+if (True == _35reg4828) {
+Obj _35reg4829 = primCdr(_35p4039);
+Obj _35reg4830 = primCdr(_35reg4829);
+Obj _35reg4831 = primEQ(Nil, _35reg4830);
+if (True == _35reg4831) {
+co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc6;
 co->nargs = 1;
+co->args[0] = _35cc4040;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1899,8 +1910,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc6;
 co->nargs = 1;
+co->args[0] = _35cc4040;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1910,8 +1921,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc6;
 co->nargs = 1;
+co->args[0] = _35cc4040;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1921,8 +1932,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc6;
 co->nargs = 1;
+co->args[0] = _35cc4040;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1932,8 +1943,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc6;
 co->nargs = 1;
+co->args[0] = _35cc4040;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1943,8 +1954,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc6;
 co->nargs = 1;
+co->args[0] = _35cc4040;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1954,8 +1965,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc6;
 co->nargs = 1;
+co->args[0] = _35cc4040;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1965,8 +1976,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc6;
 co->nargs = 1;
+co->args[0] = _35cc4040;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1976,8 +1987,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc6;
 co->nargs = 1;
+co->args[0] = _35cc4040;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1988,64 +1999,65 @@ return;
 }
 }
 
-void _35clofun1165(struct Cora* co) {
-Obj _35cc7 = makeNative(_35clofun1166, 0, 1, closureRef(co, 0));
-Obj _35reg720 = primIsCons(closureRef(co, 0));
-if (True == _35reg720) {
-Obj _35reg721 = primCar(closureRef(co, 0));
-Obj _35reg722 = primEQ(intern("cdr"), _35reg721);
-if (True == _35reg722) {
-Obj _35reg723 = primCdr(closureRef(co, 0));
-Obj _35reg724 = primIsCons(_35reg723);
-if (True == _35reg724) {
-Obj _35reg725 = primCdr(closureRef(co, 0));
-Obj _35reg726 = primCar(_35reg725);
-Obj _35reg727 = primIsCons(_35reg726);
-if (True == _35reg727) {
-Obj _35reg728 = primCdr(closureRef(co, 0));
-Obj _35reg729 = primCar(_35reg728);
-Obj _35reg730 = primCar(_35reg729);
-Obj _35reg731 = primEQ(intern("cons"), _35reg730);
-if (True == _35reg731) {
-Obj _35reg732 = primCdr(closureRef(co, 0));
-Obj _35reg733 = primCar(_35reg732);
-Obj _35reg734 = primCdr(_35reg733);
-Obj _35reg735 = primIsCons(_35reg734);
-if (True == _35reg735) {
-Obj _35reg736 = primCdr(closureRef(co, 0));
-Obj _35reg737 = primCar(_35reg736);
-Obj _35reg738 = primCdr(_35reg737);
-Obj _35reg739 = primCar(_35reg738);
-Obj __ = _35reg739;
-Obj _35reg740 = primCdr(closureRef(co, 0));
-Obj _35reg741 = primCar(_35reg740);
-Obj _35reg742 = primCdr(_35reg741);
-Obj _35reg743 = primCdr(_35reg742);
-Obj _35reg744 = primIsCons(_35reg743);
-if (True == _35reg744) {
-Obj _35reg745 = primCdr(closureRef(co, 0));
-Obj _35reg746 = primCar(_35reg745);
-Obj _35reg747 = primCdr(_35reg746);
-Obj _35reg748 = primCdr(_35reg747);
-Obj _35reg749 = primCar(_35reg748);
-Obj x = _35reg749;
-Obj _35reg750 = primCdr(closureRef(co, 0));
-Obj _35reg751 = primCar(_35reg750);
-Obj _35reg752 = primCdr(_35reg751);
-Obj _35reg753 = primCdr(_35reg752);
-Obj _35reg754 = primCdr(_35reg753);
-Obj _35reg755 = primEQ(Nil, _35reg754);
-if (True == _35reg755) {
-Obj _35reg756 = primCdr(closureRef(co, 0));
-Obj _35reg757 = primCdr(_35reg756);
-Obj _35reg758 = primEQ(Nil, _35reg757);
-if (True == _35reg758) {
+void _35clofun5199(struct Cora* co) {
+Obj _35cc4041 = makeNative(_35clofun5200, 0, 1, closureRef(co, 0));
+Obj _35reg4754 = primIsCons(closureRef(co, 0));
+if (True == _35reg4754) {
+Obj _35reg4755 = primCar(closureRef(co, 0));
+Obj _35reg4756 = primEQ(intern("cdr"), _35reg4755);
+if (True == _35reg4756) {
+Obj _35reg4757 = primCdr(closureRef(co, 0));
+Obj _35reg4758 = primIsCons(_35reg4757);
+if (True == _35reg4758) {
+Obj _35reg4759 = primCdr(closureRef(co, 0));
+Obj _35reg4760 = primCar(_35reg4759);
+Obj _35reg4761 = primIsCons(_35reg4760);
+if (True == _35reg4761) {
+Obj _35reg4762 = primCdr(closureRef(co, 0));
+Obj _35reg4763 = primCar(_35reg4762);
+Obj _35reg4764 = primCar(_35reg4763);
+Obj _35reg4765 = primEQ(intern("cons"), _35reg4764);
+if (True == _35reg4765) {
+Obj _35reg4766 = primCdr(closureRef(co, 0));
+Obj _35reg4767 = primCar(_35reg4766);
+Obj _35reg4768 = primCdr(_35reg4767);
+Obj _35reg4769 = primIsCons(_35reg4768);
+if (True == _35reg4769) {
+Obj _35reg4770 = primCdr(closureRef(co, 0));
+Obj _35reg4771 = primCar(_35reg4770);
+Obj _35reg4772 = primCdr(_35reg4771);
+Obj _35reg4773 = primCar(_35reg4772);
+Obj __ = _35reg4773;
+Obj _35reg4774 = primCdr(closureRef(co, 0));
+Obj _35reg4775 = primCar(_35reg4774);
+Obj _35reg4776 = primCdr(_35reg4775);
+Obj _35reg4777 = primCdr(_35reg4776);
+Obj _35reg4778 = primIsCons(_35reg4777);
+if (True == _35reg4778) {
+Obj _35reg4779 = primCdr(closureRef(co, 0));
+Obj _35reg4780 = primCar(_35reg4779);
+Obj _35reg4781 = primCdr(_35reg4780);
+Obj _35reg4782 = primCdr(_35reg4781);
+Obj _35reg4783 = primCar(_35reg4782);
+Obj x = _35reg4783;
+Obj _35reg4784 = primCdr(closureRef(co, 0));
+Obj _35reg4785 = primCar(_35reg4784);
+Obj _35reg4786 = primCdr(_35reg4785);
+Obj _35reg4787 = primCdr(_35reg4786);
+Obj _35reg4788 = primCdr(_35reg4787);
+Obj _35reg4789 = primEQ(Nil, _35reg4788);
+if (True == _35reg4789) {
+Obj _35reg4790 = primCdr(closureRef(co, 0));
+Obj _35reg4791 = primCdr(_35reg4790);
+Obj _35reg4792 = primEQ(Nil, _35reg4791);
+if (True == _35reg4792) {
+co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc7;
 co->nargs = 1;
+co->args[0] = _35cc4041;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2055,8 +2067,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc7;
 co->nargs = 1;
+co->args[0] = _35cc4041;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2066,8 +2078,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc7;
 co->nargs = 1;
+co->args[0] = _35cc4041;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2077,8 +2089,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc7;
 co->nargs = 1;
+co->args[0] = _35cc4041;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2088,8 +2100,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc7;
 co->nargs = 1;
+co->args[0] = _35cc4041;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2099,8 +2111,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc7;
 co->nargs = 1;
+co->args[0] = _35cc4041;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2110,8 +2122,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc7;
 co->nargs = 1;
+co->args[0] = _35cc4041;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2121,8 +2133,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc7;
 co->nargs = 1;
+co->args[0] = _35cc4041;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2132,8 +2144,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc7;
 co->nargs = 1;
+co->args[0] = _35cc4041;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2144,64 +2156,65 @@ return;
 }
 }
 
-void _35clofun1166(struct Cora* co) {
-Obj _35cc8 = makeNative(_35clofun1167, 0, 1, closureRef(co, 0));
-Obj _35reg681 = primIsCons(closureRef(co, 0));
-if (True == _35reg681) {
-Obj _35reg682 = primCar(closureRef(co, 0));
-Obj _35reg683 = primEQ(intern("cons?"), _35reg682);
-if (True == _35reg683) {
-Obj _35reg684 = primCdr(closureRef(co, 0));
-Obj _35reg685 = primIsCons(_35reg684);
-if (True == _35reg685) {
-Obj _35reg686 = primCdr(closureRef(co, 0));
-Obj _35reg687 = primCar(_35reg686);
-Obj _35reg688 = primIsCons(_35reg687);
-if (True == _35reg688) {
-Obj _35reg689 = primCdr(closureRef(co, 0));
-Obj _35reg690 = primCar(_35reg689);
-Obj _35reg691 = primCar(_35reg690);
-Obj _35reg692 = primEQ(intern("cons"), _35reg691);
-if (True == _35reg692) {
-Obj _35reg693 = primCdr(closureRef(co, 0));
-Obj _35reg694 = primCar(_35reg693);
-Obj _35reg695 = primCdr(_35reg694);
-Obj _35reg696 = primIsCons(_35reg695);
-if (True == _35reg696) {
-Obj _35reg697 = primCdr(closureRef(co, 0));
-Obj _35reg698 = primCar(_35reg697);
-Obj _35reg699 = primCdr(_35reg698);
-Obj _35reg700 = primCar(_35reg699);
-Obj __ = _35reg700;
-Obj _35reg701 = primCdr(closureRef(co, 0));
-Obj _35reg702 = primCar(_35reg701);
-Obj _35reg703 = primCdr(_35reg702);
-Obj _35reg704 = primCdr(_35reg703);
-Obj _35reg705 = primIsCons(_35reg704);
-if (True == _35reg705) {
-Obj _35reg706 = primCdr(closureRef(co, 0));
-Obj _35reg707 = primCar(_35reg706);
-Obj _35reg708 = primCdr(_35reg707);
-Obj _35reg709 = primCdr(_35reg708);
-Obj _35reg710 = primCar(_35reg709);
-__ = _35reg710;
-Obj _35reg711 = primCdr(closureRef(co, 0));
-Obj _35reg712 = primCar(_35reg711);
-Obj _35reg713 = primCdr(_35reg712);
-Obj _35reg714 = primCdr(_35reg713);
-Obj _35reg715 = primCdr(_35reg714);
-Obj _35reg716 = primEQ(Nil, _35reg715);
-if (True == _35reg716) {
-Obj _35reg717 = primCdr(closureRef(co, 0));
-Obj _35reg718 = primCdr(_35reg717);
-Obj _35reg719 = primEQ(Nil, _35reg718);
-if (True == _35reg719) {
+void _35clofun5200(struct Cora* co) {
+Obj _35cc4042 = makeNative(_35clofun5201, 0, 1, closureRef(co, 0));
+Obj _35reg4715 = primIsCons(closureRef(co, 0));
+if (True == _35reg4715) {
+Obj _35reg4716 = primCar(closureRef(co, 0));
+Obj _35reg4717 = primEQ(intern("cons?"), _35reg4716);
+if (True == _35reg4717) {
+Obj _35reg4718 = primCdr(closureRef(co, 0));
+Obj _35reg4719 = primIsCons(_35reg4718);
+if (True == _35reg4719) {
+Obj _35reg4720 = primCdr(closureRef(co, 0));
+Obj _35reg4721 = primCar(_35reg4720);
+Obj _35reg4722 = primIsCons(_35reg4721);
+if (True == _35reg4722) {
+Obj _35reg4723 = primCdr(closureRef(co, 0));
+Obj _35reg4724 = primCar(_35reg4723);
+Obj _35reg4725 = primCar(_35reg4724);
+Obj _35reg4726 = primEQ(intern("cons"), _35reg4725);
+if (True == _35reg4726) {
+Obj _35reg4727 = primCdr(closureRef(co, 0));
+Obj _35reg4728 = primCar(_35reg4727);
+Obj _35reg4729 = primCdr(_35reg4728);
+Obj _35reg4730 = primIsCons(_35reg4729);
+if (True == _35reg4730) {
+Obj _35reg4731 = primCdr(closureRef(co, 0));
+Obj _35reg4732 = primCar(_35reg4731);
+Obj _35reg4733 = primCdr(_35reg4732);
+Obj _35reg4734 = primCar(_35reg4733);
+Obj __ = _35reg4734;
+Obj _35reg4735 = primCdr(closureRef(co, 0));
+Obj _35reg4736 = primCar(_35reg4735);
+Obj _35reg4737 = primCdr(_35reg4736);
+Obj _35reg4738 = primCdr(_35reg4737);
+Obj _35reg4739 = primIsCons(_35reg4738);
+if (True == _35reg4739) {
+Obj _35reg4740 = primCdr(closureRef(co, 0));
+Obj _35reg4741 = primCar(_35reg4740);
+Obj _35reg4742 = primCdr(_35reg4741);
+Obj _35reg4743 = primCdr(_35reg4742);
+Obj _35reg4744 = primCar(_35reg4743);
+__ = _35reg4744;
+Obj _35reg4745 = primCdr(closureRef(co, 0));
+Obj _35reg4746 = primCar(_35reg4745);
+Obj _35reg4747 = primCdr(_35reg4746);
+Obj _35reg4748 = primCdr(_35reg4747);
+Obj _35reg4749 = primCdr(_35reg4748);
+Obj _35reg4750 = primEQ(Nil, _35reg4749);
+if (True == _35reg4750) {
+Obj _35reg4751 = primCdr(closureRef(co, 0));
+Obj _35reg4752 = primCdr(_35reg4751);
+Obj _35reg4753 = primEQ(Nil, _35reg4752);
+if (True == _35reg4753) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc8;
 co->nargs = 1;
+co->args[0] = _35cc4042;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2211,8 +2224,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc8;
 co->nargs = 1;
+co->args[0] = _35cc4042;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2222,8 +2235,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc8;
 co->nargs = 1;
+co->args[0] = _35cc4042;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2233,8 +2246,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc8;
 co->nargs = 1;
+co->args[0] = _35cc4042;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2244,8 +2257,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc8;
 co->nargs = 1;
+co->args[0] = _35cc4042;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2255,8 +2268,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc8;
 co->nargs = 1;
+co->args[0] = _35cc4042;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2266,8 +2279,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc8;
 co->nargs = 1;
+co->args[0] = _35cc4042;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2277,8 +2290,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc8;
 co->nargs = 1;
+co->args[0] = _35cc4042;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2288,8 +2301,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc8;
 co->nargs = 1;
+co->args[0] = _35cc4042;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2300,40 +2313,41 @@ return;
 }
 }
 
-void _35clofun1167(struct Cora* co) {
-Obj _35cc9 = makeNative(_35clofun1168, 0, 1, closureRef(co, 0));
-Obj _35reg662 = primIsCons(closureRef(co, 0));
-if (True == _35reg662) {
-Obj _35reg663 = primCar(closureRef(co, 0));
-Obj _35reg664 = primEQ(intern("and"), _35reg663);
-if (True == _35reg664) {
-Obj _35reg665 = primCdr(closureRef(co, 0));
-Obj _35reg666 = primIsCons(_35reg665);
-if (True == _35reg666) {
-Obj _35reg667 = primCdr(closureRef(co, 0));
-Obj _35reg668 = primCar(_35reg667);
-Obj _35reg669 = primEQ(True, _35reg668);
-if (True == _35reg669) {
-Obj _35reg670 = primCdr(closureRef(co, 0));
-Obj _35reg671 = primCdr(_35reg670);
-Obj _35reg672 = primIsCons(_35reg671);
-if (True == _35reg672) {
-Obj _35reg673 = primCdr(closureRef(co, 0));
-Obj _35reg674 = primCdr(_35reg673);
-Obj _35reg675 = primCar(_35reg674);
-Obj _35reg676 = primEQ(True, _35reg675);
-if (True == _35reg676) {
-Obj _35reg677 = primCdr(closureRef(co, 0));
-Obj _35reg678 = primCdr(_35reg677);
-Obj _35reg679 = primCdr(_35reg678);
-Obj _35reg680 = primEQ(Nil, _35reg679);
-if (True == _35reg680) {
+void _35clofun5201(struct Cora* co) {
+Obj _35cc4043 = makeNative(_35clofun5202, 0, 1, closureRef(co, 0));
+Obj _35reg4696 = primIsCons(closureRef(co, 0));
+if (True == _35reg4696) {
+Obj _35reg4697 = primCar(closureRef(co, 0));
+Obj _35reg4698 = primEQ(intern("and"), _35reg4697);
+if (True == _35reg4698) {
+Obj _35reg4699 = primCdr(closureRef(co, 0));
+Obj _35reg4700 = primIsCons(_35reg4699);
+if (True == _35reg4700) {
+Obj _35reg4701 = primCdr(closureRef(co, 0));
+Obj _35reg4702 = primCar(_35reg4701);
+Obj _35reg4703 = primEQ(True, _35reg4702);
+if (True == _35reg4703) {
+Obj _35reg4704 = primCdr(closureRef(co, 0));
+Obj _35reg4705 = primCdr(_35reg4704);
+Obj _35reg4706 = primIsCons(_35reg4705);
+if (True == _35reg4706) {
+Obj _35reg4707 = primCdr(closureRef(co, 0));
+Obj _35reg4708 = primCdr(_35reg4707);
+Obj _35reg4709 = primCar(_35reg4708);
+Obj _35reg4710 = primEQ(True, _35reg4709);
+if (True == _35reg4710) {
+Obj _35reg4711 = primCdr(closureRef(co, 0));
+Obj _35reg4712 = primCdr(_35reg4711);
+Obj _35reg4713 = primCdr(_35reg4712);
+Obj _35reg4714 = primEQ(Nil, _35reg4713);
+if (True == _35reg4714) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc9;
 co->nargs = 1;
+co->args[0] = _35cc4043;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2343,8 +2357,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc9;
 co->nargs = 1;
+co->args[0] = _35cc4043;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2354,8 +2368,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc9;
 co->nargs = 1;
+co->args[0] = _35cc4043;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2365,8 +2379,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc9;
 co->nargs = 1;
+co->args[0] = _35cc4043;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2376,8 +2390,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc9;
 co->nargs = 1;
+co->args[0] = _35cc4043;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2387,8 +2401,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc9;
 co->nargs = 1;
+co->args[0] = _35cc4043;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2398,8 +2412,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc9;
 co->nargs = 1;
+co->args[0] = _35cc4043;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2410,30 +2424,31 @@ return;
 }
 }
 
-void _35clofun1168(struct Cora* co) {
-Obj _35cc10 = makeNative(_35clofun1169, 0, 1, closureRef(co, 0));
-Obj _35reg651 = primIsCons(closureRef(co, 0));
-if (True == _35reg651) {
-Obj _35reg652 = primCar(closureRef(co, 0));
-Obj _35reg653 = primEQ(intern("null?"), _35reg652);
-if (True == _35reg653) {
-Obj _35reg654 = primCdr(closureRef(co, 0));
-Obj _35reg655 = primIsCons(_35reg654);
-if (True == _35reg655) {
-Obj _35reg656 = primCdr(closureRef(co, 0));
-Obj _35reg657 = primCar(_35reg656);
-Obj _35reg658 = primEQ(Nil, _35reg657);
-if (True == _35reg658) {
-Obj _35reg659 = primCdr(closureRef(co, 0));
-Obj _35reg660 = primCdr(_35reg659);
-Obj _35reg661 = primEQ(Nil, _35reg660);
-if (True == _35reg661) {
+void _35clofun5202(struct Cora* co) {
+Obj _35cc4044 = makeNative(_35clofun5203, 0, 1, closureRef(co, 0));
+Obj _35reg4685 = primIsCons(closureRef(co, 0));
+if (True == _35reg4685) {
+Obj _35reg4686 = primCar(closureRef(co, 0));
+Obj _35reg4687 = primEQ(intern("null?"), _35reg4686);
+if (True == _35reg4687) {
+Obj _35reg4688 = primCdr(closureRef(co, 0));
+Obj _35reg4689 = primIsCons(_35reg4688);
+if (True == _35reg4689) {
+Obj _35reg4690 = primCdr(closureRef(co, 0));
+Obj _35reg4691 = primCar(_35reg4690);
+Obj _35reg4692 = primEQ(Nil, _35reg4691);
+if (True == _35reg4692) {
+Obj _35reg4693 = primCdr(closureRef(co, 0));
+Obj _35reg4694 = primCdr(_35reg4693);
+Obj _35reg4695 = primEQ(Nil, _35reg4694);
+if (True == _35reg4695) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc10;
 co->nargs = 1;
+co->args[0] = _35cc4044;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2443,8 +2458,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc10;
 co->nargs = 1;
+co->args[0] = _35cc4044;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2454,8 +2469,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc10;
 co->nargs = 1;
+co->args[0] = _35cc4044;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2465,8 +2480,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc10;
 co->nargs = 1;
+co->args[0] = _35cc4044;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2476,8 +2491,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc10;
 co->nargs = 1;
+co->args[0] = _35cc4044;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2488,64 +2503,65 @@ return;
 }
 }
 
-void _35clofun1169(struct Cora* co) {
-Obj _35cc11 = makeNative(_35clofun1170, 0, 1, closureRef(co, 0));
-Obj _35reg612 = primIsCons(closureRef(co, 0));
-if (True == _35reg612) {
-Obj _35reg613 = primCar(closureRef(co, 0));
-Obj _35reg614 = primEQ(intern("null?"), _35reg613);
-if (True == _35reg614) {
-Obj _35reg615 = primCdr(closureRef(co, 0));
-Obj _35reg616 = primIsCons(_35reg615);
-if (True == _35reg616) {
-Obj _35reg617 = primCdr(closureRef(co, 0));
-Obj _35reg618 = primCar(_35reg617);
-Obj _35reg619 = primIsCons(_35reg618);
-if (True == _35reg619) {
-Obj _35reg620 = primCdr(closureRef(co, 0));
-Obj _35reg621 = primCar(_35reg620);
-Obj _35reg622 = primCar(_35reg621);
-Obj _35reg623 = primEQ(intern("cons"), _35reg622);
-if (True == _35reg623) {
-Obj _35reg624 = primCdr(closureRef(co, 0));
-Obj _35reg625 = primCar(_35reg624);
-Obj _35reg626 = primCdr(_35reg625);
-Obj _35reg627 = primIsCons(_35reg626);
-if (True == _35reg627) {
-Obj _35reg628 = primCdr(closureRef(co, 0));
-Obj _35reg629 = primCar(_35reg628);
-Obj _35reg630 = primCdr(_35reg629);
-Obj _35reg631 = primCar(_35reg630);
-Obj __ = _35reg631;
-Obj _35reg632 = primCdr(closureRef(co, 0));
-Obj _35reg633 = primCar(_35reg632);
-Obj _35reg634 = primCdr(_35reg633);
-Obj _35reg635 = primCdr(_35reg634);
-Obj _35reg636 = primIsCons(_35reg635);
-if (True == _35reg636) {
-Obj _35reg637 = primCdr(closureRef(co, 0));
-Obj _35reg638 = primCar(_35reg637);
-Obj _35reg639 = primCdr(_35reg638);
-Obj _35reg640 = primCdr(_35reg639);
-Obj _35reg641 = primCar(_35reg640);
-__ = _35reg641;
-Obj _35reg642 = primCdr(closureRef(co, 0));
-Obj _35reg643 = primCar(_35reg642);
-Obj _35reg644 = primCdr(_35reg643);
-Obj _35reg645 = primCdr(_35reg644);
-Obj _35reg646 = primCdr(_35reg645);
-Obj _35reg647 = primEQ(Nil, _35reg646);
-if (True == _35reg647) {
-Obj _35reg648 = primCdr(closureRef(co, 0));
-Obj _35reg649 = primCdr(_35reg648);
-Obj _35reg650 = primEQ(Nil, _35reg649);
-if (True == _35reg650) {
+void _35clofun5203(struct Cora* co) {
+Obj _35cc4045 = makeNative(_35clofun5204, 0, 1, closureRef(co, 0));
+Obj _35reg4646 = primIsCons(closureRef(co, 0));
+if (True == _35reg4646) {
+Obj _35reg4647 = primCar(closureRef(co, 0));
+Obj _35reg4648 = primEQ(intern("null?"), _35reg4647);
+if (True == _35reg4648) {
+Obj _35reg4649 = primCdr(closureRef(co, 0));
+Obj _35reg4650 = primIsCons(_35reg4649);
+if (True == _35reg4650) {
+Obj _35reg4651 = primCdr(closureRef(co, 0));
+Obj _35reg4652 = primCar(_35reg4651);
+Obj _35reg4653 = primIsCons(_35reg4652);
+if (True == _35reg4653) {
+Obj _35reg4654 = primCdr(closureRef(co, 0));
+Obj _35reg4655 = primCar(_35reg4654);
+Obj _35reg4656 = primCar(_35reg4655);
+Obj _35reg4657 = primEQ(intern("cons"), _35reg4656);
+if (True == _35reg4657) {
+Obj _35reg4658 = primCdr(closureRef(co, 0));
+Obj _35reg4659 = primCar(_35reg4658);
+Obj _35reg4660 = primCdr(_35reg4659);
+Obj _35reg4661 = primIsCons(_35reg4660);
+if (True == _35reg4661) {
+Obj _35reg4662 = primCdr(closureRef(co, 0));
+Obj _35reg4663 = primCar(_35reg4662);
+Obj _35reg4664 = primCdr(_35reg4663);
+Obj _35reg4665 = primCar(_35reg4664);
+Obj __ = _35reg4665;
+Obj _35reg4666 = primCdr(closureRef(co, 0));
+Obj _35reg4667 = primCar(_35reg4666);
+Obj _35reg4668 = primCdr(_35reg4667);
+Obj _35reg4669 = primCdr(_35reg4668);
+Obj _35reg4670 = primIsCons(_35reg4669);
+if (True == _35reg4670) {
+Obj _35reg4671 = primCdr(closureRef(co, 0));
+Obj _35reg4672 = primCar(_35reg4671);
+Obj _35reg4673 = primCdr(_35reg4672);
+Obj _35reg4674 = primCdr(_35reg4673);
+Obj _35reg4675 = primCar(_35reg4674);
+__ = _35reg4675;
+Obj _35reg4676 = primCdr(closureRef(co, 0));
+Obj _35reg4677 = primCar(_35reg4676);
+Obj _35reg4678 = primCdr(_35reg4677);
+Obj _35reg4679 = primCdr(_35reg4678);
+Obj _35reg4680 = primCdr(_35reg4679);
+Obj _35reg4681 = primEQ(Nil, _35reg4680);
+if (True == _35reg4681) {
+Obj _35reg4682 = primCdr(closureRef(co, 0));
+Obj _35reg4683 = primCdr(_35reg4682);
+Obj _35reg4684 = primEQ(Nil, _35reg4683);
+if (True == _35reg4684) {
+co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc11;
 co->nargs = 1;
+co->args[0] = _35cc4045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2555,8 +2571,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc11;
 co->nargs = 1;
+co->args[0] = _35cc4045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2566,8 +2582,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc11;
 co->nargs = 1;
+co->args[0] = _35cc4045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2577,8 +2593,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc11;
 co->nargs = 1;
+co->args[0] = _35cc4045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2588,8 +2604,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc11;
 co->nargs = 1;
+co->args[0] = _35cc4045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2599,8 +2615,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc11;
 co->nargs = 1;
+co->args[0] = _35cc4045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2610,8 +2626,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc11;
 co->nargs = 1;
+co->args[0] = _35cc4045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2621,8 +2637,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc11;
 co->nargs = 1;
+co->args[0] = _35cc4045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2632,8 +2648,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc11;
 co->nargs = 1;
+co->args[0] = _35cc4045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2644,30 +2660,31 @@ return;
 }
 }
 
-void _35clofun1170(struct Cora* co) {
-Obj _35cc12 = makeNative(_35clofun1171, 0, 1, closureRef(co, 0));
-Obj _35reg601 = primIsCons(closureRef(co, 0));
-if (True == _35reg601) {
-Obj _35reg602 = primCar(closureRef(co, 0));
-Obj _35reg603 = primEQ(intern("not"), _35reg602);
-if (True == _35reg603) {
-Obj _35reg604 = primCdr(closureRef(co, 0));
-Obj _35reg605 = primIsCons(_35reg604);
-if (True == _35reg605) {
-Obj _35reg606 = primCdr(closureRef(co, 0));
-Obj _35reg607 = primCar(_35reg606);
-Obj _35reg608 = primEQ(True, _35reg607);
-if (True == _35reg608) {
-Obj _35reg609 = primCdr(closureRef(co, 0));
-Obj _35reg610 = primCdr(_35reg609);
-Obj _35reg611 = primEQ(Nil, _35reg610);
-if (True == _35reg611) {
+void _35clofun5204(struct Cora* co) {
+Obj _35cc4046 = makeNative(_35clofun5205, 0, 1, closureRef(co, 0));
+Obj _35reg4635 = primIsCons(closureRef(co, 0));
+if (True == _35reg4635) {
+Obj _35reg4636 = primCar(closureRef(co, 0));
+Obj _35reg4637 = primEQ(intern("not"), _35reg4636);
+if (True == _35reg4637) {
+Obj _35reg4638 = primCdr(closureRef(co, 0));
+Obj _35reg4639 = primIsCons(_35reg4638);
+if (True == _35reg4639) {
+Obj _35reg4640 = primCdr(closureRef(co, 0));
+Obj _35reg4641 = primCar(_35reg4640);
+Obj _35reg4642 = primEQ(True, _35reg4641);
+if (True == _35reg4642) {
+Obj _35reg4643 = primCdr(closureRef(co, 0));
+Obj _35reg4644 = primCdr(_35reg4643);
+Obj _35reg4645 = primEQ(Nil, _35reg4644);
+if (True == _35reg4645) {
+co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc12;
 co->nargs = 1;
+co->args[0] = _35cc4046;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2677,8 +2694,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc12;
 co->nargs = 1;
+co->args[0] = _35cc4046;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2688,8 +2705,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc12;
 co->nargs = 1;
+co->args[0] = _35cc4046;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2699,8 +2716,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc12;
 co->nargs = 1;
+co->args[0] = _35cc4046;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2710,8 +2727,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc12;
 co->nargs = 1;
+co->args[0] = _35cc4046;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2722,30 +2739,31 @@ return;
 }
 }
 
-void _35clofun1171(struct Cora* co) {
-Obj _35cc13 = makeNative(_35clofun1172, 0, 1, closureRef(co, 0));
-Obj _35reg590 = primIsCons(closureRef(co, 0));
-if (True == _35reg590) {
-Obj _35reg591 = primCar(closureRef(co, 0));
-Obj _35reg592 = primEQ(intern("not"), _35reg591);
-if (True == _35reg592) {
-Obj _35reg593 = primCdr(closureRef(co, 0));
-Obj _35reg594 = primIsCons(_35reg593);
-if (True == _35reg594) {
-Obj _35reg595 = primCdr(closureRef(co, 0));
-Obj _35reg596 = primCar(_35reg595);
-Obj _35reg597 = primEQ(False, _35reg596);
-if (True == _35reg597) {
-Obj _35reg598 = primCdr(closureRef(co, 0));
-Obj _35reg599 = primCdr(_35reg598);
-Obj _35reg600 = primEQ(Nil, _35reg599);
-if (True == _35reg600) {
+void _35clofun5205(struct Cora* co) {
+Obj _35cc4047 = makeNative(_35clofun5206, 0, 1, closureRef(co, 0));
+Obj _35reg4624 = primIsCons(closureRef(co, 0));
+if (True == _35reg4624) {
+Obj _35reg4625 = primCar(closureRef(co, 0));
+Obj _35reg4626 = primEQ(intern("not"), _35reg4625);
+if (True == _35reg4626) {
+Obj _35reg4627 = primCdr(closureRef(co, 0));
+Obj _35reg4628 = primIsCons(_35reg4627);
+if (True == _35reg4628) {
+Obj _35reg4629 = primCdr(closureRef(co, 0));
+Obj _35reg4630 = primCar(_35reg4629);
+Obj _35reg4631 = primEQ(False, _35reg4630);
+if (True == _35reg4631) {
+Obj _35reg4632 = primCdr(closureRef(co, 0));
+Obj _35reg4633 = primCdr(_35reg4632);
+Obj _35reg4634 = primEQ(Nil, _35reg4633);
+if (True == _35reg4634) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc13;
 co->nargs = 1;
+co->args[0] = _35cc4047;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2755,8 +2773,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc13;
 co->nargs = 1;
+co->args[0] = _35cc4047;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2766,8 +2784,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc13;
 co->nargs = 1;
+co->args[0] = _35cc4047;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2777,8 +2795,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc13;
 co->nargs = 1;
+co->args[0] = _35cc4047;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2788,8 +2806,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc13;
 co->nargs = 1;
+co->args[0] = _35cc4047;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2800,50 +2818,51 @@ return;
 }
 }
 
-void _35clofun1172(struct Cora* co) {
-Obj _35cc14 = makeNative(_35clofun1173, 0, 1, closureRef(co, 0));
-Obj _35reg563 = primIsCons(closureRef(co, 0));
-if (True == _35reg563) {
-Obj _35reg564 = primCar(closureRef(co, 0));
-Obj _35reg565 = primEQ(intern("if"), _35reg564);
-if (True == _35reg565) {
-Obj _35reg566 = primCdr(closureRef(co, 0));
-Obj _35reg567 = primIsCons(_35reg566);
-if (True == _35reg567) {
-Obj _35reg568 = primCdr(closureRef(co, 0));
-Obj _35reg569 = primCar(_35reg568);
-Obj _35reg570 = primEQ(True, _35reg569);
-if (True == _35reg570) {
-Obj _35reg571 = primCdr(closureRef(co, 0));
-Obj _35reg572 = primCdr(_35reg571);
-Obj _35reg573 = primIsCons(_35reg572);
-if (True == _35reg573) {
-Obj _35reg574 = primCdr(closureRef(co, 0));
-Obj _35reg575 = primCdr(_35reg574);
-Obj _35reg576 = primCar(_35reg575);
-Obj y = _35reg576;
-Obj _35reg577 = primCdr(closureRef(co, 0));
-Obj _35reg578 = primCdr(_35reg577);
-Obj _35reg579 = primCdr(_35reg578);
-Obj _35reg580 = primIsCons(_35reg579);
-if (True == _35reg580) {
-Obj _35reg581 = primCdr(closureRef(co, 0));
-Obj _35reg582 = primCdr(_35reg581);
-Obj _35reg583 = primCdr(_35reg582);
-Obj _35reg584 = primCar(_35reg583);
-Obj z = _35reg584;
-Obj _35reg585 = primCdr(closureRef(co, 0));
-Obj _35reg586 = primCdr(_35reg585);
-Obj _35reg587 = primCdr(_35reg586);
-Obj _35reg588 = primCdr(_35reg587);
-Obj _35reg589 = primEQ(Nil, _35reg588);
-if (True == _35reg589) {
+void _35clofun5206(struct Cora* co) {
+Obj _35cc4048 = makeNative(_35clofun5207, 0, 1, closureRef(co, 0));
+Obj _35reg4597 = primIsCons(closureRef(co, 0));
+if (True == _35reg4597) {
+Obj _35reg4598 = primCar(closureRef(co, 0));
+Obj _35reg4599 = primEQ(intern("if"), _35reg4598);
+if (True == _35reg4599) {
+Obj _35reg4600 = primCdr(closureRef(co, 0));
+Obj _35reg4601 = primIsCons(_35reg4600);
+if (True == _35reg4601) {
+Obj _35reg4602 = primCdr(closureRef(co, 0));
+Obj _35reg4603 = primCar(_35reg4602);
+Obj _35reg4604 = primEQ(True, _35reg4603);
+if (True == _35reg4604) {
+Obj _35reg4605 = primCdr(closureRef(co, 0));
+Obj _35reg4606 = primCdr(_35reg4605);
+Obj _35reg4607 = primIsCons(_35reg4606);
+if (True == _35reg4607) {
+Obj _35reg4608 = primCdr(closureRef(co, 0));
+Obj _35reg4609 = primCdr(_35reg4608);
+Obj _35reg4610 = primCar(_35reg4609);
+Obj y = _35reg4610;
+Obj _35reg4611 = primCdr(closureRef(co, 0));
+Obj _35reg4612 = primCdr(_35reg4611);
+Obj _35reg4613 = primCdr(_35reg4612);
+Obj _35reg4614 = primIsCons(_35reg4613);
+if (True == _35reg4614) {
+Obj _35reg4615 = primCdr(closureRef(co, 0));
+Obj _35reg4616 = primCdr(_35reg4615);
+Obj _35reg4617 = primCdr(_35reg4616);
+Obj _35reg4618 = primCar(_35reg4617);
+Obj z = _35reg4618;
+Obj _35reg4619 = primCdr(closureRef(co, 0));
+Obj _35reg4620 = primCdr(_35reg4619);
+Obj _35reg4621 = primCdr(_35reg4620);
+Obj _35reg4622 = primCdr(_35reg4621);
+Obj _35reg4623 = primEQ(Nil, _35reg4622);
+if (True == _35reg4623) {
+co->nargs = 2;
 co->args[1] = y;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc14;
 co->nargs = 1;
+co->args[0] = _35cc4048;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2853,8 +2872,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc14;
 co->nargs = 1;
+co->args[0] = _35cc4048;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2864,8 +2883,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc14;
 co->nargs = 1;
+co->args[0] = _35cc4048;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2875,8 +2894,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc14;
 co->nargs = 1;
+co->args[0] = _35cc4048;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2886,8 +2905,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc14;
 co->nargs = 1;
+co->args[0] = _35cc4048;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2897,8 +2916,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc14;
 co->nargs = 1;
+co->args[0] = _35cc4048;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2908,8 +2927,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc14;
 co->nargs = 1;
+co->args[0] = _35cc4048;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2920,50 +2939,51 @@ return;
 }
 }
 
-void _35clofun1173(struct Cora* co) {
-Obj _35cc15 = makeNative(_35clofun1174, 0, 1, closureRef(co, 0));
-Obj _35reg536 = primIsCons(closureRef(co, 0));
-if (True == _35reg536) {
-Obj _35reg537 = primCar(closureRef(co, 0));
-Obj _35reg538 = primEQ(intern("if"), _35reg537);
-if (True == _35reg538) {
-Obj _35reg539 = primCdr(closureRef(co, 0));
-Obj _35reg540 = primIsCons(_35reg539);
-if (True == _35reg540) {
-Obj _35reg541 = primCdr(closureRef(co, 0));
-Obj _35reg542 = primCar(_35reg541);
-Obj _35reg543 = primEQ(False, _35reg542);
-if (True == _35reg543) {
-Obj _35reg544 = primCdr(closureRef(co, 0));
-Obj _35reg545 = primCdr(_35reg544);
-Obj _35reg546 = primIsCons(_35reg545);
-if (True == _35reg546) {
-Obj _35reg547 = primCdr(closureRef(co, 0));
-Obj _35reg548 = primCdr(_35reg547);
-Obj _35reg549 = primCar(_35reg548);
-Obj y = _35reg549;
-Obj _35reg550 = primCdr(closureRef(co, 0));
-Obj _35reg551 = primCdr(_35reg550);
-Obj _35reg552 = primCdr(_35reg551);
-Obj _35reg553 = primIsCons(_35reg552);
-if (True == _35reg553) {
-Obj _35reg554 = primCdr(closureRef(co, 0));
-Obj _35reg555 = primCdr(_35reg554);
-Obj _35reg556 = primCdr(_35reg555);
-Obj _35reg557 = primCar(_35reg556);
-Obj z = _35reg557;
-Obj _35reg558 = primCdr(closureRef(co, 0));
-Obj _35reg559 = primCdr(_35reg558);
-Obj _35reg560 = primCdr(_35reg559);
-Obj _35reg561 = primCdr(_35reg560);
-Obj _35reg562 = primEQ(Nil, _35reg561);
-if (True == _35reg562) {
+void _35clofun5207(struct Cora* co) {
+Obj _35cc4049 = makeNative(_35clofun5208, 0, 1, closureRef(co, 0));
+Obj _35reg4570 = primIsCons(closureRef(co, 0));
+if (True == _35reg4570) {
+Obj _35reg4571 = primCar(closureRef(co, 0));
+Obj _35reg4572 = primEQ(intern("if"), _35reg4571);
+if (True == _35reg4572) {
+Obj _35reg4573 = primCdr(closureRef(co, 0));
+Obj _35reg4574 = primIsCons(_35reg4573);
+if (True == _35reg4574) {
+Obj _35reg4575 = primCdr(closureRef(co, 0));
+Obj _35reg4576 = primCar(_35reg4575);
+Obj _35reg4577 = primEQ(False, _35reg4576);
+if (True == _35reg4577) {
+Obj _35reg4578 = primCdr(closureRef(co, 0));
+Obj _35reg4579 = primCdr(_35reg4578);
+Obj _35reg4580 = primIsCons(_35reg4579);
+if (True == _35reg4580) {
+Obj _35reg4581 = primCdr(closureRef(co, 0));
+Obj _35reg4582 = primCdr(_35reg4581);
+Obj _35reg4583 = primCar(_35reg4582);
+Obj y = _35reg4583;
+Obj _35reg4584 = primCdr(closureRef(co, 0));
+Obj _35reg4585 = primCdr(_35reg4584);
+Obj _35reg4586 = primCdr(_35reg4585);
+Obj _35reg4587 = primIsCons(_35reg4586);
+if (True == _35reg4587) {
+Obj _35reg4588 = primCdr(closureRef(co, 0));
+Obj _35reg4589 = primCdr(_35reg4588);
+Obj _35reg4590 = primCdr(_35reg4589);
+Obj _35reg4591 = primCar(_35reg4590);
+Obj z = _35reg4591;
+Obj _35reg4592 = primCdr(closureRef(co, 0));
+Obj _35reg4593 = primCdr(_35reg4592);
+Obj _35reg4594 = primCdr(_35reg4593);
+Obj _35reg4595 = primCdr(_35reg4594);
+Obj _35reg4596 = primEQ(Nil, _35reg4595);
+if (True == _35reg4596) {
+co->nargs = 2;
 co->args[1] = z;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc15;
 co->nargs = 1;
+co->args[0] = _35cc4049;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2973,8 +2993,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc15;
 co->nargs = 1;
+co->args[0] = _35cc4049;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2984,8 +3004,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc15;
 co->nargs = 1;
+co->args[0] = _35cc4049;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2995,8 +3015,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc15;
 co->nargs = 1;
+co->args[0] = _35cc4049;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3006,8 +3026,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc15;
 co->nargs = 1;
+co->args[0] = _35cc4049;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3017,8 +3037,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc15;
 co->nargs = 1;
+co->args[0] = _35cc4049;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3028,8 +3048,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc15;
 co->nargs = 1;
+co->args[0] = _35cc4049;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3040,18 +3060,19 @@ return;
 }
 }
 
-void _35clofun1174(struct Cora* co) {
-Obj _35cc16 = makeNative(_35clofun1175, 0, 0);
+void _35clofun5208(struct Cora* co) {
+Obj _35cc4050 = makeNative(_35clofun5209, 0, 0);
 Obj x = closureRef(co, 0);
+co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1175(struct Cora* co) {
+void _35clofun5209(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3061,12 +3082,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1157(struct Cora* co) {
+void _35clofun5191(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun1158, 1, exp);
+pushCont(co, _35clofun5192, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cddr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3076,13 +3097,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1158(struct Cora* co) {
-Obj _35val523 = co->args[1];
+void _35clofun5192(struct Cora* co) {
+Obj _35val4557 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-pushCont(co, _35clofun1159, 1, exp);
+pushCont(co, _35clofun5193, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.extract-rules"));
-co->args[1] = _35val523;
-co->nargs = 2;
+co->args[1] = _35val4557;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3092,14 +3113,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1159(struct Cora* co) {
-Obj _35val524 = co->args[1];
+void _35clofun5193(struct Cora* co) {
+Obj _35val4558 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj body = _35val524;
-pushCont(co, _35clofun1160, 2, exp, body);
+Obj body = _35val4558;
+pushCont(co, _35clofun5194, 2, exp, body);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rules-arg-count"));
 co->args[1] = body;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3109,15 +3130,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1160(struct Cora* co) {
-Obj _35val525 = co->args[1];
+void _35clofun5194(struct Cora* co) {
+Obj _35val4559 = co->args[1];
 Obj exp = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
-Obj nargs = _35val525;
-pushCont(co, _35clofun1161, 2, exp, body);
+Obj nargs = _35val4559;
+pushCont(co, _35clofun5195, 2, exp, body);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.gen-parameters"));
 co->args[1] = nargs;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3127,15 +3148,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1161(struct Cora* co) {
-Obj _35val526 = co->args[1];
+void _35clofun5195(struct Cora* co) {
+Obj _35val4560 = co->args[1];
 Obj exp = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
-Obj args = _35val526;
-pushCont(co, _35clofun1162, 2, body, args);
+Obj args = _35val4560;
+pushCont(co, _35clofun5196, 2, body, args);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3145,36 +3166,38 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1162(struct Cora* co) {
-Obj _35val527 = co->args[1];
+void _35clofun5196(struct Cora* co) {
+Obj _35val4561 = co->args[1];
 Obj body = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
-Obj _35reg528 = primCons(intern("list"), args);
-Obj _35reg529 = primCons(_35reg528, body);
-Obj _35reg530 = primCons(intern("match"), _35reg529);
-Obj _35reg531 = primCons(_35reg530, Nil);
-Obj _35reg532 = primCons(args, _35reg531);
-Obj _35reg533 = primCons(_35val527, _35reg532);
-Obj _35reg534 = primCons(intern("defun"), _35reg533);
-co->args[1] = _35reg534;
+Obj _35reg4562 = primCons(intern("list"), args);
+Obj _35reg4563 = primCons(_35reg4562, body);
+Obj _35reg4564 = primCons(intern("match"), _35reg4563);
+Obj _35reg4565 = primCons(_35reg4564, Nil);
+Obj _35reg4566 = primCons(args, _35reg4565);
+Obj _35reg4567 = primCons(_35val4561, _35reg4566);
+Obj _35reg4568 = primCons(intern("defun"), _35reg4567);
+co->nargs = 2;
+co->args[1] = _35reg4568;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1155(struct Cora* co) {
+void _35clofun5189(struct Cora* co) {
 Obj n = co->args[1];
-Obj _35reg517 = primEQ(n, makeNumber(0));
-if (True == _35reg517) {
+Obj _35reg4551 = primEQ(n, makeNumber(0));
+if (True == _35reg4551) {
+co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg518 = primGenSym(intern("p"));
-Obj _35reg519 = primSub(n, makeNumber(1));
-pushCont(co, _35clofun1156, 1, _35reg518);
-co->args[0] = globalRef(intern("cora/init.gen-parameters"));
-co->args[1] = _35reg519;
+Obj _35reg4552 = primGenSym(intern("p"));
+Obj _35reg4553 = primSub(n, makeNumber(1));
+pushCont(co, _35clofun5190, 1, _35reg4552);
 co->nargs = 2;
+co->args[0] = globalRef(intern("cora/init.gen-parameters"));
+co->args[1] = _35reg4553;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3185,22 +3208,23 @@ return;
 }
 }
 
-void _35clofun1156(struct Cora* co) {
-Obj _35val520 = co->args[1];
-Obj _35reg518 = co->stack[co->base + 0];
-Obj _35reg521 = primCons(_35reg518, _35val520);
-co->args[1] = _35reg521;
+void _35clofun5190(struct Cora* co) {
+Obj _35val4554 = co->args[1];
+Obj _35reg4552 = co->stack[co->base + 0];
+Obj _35reg4555 = primCons(_35reg4552, _35val4554);
+co->nargs = 2;
+co->args[1] = _35reg4555;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1148(struct Cora* co) {
+void _35clofun5182(struct Cora* co) {
 Obj rules = co->args[1];
-pushCont(co, _35clofun1149, 0);
+pushCont(co, _35clofun5183, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.rules-patterns"));
 co->args[1] = Nil;
 co->args[2] = rules;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3210,15 +3234,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1149(struct Cora* co) {
-Obj _35val506 = co->args[1];
-Obj pats = _35val506;
-Obj len = makeNative(_35clofun1150, 1, 0);
-pushCont(co, _35clofun1151, 0);
+void _35clofun5183(struct Cora* co) {
+Obj _35val4540 = co->args[1];
+Obj pats = _35val4540;
+Obj len = makeNative(_35clofun5184, 1, 0);
+pushCont(co, _35clofun5185, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = len;
 co->args[2] = pats;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3228,18 +3252,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1151(struct Cora* co) {
-Obj _35val508 = co->args[1];
-Obj counts = _35val508;
-Obj _35reg509 = primCar(counts);
-Obj n = _35reg509;
-Obj dif = makeNative(_35clofun1152, 1, 1, n);
-Obj _35reg512 = primCdr(counts);
-pushCont(co, _35clofun1153, 1, n);
+void _35clofun5185(struct Cora* co) {
+Obj _35val4542 = co->args[1];
+Obj counts = _35val4542;
+Obj _35reg4543 = primCar(counts);
+Obj n = _35reg4543;
+Obj dif = makeNative(_35clofun5186, 1, 1, n);
+Obj _35reg4546 = primCdr(counts);
+pushCont(co, _35clofun5187, 1, n);
+co->nargs = 3;
 co->args[0] = globalRef(intern("filter"));
 co->args[1] = dif;
-co->args[2] = _35reg512;
-co->nargs = 3;
+co->args[2] = _35reg4546;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3249,13 +3273,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1153(struct Cora* co) {
-Obj _35val513 = co->args[1];
+void _35clofun5187(struct Cora* co) {
+Obj _35val4547 = co->args[1];
 Obj n = co->stack[co->base + 0];
-pushCont(co, _35clofun1154, 1, n);
-co->args[0] = globalRef(intern("null?"));
-co->args[1] = _35val513;
+pushCont(co, _35clofun5188, 1, n);
 co->nargs = 2;
+co->args[0] = globalRef(intern("null?"));
+co->args[1] = _35val4547;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3265,14 +3289,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1154(struct Cora* co) {
-Obj _35val514 = co->args[1];
+void _35clofun5188(struct Cora* co) {
+Obj _35val4548 = co->args[1];
 Obj n = co->stack[co->base + 0];
-Obj _35reg515 = primNot(_35val514);
-if (True == _35reg515) {
+Obj _35reg4549 = primNot(_35val4548);
+if (True == _35reg4549) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("inconsistent func rule args count");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3281,27 +3305,29 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[1] = n;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun1152(struct Cora* co) {
+void _35clofun5186(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg510 = primEQ(closureRef(co, 0), x);
-Obj _35reg511 = primNot(_35reg510);
-co->args[1] = _35reg511;
+Obj _35reg4544 = primEQ(closureRef(co, 0), x);
+Obj _35reg4545 = primNot(_35reg4544);
+co->nargs = 2;
+co->args[1] = _35reg4545;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1150(struct Cora* co) {
+void _35clofun5184(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg507 = primCdr(x);
-co->args[0] = globalRef(intern("length"));
-co->args[1] = _35reg507;
+Obj _35reg4541 = primCdr(x);
 co->nargs = 2;
+co->args[0] = globalRef(intern("length"));
+co->args[1] = _35reg4541;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3311,22 +3337,23 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1146(struct Cora* co) {
+void _35clofun5180(struct Cora* co) {
 Obj l1 = co->args[1];
 Obj l2 = co->args[2];
-Obj _35reg500 = primEQ(l1, Nil);
-if (True == _35reg500) {
+Obj _35reg4534 = primEQ(l1, Nil);
+if (True == _35reg4534) {
+co->nargs = 2;
 co->args[1] = l2;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg501 = primCar(l1);
-Obj _35reg502 = primCdr(l1);
-pushCont(co, _35clofun1147, 1, _35reg501);
-co->args[0] = globalRef(intern("append"));
-co->args[1] = _35reg502;
-co->args[2] = l2;
+Obj _35reg4535 = primCar(l1);
+Obj _35reg4536 = primCdr(l1);
+pushCont(co, _35clofun5181, 1, _35reg4535);
 co->nargs = 3;
+co->args[0] = globalRef(intern("append"));
+co->args[1] = _35reg4536;
+co->args[2] = l2;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3337,23 +3364,24 @@ return;
 }
 }
 
-void _35clofun1147(struct Cora* co) {
-Obj _35val503 = co->args[1];
-Obj _35reg501 = co->stack[co->base + 0];
-Obj _35reg504 = primCons(_35reg501, _35val503);
-co->args[1] = _35reg504;
+void _35clofun5181(struct Cora* co) {
+Obj _35val4537 = co->args[1];
+Obj _35reg4535 = co->stack[co->base + 0];
+Obj _35reg4538 = primCons(_35reg4535, _35val4537);
+co->nargs = 2;
+co->args[1] = _35reg4538;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1145(struct Cora* co) {
+void _35clofun5179(struct Cora* co) {
 Obj fn = co->args[1];
 Obj l = co->args[2];
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/init.filter-h"));
 co->args[1] = Nil;
 co->args[2] = fn;
 co->args[3] = l;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3363,17 +3391,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1143(struct Cora* co) {
+void _35clofun5177(struct Cora* co) {
 Obj res = co->args[1];
 Obj fn = co->args[2];
 Obj l = co->args[3];
-Obj _35reg491 = primIsCons(l);
-if (True == _35reg491) {
-Obj _35reg492 = primCar(l);
-pushCont(co, _35clofun1144, 3, l, res, fn);
-co->args[0] = fn;
-co->args[1] = _35reg492;
+Obj _35reg4525 = primIsCons(l);
+if (True == _35reg4525) {
+Obj _35reg4526 = primCar(l);
+pushCont(co, _35clofun5178, 3, l, res, fn);
 co->nargs = 2;
+co->args[0] = fn;
+co->args[1] = _35reg4526;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3382,9 +3410,9 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = res;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3395,20 +3423,20 @@ return;
 }
 }
 
-void _35clofun1144(struct Cora* co) {
-Obj _35val493 = co->args[1];
+void _35clofun5178(struct Cora* co) {
+Obj _35val4527 = co->args[1];
 Obj l = co->stack[co->base + 0];
 Obj res = co->stack[co->base + 1];
 Obj fn = co->stack[co->base + 2];
-if (True == _35val493) {
-Obj _35reg494 = primCar(l);
-Obj _35reg495 = primCons(_35reg494, res);
-Obj _35reg496 = primCdr(l);
-co->args[0] = globalRef(intern("cora/init.filter-h"));
-co->args[1] = _35reg495;
-co->args[2] = fn;
-co->args[3] = _35reg496;
+if (True == _35val4527) {
+Obj _35reg4528 = primCar(l);
+Obj _35reg4529 = primCons(_35reg4528, res);
+Obj _35reg4530 = primCdr(l);
 co->nargs = 4;
+co->args[0] = globalRef(intern("cora/init.filter-h"));
+co->args[1] = _35reg4529;
+co->args[2] = fn;
+co->args[3] = _35reg4530;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3417,12 +3445,12 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg497 = primCdr(l);
+Obj _35reg4531 = primCdr(l);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/init.filter-h"));
 co->args[1] = res;
 co->args[2] = fn;
-co->args[3] = _35reg497;
-co->nargs = 4;
+co->args[3] = _35reg4531;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3433,12 +3461,12 @@ return;
 }
 }
 
-void _35clofun1142(struct Cora* co) {
+void _35clofun5176(struct Cora* co) {
 Obj l = co->args[1];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.length-h"));
 co->args[1] = makeNumber(0);
 co->args[2] = l;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3448,21 +3476,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1141(struct Cora* co) {
+void _35clofun5175(struct Cora* co) {
 Obj i = co->args[1];
 Obj l = co->args[2];
-Obj _35reg486 = primEQ(l, Nil);
-if (True == _35reg486) {
+Obj _35reg4520 = primEQ(l, Nil);
+if (True == _35reg4520) {
+co->nargs = 2;
 co->args[1] = i;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg487 = primAdd(i, makeNumber(1));
-Obj _35reg488 = primCdr(l);
-co->args[0] = globalRef(intern("cora/init.length-h"));
-co->args[1] = _35reg487;
-co->args[2] = _35reg488;
+Obj _35reg4521 = primAdd(i, makeNumber(1));
+Obj _35reg4522 = primCdr(l);
 co->nargs = 3;
+co->args[0] = globalRef(intern("cora/init.length-h"));
+co->args[1] = _35reg4521;
+co->args[2] = _35reg4522;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3473,13 +3502,13 @@ return;
 }
 }
 
-void _35clofun1138(struct Cora* co) {
+void _35clofun5172(struct Cora* co) {
 Obj res = co->args[1];
 Obj rules = co->args[2];
-pushCont(co, _35clofun1139, 2, res, rules);
+pushCont(co, _35clofun5173, 2, res, rules);
+co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = rules;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3489,14 +3518,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1139(struct Cora* co) {
-Obj _35val481 = co->args[1];
+void _35clofun5173(struct Cora* co) {
+Obj _35val4515 = co->args[1];
 Obj res = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
-if (True == _35val481) {
+if (True == _35val4515) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = res;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3505,12 +3534,12 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg482 = primCar(rules);
-Obj _35reg483 = primCons(_35reg482, res);
-pushCont(co, _35clofun1140, 1, _35reg483);
+Obj _35reg4516 = primCar(rules);
+Obj _35reg4517 = primCons(_35reg4516, res);
+pushCont(co, _35clofun5174, 1, _35reg4517);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cddr"));
 co->args[1] = rules;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3521,13 +3550,13 @@ return;
 }
 }
 
-void _35clofun1140(struct Cora* co) {
-Obj _35val484 = co->args[1];
-Obj _35reg483 = co->stack[co->base + 0];
-co->args[0] = globalRef(intern("cora/init.rules-patterns"));
-co->args[1] = _35reg483;
-co->args[2] = _35val484;
+void _35clofun5174(struct Cora* co) {
+Obj _35val4518 = co->args[1];
+Obj _35reg4517 = co->stack[co->base + 0];
 co->nargs = 3;
+co->args[0] = globalRef(intern("cora/init.rules-patterns"));
+co->args[1] = _35reg4517;
+co->args[2] = _35val4518;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3537,13 +3566,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1137(struct Cora* co) {
+void _35clofun5171(struct Cora* co) {
 Obj input = co->args[1];
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/init.extract-rules1"));
 co->args[1] = input;
 co->args[2] = Nil;
 co->args[3] = Nil;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3553,16 +3582,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1130(struct Cora* co) {
+void _35clofun5164(struct Cora* co) {
 Obj input = co->args[1];
 Obj current = co->args[2];
 Obj result = co->args[3];
-Obj _35cc1 = makeNative(_35clofun1131, 0, 3, input, current, result);
-Obj _35reg478 = primEQ(Nil, input);
-if (True == _35reg478) {
+Obj _35cc4035 = makeNative(_35clofun5165, 0, 3, input, current, result);
+Obj _35reg4512 = primEQ(Nil, input);
+if (True == _35reg4512) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = result;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3571,8 +3600,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1;
 co->nargs = 1;
+co->args[0] = _35cc4035;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3583,47 +3612,47 @@ return;
 }
 }
 
-void _35clofun1131(struct Cora* co) {
-Obj _35cc2 = makeNative(_35clofun1132, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj _35reg445 = primIsCons(closureRef(co, 0));
-if (True == _35reg445) {
-Obj _35reg446 = primCar(closureRef(co, 0));
-Obj _35reg447 = primEQ(intern("=>"), _35reg446);
-if (True == _35reg447) {
-Obj _35reg448 = primCdr(closureRef(co, 0));
-Obj _35reg449 = primIsCons(_35reg448);
-if (True == _35reg449) {
-Obj _35reg450 = primCdr(closureRef(co, 0));
-Obj _35reg451 = primCar(_35reg450);
-Obj act = _35reg451;
-Obj _35reg452 = primCdr(closureRef(co, 0));
-Obj _35reg453 = primCdr(_35reg452);
-Obj _35reg454 = primIsCons(_35reg453);
-if (True == _35reg454) {
-Obj _35reg455 = primCdr(closureRef(co, 0));
-Obj _35reg456 = primCdr(_35reg455);
-Obj _35reg457 = primCar(_35reg456);
-Obj _35reg458 = primEQ(intern("where"), _35reg457);
-if (True == _35reg458) {
-Obj _35reg459 = primCdr(closureRef(co, 0));
-Obj _35reg460 = primCdr(_35reg459);
-Obj _35reg461 = primCdr(_35reg460);
-Obj _35reg462 = primIsCons(_35reg461);
-if (True == _35reg462) {
-Obj _35reg463 = primCdr(closureRef(co, 0));
-Obj _35reg464 = primCdr(_35reg463);
-Obj _35reg465 = primCdr(_35reg464);
-Obj _35reg466 = primCar(_35reg465);
-Obj pred = _35reg466;
-Obj _35reg467 = primCdr(closureRef(co, 0));
-Obj _35reg468 = primCdr(_35reg467);
-Obj _35reg469 = primCdr(_35reg468);
-Obj _35reg470 = primCdr(_35reg469);
-Obj remain = _35reg470;
-pushCont(co, _35clofun1136, 3, act, pred, remain);
+void _35clofun5165(struct Cora* co) {
+Obj _35cc4036 = makeNative(_35clofun5166, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35reg4479 = primIsCons(closureRef(co, 0));
+if (True == _35reg4479) {
+Obj _35reg4480 = primCar(closureRef(co, 0));
+Obj _35reg4481 = primEQ(intern("=>"), _35reg4480);
+if (True == _35reg4481) {
+Obj _35reg4482 = primCdr(closureRef(co, 0));
+Obj _35reg4483 = primIsCons(_35reg4482);
+if (True == _35reg4483) {
+Obj _35reg4484 = primCdr(closureRef(co, 0));
+Obj _35reg4485 = primCar(_35reg4484);
+Obj act = _35reg4485;
+Obj _35reg4486 = primCdr(closureRef(co, 0));
+Obj _35reg4487 = primCdr(_35reg4486);
+Obj _35reg4488 = primIsCons(_35reg4487);
+if (True == _35reg4488) {
+Obj _35reg4489 = primCdr(closureRef(co, 0));
+Obj _35reg4490 = primCdr(_35reg4489);
+Obj _35reg4491 = primCar(_35reg4490);
+Obj _35reg4492 = primEQ(intern("where"), _35reg4491);
+if (True == _35reg4492) {
+Obj _35reg4493 = primCdr(closureRef(co, 0));
+Obj _35reg4494 = primCdr(_35reg4493);
+Obj _35reg4495 = primCdr(_35reg4494);
+Obj _35reg4496 = primIsCons(_35reg4495);
+if (True == _35reg4496) {
+Obj _35reg4497 = primCdr(closureRef(co, 0));
+Obj _35reg4498 = primCdr(_35reg4497);
+Obj _35reg4499 = primCdr(_35reg4498);
+Obj _35reg4500 = primCar(_35reg4499);
+Obj pred = _35reg4500;
+Obj _35reg4501 = primCdr(closureRef(co, 0));
+Obj _35reg4502 = primCdr(_35reg4501);
+Obj _35reg4503 = primCdr(_35reg4502);
+Obj _35reg4504 = primCdr(_35reg4503);
+Obj remain = _35reg4504;
+pushCont(co, _35clofun5170, 3, act, pred, remain);
+co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = closureRef(co, 1);
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3632,8 +3661,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc2;
 co->nargs = 1;
+co->args[0] = _35cc4036;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3643,8 +3672,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc2;
 co->nargs = 1;
+co->args[0] = _35cc4036;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3654,8 +3683,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc2;
 co->nargs = 1;
+co->args[0] = _35cc4036;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3665,8 +3694,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc2;
 co->nargs = 1;
+co->args[0] = _35cc4036;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3676,8 +3705,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc2;
 co->nargs = 1;
+co->args[0] = _35cc4036;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3687,8 +3716,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc2;
 co->nargs = 1;
+co->args[0] = _35cc4036;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3699,23 +3728,23 @@ return;
 }
 }
 
-void _35clofun1136(struct Cora* co) {
-Obj _35val471 = co->args[1];
+void _35clofun5170(struct Cora* co) {
+Obj _35val4505 = co->args[1];
 Obj act = co->stack[co->base + 0];
 Obj pred = co->stack[co->base + 1];
 Obj remain = co->stack[co->base + 2];
-Obj _35reg472 = primCons(intern("list"), _35val471);
-Obj pat = _35reg472;
-Obj _35reg473 = primCons(act, Nil);
-Obj _35reg474 = primCons(pred, _35reg473);
-Obj _35reg475 = primCons(intern("where"), _35reg474);
-Obj _35reg476 = primCons(pat, closureRef(co, 2));
-Obj _35reg477 = primCons(_35reg475, _35reg476);
+Obj _35reg4506 = primCons(intern("list"), _35val4505);
+Obj pat = _35reg4506;
+Obj _35reg4507 = primCons(act, Nil);
+Obj _35reg4508 = primCons(pred, _35reg4507);
+Obj _35reg4509 = primCons(intern("where"), _35reg4508);
+Obj _35reg4510 = primCons(pat, closureRef(co, 2));
+Obj _35reg4511 = primCons(_35reg4509, _35reg4510);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/init.extract-rules1"));
 co->args[1] = remain;
 co->args[2] = Nil;
-co->args[3] = _35reg477;
-co->nargs = 4;
+co->args[3] = _35reg4511;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3725,26 +3754,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1132(struct Cora* co) {
-Obj _35cc3 = makeNative(_35clofun1133, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj _35reg432 = primIsCons(closureRef(co, 0));
-if (True == _35reg432) {
-Obj _35reg433 = primCar(closureRef(co, 0));
-Obj _35reg434 = primEQ(intern("=>"), _35reg433);
-if (True == _35reg434) {
-Obj _35reg435 = primCdr(closureRef(co, 0));
-Obj _35reg436 = primIsCons(_35reg435);
-if (True == _35reg436) {
-Obj _35reg437 = primCdr(closureRef(co, 0));
-Obj _35reg438 = primCar(_35reg437);
-Obj act = _35reg438;
-Obj _35reg439 = primCdr(closureRef(co, 0));
-Obj _35reg440 = primCdr(_35reg439);
-Obj remain = _35reg440;
-pushCont(co, _35clofun1135, 2, act, remain);
+void _35clofun5166(struct Cora* co) {
+Obj _35cc4037 = makeNative(_35clofun5167, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35reg4466 = primIsCons(closureRef(co, 0));
+if (True == _35reg4466) {
+Obj _35reg4467 = primCar(closureRef(co, 0));
+Obj _35reg4468 = primEQ(intern("=>"), _35reg4467);
+if (True == _35reg4468) {
+Obj _35reg4469 = primCdr(closureRef(co, 0));
+Obj _35reg4470 = primIsCons(_35reg4469);
+if (True == _35reg4470) {
+Obj _35reg4471 = primCdr(closureRef(co, 0));
+Obj _35reg4472 = primCar(_35reg4471);
+Obj act = _35reg4472;
+Obj _35reg4473 = primCdr(closureRef(co, 0));
+Obj _35reg4474 = primCdr(_35reg4473);
+Obj remain = _35reg4474;
+pushCont(co, _35clofun5169, 2, act, remain);
+co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = closureRef(co, 1);
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3753,8 +3782,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc3;
 co->nargs = 1;
+co->args[0] = _35cc4037;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3764,8 +3793,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc3;
 co->nargs = 1;
+co->args[0] = _35cc4037;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3775,8 +3804,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc3;
 co->nargs = 1;
+co->args[0] = _35cc4037;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3787,19 +3816,19 @@ return;
 }
 }
 
-void _35clofun1135(struct Cora* co) {
-Obj _35val441 = co->args[1];
+void _35clofun5169(struct Cora* co) {
+Obj _35val4475 = co->args[1];
 Obj act = co->stack[co->base + 0];
 Obj remain = co->stack[co->base + 1];
-Obj _35reg442 = primCons(intern("list"), _35val441);
-Obj pat = _35reg442;
-Obj _35reg443 = primCons(pat, closureRef(co, 2));
-Obj _35reg444 = primCons(act, _35reg443);
+Obj _35reg4476 = primCons(intern("list"), _35val4475);
+Obj pat = _35reg4476;
+Obj _35reg4477 = primCons(pat, closureRef(co, 2));
+Obj _35reg4478 = primCons(act, _35reg4477);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/init.extract-rules1"));
 co->args[1] = remain;
 co->args[2] = Nil;
-co->args[3] = _35reg444;
-co->nargs = 4;
+co->args[3] = _35reg4478;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3809,20 +3838,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1133(struct Cora* co) {
-Obj _35cc4 = makeNative(_35clofun1134, 0, 0);
-Obj _35reg428 = primIsCons(closureRef(co, 0));
-if (True == _35reg428) {
-Obj _35reg429 = primCar(closureRef(co, 0));
-Obj x = _35reg429;
-Obj _35reg430 = primCdr(closureRef(co, 0));
-Obj y = _35reg430;
-Obj _35reg431 = primCons(x, closureRef(co, 1));
+void _35clofun5167(struct Cora* co) {
+Obj _35cc4038 = makeNative(_35clofun5168, 0, 0);
+Obj _35reg4462 = primIsCons(closureRef(co, 0));
+if (True == _35reg4462) {
+Obj _35reg4463 = primCar(closureRef(co, 0));
+Obj x = _35reg4463;
+Obj _35reg4464 = primCdr(closureRef(co, 0));
+Obj y = _35reg4464;
+Obj _35reg4465 = primCons(x, closureRef(co, 1));
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/init.extract-rules1"));
 co->args[1] = y;
-co->args[2] = _35reg431;
+co->args[2] = _35reg4465;
 co->args[3] = closureRef(co, 2);
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3831,8 +3860,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc4;
 co->nargs = 1;
+co->args[0] = _35cc4038;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3843,10 +3872,10 @@ return;
 }
 }
 
-void _35clofun1134(struct Cora* co) {
+void _35clofun5168(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3856,11 +3885,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1128(struct Cora* co) {
+void _35clofun5162(struct Cora* co) {
 Obj exp = co->args[1];
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-match"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3870,12 +3899,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1121(struct Cora* co) {
+void _35clofun5155(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun1122, 1, exp);
+pushCont(co, _35clofun5156, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3885,13 +3914,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1122(struct Cora* co) {
-Obj _35val401 = co->args[1];
+void _35clofun5156(struct Cora* co) {
+Obj _35val4435 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-pushCont(co, _35clofun1123, 1, exp);
+pushCont(co, _35clofun5157, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("macroexpand"));
-co->args[1] = _35val401;
-co->nargs = 2;
+co->args[1] = _35val4435;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3901,14 +3930,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1123(struct Cora* co) {
-Obj _35val402 = co->args[1];
+void _35clofun5157(struct Cora* co) {
+Obj _35val4436 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj value = _35val402;
-pushCont(co, _35clofun1124, 1, value);
+Obj value = _35val4436;
+pushCont(co, _35clofun5158, 1, value);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cddr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3918,24 +3947,24 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1124(struct Cora* co) {
-Obj _35val403 = co->args[1];
+void _35clofun5158(struct Cora* co) {
+Obj _35val4437 = co->args[1];
 Obj value = co->stack[co->base + 0];
-Obj rules = _35val403;
-Obj _35reg404 = primIsCons(value);
-if (True == _35reg404) {
-Obj _35reg405 = primCar(value);
-Obj _35reg406 = primEQ(intern("cons"), _35reg405);
-Obj _35reg407 = primNot(_35reg406);
-if (True == _35reg407) {
+Obj rules = _35val4437;
+Obj _35reg4438 = primIsCons(value);
+if (True == _35reg4438) {
+Obj _35reg4439 = primCar(value);
+Obj _35reg4440 = primEQ(intern("cons"), _35reg4439);
+Obj _35reg4441 = primNot(_35reg4440);
+if (True == _35reg4441) {
 if (True == True) {
-Obj _35reg408 = primGenSym(intern("val"));
-Obj val = _35reg408;
-pushCont(co, _35clofun1125, 2, value, val);
+Obj _35reg4442 = primGenSym(intern("val"));
+Obj val = _35reg4442;
+pushCont(co, _35clofun5159, 2, value, val);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = val;
 co->args[2] = rules;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3944,10 +3973,10 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = value;
 co->args[2] = rules;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3958,13 +3987,13 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg414 = primGenSym(intern("val"));
-Obj val = _35reg414;
-pushCont(co, _35clofun1126, 2, value, val);
+Obj _35reg4448 = primGenSym(intern("val"));
+Obj val = _35reg4448;
+pushCont(co, _35clofun5160, 2, value, val);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = val;
 co->args[2] = rules;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3973,10 +4002,10 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = value;
 co->args[2] = rules;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3988,13 +4017,13 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg420 = primGenSym(intern("val"));
-Obj val = _35reg420;
-pushCont(co, _35clofun1127, 2, value, val);
+Obj _35reg4454 = primGenSym(intern("val"));
+Obj val = _35reg4454;
+pushCont(co, _35clofun5161, 2, value, val);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = val;
 co->args[2] = rules;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4003,10 +4032,10 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = value;
 co->args[2] = rules;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4018,52 +4047,55 @@ return;
 }
 }
 
-void _35clofun1127(struct Cora* co) {
-Obj _35val421 = co->args[1];
+void _35clofun5161(struct Cora* co) {
+Obj _35val4455 = co->args[1];
 Obj value = co->stack[co->base + 0];
 Obj val = co->stack[co->base + 1];
-Obj _35reg422 = primCons(_35val421, Nil);
-Obj _35reg423 = primCons(value, _35reg422);
-Obj _35reg424 = primCons(val, _35reg423);
-Obj _35reg425 = primCons(intern("let"), _35reg424);
-co->args[1] = _35reg425;
+Obj _35reg4456 = primCons(_35val4455, Nil);
+Obj _35reg4457 = primCons(value, _35reg4456);
+Obj _35reg4458 = primCons(val, _35reg4457);
+Obj _35reg4459 = primCons(intern("let"), _35reg4458);
+co->nargs = 2;
+co->args[1] = _35reg4459;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1126(struct Cora* co) {
-Obj _35val415 = co->args[1];
+void _35clofun5160(struct Cora* co) {
+Obj _35val4449 = co->args[1];
 Obj value = co->stack[co->base + 0];
 Obj val = co->stack[co->base + 1];
-Obj _35reg416 = primCons(_35val415, Nil);
-Obj _35reg417 = primCons(value, _35reg416);
-Obj _35reg418 = primCons(val, _35reg417);
-Obj _35reg419 = primCons(intern("let"), _35reg418);
-co->args[1] = _35reg419;
+Obj _35reg4450 = primCons(_35val4449, Nil);
+Obj _35reg4451 = primCons(value, _35reg4450);
+Obj _35reg4452 = primCons(val, _35reg4451);
+Obj _35reg4453 = primCons(intern("let"), _35reg4452);
+co->nargs = 2;
+co->args[1] = _35reg4453;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1125(struct Cora* co) {
-Obj _35val409 = co->args[1];
+void _35clofun5159(struct Cora* co) {
+Obj _35val4443 = co->args[1];
 Obj value = co->stack[co->base + 0];
 Obj val = co->stack[co->base + 1];
-Obj _35reg410 = primCons(_35val409, Nil);
-Obj _35reg411 = primCons(value, _35reg410);
-Obj _35reg412 = primCons(val, _35reg411);
-Obj _35reg413 = primCons(intern("let"), _35reg412);
-co->args[1] = _35reg413;
+Obj _35reg4444 = primCons(_35val4443, Nil);
+Obj _35reg4445 = primCons(value, _35reg4444);
+Obj _35reg4446 = primCons(val, _35reg4445);
+Obj _35reg4447 = primCons(intern("let"), _35reg4446);
+co->nargs = 2;
+co->args[1] = _35reg4447;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1105(struct Cora* co) {
+void _35clofun5139(struct Cora* co) {
 Obj value = co->args[1];
 Obj rules = co->args[2];
-pushCont(co, _35clofun1106, 2, rules, value);
+pushCont(co, _35clofun5140, 2, rules, value);
+co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = rules;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4073,21 +4105,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1106(struct Cora* co) {
-Obj _35val349 = co->args[1];
+void _35clofun5140(struct Cora* co) {
+Obj _35val4383 = co->args[1];
 Obj rules = co->stack[co->base + 0];
 Obj value = co->stack[co->base + 1];
-if (True == _35val349) {
-Obj _35reg350 = primCons(makeString1("no match-help found!"), Nil);
-Obj _35reg351 = primCons(intern("error"), _35reg350);
-co->args[1] = _35reg351;
+if (True == _35val4383) {
+Obj _35reg4384 = primCons(makeString1("no match-help found!"), Nil);
+Obj _35reg4385 = primCons(intern("error"), _35reg4384);
+co->nargs = 2;
+co->args[1] = _35reg4385;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-pushCont(co, _35clofun1107, 2, rules, value);
+pushCont(co, _35clofun5141, 2, rules, value);
+co->nargs = 2;
 co->args[0] = globalRef(intern("pair?"));
 co->args[1] = rules;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4098,16 +4131,16 @@ return;
 }
 }
 
-void _35clofun1107(struct Cora* co) {
-Obj _35val352 = co->args[1];
+void _35clofun5141(struct Cora* co) {
+Obj _35val4386 = co->args[1];
 Obj rules = co->stack[co->base + 0];
 Obj value = co->stack[co->base + 1];
-if (True == _35val352) {
-Obj _35reg353 = primCdr(rules);
-pushCont(co, _35clofun1108, 2, rules, value);
-co->args[0] = globalRef(intern("pair?"));
-co->args[1] = _35reg353;
+if (True == _35val4386) {
+Obj _35reg4387 = primCdr(rules);
+pushCont(co, _35clofun5142, 2, rules, value);
 co->nargs = 2;
+co->args[0] = globalRef(intern("pair?"));
+co->args[1] = _35reg4387;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4117,15 +4150,15 @@ co->pc = coraCall;
 return;
 } else {
 if (True == False) {
-Obj _35reg385 = primCar(rules);
-Obj pat = _35reg385;
-Obj _35reg386 = primGenSym(intern("cc"));
-Obj cc = _35reg386;
-pushCont(co, _35clofun1117, 4, pat, rules, value, cc);
+Obj _35reg4419 = primCar(rules);
+Obj pat = _35reg4419;
+Obj _35reg4420 = primGenSym(intern("cc"));
+Obj cc = _35reg4420;
+pushCont(co, _35clofun5151, 4, pat, rules, value, cc);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.extract-rule-action"));
 co->args[1] = rules;
 co->args[2] = cc;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4134,9 +4167,9 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no cond match");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4148,17 +4181,17 @@ return;
 }
 }
 
-void _35clofun1117(struct Cora* co) {
-Obj _35val387 = co->args[1];
+void _35clofun5151(struct Cora* co) {
+Obj _35val4421 = co->args[1];
 Obj pat = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
 Obj value = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-Obj action = _35val387;
-pushCont(co, _35clofun1118, 4, action, rules, value, cc);
+Obj action = _35val4421;
+pushCont(co, _35clofun5152, 4, action, rules, value, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("macroexpand"));
 co->args[1] = pat;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4168,19 +4201,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1118(struct Cora* co) {
-Obj _35val388 = co->args[1];
+void _35clofun5152(struct Cora* co) {
+Obj _35val4422 = co->args[1];
 Obj action = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
 Obj value = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-pushCont(co, _35clofun1119, 3, rules, value, cc);
+pushCont(co, _35clofun5153, 3, rules, value, cc);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
-co->args[1] = _35val388;
+co->args[1] = _35val4422;
 co->args[2] = value;
 co->args[3] = action;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4190,19 +4223,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1119(struct Cora* co) {
-Obj _35val389 = co->args[1];
+void _35clofun5153(struct Cora* co) {
+Obj _35val4423 = co->args[1];
 Obj rules = co->stack[co->base + 0];
 Obj value = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
-Obj curr = _35val389;
-Obj _35reg390 = primCdr(rules);
-Obj _35reg391 = primCdr(_35reg390);
-pushCont(co, _35clofun1120, 2, curr, cc);
+Obj curr = _35val4423;
+Obj _35reg4424 = primCdr(rules);
+Obj _35reg4425 = primCdr(_35reg4424);
+pushCont(co, _35clofun5154, 2, curr, cc);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = value;
-co->args[2] = _35reg391;
-co->nargs = 3;
+co->args[2] = _35reg4425;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4212,38 +4245,39 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1120(struct Cora* co) {
-Obj _35val392 = co->args[1];
+void _35clofun5154(struct Cora* co) {
+Obj _35val4426 = co->args[1];
 Obj curr = co->stack[co->base + 0];
 Obj cc = co->stack[co->base + 1];
-Obj rest = _35val392;
-Obj _35reg393 = primCons(rest, Nil);
-Obj _35reg394 = primCons(Nil, _35reg393);
-Obj _35reg395 = primCons(intern("lambda"), _35reg394);
-Obj _35reg396 = primCons(curr, Nil);
-Obj _35reg397 = primCons(_35reg395, _35reg396);
-Obj _35reg398 = primCons(cc, _35reg397);
-Obj _35reg399 = primCons(intern("let"), _35reg398);
-co->args[1] = _35reg399;
+Obj rest = _35val4426;
+Obj _35reg4427 = primCons(rest, Nil);
+Obj _35reg4428 = primCons(Nil, _35reg4427);
+Obj _35reg4429 = primCons(intern("lambda"), _35reg4428);
+Obj _35reg4430 = primCons(curr, Nil);
+Obj _35reg4431 = primCons(_35reg4429, _35reg4430);
+Obj _35reg4432 = primCons(cc, _35reg4431);
+Obj _35reg4433 = primCons(intern("let"), _35reg4432);
+co->nargs = 2;
+co->args[1] = _35reg4433;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1108(struct Cora* co) {
-Obj _35val354 = co->args[1];
+void _35clofun5142(struct Cora* co) {
+Obj _35val4388 = co->args[1];
 Obj rules = co->stack[co->base + 0];
 Obj value = co->stack[co->base + 1];
-if (True == _35val354) {
+if (True == _35val4388) {
 if (True == True) {
-Obj _35reg355 = primCar(rules);
-Obj pat = _35reg355;
-Obj _35reg356 = primGenSym(intern("cc"));
-Obj cc = _35reg356;
-pushCont(co, _35clofun1109, 4, pat, rules, value, cc);
+Obj _35reg4389 = primCar(rules);
+Obj pat = _35reg4389;
+Obj _35reg4390 = primGenSym(intern("cc"));
+Obj cc = _35reg4390;
+pushCont(co, _35clofun5143, 4, pat, rules, value, cc);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.extract-rule-action"));
 co->args[1] = rules;
 co->args[2] = cc;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4252,9 +4286,9 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no cond match");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4265,15 +4299,15 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg370 = primCar(rules);
-Obj pat = _35reg370;
-Obj _35reg371 = primGenSym(intern("cc"));
-Obj cc = _35reg371;
-pushCont(co, _35clofun1113, 4, pat, rules, value, cc);
+Obj _35reg4404 = primCar(rules);
+Obj pat = _35reg4404;
+Obj _35reg4405 = primGenSym(intern("cc"));
+Obj cc = _35reg4405;
+pushCont(co, _35clofun5147, 4, pat, rules, value, cc);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.extract-rule-action"));
 co->args[1] = rules;
 co->args[2] = cc;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4282,9 +4316,9 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no cond match");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4296,17 +4330,17 @@ return;
 }
 }
 
-void _35clofun1113(struct Cora* co) {
-Obj _35val372 = co->args[1];
+void _35clofun5147(struct Cora* co) {
+Obj _35val4406 = co->args[1];
 Obj pat = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
 Obj value = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-Obj action = _35val372;
-pushCont(co, _35clofun1114, 4, action, rules, value, cc);
+Obj action = _35val4406;
+pushCont(co, _35clofun5148, 4, action, rules, value, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("macroexpand"));
 co->args[1] = pat;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4316,19 +4350,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1114(struct Cora* co) {
-Obj _35val373 = co->args[1];
+void _35clofun5148(struct Cora* co) {
+Obj _35val4407 = co->args[1];
 Obj action = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
 Obj value = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-pushCont(co, _35clofun1115, 3, rules, value, cc);
+pushCont(co, _35clofun5149, 3, rules, value, cc);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
-co->args[1] = _35val373;
+co->args[1] = _35val4407;
 co->args[2] = value;
 co->args[3] = action;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4338,19 +4372,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1115(struct Cora* co) {
-Obj _35val374 = co->args[1];
+void _35clofun5149(struct Cora* co) {
+Obj _35val4408 = co->args[1];
 Obj rules = co->stack[co->base + 0];
 Obj value = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
-Obj curr = _35val374;
-Obj _35reg375 = primCdr(rules);
-Obj _35reg376 = primCdr(_35reg375);
-pushCont(co, _35clofun1116, 2, curr, cc);
+Obj curr = _35val4408;
+Obj _35reg4409 = primCdr(rules);
+Obj _35reg4410 = primCdr(_35reg4409);
+pushCont(co, _35clofun5150, 2, curr, cc);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = value;
-co->args[2] = _35reg376;
-co->nargs = 3;
+co->args[2] = _35reg4410;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4360,34 +4394,35 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1116(struct Cora* co) {
-Obj _35val377 = co->args[1];
+void _35clofun5150(struct Cora* co) {
+Obj _35val4411 = co->args[1];
 Obj curr = co->stack[co->base + 0];
 Obj cc = co->stack[co->base + 1];
-Obj rest = _35val377;
-Obj _35reg378 = primCons(rest, Nil);
-Obj _35reg379 = primCons(Nil, _35reg378);
-Obj _35reg380 = primCons(intern("lambda"), _35reg379);
-Obj _35reg381 = primCons(curr, Nil);
-Obj _35reg382 = primCons(_35reg380, _35reg381);
-Obj _35reg383 = primCons(cc, _35reg382);
-Obj _35reg384 = primCons(intern("let"), _35reg383);
-co->args[1] = _35reg384;
+Obj rest = _35val4411;
+Obj _35reg4412 = primCons(rest, Nil);
+Obj _35reg4413 = primCons(Nil, _35reg4412);
+Obj _35reg4414 = primCons(intern("lambda"), _35reg4413);
+Obj _35reg4415 = primCons(curr, Nil);
+Obj _35reg4416 = primCons(_35reg4414, _35reg4415);
+Obj _35reg4417 = primCons(cc, _35reg4416);
+Obj _35reg4418 = primCons(intern("let"), _35reg4417);
+co->nargs = 2;
+co->args[1] = _35reg4418;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1109(struct Cora* co) {
-Obj _35val357 = co->args[1];
+void _35clofun5143(struct Cora* co) {
+Obj _35val4391 = co->args[1];
 Obj pat = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
 Obj value = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-Obj action = _35val357;
-pushCont(co, _35clofun1110, 4, action, rules, value, cc);
+Obj action = _35val4391;
+pushCont(co, _35clofun5144, 4, action, rules, value, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("macroexpand"));
 co->args[1] = pat;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4397,19 +4432,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1110(struct Cora* co) {
-Obj _35val358 = co->args[1];
+void _35clofun5144(struct Cora* co) {
+Obj _35val4392 = co->args[1];
 Obj action = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
 Obj value = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-pushCont(co, _35clofun1111, 3, rules, value, cc);
+pushCont(co, _35clofun5145, 3, rules, value, cc);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
-co->args[1] = _35val358;
+co->args[1] = _35val4392;
 co->args[2] = value;
 co->args[3] = action;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4419,19 +4454,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1111(struct Cora* co) {
-Obj _35val359 = co->args[1];
+void _35clofun5145(struct Cora* co) {
+Obj _35val4393 = co->args[1];
 Obj rules = co->stack[co->base + 0];
 Obj value = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
-Obj curr = _35val359;
-Obj _35reg360 = primCdr(rules);
-Obj _35reg361 = primCdr(_35reg360);
-pushCont(co, _35clofun1112, 2, curr, cc);
+Obj curr = _35val4393;
+Obj _35reg4394 = primCdr(rules);
+Obj _35reg4395 = primCdr(_35reg4394);
+pushCont(co, _35clofun5146, 2, curr, cc);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = value;
-co->args[2] = _35reg361;
-co->nargs = 3;
+co->args[2] = _35reg4395;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4441,33 +4476,34 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1112(struct Cora* co) {
-Obj _35val362 = co->args[1];
+void _35clofun5146(struct Cora* co) {
+Obj _35val4396 = co->args[1];
 Obj curr = co->stack[co->base + 0];
 Obj cc = co->stack[co->base + 1];
-Obj rest = _35val362;
-Obj _35reg363 = primCons(rest, Nil);
-Obj _35reg364 = primCons(Nil, _35reg363);
-Obj _35reg365 = primCons(intern("lambda"), _35reg364);
-Obj _35reg366 = primCons(curr, Nil);
-Obj _35reg367 = primCons(_35reg365, _35reg366);
-Obj _35reg368 = primCons(cc, _35reg367);
-Obj _35reg369 = primCons(intern("let"), _35reg368);
-co->args[1] = _35reg369;
+Obj rest = _35val4396;
+Obj _35reg4397 = primCons(rest, Nil);
+Obj _35reg4398 = primCons(Nil, _35reg4397);
+Obj _35reg4399 = primCons(intern("lambda"), _35reg4398);
+Obj _35reg4400 = primCons(curr, Nil);
+Obj _35reg4401 = primCons(_35reg4399, _35reg4400);
+Obj _35reg4402 = primCons(cc, _35reg4401);
+Obj _35reg4403 = primCons(intern("let"), _35reg4402);
+co->nargs = 2;
+co->args[1] = _35reg4403;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1097(struct Cora* co) {
+void _35clofun5131(struct Cora* co) {
 Obj rules = co->args[1];
 Obj cc = co->args[2];
-Obj _35reg322 = primCdr(rules);
-Obj _35reg323 = primCar(_35reg322);
-Obj action = _35reg323;
-pushCont(co, _35clofun1098, 2, cc, action);
+Obj _35reg4356 = primCdr(rules);
+Obj _35reg4357 = primCar(_35reg4356);
+Obj action = _35reg4357;
+pushCont(co, _35clofun5132, 2, cc, action);
+co->nargs = 2;
 co->args[0] = globalRef(intern("pair?"));
 co->args[1] = action;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4477,19 +4513,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1098(struct Cora* co) {
-Obj _35val324 = co->args[1];
+void _35clofun5132(struct Cora* co) {
+Obj _35val4358 = co->args[1];
 Obj cc = co->stack[co->base + 0];
 Obj action = co->stack[co->base + 1];
-if (True == _35val324) {
-Obj _35reg325 = primCar(action);
-Obj _35reg326 = primEQ(_35reg325, intern("where"));
-if (True == _35reg326) {
+if (True == _35val4358) {
+Obj _35reg4359 = primCar(action);
+Obj _35reg4360 = primEQ(_35reg4359, intern("where"));
+if (True == _35reg4360) {
 if (True == True) {
-pushCont(co, _35clofun1099, 2, action, cc);
+pushCont(co, _35clofun5133, 2, action, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = action;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4498,16 +4534,17 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[1] = action;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 } else {
 if (True == False) {
-pushCont(co, _35clofun1101, 2, action, cc);
+pushCont(co, _35clofun5135, 2, action, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = action;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4516,6 +4553,7 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[1] = action;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
@@ -4523,10 +4561,10 @@ return;
 }
 } else {
 if (True == False) {
-pushCont(co, _35clofun1103, 2, action, cc);
+pushCont(co, _35clofun5137, 2, action, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = action;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4535,6 +4573,7 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[1] = action;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
@@ -4542,14 +4581,14 @@ return;
 }
 }
 
-void _35clofun1103(struct Cora* co) {
-Obj _35val341 = co->args[1];
+void _35clofun5137(struct Cora* co) {
+Obj _35val4375 = co->args[1];
 Obj action = co->stack[co->base + 0];
 Obj cc = co->stack[co->base + 1];
-pushCont(co, _35clofun1104, 2, cc, _35val341);
+pushCont(co, _35clofun5138, 2, cc, _35val4375);
+co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = action;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4559,28 +4598,29 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1104(struct Cora* co) {
-Obj _35val342 = co->args[1];
+void _35clofun5138(struct Cora* co) {
+Obj _35val4376 = co->args[1];
 Obj cc = co->stack[co->base + 0];
-Obj _35val341 = co->stack[co->base + 1];
-Obj _35reg343 = primCons(cc, Nil);
-Obj _35reg344 = primCons(_35reg343, Nil);
-Obj _35reg345 = primCons(_35val342, _35reg344);
-Obj _35reg346 = primCons(_35val341, _35reg345);
-Obj _35reg347 = primCons(intern("if"), _35reg346);
-co->args[1] = _35reg347;
+Obj _35val4375 = co->stack[co->base + 1];
+Obj _35reg4377 = primCons(cc, Nil);
+Obj _35reg4378 = primCons(_35reg4377, Nil);
+Obj _35reg4379 = primCons(_35val4376, _35reg4378);
+Obj _35reg4380 = primCons(_35val4375, _35reg4379);
+Obj _35reg4381 = primCons(intern("if"), _35reg4380);
+co->nargs = 2;
+co->args[1] = _35reg4381;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1101(struct Cora* co) {
-Obj _35val334 = co->args[1];
+void _35clofun5135(struct Cora* co) {
+Obj _35val4368 = co->args[1];
 Obj action = co->stack[co->base + 0];
 Obj cc = co->stack[co->base + 1];
-pushCont(co, _35clofun1102, 2, cc, _35val334);
+pushCont(co, _35clofun5136, 2, cc, _35val4368);
+co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = action;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4590,28 +4630,29 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1102(struct Cora* co) {
-Obj _35val335 = co->args[1];
+void _35clofun5136(struct Cora* co) {
+Obj _35val4369 = co->args[1];
 Obj cc = co->stack[co->base + 0];
-Obj _35val334 = co->stack[co->base + 1];
-Obj _35reg336 = primCons(cc, Nil);
-Obj _35reg337 = primCons(_35reg336, Nil);
-Obj _35reg338 = primCons(_35val335, _35reg337);
-Obj _35reg339 = primCons(_35val334, _35reg338);
-Obj _35reg340 = primCons(intern("if"), _35reg339);
-co->args[1] = _35reg340;
+Obj _35val4368 = co->stack[co->base + 1];
+Obj _35reg4370 = primCons(cc, Nil);
+Obj _35reg4371 = primCons(_35reg4370, Nil);
+Obj _35reg4372 = primCons(_35val4369, _35reg4371);
+Obj _35reg4373 = primCons(_35val4368, _35reg4372);
+Obj _35reg4374 = primCons(intern("if"), _35reg4373);
+co->nargs = 2;
+co->args[1] = _35reg4374;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1099(struct Cora* co) {
-Obj _35val327 = co->args[1];
+void _35clofun5133(struct Cora* co) {
+Obj _35val4361 = co->args[1];
 Obj action = co->stack[co->base + 0];
 Obj cc = co->stack[co->base + 1];
-pushCont(co, _35clofun1100, 2, cc, _35val327);
+pushCont(co, _35clofun5134, 2, cc, _35val4361);
+co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = action;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4621,30 +4662,31 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1100(struct Cora* co) {
-Obj _35val328 = co->args[1];
+void _35clofun5134(struct Cora* co) {
+Obj _35val4362 = co->args[1];
 Obj cc = co->stack[co->base + 0];
-Obj _35val327 = co->stack[co->base + 1];
-Obj _35reg329 = primCons(cc, Nil);
-Obj _35reg330 = primCons(_35reg329, Nil);
-Obj _35reg331 = primCons(_35val328, _35reg330);
-Obj _35reg332 = primCons(_35val327, _35reg331);
-Obj _35reg333 = primCons(intern("if"), _35reg332);
-co->args[1] = _35reg333;
+Obj _35val4361 = co->stack[co->base + 1];
+Obj _35reg4363 = primCons(cc, Nil);
+Obj _35reg4364 = primCons(_35reg4363, Nil);
+Obj _35reg4365 = primCons(_35val4362, _35reg4364);
+Obj _35reg4366 = primCons(_35val4361, _35reg4365);
+Obj _35reg4367 = primCons(intern("if"), _35reg4366);
+co->nargs = 2;
+co->args[1] = _35reg4367;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1091(struct Cora* co) {
+void _35clofun5125(struct Cora* co) {
 Obj pat = co->args[1];
 Obj expr = co->args[2];
 Obj body = co->args[3];
 Obj cc = co->args[4];
-Obj literal_63 = makeNative(_35clofun1092, 1, 0);
-pushCont(co, _35clofun1094, 4, expr, body, cc, pat);
+Obj literal_63 = makeNative(_35clofun5126, 1, 0);
+pushCont(co, _35clofun5128, 4, expr, body, cc, pat);
+co->nargs = 2;
 co->args[0] = literal_63;
 co->args[1] = pat;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4654,46 +4696,49 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1094(struct Cora* co) {
-Obj _35val292 = co->args[1];
+void _35clofun5128(struct Cora* co) {
+Obj _35val4326 = co->args[1];
 Obj expr = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
 Obj pat = co->stack[co->base + 3];
-if (True == _35val292) {
-Obj _35reg293 = primEQ(pat, expr);
-if (True == _35reg293) {
+if (True == _35val4326) {
+Obj _35reg4327 = primEQ(pat, expr);
+if (True == _35reg4327) {
+co->nargs = 2;
 co->args[1] = body;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg294 = primCons(expr, Nil);
-Obj _35reg295 = primCons(pat, _35reg294);
-Obj _35reg296 = primCons(intern("="), _35reg295);
-Obj _35reg297 = primCons(cc, Nil);
-Obj _35reg298 = primCons(_35reg297, Nil);
-Obj _35reg299 = primCons(body, _35reg298);
-Obj _35reg300 = primCons(_35reg296, _35reg299);
-Obj _35reg301 = primCons(intern("if"), _35reg300);
-co->args[1] = _35reg301;
+Obj _35reg4328 = primCons(expr, Nil);
+Obj _35reg4329 = primCons(pat, _35reg4328);
+Obj _35reg4330 = primCons(intern("="), _35reg4329);
+Obj _35reg4331 = primCons(cc, Nil);
+Obj _35reg4332 = primCons(_35reg4331, Nil);
+Obj _35reg4333 = primCons(body, _35reg4332);
+Obj _35reg4334 = primCons(_35reg4330, _35reg4333);
+Obj _35reg4335 = primCons(intern("if"), _35reg4334);
+co->nargs = 2;
+co->args[1] = _35reg4335;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 } else {
-Obj _35reg302 = primIsSymbol(pat);
-if (True == _35reg302) {
-Obj _35reg303 = primCons(body, Nil);
-Obj _35reg304 = primCons(expr, _35reg303);
-Obj _35reg305 = primCons(pat, _35reg304);
-Obj _35reg306 = primCons(intern("let"), _35reg305);
-co->args[1] = _35reg306;
+Obj _35reg4336 = primIsSymbol(pat);
+if (True == _35reg4336) {
+Obj _35reg4337 = primCons(body, Nil);
+Obj _35reg4338 = primCons(expr, _35reg4337);
+Obj _35reg4339 = primCons(pat, _35reg4338);
+Obj _35reg4340 = primCons(intern("let"), _35reg4339);
+co->nargs = 2;
+co->args[1] = _35reg4340;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-pushCont(co, _35clofun1095, 4, expr, body, cc, pat);
+pushCont(co, _35clofun5129, 4, expr, body, cc, pat);
+co->nargs = 2;
 co->args[0] = globalRef(intern("pair?"));
 co->args[1] = pat;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4705,37 +4750,38 @@ return;
 }
 }
 
-void _35clofun1095(struct Cora* co) {
-Obj _35val307 = co->args[1];
+void _35clofun5129(struct Cora* co) {
+Obj _35val4341 = co->args[1];
 Obj expr = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
 Obj pat = co->stack[co->base + 3];
-if (True == _35val307) {
-Obj _35reg308 = primCar(pat);
-Obj _35reg309 = primEQ(_35reg308, intern("quote"));
-if (True == _35reg309) {
-Obj _35reg310 = primCons(expr, Nil);
-Obj _35reg311 = primCons(pat, _35reg310);
-Obj _35reg312 = primCons(intern("="), _35reg311);
-Obj _35reg313 = primCons(cc, Nil);
-Obj _35reg314 = primCons(_35reg313, Nil);
-Obj _35reg315 = primCons(body, _35reg314);
-Obj _35reg316 = primCons(_35reg312, _35reg315);
-Obj _35reg317 = primCons(intern("if"), _35reg316);
-co->args[1] = _35reg317;
+if (True == _35val4341) {
+Obj _35reg4342 = primCar(pat);
+Obj _35reg4343 = primEQ(_35reg4342, intern("quote"));
+if (True == _35reg4343) {
+Obj _35reg4344 = primCons(expr, Nil);
+Obj _35reg4345 = primCons(pat, _35reg4344);
+Obj _35reg4346 = primCons(intern("="), _35reg4345);
+Obj _35reg4347 = primCons(cc, Nil);
+Obj _35reg4348 = primCons(_35reg4347, Nil);
+Obj _35reg4349 = primCons(body, _35reg4348);
+Obj _35reg4350 = primCons(_35reg4346, _35reg4349);
+Obj _35reg4351 = primCons(intern("if"), _35reg4350);
+co->nargs = 2;
+co->args[1] = _35reg4351;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg318 = primCar(pat);
-Obj _35reg319 = primEQ(_35reg318, intern("cons"));
-if (True == _35reg319) {
+Obj _35reg4352 = primCar(pat);
+Obj _35reg4353 = primEQ(_35reg4352, intern("cons"));
+if (True == _35reg4353) {
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match-cons-expander"));
 co->args[1] = pat;
 co->args[2] = expr;
 co->args[3] = body;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4744,9 +4790,9 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no cond match");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4757,11 +4803,11 @@ return;
 }
 }
 } else {
-pushCont(co, _35clofun1096, 0);
+pushCont(co, _35clofun5130, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("str"));
 co->args[1] = makeString1("match fail ");
 co->args[2] = pat;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4772,11 +4818,11 @@ return;
 }
 }
 
-void _35clofun1096(struct Cora* co) {
-Obj _35val320 = co->args[1];
-co->args[0] = globalRef(intern("error"));
-co->args[1] = _35val320;
+void _35clofun5130(struct Cora* co) {
+Obj _35val4354 = co->args[1];
 co->nargs = 2;
+co->args[0] = globalRef(intern("error"));
+co->args[1] = _35val4354;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4786,12 +4832,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1092(struct Cora* co) {
+void _35clofun5126(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun1093, 1, x);
+pushCont(co, _35clofun5127, 1, x);
+co->nargs = 2;
 co->args[0] = globalRef(intern("atom?"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4801,37 +4847,40 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1093(struct Cora* co) {
-Obj _35val289 = co->args[1];
+void _35clofun5127(struct Cora* co) {
+Obj _35val4323 = co->args[1];
 Obj x = co->stack[co->base + 0];
-if (True == _35val289) {
-Obj _35reg290 = primIsSymbol(x);
-Obj _35reg291 = primNot(_35reg290);
-if (True == _35reg291) {
+if (True == _35val4323) {
+Obj _35reg4324 = primIsSymbol(x);
+Obj _35reg4325 = primNot(_35reg4324);
+if (True == _35reg4325) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
+co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 } else {
+co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun1073(struct Cora* co) {
+void _35clofun5107(struct Cora* co) {
 Obj pat = co->args[1];
 Obj expr = co->args[2];
 Obj body = co->args[3];
 Obj cc = co->args[4];
-pushCont(co, _35clofun1074, 4, pat, expr, body, cc);
+pushCont(co, _35clofun5108, 4, pat, expr, body, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = pat;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4841,17 +4890,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1074(struct Cora* co) {
-Obj _35val235 = co->args[1];
+void _35clofun5108(struct Cora* co) {
+Obj _35val4269 = co->args[1];
 Obj pat = co->stack[co->base + 0];
 Obj expr = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-Obj x = _35val235;
-pushCont(co, _35clofun1075, 4, expr, body, x, cc);
+Obj x = _35val4269;
+pushCont(co, _35clofun5109, 4, expr, body, x, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = pat;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4861,23 +4910,23 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1075(struct Cora* co) {
-Obj _35val236 = co->args[1];
+void _35clofun5109(struct Cora* co) {
+Obj _35val4270 = co->args[1];
 Obj expr = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj x = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-Obj y = _35val236;
-Obj _35reg237 = primIsCons(expr);
-if (True == _35reg237) {
-Obj _35reg238 = primCar(expr);
-Obj _35reg239 = primEQ(_35reg238, intern("cons"));
-if (True == _35reg239) {
+Obj y = _35val4270;
+Obj _35reg4271 = primIsCons(expr);
+if (True == _35reg4271) {
+Obj _35reg4272 = primCar(expr);
+Obj _35reg4273 = primEQ(_35reg4272, intern("cons"));
+if (True == _35reg4273) {
 if (True == True) {
-pushCont(co, _35clofun1076, 5, expr, y, body, x, cc);
+pushCont(co, _35clofun5110, 5, expr, y, body, x, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = expr;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4886,19 +4935,19 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg243 = primCons(expr, Nil);
-Obj _35reg244 = primCons(intern("cons?"), _35reg243);
-Obj _35reg245 = primCons(expr, Nil);
-Obj _35reg246 = primCons(intern("car"), _35reg245);
-Obj _35reg247 = primCons(expr, Nil);
-Obj _35reg248 = primCons(intern("cdr"), _35reg247);
-pushCont(co, _35clofun1079, 4, x, _35reg246, cc, _35reg244);
+Obj _35reg4277 = primCons(expr, Nil);
+Obj _35reg4278 = primCons(intern("cons?"), _35reg4277);
+Obj _35reg4279 = primCons(expr, Nil);
+Obj _35reg4280 = primCons(intern("car"), _35reg4279);
+Obj _35reg4281 = primCons(expr, Nil);
+Obj _35reg4282 = primCons(intern("cdr"), _35reg4281);
+pushCont(co, _35clofun5113, 4, x, _35reg4280, cc, _35reg4278);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = y;
-co->args[2] = _35reg248;
+co->args[2] = _35reg4282;
 co->args[3] = body;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4909,10 +4958,10 @@ return;
 }
 } else {
 if (True == False) {
-pushCont(co, _35clofun1081, 5, expr, y, body, x, cc);
+pushCont(co, _35clofun5115, 5, expr, y, body, x, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = expr;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4921,19 +4970,19 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg259 = primCons(expr, Nil);
-Obj _35reg260 = primCons(intern("cons?"), _35reg259);
-Obj _35reg261 = primCons(expr, Nil);
-Obj _35reg262 = primCons(intern("car"), _35reg261);
-Obj _35reg263 = primCons(expr, Nil);
-Obj _35reg264 = primCons(intern("cdr"), _35reg263);
-pushCont(co, _35clofun1084, 4, x, _35reg262, cc, _35reg260);
+Obj _35reg4293 = primCons(expr, Nil);
+Obj _35reg4294 = primCons(intern("cons?"), _35reg4293);
+Obj _35reg4295 = primCons(expr, Nil);
+Obj _35reg4296 = primCons(intern("car"), _35reg4295);
+Obj _35reg4297 = primCons(expr, Nil);
+Obj _35reg4298 = primCons(intern("cdr"), _35reg4297);
+pushCont(co, _35clofun5118, 4, x, _35reg4296, cc, _35reg4294);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = y;
-co->args[2] = _35reg264;
+co->args[2] = _35reg4298;
 co->args[3] = body;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4945,10 +4994,10 @@ return;
 }
 } else {
 if (True == False) {
-pushCont(co, _35clofun1086, 5, expr, y, body, x, cc);
+pushCont(co, _35clofun5120, 5, expr, y, body, x, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = expr;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4957,19 +5006,19 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg275 = primCons(expr, Nil);
-Obj _35reg276 = primCons(intern("cons?"), _35reg275);
-Obj _35reg277 = primCons(expr, Nil);
-Obj _35reg278 = primCons(intern("car"), _35reg277);
-Obj _35reg279 = primCons(expr, Nil);
-Obj _35reg280 = primCons(intern("cdr"), _35reg279);
-pushCont(co, _35clofun1089, 4, x, _35reg278, cc, _35reg276);
+Obj _35reg4309 = primCons(expr, Nil);
+Obj _35reg4310 = primCons(intern("cons?"), _35reg4309);
+Obj _35reg4311 = primCons(expr, Nil);
+Obj _35reg4312 = primCons(intern("car"), _35reg4311);
+Obj _35reg4313 = primCons(expr, Nil);
+Obj _35reg4314 = primCons(intern("cdr"), _35reg4313);
+pushCont(co, _35clofun5123, 4, x, _35reg4312, cc, _35reg4310);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = y;
-co->args[2] = _35reg280;
+co->args[2] = _35reg4314;
 co->args[3] = body;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4981,19 +5030,19 @@ return;
 }
 }
 
-void _35clofun1089(struct Cora* co) {
-Obj _35val281 = co->args[1];
+void _35clofun5123(struct Cora* co) {
+Obj _35val4315 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35reg278 = co->stack[co->base + 1];
+Obj _35reg4312 = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
-Obj _35reg276 = co->stack[co->base + 3];
-pushCont(co, _35clofun1090, 2, cc, _35reg276);
+Obj _35reg4310 = co->stack[co->base + 3];
+pushCont(co, _35clofun5124, 2, cc, _35reg4310);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = x;
-co->args[2] = _35reg278;
-co->args[3] = _35val281;
+co->args[2] = _35reg4312;
+co->args[3] = _35val4315;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5003,32 +5052,33 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1090(struct Cora* co) {
-Obj _35val282 = co->args[1];
+void _35clofun5124(struct Cora* co) {
+Obj _35val4316 = co->args[1];
 Obj cc = co->stack[co->base + 0];
-Obj _35reg276 = co->stack[co->base + 1];
-Obj _35reg283 = primCons(cc, Nil);
-Obj _35reg284 = primCons(_35reg283, Nil);
-Obj _35reg285 = primCons(_35val282, _35reg284);
-Obj _35reg286 = primCons(_35reg276, _35reg285);
-Obj _35reg287 = primCons(intern("if"), _35reg286);
-co->args[1] = _35reg287;
+Obj _35reg4310 = co->stack[co->base + 1];
+Obj _35reg4317 = primCons(cc, Nil);
+Obj _35reg4318 = primCons(_35reg4317, Nil);
+Obj _35reg4319 = primCons(_35val4316, _35reg4318);
+Obj _35reg4320 = primCons(_35reg4310, _35reg4319);
+Obj _35reg4321 = primCons(intern("if"), _35reg4320);
+co->nargs = 2;
+co->args[1] = _35reg4321;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1086(struct Cora* co) {
-Obj _35val272 = co->args[1];
+void _35clofun5120(struct Cora* co) {
+Obj _35val4306 = co->args[1];
 Obj expr = co->stack[co->base + 0];
 Obj y = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj x = co->stack[co->base + 3];
 Obj cc = co->stack[co->base + 4];
-Obj e1 = _35val272;
-pushCont(co, _35clofun1087, 5, y, body, x, e1, cc);
+Obj e1 = _35val4306;
+pushCont(co, _35clofun5121, 5, y, body, x, e1, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = expr;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5038,21 +5088,21 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1087(struct Cora* co) {
-Obj _35val273 = co->args[1];
+void _35clofun5121(struct Cora* co) {
+Obj _35val4307 = co->args[1];
 Obj y = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj x = co->stack[co->base + 2];
 Obj e1 = co->stack[co->base + 3];
 Obj cc = co->stack[co->base + 4];
-Obj e2 = _35val273;
-pushCont(co, _35clofun1088, 3, x, e1, cc);
+Obj e2 = _35val4307;
+pushCont(co, _35clofun5122, 3, x, e1, cc);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = y;
 co->args[2] = e2;
 co->args[3] = body;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5062,17 +5112,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1088(struct Cora* co) {
-Obj _35val274 = co->args[1];
+void _35clofun5122(struct Cora* co) {
+Obj _35val4308 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj e1 = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = x;
 co->args[2] = e1;
-co->args[3] = _35val274;
+co->args[3] = _35val4308;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5082,19 +5132,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1084(struct Cora* co) {
-Obj _35val265 = co->args[1];
+void _35clofun5118(struct Cora* co) {
+Obj _35val4299 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35reg262 = co->stack[co->base + 1];
+Obj _35reg4296 = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
-Obj _35reg260 = co->stack[co->base + 3];
-pushCont(co, _35clofun1085, 2, cc, _35reg260);
+Obj _35reg4294 = co->stack[co->base + 3];
+pushCont(co, _35clofun5119, 2, cc, _35reg4294);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = x;
-co->args[2] = _35reg262;
-co->args[3] = _35val265;
+co->args[2] = _35reg4296;
+co->args[3] = _35val4299;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5104,32 +5154,33 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1085(struct Cora* co) {
-Obj _35val266 = co->args[1];
+void _35clofun5119(struct Cora* co) {
+Obj _35val4300 = co->args[1];
 Obj cc = co->stack[co->base + 0];
-Obj _35reg260 = co->stack[co->base + 1];
-Obj _35reg267 = primCons(cc, Nil);
-Obj _35reg268 = primCons(_35reg267, Nil);
-Obj _35reg269 = primCons(_35val266, _35reg268);
-Obj _35reg270 = primCons(_35reg260, _35reg269);
-Obj _35reg271 = primCons(intern("if"), _35reg270);
-co->args[1] = _35reg271;
+Obj _35reg4294 = co->stack[co->base + 1];
+Obj _35reg4301 = primCons(cc, Nil);
+Obj _35reg4302 = primCons(_35reg4301, Nil);
+Obj _35reg4303 = primCons(_35val4300, _35reg4302);
+Obj _35reg4304 = primCons(_35reg4294, _35reg4303);
+Obj _35reg4305 = primCons(intern("if"), _35reg4304);
+co->nargs = 2;
+co->args[1] = _35reg4305;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1081(struct Cora* co) {
-Obj _35val256 = co->args[1];
+void _35clofun5115(struct Cora* co) {
+Obj _35val4290 = co->args[1];
 Obj expr = co->stack[co->base + 0];
 Obj y = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj x = co->stack[co->base + 3];
 Obj cc = co->stack[co->base + 4];
-Obj e1 = _35val256;
-pushCont(co, _35clofun1082, 5, y, body, x, e1, cc);
+Obj e1 = _35val4290;
+pushCont(co, _35clofun5116, 5, y, body, x, e1, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = expr;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5139,21 +5190,21 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1082(struct Cora* co) {
-Obj _35val257 = co->args[1];
+void _35clofun5116(struct Cora* co) {
+Obj _35val4291 = co->args[1];
 Obj y = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj x = co->stack[co->base + 2];
 Obj e1 = co->stack[co->base + 3];
 Obj cc = co->stack[co->base + 4];
-Obj e2 = _35val257;
-pushCont(co, _35clofun1083, 3, x, e1, cc);
+Obj e2 = _35val4291;
+pushCont(co, _35clofun5117, 3, x, e1, cc);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = y;
 co->args[2] = e2;
 co->args[3] = body;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5163,17 +5214,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1083(struct Cora* co) {
-Obj _35val258 = co->args[1];
+void _35clofun5117(struct Cora* co) {
+Obj _35val4292 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj e1 = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = x;
 co->args[2] = e1;
-co->args[3] = _35val258;
+co->args[3] = _35val4292;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5183,19 +5234,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1079(struct Cora* co) {
-Obj _35val249 = co->args[1];
+void _35clofun5113(struct Cora* co) {
+Obj _35val4283 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35reg246 = co->stack[co->base + 1];
+Obj _35reg4280 = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
-Obj _35reg244 = co->stack[co->base + 3];
-pushCont(co, _35clofun1080, 2, cc, _35reg244);
+Obj _35reg4278 = co->stack[co->base + 3];
+pushCont(co, _35clofun5114, 2, cc, _35reg4278);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = x;
-co->args[2] = _35reg246;
-co->args[3] = _35val249;
+co->args[2] = _35reg4280;
+co->args[3] = _35val4283;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5205,32 +5256,33 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1080(struct Cora* co) {
-Obj _35val250 = co->args[1];
+void _35clofun5114(struct Cora* co) {
+Obj _35val4284 = co->args[1];
 Obj cc = co->stack[co->base + 0];
-Obj _35reg244 = co->stack[co->base + 1];
-Obj _35reg251 = primCons(cc, Nil);
-Obj _35reg252 = primCons(_35reg251, Nil);
-Obj _35reg253 = primCons(_35val250, _35reg252);
-Obj _35reg254 = primCons(_35reg244, _35reg253);
-Obj _35reg255 = primCons(intern("if"), _35reg254);
-co->args[1] = _35reg255;
+Obj _35reg4278 = co->stack[co->base + 1];
+Obj _35reg4285 = primCons(cc, Nil);
+Obj _35reg4286 = primCons(_35reg4285, Nil);
+Obj _35reg4287 = primCons(_35val4284, _35reg4286);
+Obj _35reg4288 = primCons(_35reg4278, _35reg4287);
+Obj _35reg4289 = primCons(intern("if"), _35reg4288);
+co->nargs = 2;
+co->args[1] = _35reg4289;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1076(struct Cora* co) {
-Obj _35val240 = co->args[1];
+void _35clofun5110(struct Cora* co) {
+Obj _35val4274 = co->args[1];
 Obj expr = co->stack[co->base + 0];
 Obj y = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj x = co->stack[co->base + 3];
 Obj cc = co->stack[co->base + 4];
-Obj e1 = _35val240;
-pushCont(co, _35clofun1077, 5, y, body, x, e1, cc);
+Obj e1 = _35val4274;
+pushCont(co, _35clofun5111, 5, y, body, x, e1, cc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = expr;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5240,21 +5292,21 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1077(struct Cora* co) {
-Obj _35val241 = co->args[1];
+void _35clofun5111(struct Cora* co) {
+Obj _35val4275 = co->args[1];
 Obj y = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj x = co->stack[co->base + 2];
 Obj e1 = co->stack[co->base + 3];
 Obj cc = co->stack[co->base + 4];
-Obj e2 = _35val241;
-pushCont(co, _35clofun1078, 3, x, e1, cc);
+Obj e2 = _35val4275;
+pushCont(co, _35clofun5112, 3, x, e1, cc);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = y;
 co->args[2] = e2;
 co->args[3] = body;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5264,17 +5316,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1078(struct Cora* co) {
-Obj _35val242 = co->args[1];
+void _35clofun5112(struct Cora* co) {
+Obj _35val4276 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj e1 = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = x;
 co->args[2] = e1;
-co->args[3] = _35val242;
+co->args[3] = _35val4276;
 co->args[4] = cc;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5284,12 +5336,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1071(struct Cora* co) {
+void _35clofun5105(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg233 = primCdr(exp);
-co->args[0] = globalRef(intern("cora/init.rcons1"));
-co->args[1] = _35reg233;
+Obj _35reg4267 = primCdr(exp);
 co->nargs = 2;
+co->args[0] = globalRef(intern("cora/init.rcons1"));
+co->args[1] = _35reg4267;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5299,13 +5351,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1068(struct Cora* co) {
+void _35clofun5102(struct Cora* co) {
 Obj pat = co->args[1];
-Obj _35reg223 = primCdr(pat);
-pushCont(co, _35clofun1069, 1, pat);
+Obj _35reg4257 = primCdr(pat);
+pushCont(co, _35clofun5103, 1, pat);
+co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
-co->args[1] = _35reg223;
-co->nargs = 2;
+co->args[1] = _35reg4257;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5315,21 +5367,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1069(struct Cora* co) {
-Obj _35val224 = co->args[1];
+void _35clofun5103(struct Cora* co) {
+Obj _35val4258 = co->args[1];
 Obj pat = co->stack[co->base + 0];
-if (True == _35val224) {
-Obj _35reg225 = primCar(pat);
-co->args[1] = _35reg225;
+if (True == _35val4258) {
+Obj _35reg4259 = primCar(pat);
+co->nargs = 2;
+co->args[1] = _35reg4259;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg226 = primCar(pat);
-Obj _35reg227 = primCdr(pat);
-pushCont(co, _35clofun1070, 1, _35reg226);
+Obj _35reg4260 = primCar(pat);
+Obj _35reg4261 = primCdr(pat);
+pushCont(co, _35clofun5104, 1, _35reg4260);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rcons1"));
-co->args[1] = _35reg227;
-co->nargs = 2;
+co->args[1] = _35reg4261;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5340,31 +5393,35 @@ return;
 }
 }
 
-void _35clofun1070(struct Cora* co) {
-Obj _35val228 = co->args[1];
-Obj _35reg226 = co->stack[co->base + 0];
-Obj _35reg229 = primCons(_35val228, Nil);
-Obj _35reg230 = primCons(_35reg226, _35reg229);
-Obj _35reg231 = primCons(intern("cons"), _35reg230);
-co->args[1] = _35reg231;
+void _35clofun5104(struct Cora* co) {
+Obj _35val4262 = co->args[1];
+Obj _35reg4260 = co->stack[co->base + 0];
+Obj _35reg4263 = primCons(_35val4262, Nil);
+Obj _35reg4264 = primCons(_35reg4260, _35reg4263);
+Obj _35reg4265 = primCons(intern("cons"), _35reg4264);
+co->nargs = 2;
+co->args[1] = _35reg4265;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1067(struct Cora* co) {
+void _35clofun5101(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg220 = primEQ(x, True);
-if (True == _35reg220) {
+Obj _35reg4254 = primEQ(x, True);
+if (True == _35reg4254) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg221 = primEQ(x, False);
-if (True == _35reg221) {
+Obj _35reg4255 = primEQ(x, False);
+if (True == _35reg4255) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
+co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
@@ -5372,12 +5429,12 @@ return;
 }
 }
 
-void _35clofun1065(struct Cora* co) {
+void _35clofun5099(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg218 = primCdr(exp);
+Obj _35reg4252 = primCdr(exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-and"));
-co->args[1] = _35reg218;
-co->nargs = 2;
+co->args[1] = _35reg4252;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5387,26 +5444,28 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1063(struct Cora* co) {
+void _35clofun5097(struct Cora* co) {
 Obj l = co->args[1];
-Obj _35reg206 = primEQ(Nil, l);
-if (True == _35reg206) {
+Obj _35reg4240 = primEQ(Nil, l);
+if (True == _35reg4240) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg207 = primCar(l);
-Obj _35reg208 = primEQ(_35reg207, False);
-if (True == _35reg208) {
+Obj _35reg4241 = primCar(l);
+Obj _35reg4242 = primEQ(_35reg4241, False);
+if (True == _35reg4242) {
+co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg209 = primCdr(l);
-pushCont(co, _35clofun1064, 1, l);
+Obj _35reg4243 = primCdr(l);
+pushCont(co, _35clofun5098, 1, l);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-and"));
-co->args[1] = _35reg209;
-co->nargs = 2;
+co->args[1] = _35reg4243;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5418,33 +5477,35 @@ return;
 }
 }
 
-void _35clofun1064(struct Cora* co) {
-Obj _35val210 = co->args[1];
+void _35clofun5098(struct Cora* co) {
+Obj _35val4244 = co->args[1];
 Obj l = co->stack[co->base + 0];
-Obj more = _35val210;
-Obj _35reg211 = primEQ(more, False);
-if (True == _35reg211) {
+Obj more = _35val4244;
+Obj _35reg4245 = primEQ(more, False);
+if (True == _35reg4245) {
+co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg212 = primCar(l);
-Obj _35reg213 = primCons(False, Nil);
-Obj _35reg214 = primCons(more, _35reg213);
-Obj _35reg215 = primCons(_35reg212, _35reg214);
-Obj _35reg216 = primCons(intern("if"), _35reg215);
-co->args[1] = _35reg216;
+Obj _35reg4246 = primCar(l);
+Obj _35reg4247 = primCons(False, Nil);
+Obj _35reg4248 = primCons(more, _35reg4247);
+Obj _35reg4249 = primCons(_35reg4246, _35reg4248);
+Obj _35reg4250 = primCons(intern("if"), _35reg4249);
+co->nargs = 2;
+co->args[1] = _35reg4250;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun1061(struct Cora* co) {
+void _35clofun5095(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg204 = primCdr(exp);
-co->args[0] = globalRef(intern("cora/init.rewrite-or"));
-co->args[1] = _35reg204;
+Obj _35reg4238 = primCdr(exp);
 co->nargs = 2;
+co->args[0] = globalRef(intern("cora/init.rewrite-or"));
+co->args[1] = _35reg4238;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5454,26 +5515,28 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1059(struct Cora* co) {
+void _35clofun5093(struct Cora* co) {
 Obj l = co->args[1];
-Obj _35reg192 = primEQ(l, Nil);
-if (True == _35reg192) {
+Obj _35reg4226 = primEQ(l, Nil);
+if (True == _35reg4226) {
+co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg193 = primCar(l);
-Obj _35reg194 = primEQ(_35reg193, True);
-if (True == _35reg194) {
+Obj _35reg4227 = primCar(l);
+Obj _35reg4228 = primEQ(_35reg4227, True);
+if (True == _35reg4228) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg195 = primCdr(l);
-pushCont(co, _35clofun1060, 1, l);
-co->args[0] = globalRef(intern("cora/init.rewrite-or"));
-co->args[1] = _35reg195;
+Obj _35reg4229 = primCdr(l);
+pushCont(co, _35clofun5094, 1, l);
 co->nargs = 2;
+co->args[0] = globalRef(intern("cora/init.rewrite-or"));
+co->args[1] = _35reg4229;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5485,42 +5548,45 @@ return;
 }
 }
 
-void _35clofun1060(struct Cora* co) {
-Obj _35val196 = co->args[1];
+void _35clofun5094(struct Cora* co) {
+Obj _35val4230 = co->args[1];
 Obj l = co->stack[co->base + 0];
-Obj more = _35val196;
-Obj _35reg197 = primEQ(more, True);
-if (True == _35reg197) {
+Obj more = _35val4230;
+Obj _35reg4231 = primEQ(more, True);
+if (True == _35reg4231) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg198 = primCar(l);
-Obj _35reg199 = primCons(more, Nil);
-Obj _35reg200 = primCons(True, _35reg199);
-Obj _35reg201 = primCons(_35reg198, _35reg200);
-Obj _35reg202 = primCons(intern("if"), _35reg201);
-co->args[1] = _35reg202;
+Obj _35reg4232 = primCar(l);
+Obj _35reg4233 = primCons(more, Nil);
+Obj _35reg4234 = primCons(True, _35reg4233);
+Obj _35reg4235 = primCons(_35reg4232, _35reg4234);
+Obj _35reg4236 = primCons(intern("if"), _35reg4235);
+co->nargs = 2;
+co->args[1] = _35reg4236;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun1054(struct Cora* co) {
+void _35clofun5088(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg178 = primCdr(exp);
-Obj _35reg179 = primEQ(Nil, _35reg178);
-if (True == _35reg179) {
-Obj _35reg180 = primCons(makeString1("no cond match"), Nil);
-Obj _35reg181 = primCons(intern("error"), _35reg180);
-co->args[1] = _35reg181;
+Obj _35reg4212 = primCdr(exp);
+Obj _35reg4213 = primEQ(Nil, _35reg4212);
+if (True == _35reg4213) {
+Obj _35reg4214 = primCons(makeString1("no cond match"), Nil);
+Obj _35reg4215 = primCons(intern("error"), _35reg4214);
+co->nargs = 2;
+co->args[1] = _35reg4215;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-pushCont(co, _35clofun1055, 1, exp);
+pushCont(co, _35clofun5089, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5531,15 +5597,15 @@ return;
 }
 }
 
-void _35clofun1055(struct Cora* co) {
-Obj _35val182 = co->args[1];
+void _35clofun5089(struct Cora* co) {
+Obj _35val4216 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj curr = _35val182;
-Obj _35reg183 = primCar(curr);
-pushCont(co, _35clofun1056, 2, exp, _35reg183);
+Obj curr = _35val4216;
+Obj _35reg4217 = primCar(curr);
+pushCont(co, _35clofun5090, 2, exp, _35reg4217);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = curr;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5549,14 +5615,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1056(struct Cora* co) {
-Obj _35val184 = co->args[1];
+void _35clofun5090(struct Cora* co) {
+Obj _35val4218 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg183 = co->stack[co->base + 1];
-pushCont(co, _35clofun1057, 2, _35val184, _35reg183);
+Obj _35reg4217 = co->stack[co->base + 1];
+pushCont(co, _35clofun5091, 2, _35val4218, _35reg4217);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cddr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5566,26 +5632,27 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1057(struct Cora* co) {
-Obj _35val185 = co->args[1];
-Obj _35val184 = co->stack[co->base + 0];
-Obj _35reg183 = co->stack[co->base + 1];
-Obj _35reg186 = primCons(intern("cond"), _35val185);
-Obj _35reg187 = primCons(_35reg186, Nil);
-Obj _35reg188 = primCons(_35val184, _35reg187);
-Obj _35reg189 = primCons(_35reg183, _35reg188);
-Obj _35reg190 = primCons(intern("if"), _35reg189);
-co->args[1] = _35reg190;
+void _35clofun5091(struct Cora* co) {
+Obj _35val4219 = co->args[1];
+Obj _35val4218 = co->stack[co->base + 0];
+Obj _35reg4217 = co->stack[co->base + 1];
+Obj _35reg4220 = primCons(intern("cond"), _35val4219);
+Obj _35reg4221 = primCons(_35reg4220, Nil);
+Obj _35reg4222 = primCons(_35val4218, _35reg4221);
+Obj _35reg4223 = primCons(_35reg4217, _35reg4222);
+Obj _35reg4224 = primCons(intern("if"), _35reg4223);
+co->nargs = 2;
+co->args[1] = _35reg4224;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1052(struct Cora* co) {
+void _35clofun5086(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg176 = primCdr(exp);
+Obj _35reg4210 = primCdr(exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-let"));
-co->args[1] = _35reg176;
-co->nargs = 2;
+co->args[1] = _35reg4210;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5595,13 +5662,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1047(struct Cora* co) {
+void _35clofun5081(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg164 = primCdr(exp);
-pushCont(co, _35clofun1048, 1, exp);
-co->args[0] = globalRef(intern("null?"));
-co->args[1] = _35reg164;
+Obj _35reg4198 = primCdr(exp);
+pushCont(co, _35clofun5082, 1, exp);
 co->nargs = 2;
+co->args[0] = globalRef(intern("null?"));
+co->args[1] = _35reg4198;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5611,20 +5678,21 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1048(struct Cora* co) {
-Obj _35val165 = co->args[1];
+void _35clofun5082(struct Cora* co) {
+Obj _35val4199 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-if (True == _35val165) {
-Obj _35reg166 = primCar(exp);
-co->args[1] = _35reg166;
+if (True == _35val4199) {
+Obj _35reg4200 = primCar(exp);
+co->nargs = 2;
+co->args[1] = _35reg4200;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg167 = primCar(exp);
-pushCont(co, _35clofun1049, 2, exp, _35reg167);
+Obj _35reg4201 = primCar(exp);
+pushCont(co, _35clofun5083, 2, exp, _35reg4201);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5635,14 +5703,14 @@ return;
 }
 }
 
-void _35clofun1049(struct Cora* co) {
-Obj _35val168 = co->args[1];
+void _35clofun5083(struct Cora* co) {
+Obj _35val4202 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg167 = co->stack[co->base + 1];
-pushCont(co, _35clofun1050, 2, _35val168, _35reg167);
+Obj _35reg4201 = co->stack[co->base + 1];
+pushCont(co, _35clofun5084, 2, _35val4202, _35reg4201);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cddr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5652,14 +5720,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1050(struct Cora* co) {
-Obj _35val169 = co->args[1];
-Obj _35val168 = co->stack[co->base + 0];
-Obj _35reg167 = co->stack[co->base + 1];
-pushCont(co, _35clofun1051, 2, _35val168, _35reg167);
+void _35clofun5084(struct Cora* co) {
+Obj _35val4203 = co->args[1];
+Obj _35val4202 = co->stack[co->base + 0];
+Obj _35reg4201 = co->stack[co->base + 1];
+pushCont(co, _35clofun5085, 2, _35val4202, _35reg4201);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-let"));
-co->args[1] = _35val169;
-co->nargs = 2;
+co->args[1] = _35val4203;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5669,45 +5737,48 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1051(struct Cora* co) {
-Obj _35val170 = co->args[1];
-Obj _35val168 = co->stack[co->base + 0];
-Obj _35reg167 = co->stack[co->base + 1];
-Obj _35reg171 = primCons(_35val170, Nil);
-Obj _35reg172 = primCons(_35val168, _35reg171);
-Obj _35reg173 = primCons(_35reg167, _35reg172);
-Obj _35reg174 = primCons(intern("let"), _35reg173);
-co->args[1] = _35reg174;
+void _35clofun5085(struct Cora* co) {
+Obj _35val4204 = co->args[1];
+Obj _35val4202 = co->stack[co->base + 0];
+Obj _35reg4201 = co->stack[co->base + 1];
+Obj _35reg4205 = primCons(_35val4204, Nil);
+Obj _35reg4206 = primCons(_35val4202, _35reg4205);
+Obj _35reg4207 = primCons(_35reg4201, _35reg4206);
+Obj _35reg4208 = primCons(intern("let"), _35reg4207);
+co->nargs = 2;
+co->args[1] = _35reg4208;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1046(struct Cora* co) {
+void _35clofun5080(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg161 = primIsCons(x);
-Obj _35reg162 = primNot(_35reg161);
-co->args[1] = _35reg162;
+Obj _35reg4195 = primIsCons(x);
+Obj _35reg4196 = primNot(_35reg4195);
+co->nargs = 2;
+co->args[1] = _35reg4196;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1045(struct Cora* co) {
+void _35clofun5079(struct Cora* co) {
 Obj x = co->args[1];
 Obj l = co->args[2];
-Obj _35reg156 = primIsCons(l);
-if (True == _35reg156) {
-Obj _35reg157 = primCar(l);
-Obj _35reg158 = primEQ(_35reg157, x);
-if (True == _35reg158) {
+Obj _35reg4190 = primIsCons(l);
+if (True == _35reg4190) {
+Obj _35reg4191 = primCar(l);
+Obj _35reg4192 = primEQ(_35reg4191, x);
+if (True == _35reg4192) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg159 = primCdr(l);
+Obj _35reg4193 = primCdr(l);
+co->nargs = 3;
 co->args[0] = globalRef(intern("elem?"));
 co->args[1] = x;
-co->args[2] = _35reg159;
-co->nargs = 3;
+co->args[2] = _35reg4193;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5717,18 +5788,19 @@ co->pc = coraCall;
 return;
 }
 } else {
+co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun1040(struct Cora* co) {
+void _35clofun5074(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun1041, 1, exp);
+pushCont(co, _35clofun5075, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5738,15 +5810,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1041(struct Cora* co) {
-Obj _35val144 = co->args[1];
+void _35clofun5075(struct Cora* co) {
+Obj _35val4178 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg145 = primCons(_35val144, Nil);
-Obj _35reg146 = primCons(intern("quote"), _35reg145);
-pushCont(co, _35clofun1042, 2, exp, _35reg146);
+Obj _35reg4179 = primCons(_35val4178, Nil);
+Obj _35reg4180 = primCons(intern("quote"), _35reg4179);
+pushCont(co, _35clofun5076, 2, exp, _35reg4180);
+co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5756,14 +5828,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1042(struct Cora* co) {
-Obj _35val147 = co->args[1];
+void _35clofun5076(struct Cora* co) {
+Obj _35val4181 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg146 = co->stack[co->base + 1];
-pushCont(co, _35clofun1043, 2, _35val147, _35reg146);
+Obj _35reg4180 = co->stack[co->base + 1];
+pushCont(co, _35clofun5077, 2, _35val4181, _35reg4180);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadddr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5773,27 +5845,28 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1043(struct Cora* co) {
-Obj _35val148 = co->args[1];
-Obj _35val147 = co->stack[co->base + 0];
-Obj _35reg146 = co->stack[co->base + 1];
-Obj _35reg149 = primCons(_35val148, Nil);
-Obj _35reg150 = primCons(_35val147, _35reg149);
-Obj _35reg151 = primCons(intern("lambda"), _35reg150);
-Obj _35reg152 = primCons(_35reg151, Nil);
-Obj _35reg153 = primCons(_35reg146, _35reg152);
-Obj _35reg154 = primCons(intern("set"), _35reg153);
-co->args[1] = _35reg154;
+void _35clofun5077(struct Cora* co) {
+Obj _35val4182 = co->args[1];
+Obj _35val4181 = co->stack[co->base + 0];
+Obj _35reg4180 = co->stack[co->base + 1];
+Obj _35reg4183 = primCons(_35val4182, Nil);
+Obj _35reg4184 = primCons(_35val4181, _35reg4183);
+Obj _35reg4185 = primCons(intern("lambda"), _35reg4184);
+Obj _35reg4186 = primCons(_35reg4185, Nil);
+Obj _35reg4187 = primCons(_35reg4180, _35reg4186);
+Obj _35reg4188 = primCons(intern("set"), _35reg4187);
+co->nargs = 2;
+co->args[1] = _35reg4188;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1038(struct Cora* co) {
+void _35clofun5072(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg142 = primCdr(exp);
-co->args[0] = globalRef(intern("rcons"));
-co->args[1] = _35reg142;
+Obj _35reg4176 = primCdr(exp);
 co->nargs = 2;
+co->args[0] = globalRef(intern("rcons"));
+co->args[1] = _35reg4176;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5803,12 +5876,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1033(struct Cora* co) {
+void _35clofun5067(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun1034, 1, exp);
+pushCont(co, _35clofun5068, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5818,15 +5891,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1034(struct Cora* co) {
-Obj _35val130 = co->args[1];
+void _35clofun5068(struct Cora* co) {
+Obj _35val4164 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg131 = primCons(_35val130, Nil);
-Obj _35reg132 = primCons(intern("quote"), _35reg131);
-pushCont(co, _35clofun1035, 2, exp, _35reg132);
+Obj _35reg4165 = primCons(_35val4164, Nil);
+Obj _35reg4166 = primCons(intern("quote"), _35reg4165);
+pushCont(co, _35clofun5069, 2, exp, _35reg4166);
+co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5836,14 +5909,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1035(struct Cora* co) {
-Obj _35val133 = co->args[1];
+void _35clofun5069(struct Cora* co) {
+Obj _35val4167 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg132 = co->stack[co->base + 1];
-pushCont(co, _35clofun1036, 2, _35val133, _35reg132);
+Obj _35reg4166 = co->stack[co->base + 1];
+pushCont(co, _35clofun5070, 2, _35val4167, _35reg4166);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cdddr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5853,39 +5926,41 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1036(struct Cora* co) {
-Obj _35val134 = co->args[1];
-Obj _35val133 = co->stack[co->base + 0];
-Obj _35reg132 = co->stack[co->base + 1];
-Obj _35reg135 = primCons(_35val133, _35val134);
-Obj _35reg136 = primCons(intern("lambda"), _35reg135);
-Obj _35reg137 = primCons(_35reg136, Nil);
-Obj _35reg138 = primCons(_35reg132, _35reg137);
-Obj _35reg139 = primCons(intern("cora/init.add-to-*macros*"), _35reg138);
-co->args[1] = _35reg139;
+void _35clofun5070(struct Cora* co) {
+Obj _35val4168 = co->args[1];
+Obj _35val4167 = co->stack[co->base + 0];
+Obj _35reg4166 = co->stack[co->base + 1];
+Obj _35reg4169 = primCons(_35val4167, _35val4168);
+Obj _35reg4170 = primCons(intern("lambda"), _35reg4169);
+Obj _35reg4171 = primCons(_35reg4170, Nil);
+Obj _35reg4172 = primCons(_35reg4166, _35reg4171);
+Obj _35reg4173 = primCons(intern("cora/init.add-to-*macros*"), _35reg4172);
+co->nargs = 2;
+co->args[1] = _35reg4173;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1027(struct Cora* co) {
+void _35clofun5061(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg112 = primIsCons(exp);
-if (True == _35reg112) {
-Obj _35reg113 = primCar(exp);
-Obj _35reg114 = primEQ(_35reg113, globalRef(intern("*protect-symbol*")));
-if (True == _35reg114) {
-Obj _35reg115 = primCdr(exp);
-co->args[1] = _35reg115;
+Obj _35reg4146 = primIsCons(exp);
+if (True == _35reg4146) {
+Obj _35reg4147 = primCar(exp);
+Obj _35reg4148 = primEQ(_35reg4147, globalRef(intern("*protect-symbol*")));
+if (True == _35reg4148) {
+Obj _35reg4149 = primCdr(exp);
+co->nargs = 2;
+co->args[1] = _35reg4149;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg116 = primCar(exp);
-Obj _35reg117 = primEQ(_35reg116, intern("lambda"));
-if (True == _35reg117) {
-pushCont(co, _35clofun1028, 1, exp);
+Obj _35reg4150 = primCar(exp);
+Obj _35reg4151 = primEQ(_35reg4150, intern("lambda"));
+if (True == _35reg4151) {
+pushCont(co, _35clofun5062, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5894,17 +5969,18 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg124 = primCar(exp);
-Obj _35reg125 = primEQ(_35reg124, intern("quote"));
-if (True == _35reg125) {
+Obj _35reg4158 = primCar(exp);
+Obj _35reg4159 = primEQ(_35reg4158, intern("quote"));
+if (True == _35reg4159) {
+co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-pushCont(co, _35clofun1031, 1, exp);
+pushCont(co, _35clofun5065, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.macroexpand1"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5916,18 +5992,19 @@ return;
 }
 }
 } else {
+co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun1031(struct Cora* co) {
-Obj _35val127 = co->args[1];
+void _35clofun5065(struct Cora* co) {
+Obj _35val4161 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-co->args[0] = makeNative(_35clofun1032, 1, 1, exp);
-co->args[1] = _35val127;
 co->nargs = 2;
+co->args[0] = makeNative(_35clofun5066, 1, 1, exp);
+co->args[1] = _35val4161;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5937,14 +6014,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1032(struct Cora* co) {
+void _35clofun5066(struct Cora* co) {
 Obj exp1 = co->args[1];
-Obj _35reg126 = primEQ(exp1, closureRef(co, 0));
-if (True == _35reg126) {
+Obj _35reg4160 = primEQ(exp1, closureRef(co, 0));
+if (True == _35reg4160) {
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/init.macroexpand-boot"));
 co->args[2] = exp1;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5953,9 +6030,9 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.macroexpand-boot"));
 co->args[1] = exp1;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5966,13 +6043,13 @@ return;
 }
 }
 
-void _35clofun1028(struct Cora* co) {
-Obj _35val118 = co->args[1];
+void _35clofun5062(struct Cora* co) {
+Obj _35val4152 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-pushCont(co, _35clofun1029, 1, _35val118);
+pushCont(co, _35clofun5063, 1, _35val4152);
+co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5982,13 +6059,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1029(struct Cora* co) {
-Obj _35val119 = co->args[1];
-Obj _35val118 = co->stack[co->base + 0];
-pushCont(co, _35clofun1030, 1, _35val118);
+void _35clofun5063(struct Cora* co) {
+Obj _35val4153 = co->args[1];
+Obj _35val4152 = co->stack[co->base + 0];
+pushCont(co, _35clofun5064, 1, _35val4152);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.macroexpand-boot"));
-co->args[1] = _35val119;
-co->nargs = 2;
+co->args[1] = _35val4153;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5998,23 +6075,24 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1030(struct Cora* co) {
-Obj _35val120 = co->args[1];
-Obj _35val118 = co->stack[co->base + 0];
-Obj _35reg121 = primCons(_35val120, Nil);
-Obj _35reg122 = primCons(_35val118, _35reg121);
-Obj _35reg123 = primCons(intern("lambda"), _35reg122);
-co->args[1] = _35reg123;
+void _35clofun5064(struct Cora* co) {
+Obj _35val4154 = co->args[1];
+Obj _35val4152 = co->stack[co->base + 0];
+Obj _35reg4155 = primCons(_35val4154, Nil);
+Obj _35reg4156 = primCons(_35val4152, _35reg4155);
+Obj _35reg4157 = primCons(intern("lambda"), _35reg4156);
+co->nargs = 2;
+co->args[1] = _35reg4157;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1026(struct Cora* co) {
+void _35clofun5060(struct Cora* co) {
 Obj exp = co->args[1];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.macroexpand1-h"));
 co->args[1] = exp;
 co->args[2] = globalRef(intern("*macros*"));
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6024,19 +6102,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1024(struct Cora* co) {
+void _35clofun5058(struct Cora* co) {
 Obj exp = co->args[1];
 Obj macros = co->args[2];
-Obj _35reg98 = primEQ(Nil, macros);
-if (True == _35reg98) {
+Obj _35reg4132 = primEQ(Nil, macros);
+if (True == _35reg4132) {
+co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg109 = primCar(macros);
-co->args[0] = makeNative(_35clofun1025, 1, 2, exp, macros);
-co->args[1] = _35reg109;
+Obj _35reg4143 = primCar(macros);
 co->nargs = 2;
+co->args[0] = makeNative(_35clofun5059, 1, 2, exp, macros);
+co->args[1] = _35reg4143;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6047,19 +6126,19 @@ return;
 }
 }
 
-void _35clofun1025(struct Cora* co) {
+void _35clofun5059(struct Cora* co) {
 Obj item = co->args[1];
-Obj _35reg99 = primIsCons(closureRef(co, 0));
-if (True == _35reg99) {
-Obj _35reg100 = primCar(closureRef(co, 0));
-Obj _35reg101 = primCar(item);
-Obj _35reg102 = primEQ(_35reg100, _35reg101);
-if (True == _35reg102) {
+Obj _35reg4133 = primIsCons(closureRef(co, 0));
+if (True == _35reg4133) {
+Obj _35reg4134 = primCar(closureRef(co, 0));
+Obj _35reg4135 = primCar(item);
+Obj _35reg4136 = primEQ(_35reg4134, _35reg4135);
+if (True == _35reg4136) {
 if (True == True) {
-Obj _35reg103 = primCdr(item);
-co->args[0] = _35reg103;
-co->args[1] = closureRef(co, 0);
+Obj _35reg4137 = primCdr(item);
 co->nargs = 2;
+co->args[0] = _35reg4137;
+co->args[1] = closureRef(co, 0);
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6068,11 +6147,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg104 = primCdr(closureRef(co, 1));
+Obj _35reg4138 = primCdr(closureRef(co, 1));
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.macroexpand1-h"));
 co->args[1] = closureRef(co, 0);
-co->args[2] = _35reg104;
-co->nargs = 3;
+co->args[2] = _35reg4138;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6083,10 +6162,10 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg105 = primCdr(item);
-co->args[0] = _35reg105;
-co->args[1] = closureRef(co, 0);
+Obj _35reg4139 = primCdr(item);
 co->nargs = 2;
+co->args[0] = _35reg4139;
+co->args[1] = closureRef(co, 0);
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6095,11 +6174,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg106 = primCdr(closureRef(co, 1));
+Obj _35reg4140 = primCdr(closureRef(co, 1));
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.macroexpand1-h"));
 co->args[1] = closureRef(co, 0);
-co->args[2] = _35reg106;
-co->nargs = 3;
+co->args[2] = _35reg4140;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6111,10 +6190,10 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg107 = primCdr(item);
-co->args[0] = _35reg107;
-co->args[1] = closureRef(co, 0);
+Obj _35reg4141 = primCdr(item);
 co->nargs = 2;
+co->args[0] = _35reg4141;
+co->args[1] = closureRef(co, 0);
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6123,11 +6202,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg108 = primCdr(closureRef(co, 1));
+Obj _35reg4142 = primCdr(closureRef(co, 1));
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.macroexpand1-h"));
 co->args[1] = closureRef(co, 0);
-co->args[2] = _35reg108;
-co->nargs = 3;
+co->args[2] = _35reg4142;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6139,33 +6218,35 @@ return;
 }
 }
 
-void _35clofun1023(struct Cora* co) {
+void _35clofun5057(struct Cora* co) {
 Obj n = co->args[1];
 Obj v = co->args[2];
-Obj _35reg94 = primCons(n, v);
-Obj _35reg95 = primCons(_35reg94, globalRef(intern("*macros*")));
-Obj _35reg96 = primSet(intern("*macros*"), _35reg95);
-co->args[1] = _35reg96;
+Obj _35reg4128 = primCons(n, v);
+Obj _35reg4129 = primCons(_35reg4128, globalRef(intern("*macros*")));
+Obj _35reg4130 = primSet(intern("*macros*"), _35reg4129);
+co->nargs = 2;
+co->args[1] = _35reg4130;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1022(struct Cora* co) {
+void _35clofun5056(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg92 = primCons(globalRef(intern("*protect-symbol*")), x);
-co->args[1] = _35reg92;
+Obj _35reg4126 = primCons(globalRef(intern("*protect-symbol*")), x);
+co->nargs = 2;
+co->args[1] = _35reg4126;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1021(struct Cora* co) {
+void _35clofun5055(struct Cora* co) {
 Obj f = co->args[1];
 Obj l = co->args[2];
+co->nargs = 4;
 co->args[0] = globalRef(intern("map-h"));
 co->args[1] = Nil;
 co->args[2] = f;
 co->args[3] = l;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6175,17 +6256,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1019(struct Cora* co) {
+void _35clofun5053(struct Cora* co) {
 Obj res = co->args[1];
 Obj f = co->args[2];
 Obj l = co->args[3];
-Obj _35reg82 = primIsCons(l);
-if (True == _35reg82) {
-Obj _35reg83 = primCar(l);
-pushCont(co, _35clofun1020, 3, res, l, f);
-co->args[0] = f;
-co->args[1] = _35reg83;
+Obj _35reg4116 = primIsCons(l);
+if (True == _35reg4116) {
+Obj _35reg4117 = primCar(l);
+pushCont(co, _35clofun5054, 3, res, l, f);
 co->nargs = 2;
+co->args[0] = f;
+co->args[1] = _35reg4117;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6194,9 +6275,9 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = res;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6207,18 +6288,18 @@ return;
 }
 }
 
-void _35clofun1020(struct Cora* co) {
-Obj _35val84 = co->args[1];
+void _35clofun5054(struct Cora* co) {
+Obj _35val4118 = co->args[1];
 Obj res = co->stack[co->base + 0];
 Obj l = co->stack[co->base + 1];
 Obj f = co->stack[co->base + 2];
-Obj _35reg85 = primCons(_35val84, res);
-Obj _35reg86 = primCdr(l);
-co->args[0] = globalRef(intern("map-h"));
-co->args[1] = _35reg85;
-co->args[2] = f;
-co->args[3] = _35reg86;
+Obj _35reg4119 = primCons(_35val4118, res);
+Obj _35reg4120 = primCdr(l);
 co->nargs = 4;
+co->args[0] = globalRef(intern("map-h"));
+co->args[1] = _35reg4119;
+co->args[2] = f;
+co->args[3] = _35reg4120;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6228,18 +6309,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun1017(struct Cora* co) {
+void _35clofun5051(struct Cora* co) {
 Obj res = co->args[1];
 Obj l = co->args[2];
-Obj _35reg75 = primIsCons(l);
-if (True == _35reg75) {
-Obj _35reg76 = primCar(l);
-Obj _35reg77 = primCons(_35reg76, res);
-Obj _35reg78 = primCdr(l);
-co->args[0] = globalRef(intern("cora/init.reverse-h"));
-co->args[1] = _35reg77;
-co->args[2] = _35reg78;
+Obj _35reg4109 = primIsCons(l);
+if (True == _35reg4109) {
+Obj _35reg4110 = primCar(l);
+Obj _35reg4111 = primCons(_35reg4110, res);
+Obj _35reg4112 = primCdr(l);
 co->nargs = 3;
+co->args[0] = globalRef(intern("cora/init.reverse-h"));
+co->args[1] = _35reg4111;
+co->args[2] = _35reg4112;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6248,30 +6329,32 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[1] = res;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun1016(struct Cora* co) {
+void _35clofun5050(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg73 = primIsCons(x);
-co->args[1] = _35reg73;
+Obj _35reg4107 = primIsCons(x);
+co->nargs = 2;
+co->args[1] = _35reg4107;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1014(struct Cora* co) {
+void _35clofun5048(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg65 = primIsCons(exp);
-if (True == _35reg65) {
-Obj _35reg66 = primCar(exp);
-Obj _35reg67 = primCdr(exp);
-pushCont(co, _35clofun1015, 1, _35reg66);
-co->args[0] = globalRef(intern("rcons"));
-co->args[1] = _35reg67;
+Obj _35reg4099 = primIsCons(exp);
+if (True == _35reg4099) {
+Obj _35reg4100 = primCar(exp);
+Obj _35reg4101 = primCdr(exp);
+pushCont(co, _35clofun5049, 1, _35reg4100);
 co->nargs = 2;
+co->args[0] = globalRef(intern("rcons"));
+co->args[1] = _35reg4101;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6280,94 +6363,104 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun1015(struct Cora* co) {
-Obj _35val68 = co->args[1];
-Obj _35reg66 = co->stack[co->base + 0];
-Obj _35reg69 = primCons(_35val68, Nil);
-Obj _35reg70 = primCons(_35reg66, _35reg69);
-Obj _35reg71 = primCons(intern("cons"), _35reg70);
-co->args[1] = _35reg71;
+void _35clofun5049(struct Cora* co) {
+Obj _35val4102 = co->args[1];
+Obj _35reg4100 = co->stack[co->base + 0];
+Obj _35reg4103 = primCons(_35val4102, Nil);
+Obj _35reg4104 = primCons(_35reg4100, _35reg4103);
+Obj _35reg4105 = primCons(intern("cons"), _35reg4104);
+co->nargs = 2;
+co->args[1] = _35reg4105;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1013(struct Cora* co) {
+void _35clofun5047(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg61 = primCdr(x);
-Obj _35reg62 = primCdr(_35reg61);
-Obj _35reg63 = primCdr(_35reg62);
-co->args[1] = _35reg63;
+Obj _35reg4095 = primCdr(x);
+Obj _35reg4096 = primCdr(_35reg4095);
+Obj _35reg4097 = primCdr(_35reg4096);
+co->nargs = 2;
+co->args[1] = _35reg4097;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1012(struct Cora* co) {
+void _35clofun5046(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg56 = primCdr(x);
-Obj _35reg57 = primCdr(_35reg56);
-Obj _35reg58 = primCdr(_35reg57);
-Obj _35reg59 = primCar(_35reg58);
-co->args[1] = _35reg59;
+Obj _35reg4090 = primCdr(x);
+Obj _35reg4091 = primCdr(_35reg4090);
+Obj _35reg4092 = primCdr(_35reg4091);
+Obj _35reg4093 = primCar(_35reg4092);
+co->nargs = 2;
+co->args[1] = _35reg4093;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1011(struct Cora* co) {
+void _35clofun5045(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg52 = primCdr(x);
-Obj _35reg53 = primCdr(_35reg52);
-Obj _35reg54 = primCar(_35reg53);
-co->args[1] = _35reg54;
+Obj _35reg4086 = primCdr(x);
+Obj _35reg4087 = primCdr(_35reg4086);
+Obj _35reg4088 = primCar(_35reg4087);
+co->nargs = 2;
+co->args[1] = _35reg4088;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1010(struct Cora* co) {
+void _35clofun5044(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg49 = primCdr(x);
-Obj _35reg50 = primCdr(_35reg49);
-co->args[1] = _35reg50;
+Obj _35reg4083 = primCdr(x);
+Obj _35reg4084 = primCdr(_35reg4083);
+co->nargs = 2;
+co->args[1] = _35reg4084;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1009(struct Cora* co) {
+void _35clofun5043(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg46 = primCar(x);
-Obj _35reg47 = primCdr(_35reg46);
-co->args[1] = _35reg47;
+Obj _35reg4080 = primCar(x);
+Obj _35reg4081 = primCdr(_35reg4080);
+co->nargs = 2;
+co->args[1] = _35reg4081;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1008(struct Cora* co) {
+void _35clofun5042(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg43 = primCar(x);
-Obj _35reg44 = primCar(_35reg43);
-co->args[1] = _35reg44;
+Obj _35reg4077 = primCar(x);
+Obj _35reg4078 = primCar(_35reg4077);
+co->nargs = 2;
+co->args[1] = _35reg4078;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1007(struct Cora* co) {
+void _35clofun5041(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg40 = primCdr(x);
-Obj _35reg41 = primCar(_35reg40);
-co->args[1] = _35reg41;
+Obj _35reg4074 = primCdr(x);
+Obj _35reg4075 = primCar(_35reg4074);
+co->nargs = 2;
+co->args[1] = _35reg4075;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun1006(struct Cora* co) {
+void _35clofun5040(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg38 = primEQ(x, Nil);
-co->args[1] = _35reg38;
+Obj _35reg4072 = primEQ(x, Nil);
+co->nargs = 2;
+co->args[1] = _35reg4072;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }

--- a/init.c
+++ b/init.c
@@ -6161,6 +6161,7 @@ return;
 void _35clofun1021(struct Cora* co) {
 Obj f = co->args[1];
 Obj l = co->args[2];
+ assert(iscons(l));
 co->args[0] = globalRef(intern("map-h"));
 co->args[1] = Nil;
 co->args[2] = f;
@@ -6179,10 +6180,17 @@ void _35clofun1019(struct Cora* co) {
 Obj res = co->args[1];
 Obj f = co->args[2];
 Obj l = co->args[3];
+
+scmHead* h = getScmHead(l);
+ if (h) {
+   assert(h->forwarding == 0);
+ }
+
 Obj _35reg82 = primIsCons(l);
 if (True == _35reg82) {
 Obj _35reg83 = primCar(l);
-pushCont(co, _35clofun1020, 3, res, l, f);
+/* pushCont(co, _35clofun1020, 3, res, l, f); */
+pushCont3(co, _35clofun1020, res, l, f);
 co->args[0] = f;
 co->args[1] = _35reg83;
 co->nargs = 2;

--- a/init.c
+++ b/init.c
@@ -2,230 +2,230 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun5052(struct Cora* co);
-void _35clofun5071(struct Cora* co);
-void _35clofun5073(struct Cora* co);
-void _35clofun5078(struct Cora* co);
-void _35clofun5087(struct Cora* co);
-void _35clofun5092(struct Cora* co);
-void _35clofun5096(struct Cora* co);
-void _35clofun5100(struct Cora* co);
-void _35clofun5106(struct Cora* co);
-void _35clofun5163(struct Cora* co);
-void _35clofun5197(struct Cora* co);
-void _35clofun5241(struct Cora* co);
-void _35clofun5248(struct Cora* co);
-void _35clofun5249(struct Cora* co);
-void _35clofun5242(struct Cora* co);
-void _35clofun5243(struct Cora* co);
-void _35clofun5244(struct Cora* co);
-void _35clofun5247(struct Cora* co);
-void _35clofun5245(struct Cora* co);
-void _35clofun5246(struct Cora* co);
-void _35clofun5240(struct Cora* co);
-void _35clofun5235(struct Cora* co);
-void _35clofun5236(struct Cora* co);
-void _35clofun5237(struct Cora* co);
-void _35clofun5239(struct Cora* co);
-void _35clofun5238(struct Cora* co);
-void _35clofun5233(struct Cora* co);
-void _35clofun5234(struct Cora* co);
-void _35clofun5210(struct Cora* co);
-void _35clofun5211(struct Cora* co);
-void _35clofun5232(struct Cora* co);
-void _35clofun5212(struct Cora* co);
-void _35clofun5231(struct Cora* co);
-void _35clofun5213(struct Cora* co);
-void _35clofun5230(struct Cora* co);
-void _35clofun5214(struct Cora* co);
-void _35clofun5228(struct Cora* co);
-void _35clofun5229(struct Cora* co);
-void _35clofun5215(struct Cora* co);
-void _35clofun5227(struct Cora* co);
-void _35clofun5216(struct Cora* co);
-void _35clofun5226(struct Cora* co);
-void _35clofun5217(struct Cora* co);
-void _35clofun5223(struct Cora* co);
-void _35clofun5224(struct Cora* co);
-void _35clofun5225(struct Cora* co);
-void _35clofun5218(struct Cora* co);
-void _35clofun5222(struct Cora* co);
-void _35clofun5219(struct Cora* co);
-void _35clofun5220(struct Cora* co);
-void _35clofun5221(struct Cora* co);
-void _35clofun5198(struct Cora* co);
-void _35clofun5199(struct Cora* co);
-void _35clofun5200(struct Cora* co);
-void _35clofun5201(struct Cora* co);
-void _35clofun5202(struct Cora* co);
-void _35clofun5203(struct Cora* co);
-void _35clofun5204(struct Cora* co);
-void _35clofun5205(struct Cora* co);
-void _35clofun5206(struct Cora* co);
-void _35clofun5207(struct Cora* co);
-void _35clofun5208(struct Cora* co);
-void _35clofun5209(struct Cora* co);
-void _35clofun5191(struct Cora* co);
-void _35clofun5192(struct Cora* co);
-void _35clofun5193(struct Cora* co);
-void _35clofun5194(struct Cora* co);
-void _35clofun5195(struct Cora* co);
-void _35clofun5196(struct Cora* co);
-void _35clofun5189(struct Cora* co);
-void _35clofun5190(struct Cora* co);
-void _35clofun5182(struct Cora* co);
-void _35clofun5183(struct Cora* co);
-void _35clofun5185(struct Cora* co);
-void _35clofun5187(struct Cora* co);
-void _35clofun5188(struct Cora* co);
-void _35clofun5186(struct Cora* co);
-void _35clofun5184(struct Cora* co);
-void _35clofun5180(struct Cora* co);
-void _35clofun5181(struct Cora* co);
-void _35clofun5179(struct Cora* co);
-void _35clofun5177(struct Cora* co);
-void _35clofun5178(struct Cora* co);
-void _35clofun5176(struct Cora* co);
-void _35clofun5175(struct Cora* co);
-void _35clofun5172(struct Cora* co);
-void _35clofun5173(struct Cora* co);
-void _35clofun5174(struct Cora* co);
-void _35clofun5171(struct Cora* co);
-void _35clofun5164(struct Cora* co);
-void _35clofun5165(struct Cora* co);
-void _35clofun5170(struct Cora* co);
-void _35clofun5166(struct Cora* co);
-void _35clofun5169(struct Cora* co);
-void _35clofun5167(struct Cora* co);
-void _35clofun5168(struct Cora* co);
-void _35clofun5162(struct Cora* co);
-void _35clofun5155(struct Cora* co);
-void _35clofun5156(struct Cora* co);
-void _35clofun5157(struct Cora* co);
-void _35clofun5158(struct Cora* co);
-void _35clofun5161(struct Cora* co);
-void _35clofun5160(struct Cora* co);
-void _35clofun5159(struct Cora* co);
-void _35clofun5139(struct Cora* co);
-void _35clofun5140(struct Cora* co);
-void _35clofun5141(struct Cora* co);
-void _35clofun5151(struct Cora* co);
-void _35clofun5152(struct Cora* co);
-void _35clofun5153(struct Cora* co);
-void _35clofun5154(struct Cora* co);
-void _35clofun5142(struct Cora* co);
-void _35clofun5147(struct Cora* co);
-void _35clofun5148(struct Cora* co);
-void _35clofun5149(struct Cora* co);
-void _35clofun5150(struct Cora* co);
-void _35clofun5143(struct Cora* co);
-void _35clofun5144(struct Cora* co);
-void _35clofun5145(struct Cora* co);
-void _35clofun5146(struct Cora* co);
-void _35clofun5131(struct Cora* co);
-void _35clofun5132(struct Cora* co);
-void _35clofun5137(struct Cora* co);
-void _35clofun5138(struct Cora* co);
-void _35clofun5135(struct Cora* co);
-void _35clofun5136(struct Cora* co);
-void _35clofun5133(struct Cora* co);
-void _35clofun5134(struct Cora* co);
-void _35clofun5125(struct Cora* co);
-void _35clofun5128(struct Cora* co);
-void _35clofun5129(struct Cora* co);
-void _35clofun5130(struct Cora* co);
-void _35clofun5126(struct Cora* co);
-void _35clofun5127(struct Cora* co);
-void _35clofun5107(struct Cora* co);
-void _35clofun5108(struct Cora* co);
-void _35clofun5109(struct Cora* co);
-void _35clofun5123(struct Cora* co);
-void _35clofun5124(struct Cora* co);
-void _35clofun5120(struct Cora* co);
-void _35clofun5121(struct Cora* co);
-void _35clofun5122(struct Cora* co);
-void _35clofun5118(struct Cora* co);
-void _35clofun5119(struct Cora* co);
-void _35clofun5115(struct Cora* co);
-void _35clofun5116(struct Cora* co);
-void _35clofun5117(struct Cora* co);
-void _35clofun5113(struct Cora* co);
-void _35clofun5114(struct Cora* co);
-void _35clofun5110(struct Cora* co);
-void _35clofun5111(struct Cora* co);
-void _35clofun5112(struct Cora* co);
-void _35clofun5105(struct Cora* co);
-void _35clofun5102(struct Cora* co);
-void _35clofun5103(struct Cora* co);
-void _35clofun5104(struct Cora* co);
-void _35clofun5101(struct Cora* co);
-void _35clofun5099(struct Cora* co);
-void _35clofun5097(struct Cora* co);
-void _35clofun5098(struct Cora* co);
-void _35clofun5095(struct Cora* co);
-void _35clofun5093(struct Cora* co);
-void _35clofun5094(struct Cora* co);
-void _35clofun5088(struct Cora* co);
-void _35clofun5089(struct Cora* co);
-void _35clofun5090(struct Cora* co);
-void _35clofun5091(struct Cora* co);
-void _35clofun5086(struct Cora* co);
-void _35clofun5081(struct Cora* co);
-void _35clofun5082(struct Cora* co);
-void _35clofun5083(struct Cora* co);
-void _35clofun5084(struct Cora* co);
-void _35clofun5085(struct Cora* co);
-void _35clofun5080(struct Cora* co);
-void _35clofun5079(struct Cora* co);
-void _35clofun5074(struct Cora* co);
-void _35clofun5075(struct Cora* co);
-void _35clofun5076(struct Cora* co);
-void _35clofun5077(struct Cora* co);
-void _35clofun5072(struct Cora* co);
-void _35clofun5067(struct Cora* co);
-void _35clofun5068(struct Cora* co);
-void _35clofun5069(struct Cora* co);
-void _35clofun5070(struct Cora* co);
-void _35clofun5061(struct Cora* co);
-void _35clofun5065(struct Cora* co);
-void _35clofun5066(struct Cora* co);
-void _35clofun5062(struct Cora* co);
-void _35clofun5063(struct Cora* co);
-void _35clofun5064(struct Cora* co);
-void _35clofun5060(struct Cora* co);
-void _35clofun5058(struct Cora* co);
-void _35clofun5059(struct Cora* co);
-void _35clofun5057(struct Cora* co);
-void _35clofun5056(struct Cora* co);
-void _35clofun5055(struct Cora* co);
-void _35clofun5053(struct Cora* co);
-void _35clofun5054(struct Cora* co);
-void _35clofun5051(struct Cora* co);
-void _35clofun5050(struct Cora* co);
-void _35clofun5048(struct Cora* co);
-void _35clofun5049(struct Cora* co);
-void _35clofun5047(struct Cora* co);
-void _35clofun5046(struct Cora* co);
-void _35clofun5045(struct Cora* co);
-void _35clofun5044(struct Cora* co);
-void _35clofun5043(struct Cora* co);
-void _35clofun5042(struct Cora* co);
-void _35clofun5041(struct Cora* co);
-void _35clofun5040(struct Cora* co);
+void _35clofun1018(struct Cora* co);
+void _35clofun1037(struct Cora* co);
+void _35clofun1039(struct Cora* co);
+void _35clofun1044(struct Cora* co);
+void _35clofun1053(struct Cora* co);
+void _35clofun1058(struct Cora* co);
+void _35clofun1062(struct Cora* co);
+void _35clofun1066(struct Cora* co);
+void _35clofun1072(struct Cora* co);
+void _35clofun1129(struct Cora* co);
+void _35clofun1163(struct Cora* co);
+void _35clofun1207(struct Cora* co);
+void _35clofun1214(struct Cora* co);
+void _35clofun1215(struct Cora* co);
+void _35clofun1208(struct Cora* co);
+void _35clofun1209(struct Cora* co);
+void _35clofun1210(struct Cora* co);
+void _35clofun1213(struct Cora* co);
+void _35clofun1211(struct Cora* co);
+void _35clofun1212(struct Cora* co);
+void _35clofun1206(struct Cora* co);
+void _35clofun1201(struct Cora* co);
+void _35clofun1202(struct Cora* co);
+void _35clofun1203(struct Cora* co);
+void _35clofun1205(struct Cora* co);
+void _35clofun1204(struct Cora* co);
+void _35clofun1199(struct Cora* co);
+void _35clofun1200(struct Cora* co);
+void _35clofun1176(struct Cora* co);
+void _35clofun1177(struct Cora* co);
+void _35clofun1198(struct Cora* co);
+void _35clofun1178(struct Cora* co);
+void _35clofun1197(struct Cora* co);
+void _35clofun1179(struct Cora* co);
+void _35clofun1196(struct Cora* co);
+void _35clofun1180(struct Cora* co);
+void _35clofun1194(struct Cora* co);
+void _35clofun1195(struct Cora* co);
+void _35clofun1181(struct Cora* co);
+void _35clofun1193(struct Cora* co);
+void _35clofun1182(struct Cora* co);
+void _35clofun1192(struct Cora* co);
+void _35clofun1183(struct Cora* co);
+void _35clofun1189(struct Cora* co);
+void _35clofun1190(struct Cora* co);
+void _35clofun1191(struct Cora* co);
+void _35clofun1184(struct Cora* co);
+void _35clofun1188(struct Cora* co);
+void _35clofun1185(struct Cora* co);
+void _35clofun1186(struct Cora* co);
+void _35clofun1187(struct Cora* co);
+void _35clofun1164(struct Cora* co);
+void _35clofun1165(struct Cora* co);
+void _35clofun1166(struct Cora* co);
+void _35clofun1167(struct Cora* co);
+void _35clofun1168(struct Cora* co);
+void _35clofun1169(struct Cora* co);
+void _35clofun1170(struct Cora* co);
+void _35clofun1171(struct Cora* co);
+void _35clofun1172(struct Cora* co);
+void _35clofun1173(struct Cora* co);
+void _35clofun1174(struct Cora* co);
+void _35clofun1175(struct Cora* co);
+void _35clofun1157(struct Cora* co);
+void _35clofun1158(struct Cora* co);
+void _35clofun1159(struct Cora* co);
+void _35clofun1160(struct Cora* co);
+void _35clofun1161(struct Cora* co);
+void _35clofun1162(struct Cora* co);
+void _35clofun1155(struct Cora* co);
+void _35clofun1156(struct Cora* co);
+void _35clofun1148(struct Cora* co);
+void _35clofun1149(struct Cora* co);
+void _35clofun1151(struct Cora* co);
+void _35clofun1153(struct Cora* co);
+void _35clofun1154(struct Cora* co);
+void _35clofun1152(struct Cora* co);
+void _35clofun1150(struct Cora* co);
+void _35clofun1146(struct Cora* co);
+void _35clofun1147(struct Cora* co);
+void _35clofun1145(struct Cora* co);
+void _35clofun1143(struct Cora* co);
+void _35clofun1144(struct Cora* co);
+void _35clofun1142(struct Cora* co);
+void _35clofun1141(struct Cora* co);
+void _35clofun1138(struct Cora* co);
+void _35clofun1139(struct Cora* co);
+void _35clofun1140(struct Cora* co);
+void _35clofun1137(struct Cora* co);
+void _35clofun1130(struct Cora* co);
+void _35clofun1131(struct Cora* co);
+void _35clofun1136(struct Cora* co);
+void _35clofun1132(struct Cora* co);
+void _35clofun1135(struct Cora* co);
+void _35clofun1133(struct Cora* co);
+void _35clofun1134(struct Cora* co);
+void _35clofun1128(struct Cora* co);
+void _35clofun1121(struct Cora* co);
+void _35clofun1122(struct Cora* co);
+void _35clofun1123(struct Cora* co);
+void _35clofun1124(struct Cora* co);
+void _35clofun1127(struct Cora* co);
+void _35clofun1126(struct Cora* co);
+void _35clofun1125(struct Cora* co);
+void _35clofun1105(struct Cora* co);
+void _35clofun1106(struct Cora* co);
+void _35clofun1107(struct Cora* co);
+void _35clofun1117(struct Cora* co);
+void _35clofun1118(struct Cora* co);
+void _35clofun1119(struct Cora* co);
+void _35clofun1120(struct Cora* co);
+void _35clofun1108(struct Cora* co);
+void _35clofun1113(struct Cora* co);
+void _35clofun1114(struct Cora* co);
+void _35clofun1115(struct Cora* co);
+void _35clofun1116(struct Cora* co);
+void _35clofun1109(struct Cora* co);
+void _35clofun1110(struct Cora* co);
+void _35clofun1111(struct Cora* co);
+void _35clofun1112(struct Cora* co);
+void _35clofun1097(struct Cora* co);
+void _35clofun1098(struct Cora* co);
+void _35clofun1103(struct Cora* co);
+void _35clofun1104(struct Cora* co);
+void _35clofun1101(struct Cora* co);
+void _35clofun1102(struct Cora* co);
+void _35clofun1099(struct Cora* co);
+void _35clofun1100(struct Cora* co);
+void _35clofun1091(struct Cora* co);
+void _35clofun1094(struct Cora* co);
+void _35clofun1095(struct Cora* co);
+void _35clofun1096(struct Cora* co);
+void _35clofun1092(struct Cora* co);
+void _35clofun1093(struct Cora* co);
+void _35clofun1073(struct Cora* co);
+void _35clofun1074(struct Cora* co);
+void _35clofun1075(struct Cora* co);
+void _35clofun1089(struct Cora* co);
+void _35clofun1090(struct Cora* co);
+void _35clofun1086(struct Cora* co);
+void _35clofun1087(struct Cora* co);
+void _35clofun1088(struct Cora* co);
+void _35clofun1084(struct Cora* co);
+void _35clofun1085(struct Cora* co);
+void _35clofun1081(struct Cora* co);
+void _35clofun1082(struct Cora* co);
+void _35clofun1083(struct Cora* co);
+void _35clofun1079(struct Cora* co);
+void _35clofun1080(struct Cora* co);
+void _35clofun1076(struct Cora* co);
+void _35clofun1077(struct Cora* co);
+void _35clofun1078(struct Cora* co);
+void _35clofun1071(struct Cora* co);
+void _35clofun1068(struct Cora* co);
+void _35clofun1069(struct Cora* co);
+void _35clofun1070(struct Cora* co);
+void _35clofun1067(struct Cora* co);
+void _35clofun1065(struct Cora* co);
+void _35clofun1063(struct Cora* co);
+void _35clofun1064(struct Cora* co);
+void _35clofun1061(struct Cora* co);
+void _35clofun1059(struct Cora* co);
+void _35clofun1060(struct Cora* co);
+void _35clofun1054(struct Cora* co);
+void _35clofun1055(struct Cora* co);
+void _35clofun1056(struct Cora* co);
+void _35clofun1057(struct Cora* co);
+void _35clofun1052(struct Cora* co);
+void _35clofun1047(struct Cora* co);
+void _35clofun1048(struct Cora* co);
+void _35clofun1049(struct Cora* co);
+void _35clofun1050(struct Cora* co);
+void _35clofun1051(struct Cora* co);
+void _35clofun1046(struct Cora* co);
+void _35clofun1045(struct Cora* co);
+void _35clofun1040(struct Cora* co);
+void _35clofun1041(struct Cora* co);
+void _35clofun1042(struct Cora* co);
+void _35clofun1043(struct Cora* co);
+void _35clofun1038(struct Cora* co);
+void _35clofun1033(struct Cora* co);
+void _35clofun1034(struct Cora* co);
+void _35clofun1035(struct Cora* co);
+void _35clofun1036(struct Cora* co);
+void _35clofun1027(struct Cora* co);
+void _35clofun1031(struct Cora* co);
+void _35clofun1032(struct Cora* co);
+void _35clofun1028(struct Cora* co);
+void _35clofun1029(struct Cora* co);
+void _35clofun1030(struct Cora* co);
+void _35clofun1026(struct Cora* co);
+void _35clofun1024(struct Cora* co);
+void _35clofun1025(struct Cora* co);
+void _35clofun1023(struct Cora* co);
+void _35clofun1022(struct Cora* co);
+void _35clofun1021(struct Cora* co);
+void _35clofun1019(struct Cora* co);
+void _35clofun1020(struct Cora* co);
+void _35clofun1017(struct Cora* co);
+void _35clofun1016(struct Cora* co);
+void _35clofun1014(struct Cora* co);
+void _35clofun1015(struct Cora* co);
+void _35clofun1013(struct Cora* co);
+void _35clofun1012(struct Cora* co);
+void _35clofun1011(struct Cora* co);
+void _35clofun1010(struct Cora* co);
+void _35clofun1009(struct Cora* co);
+void _35clofun1008(struct Cora* co);
+void _35clofun1007(struct Cora* co);
+void _35clofun1006(struct Cora* co);
 
 void entry(struct Cora* co) {
-Obj _35reg4073 = primSet(intern("null?"), makeNative(_35clofun5040, 1, 0));
-Obj _35reg4076 = primSet(intern("cadr"), makeNative(_35clofun5041, 1, 0));
-Obj _35reg4079 = primSet(intern("caar"), makeNative(_35clofun5042, 1, 0));
-Obj _35reg4082 = primSet(intern("cdar"), makeNative(_35clofun5043, 1, 0));
-Obj _35reg4085 = primSet(intern("cddr"), makeNative(_35clofun5044, 1, 0));
-Obj _35reg4089 = primSet(intern("caddr"), makeNative(_35clofun5045, 1, 0));
-Obj _35reg4094 = primSet(intern("cadddr"), makeNative(_35clofun5046, 1, 0));
-Obj _35reg4098 = primSet(intern("cdddr"), makeNative(_35clofun5047, 1, 0));
-Obj _35reg4106 = primSet(intern("rcons"), makeNative(_35clofun5048, 1, 0));
-Obj _35reg4108 = primSet(intern("pair?"), makeNative(_35clofun5050, 1, 0));
-Obj _35reg4113 = primSet(intern("cora/init.reverse-h"), makeNative(_35clofun5051, 2, 0));
-pushCont(co, _35clofun5052, 0);
+Obj _35reg39 = primSet(intern("null?"), makeNative(_35clofun1006, 1, 0));
+Obj _35reg42 = primSet(intern("cadr"), makeNative(_35clofun1007, 1, 0));
+Obj _35reg45 = primSet(intern("caar"), makeNative(_35clofun1008, 1, 0));
+Obj _35reg48 = primSet(intern("cdar"), makeNative(_35clofun1009, 1, 0));
+Obj _35reg51 = primSet(intern("cddr"), makeNative(_35clofun1010, 1, 0));
+Obj _35reg55 = primSet(intern("caddr"), makeNative(_35clofun1011, 1, 0));
+Obj _35reg60 = primSet(intern("cadddr"), makeNative(_35clofun1012, 1, 0));
+Obj _35reg64 = primSet(intern("cdddr"), makeNative(_35clofun1013, 1, 0));
+Obj _35reg72 = primSet(intern("rcons"), makeNative(_35clofun1014, 1, 0));
+Obj _35reg74 = primSet(intern("pair?"), makeNative(_35clofun1016, 1, 0));
+Obj _35reg79 = primSet(intern("cora/init.reverse-h"), makeNative(_35clofun1017, 2, 0));
+pushCont(co, _35clofun1018, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.reverse-h"));
 co->args[1] = Nil;
@@ -238,22 +238,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5052(struct Cora* co) {
-Obj _35val4114 = co->args[1];
-Obj _35reg4115 = primSet(intern("reverse"), _35val4114);
-Obj _35reg4121 = primSet(intern("map-h"), makeNative(_35clofun5053, 3, 0));
-Obj _35reg4122 = primSet(intern("map"), makeNative(_35clofun5055, 2, 0));
-Obj _35reg4123 = primSet(intern("*macros*"), Nil);
-Obj _35reg4124 = primGenSym(intern("protect"));
-Obj _35reg4125 = primSet(intern("*protect-symbol*"), _35reg4124);
-Obj _35reg4127 = primSet(intern("cora/init.protect"), makeNative(_35clofun5056, 1, 0));
-Obj _35reg4131 = primSet(intern("cora/init.add-to-*macros*"), makeNative(_35clofun5057, 2, 0));
-Obj _35reg4144 = primSet(intern("cora/init.macroexpand1-h"), makeNative(_35clofun5058, 2, 0));
-Obj _35reg4145 = primSet(intern("cora/init.macroexpand1"), makeNative(_35clofun5060, 1, 0));
-Obj _35reg4162 = primSet(intern("cora/init.macroexpand-boot"), makeNative(_35clofun5061, 1, 0));
-Obj _35reg4163 = primSet(intern("macroexpand"), globalRef(intern("cora/init.macroexpand-boot")));
-Obj _35reg4174 = primSet(intern("defmacro-macro"), makeNative(_35clofun5067, 1, 0));
-pushCont(co, _35clofun5071, 0);
+void _35clofun1018(struct Cora* co) {
+Obj _35val80 = co->args[1];
+Obj _35reg81 = primSet(intern("reverse"), _35val80);
+Obj _35reg87 = primSet(intern("map-h"), makeNative(_35clofun1019, 3, 0));
+Obj _35reg88 = primSet(intern("map"), makeNative(_35clofun1021, 2, 0));
+Obj _35reg89 = primSet(intern("*macros*"), Nil);
+Obj _35reg90 = primGenSym(intern("protect"));
+Obj _35reg91 = primSet(intern("*protect-symbol*"), _35reg90);
+Obj _35reg93 = primSet(intern("cora/init.protect"), makeNative(_35clofun1022, 1, 0));
+Obj _35reg97 = primSet(intern("cora/init.add-to-*macros*"), makeNative(_35clofun1023, 2, 0));
+Obj _35reg110 = primSet(intern("cora/init.macroexpand1-h"), makeNative(_35clofun1024, 2, 0));
+Obj _35reg111 = primSet(intern("cora/init.macroexpand1"), makeNative(_35clofun1026, 1, 0));
+Obj _35reg128 = primSet(intern("cora/init.macroexpand-boot"), makeNative(_35clofun1027, 1, 0));
+Obj _35reg129 = primSet(intern("macroexpand"), globalRef(intern("cora/init.macroexpand-boot")));
+Obj _35reg140 = primSet(intern("defmacro-macro"), makeNative(_35clofun1033, 1, 0));
+pushCont(co, _35clofun1037, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("defmacro");
@@ -267,13 +267,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5071(struct Cora* co) {
-Obj _35val4175 = co->args[1];
-pushCont(co, _35clofun5073, 0);
+void _35clofun1037(struct Cora* co) {
+Obj _35val141 = co->args[1];
+pushCont(co, _35clofun1039, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("list");
-co->args[2] = makeNative(_35clofun5072, 1, 0);
+co->args[2] = makeNative(_35clofun1038, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -283,13 +283,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5073(struct Cora* co) {
-Obj _35val4177 = co->args[1];
-pushCont(co, _35clofun5078, 0);
+void _35clofun1039(struct Cora* co) {
+Obj _35val143 = co->args[1];
+pushCont(co, _35clofun1044, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("defun");
-co->args[2] = makeNative(_35clofun5074, 1, 0);
+co->args[2] = makeNative(_35clofun1040, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -299,16 +299,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5078(struct Cora* co) {
-Obj _35val4189 = co->args[1];
-Obj _35reg4194 = primSet(intern("elem?"), makeNative(_35clofun5079, 2, 0));
-Obj _35reg4197 = primSet(intern("atom?"), makeNative(_35clofun5080, 1, 0));
-Obj _35reg4209 = primSet(intern("cora/init.rewrite-let"), makeNative(_35clofun5081, 1, 0));
-pushCont(co, _35clofun5087, 0);
+void _35clofun1044(struct Cora* co) {
+Obj _35val155 = co->args[1];
+Obj _35reg160 = primSet(intern("elem?"), makeNative(_35clofun1045, 2, 0));
+Obj _35reg163 = primSet(intern("atom?"), makeNative(_35clofun1046, 1, 0));
+Obj _35reg175 = primSet(intern("cora/init.rewrite-let"), makeNative(_35clofun1047, 1, 0));
+pushCont(co, _35clofun1053, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("let");
-co->args[2] = makeNative(_35clofun5086, 1, 0);
+co->args[2] = makeNative(_35clofun1052, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -318,13 +318,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5087(struct Cora* co) {
-Obj _35val4211 = co->args[1];
-pushCont(co, _35clofun5092, 0);
+void _35clofun1053(struct Cora* co) {
+Obj _35val177 = co->args[1];
+pushCont(co, _35clofun1058, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("cond");
-co->args[2] = makeNative(_35clofun5088, 1, 0);
+co->args[2] = makeNative(_35clofun1054, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -334,14 +334,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5092(struct Cora* co) {
-Obj _35val4225 = co->args[1];
-Obj _35reg4237 = primSet(intern("cora/init.rewrite-or"), makeNative(_35clofun5093, 1, 0));
-pushCont(co, _35clofun5096, 0);
+void _35clofun1058(struct Cora* co) {
+Obj _35val191 = co->args[1];
+Obj _35reg203 = primSet(intern("cora/init.rewrite-or"), makeNative(_35clofun1059, 1, 0));
+pushCont(co, _35clofun1062, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("or");
-co->args[2] = makeNative(_35clofun5095, 1, 0);
+co->args[2] = makeNative(_35clofun1061, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -351,14 +351,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5096(struct Cora* co) {
-Obj _35val4239 = co->args[1];
-Obj _35reg4251 = primSet(intern("cora/init.rewrite-and"), makeNative(_35clofun5097, 1, 0));
-pushCont(co, _35clofun5100, 0);
+void _35clofun1062(struct Cora* co) {
+Obj _35val205 = co->args[1];
+Obj _35reg217 = primSet(intern("cora/init.rewrite-and"), makeNative(_35clofun1063, 1, 0));
+pushCont(co, _35clofun1066, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("and");
-co->args[2] = makeNative(_35clofun5099, 1, 0);
+co->args[2] = makeNative(_35clofun1065, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -368,15 +368,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5100(struct Cora* co) {
-Obj _35val4253 = co->args[1];
-Obj _35reg4256 = primSet(intern("boolean?"), makeNative(_35clofun5101, 1, 0));
-Obj _35reg4266 = primSet(intern("cora/init.rcons1"), makeNative(_35clofun5102, 1, 0));
-pushCont(co, _35clofun5106, 0);
+void _35clofun1066(struct Cora* co) {
+Obj _35val219 = co->args[1];
+Obj _35reg222 = primSet(intern("boolean?"), makeNative(_35clofun1067, 1, 0));
+Obj _35reg232 = primSet(intern("cora/init.rcons1"), makeNative(_35clofun1068, 1, 0));
+pushCont(co, _35clofun1072, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("list-rest");
-co->args[2] = makeNative(_35clofun5105, 1, 0);
+co->args[2] = makeNative(_35clofun1071, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -386,18 +386,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5106(struct Cora* co) {
-Obj _35val4268 = co->args[1];
-Obj _35reg4322 = primSet(intern("cora/init.match-cons-expander"), makeNative(_35clofun5107, 4, 0));
-Obj _35reg4355 = primSet(intern("cora/init.match1"), makeNative(_35clofun5125, 4, 0));
-Obj _35reg4382 = primSet(intern("cora/init.extract-rule-action"), makeNative(_35clofun5131, 2, 0));
-Obj _35reg4434 = primSet(intern("cora/init.match-helper"), makeNative(_35clofun5139, 2, 0));
-Obj _35reg4460 = primSet(intern("cora/init.rewrite-match"), makeNative(_35clofun5155, 1, 0));
-pushCont(co, _35clofun5163, 0);
+void _35clofun1072(struct Cora* co) {
+Obj _35val234 = co->args[1];
+Obj _35reg288 = primSet(intern("cora/init.match-cons-expander"), makeNative(_35clofun1073, 4, 0));
+Obj _35reg321 = primSet(intern("cora/init.match1"), makeNative(_35clofun1091, 4, 0));
+Obj _35reg348 = primSet(intern("cora/init.extract-rule-action"), makeNative(_35clofun1097, 2, 0));
+Obj _35reg400 = primSet(intern("cora/init.match-helper"), makeNative(_35clofun1105, 2, 0));
+Obj _35reg426 = primSet(intern("cora/init.rewrite-match"), makeNative(_35clofun1121, 1, 0));
+pushCont(co, _35clofun1129, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("match");
-co->args[2] = makeNative(_35clofun5162, 1, 0);
+co->args[2] = makeNative(_35clofun1128, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -407,23 +407,23 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5163(struct Cora* co) {
-Obj _35val4461 = co->args[1];
-Obj _35reg4513 = primSet(intern("cora/init.extract-rules1"), makeNative(_35clofun5164, 3, 0));
-Obj _35reg4514 = primSet(intern("cora/init.extract-rules"), makeNative(_35clofun5171, 1, 0));
-Obj _35reg4519 = primSet(intern("cora/init.rules-patterns"), makeNative(_35clofun5172, 2, 0));
-Obj _35reg4523 = primSet(intern("cora/init.length-h"), makeNative(_35clofun5175, 2, 0));
-Obj _35reg4524 = primSet(intern("length"), makeNative(_35clofun5176, 1, 0));
-Obj _35reg4532 = primSet(intern("cora/init.filter-h"), makeNative(_35clofun5177, 3, 0));
-Obj _35reg4533 = primSet(intern("filter"), makeNative(_35clofun5179, 2, 0));
-Obj _35reg4539 = primSet(intern("append"), makeNative(_35clofun5180, 2, 0));
-Obj _35reg4550 = primSet(intern("cora/init.rules-arg-count"), makeNative(_35clofun5182, 1, 0));
-Obj _35reg4556 = primSet(intern("cora/init.gen-parameters"), makeNative(_35clofun5189, 1, 0));
-pushCont(co, _35clofun5197, 0);
+void _35clofun1129(struct Cora* co) {
+Obj _35val427 = co->args[1];
+Obj _35reg479 = primSet(intern("cora/init.extract-rules1"), makeNative(_35clofun1130, 3, 0));
+Obj _35reg480 = primSet(intern("cora/init.extract-rules"), makeNative(_35clofun1137, 1, 0));
+Obj _35reg485 = primSet(intern("cora/init.rules-patterns"), makeNative(_35clofun1138, 2, 0));
+Obj _35reg489 = primSet(intern("cora/init.length-h"), makeNative(_35clofun1141, 2, 0));
+Obj _35reg490 = primSet(intern("length"), makeNative(_35clofun1142, 1, 0));
+Obj _35reg498 = primSet(intern("cora/init.filter-h"), makeNative(_35clofun1143, 3, 0));
+Obj _35reg499 = primSet(intern("filter"), makeNative(_35clofun1145, 2, 0));
+Obj _35reg505 = primSet(intern("append"), makeNative(_35clofun1146, 2, 0));
+Obj _35reg516 = primSet(intern("cora/init.rules-arg-count"), makeNative(_35clofun1148, 1, 0));
+Obj _35reg522 = primSet(intern("cora/init.gen-parameters"), makeNative(_35clofun1155, 1, 0));
+pushCont(co, _35clofun1163, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("func");
-co->args[2] = makeNative(_35clofun5191, 1, 0);
+co->args[2] = makeNative(_35clofun1157, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -433,17 +433,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5197(struct Cora* co) {
-Obj _35val4569 = co->args[1];
-Obj _35reg4832 = primSet(intern("cora/init.propagate-boolean0"), makeNative(_35clofun5198, 1, 0));
-Obj _35reg4990 = primSet(intern("cora/init.propagate-boolean"), makeNative(_35clofun5210, 1, 0));
-Obj _35reg4992 = primSet(intern("macroexpand"), makeNative(_35clofun5233, 1, 0));
-Obj _35reg5016 = primSet(intern("cora/init.rewrite-begin"), makeNative(_35clofun5235, 1, 0));
-pushCont(co, _35clofun5241, 0);
+void _35clofun1163(struct Cora* co) {
+Obj _35val535 = co->args[1];
+Obj _35reg798 = primSet(intern("cora/init.propagate-boolean0"), makeNative(_35clofun1164, 1, 0));
+Obj _35reg956 = primSet(intern("cora/init.propagate-boolean"), makeNative(_35clofun1176, 1, 0));
+Obj _35reg958 = primSet(intern("macroexpand"), makeNative(_35clofun1199, 1, 0));
+Obj _35reg982 = primSet(intern("cora/init.rewrite-begin"), makeNative(_35clofun1201, 1, 0));
+pushCont(co, _35clofun1207, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("begin");
-co->args[2] = makeNative(_35clofun5240, 1, 0);
+co->args[2] = makeNative(_35clofun1206, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -453,13 +453,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5241(struct Cora* co) {
-Obj _35val5018 = co->args[1];
-Obj _35reg5038 = primSet(intern("cora/init.rewrite-backquote"), makeNative(_35clofun5242, 1, 0));
+void _35clofun1207(struct Cora* co) {
+Obj _35val984 = co->args[1];
+Obj _35reg1004 = primSet(intern("cora/init.rewrite-backquote"), makeNative(_35clofun1208, 1, 0));
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("backquote");
-co->args[2] = makeNative(_35clofun5248, 1, 0);
+co->args[2] = makeNative(_35clofun1214, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -469,9 +469,9 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5248(struct Cora* co) {
+void _35clofun1214(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun5249, 0);
+pushCont(co, _35clofun1215, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -484,11 +484,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5249(struct Cora* co) {
-Obj _35val5039 = co->args[1];
+void _35clofun1215(struct Cora* co) {
+Obj _35val1005 = co->args[1];
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-backquote"));
-co->args[1] = _35val5039;
+co->args[1] = _35val1005;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -498,21 +498,21 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5242(struct Cora* co) {
-Obj _35p4067 = co->args[1];
-Obj _35cc4068 = makeNative(_35clofun5243, 0, 1, _35p4067);
-Obj x = _35p4067;
-Obj _35reg5035 = primIsSymbol(x);
-if (True == _35reg5035) {
-Obj _35reg5036 = primCons(x, Nil);
-Obj _35reg5037 = primCons(intern("quote"), _35reg5036);
+void _35clofun1208(struct Cora* co) {
+Obj _35p33 = co->args[1];
+Obj _35cc34 = makeNative(_35clofun1209, 0, 1, _35p33);
+Obj x = _35p33;
+Obj _35reg1001 = primIsSymbol(x);
+if (True == _35reg1001) {
+Obj _35reg1002 = primCons(x, Nil);
+Obj _35reg1003 = primCons(intern("quote"), _35reg1002);
 co->nargs = 2;
-co->args[1] = _35reg5037;
+co->args[1] = _35reg1003;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4068;
+co->args[0] = _35cc34;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -523,30 +523,30 @@ return;
 }
 }
 
-void _35clofun5243(struct Cora* co) {
-Obj _35cc4069 = makeNative(_35clofun5244, 0, 1, closureRef(co, 0));
-Obj _35reg5025 = primIsCons(closureRef(co, 0));
-if (True == _35reg5025) {
-Obj _35reg5026 = primCar(closureRef(co, 0));
-Obj _35reg5027 = primEQ(intern("unquote"), _35reg5026);
-if (True == _35reg5027) {
-Obj _35reg5028 = primCdr(closureRef(co, 0));
-Obj _35reg5029 = primIsCons(_35reg5028);
-if (True == _35reg5029) {
-Obj _35reg5030 = primCdr(closureRef(co, 0));
-Obj _35reg5031 = primCar(_35reg5030);
-Obj x = _35reg5031;
-Obj _35reg5032 = primCdr(closureRef(co, 0));
-Obj _35reg5033 = primCdr(_35reg5032);
-Obj _35reg5034 = primEQ(Nil, _35reg5033);
-if (True == _35reg5034) {
+void _35clofun1209(struct Cora* co) {
+Obj _35cc35 = makeNative(_35clofun1210, 0, 1, closureRef(co, 0));
+Obj _35reg991 = primIsCons(closureRef(co, 0));
+if (True == _35reg991) {
+Obj _35reg992 = primCar(closureRef(co, 0));
+Obj _35reg993 = primEQ(intern("unquote"), _35reg992);
+if (True == _35reg993) {
+Obj _35reg994 = primCdr(closureRef(co, 0));
+Obj _35reg995 = primIsCons(_35reg994);
+if (True == _35reg995) {
+Obj _35reg996 = primCdr(closureRef(co, 0));
+Obj _35reg997 = primCar(_35reg996);
+Obj x = _35reg997;
+Obj _35reg998 = primCdr(closureRef(co, 0));
+Obj _35reg999 = primCdr(_35reg998);
+Obj _35reg1000 = primEQ(Nil, _35reg999);
+if (True == _35reg1000) {
 co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4069;
+co->args[0] = _35cc35;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -557,7 +557,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4069;
+co->args[0] = _35cc35;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -568,7 +568,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4069;
+co->args[0] = _35cc35;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -579,7 +579,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4069;
+co->args[0] = _35cc35;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -590,20 +590,20 @@ return;
 }
 }
 
-void _35clofun5244(struct Cora* co) {
-Obj _35cc4070 = makeNative(_35clofun5245, 0, 1, closureRef(co, 0));
-Obj _35reg5019 = primIsCons(closureRef(co, 0));
-if (True == _35reg5019) {
-Obj _35reg5020 = primCar(closureRef(co, 0));
-Obj x = _35reg5020;
-Obj _35reg5021 = primCdr(closureRef(co, 0));
-Obj more = _35reg5021;
-Obj _35reg5022 = primCons(x, more);
-pushCont(co, _35clofun5247, 0);
+void _35clofun1210(struct Cora* co) {
+Obj _35cc36 = makeNative(_35clofun1211, 0, 1, closureRef(co, 0));
+Obj _35reg985 = primIsCons(closureRef(co, 0));
+if (True == _35reg985) {
+Obj _35reg986 = primCar(closureRef(co, 0));
+Obj x = _35reg986;
+Obj _35reg987 = primCdr(closureRef(co, 0));
+Obj more = _35reg987;
+Obj _35reg988 = primCons(x, more);
+pushCont(co, _35clofun1213, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/init.rewrite-backquote"));
-co->args[2] = _35reg5022;
+co->args[2] = _35reg988;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -613,7 +613,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4070;
+co->args[0] = _35cc36;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -624,17 +624,17 @@ return;
 }
 }
 
-void _35clofun5247(struct Cora* co) {
-Obj _35val5023 = co->args[1];
-Obj _35reg5024 = primCons(intern("list"), _35val5023);
+void _35clofun1213(struct Cora* co) {
+Obj _35val989 = co->args[1];
+Obj _35reg990 = primCons(intern("list"), _35val989);
 co->nargs = 2;
-co->args[1] = _35reg5024;
+co->args[1] = _35reg990;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5245(struct Cora* co) {
-Obj _35cc4071 = makeNative(_35clofun5246, 0, 0);
+void _35clofun1211(struct Cora* co) {
+Obj _35cc37 = makeNative(_35clofun1212, 0, 0);
 Obj x = closureRef(co, 0);
 co->nargs = 2;
 co->args[1] = x;
@@ -642,7 +642,7 @@ popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5246(struct Cora* co) {
+void _35clofun1212(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -655,12 +655,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5240(struct Cora* co) {
+void _35clofun1206(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg5017 = primCdr(exp);
+Obj _35reg983 = primCdr(exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-begin"));
-co->args[1] = _35reg5017;
+co->args[1] = _35reg983;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -670,23 +670,23 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5235(struct Cora* co) {
-Obj _35p4063 = co->args[1];
-Obj _35cc4064 = makeNative(_35clofun5236, 0, 1, _35p4063);
-Obj _35reg5012 = primIsCons(_35p4063);
-if (True == _35reg5012) {
-Obj _35reg5013 = primCar(_35p4063);
-Obj x = _35reg5013;
-Obj _35reg5014 = primCdr(_35p4063);
-Obj _35reg5015 = primEQ(Nil, _35reg5014);
-if (True == _35reg5015) {
+void _35clofun1201(struct Cora* co) {
+Obj _35p29 = co->args[1];
+Obj _35cc30 = makeNative(_35clofun1202, 0, 1, _35p29);
+Obj _35reg978 = primIsCons(_35p29);
+if (True == _35reg978) {
+Obj _35reg979 = primCar(_35p29);
+Obj x = _35reg979;
+Obj _35reg980 = primCdr(_35p29);
+Obj _35reg981 = primEQ(Nil, _35reg980);
+if (True == _35reg981) {
 co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4064;
+co->args[0] = _35cc30;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -697,7 +697,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4064;
+co->args[0] = _35cc30;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -708,32 +708,32 @@ return;
 }
 }
 
-void _35clofun5236(struct Cora* co) {
-Obj _35cc4065 = makeNative(_35clofun5237, 0, 1, closureRef(co, 0));
-Obj _35reg5000 = primIsCons(closureRef(co, 0));
-if (True == _35reg5000) {
-Obj _35reg5001 = primCar(closureRef(co, 0));
-Obj x = _35reg5001;
-Obj _35reg5002 = primCdr(closureRef(co, 0));
-Obj _35reg5003 = primIsCons(_35reg5002);
-if (True == _35reg5003) {
-Obj _35reg5004 = primCdr(closureRef(co, 0));
-Obj _35reg5005 = primCar(_35reg5004);
-Obj y = _35reg5005;
-Obj _35reg5006 = primCdr(closureRef(co, 0));
-Obj _35reg5007 = primCdr(_35reg5006);
-Obj _35reg5008 = primEQ(Nil, _35reg5007);
-if (True == _35reg5008) {
-Obj _35reg5009 = primCons(y, Nil);
-Obj _35reg5010 = primCons(x, _35reg5009);
-Obj _35reg5011 = primCons(intern("do"), _35reg5010);
+void _35clofun1202(struct Cora* co) {
+Obj _35cc31 = makeNative(_35clofun1203, 0, 1, closureRef(co, 0));
+Obj _35reg966 = primIsCons(closureRef(co, 0));
+if (True == _35reg966) {
+Obj _35reg967 = primCar(closureRef(co, 0));
+Obj x = _35reg967;
+Obj _35reg968 = primCdr(closureRef(co, 0));
+Obj _35reg969 = primIsCons(_35reg968);
+if (True == _35reg969) {
+Obj _35reg970 = primCdr(closureRef(co, 0));
+Obj _35reg971 = primCar(_35reg970);
+Obj y = _35reg971;
+Obj _35reg972 = primCdr(closureRef(co, 0));
+Obj _35reg973 = primCdr(_35reg972);
+Obj _35reg974 = primEQ(Nil, _35reg973);
+if (True == _35reg974) {
+Obj _35reg975 = primCons(y, Nil);
+Obj _35reg976 = primCons(x, _35reg975);
+Obj _35reg977 = primCons(intern("do"), _35reg976);
 co->nargs = 2;
-co->args[1] = _35reg5011;
+co->args[1] = _35reg977;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4065;
+co->args[0] = _35cc31;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -744,7 +744,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4065;
+co->args[0] = _35cc31;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -755,7 +755,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4065;
+co->args[0] = _35cc31;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -766,15 +766,15 @@ return;
 }
 }
 
-void _35clofun5237(struct Cora* co) {
-Obj _35cc4066 = makeNative(_35clofun5238, 0, 0);
-Obj _35reg4993 = primIsCons(closureRef(co, 0));
-if (True == _35reg4993) {
-Obj _35reg4994 = primCar(closureRef(co, 0));
-Obj x = _35reg4994;
-Obj _35reg4995 = primCdr(closureRef(co, 0));
-Obj y = _35reg4995;
-pushCont(co, _35clofun5239, 1, x);
+void _35clofun1203(struct Cora* co) {
+Obj _35cc32 = makeNative(_35clofun1204, 0, 0);
+Obj _35reg959 = primIsCons(closureRef(co, 0));
+if (True == _35reg959) {
+Obj _35reg960 = primCar(closureRef(co, 0));
+Obj x = _35reg960;
+Obj _35reg961 = primCdr(closureRef(co, 0));
+Obj y = _35reg961;
+pushCont(co, _35clofun1205, 1, x);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-begin"));
 co->args[1] = y;
@@ -787,7 +787,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4066;
+co->args[0] = _35cc32;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -798,19 +798,19 @@ return;
 }
 }
 
-void _35clofun5239(struct Cora* co) {
-Obj _35val4996 = co->args[1];
+void _35clofun1205(struct Cora* co) {
+Obj _35val962 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35reg4997 = primCons(_35val4996, Nil);
-Obj _35reg4998 = primCons(x, _35reg4997);
-Obj _35reg4999 = primCons(intern("do"), _35reg4998);
+Obj _35reg963 = primCons(_35val962, Nil);
+Obj _35reg964 = primCons(x, _35reg963);
+Obj _35reg965 = primCons(intern("do"), _35reg964);
 co->nargs = 2;
-co->args[1] = _35reg4999;
+co->args[1] = _35reg965;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5238(struct Cora* co) {
+void _35clofun1204(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -823,9 +823,9 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5233(struct Cora* co) {
+void _35clofun1199(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun5234, 0);
+pushCont(co, _35clofun1200, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.macroexpand-boot"));
 co->args[1] = exp;
@@ -838,11 +838,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5234(struct Cora* co) {
-Obj _35val4991 = co->args[1];
+void _35clofun1200(struct Cora* co) {
+Obj _35val957 = co->args[1];
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
-co->args[1] = _35val4991;
+co->args[1] = _35val957;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -852,33 +852,33 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5210(struct Cora* co) {
-Obj _35p4051 = co->args[1];
-Obj _35cc4052 = makeNative(_35clofun5211, 0, 1, _35p4051);
-Obj _35reg4978 = primIsCons(_35p4051);
-if (True == _35reg4978) {
-Obj _35reg4979 = primCar(_35p4051);
-Obj _35reg4980 = primEQ(intern("quote"), _35reg4979);
-if (True == _35reg4980) {
-Obj _35reg4981 = primCdr(_35p4051);
-Obj _35reg4982 = primIsCons(_35reg4981);
-if (True == _35reg4982) {
-Obj _35reg4983 = primCdr(_35p4051);
-Obj _35reg4984 = primCar(_35reg4983);
-Obj x = _35reg4984;
-Obj _35reg4985 = primCdr(_35p4051);
-Obj _35reg4986 = primCdr(_35reg4985);
-Obj _35reg4987 = primEQ(Nil, _35reg4986);
-if (True == _35reg4987) {
-Obj _35reg4988 = primCons(x, Nil);
-Obj _35reg4989 = primCons(intern("quote"), _35reg4988);
+void _35clofun1176(struct Cora* co) {
+Obj _35p17 = co->args[1];
+Obj _35cc18 = makeNative(_35clofun1177, 0, 1, _35p17);
+Obj _35reg944 = primIsCons(_35p17);
+if (True == _35reg944) {
+Obj _35reg945 = primCar(_35p17);
+Obj _35reg946 = primEQ(intern("quote"), _35reg945);
+if (True == _35reg946) {
+Obj _35reg947 = primCdr(_35p17);
+Obj _35reg948 = primIsCons(_35reg947);
+if (True == _35reg948) {
+Obj _35reg949 = primCdr(_35p17);
+Obj _35reg950 = primCar(_35reg949);
+Obj x = _35reg950;
+Obj _35reg951 = primCdr(_35p17);
+Obj _35reg952 = primCdr(_35reg951);
+Obj _35reg953 = primEQ(Nil, _35reg952);
+if (True == _35reg953) {
+Obj _35reg954 = primCons(x, Nil);
+Obj _35reg955 = primCons(intern("quote"), _35reg954);
 co->nargs = 2;
-co->args[1] = _35reg4989;
+co->args[1] = _35reg955;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4052;
+co->args[0] = _35cc18;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -889,7 +889,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4052;
+co->args[0] = _35cc18;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -900,7 +900,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4052;
+co->args[0] = _35cc18;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -911,7 +911,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4052;
+co->args[0] = _35cc18;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -922,24 +922,24 @@ return;
 }
 }
 
-void _35clofun5211(struct Cora* co) {
-Obj _35cc4053 = makeNative(_35clofun5212, 0, 1, closureRef(co, 0));
-Obj _35reg4965 = primIsCons(closureRef(co, 0));
-if (True == _35reg4965) {
-Obj _35reg4966 = primCar(closureRef(co, 0));
-Obj _35reg4967 = primEQ(intern("cons?"), _35reg4966);
-if (True == _35reg4967) {
-Obj _35reg4968 = primCdr(closureRef(co, 0));
-Obj _35reg4969 = primIsCons(_35reg4968);
-if (True == _35reg4969) {
-Obj _35reg4970 = primCdr(closureRef(co, 0));
-Obj _35reg4971 = primCar(_35reg4970);
-Obj x = _35reg4971;
-Obj _35reg4972 = primCdr(closureRef(co, 0));
-Obj _35reg4973 = primCdr(_35reg4972);
-Obj _35reg4974 = primEQ(Nil, _35reg4973);
-if (True == _35reg4974) {
-pushCont(co, _35clofun5232, 0);
+void _35clofun1177(struct Cora* co) {
+Obj _35cc19 = makeNative(_35clofun1178, 0, 1, closureRef(co, 0));
+Obj _35reg931 = primIsCons(closureRef(co, 0));
+if (True == _35reg931) {
+Obj _35reg932 = primCar(closureRef(co, 0));
+Obj _35reg933 = primEQ(intern("cons?"), _35reg932);
+if (True == _35reg933) {
+Obj _35reg934 = primCdr(closureRef(co, 0));
+Obj _35reg935 = primIsCons(_35reg934);
+if (True == _35reg935) {
+Obj _35reg936 = primCdr(closureRef(co, 0));
+Obj _35reg937 = primCar(_35reg936);
+Obj x = _35reg937;
+Obj _35reg938 = primCdr(closureRef(co, 0));
+Obj _35reg939 = primCdr(_35reg938);
+Obj _35reg940 = primEQ(Nil, _35reg939);
+if (True == _35reg940) {
+pushCont(co, _35clofun1198, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
@@ -952,7 +952,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4053;
+co->args[0] = _35cc19;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -963,7 +963,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4053;
+co->args[0] = _35cc19;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -974,7 +974,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4053;
+co->args[0] = _35cc19;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -985,7 +985,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4053;
+co->args[0] = _35cc19;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -996,14 +996,14 @@ return;
 }
 }
 
-void _35clofun5232(struct Cora* co) {
-Obj _35val4975 = co->args[1];
-Obj x1 = _35val4975;
-Obj _35reg4976 = primCons(x1, Nil);
-Obj _35reg4977 = primCons(intern("cons?"), _35reg4976);
+void _35clofun1198(struct Cora* co) {
+Obj _35val941 = co->args[1];
+Obj x1 = _35val941;
+Obj _35reg942 = primCons(x1, Nil);
+Obj _35reg943 = primCons(intern("cons?"), _35reg942);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg4977;
+co->args[1] = _35reg943;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1013,24 +1013,24 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5212(struct Cora* co) {
-Obj _35cc4054 = makeNative(_35clofun5213, 0, 1, closureRef(co, 0));
-Obj _35reg4952 = primIsCons(closureRef(co, 0));
-if (True == _35reg4952) {
-Obj _35reg4953 = primCar(closureRef(co, 0));
-Obj _35reg4954 = primEQ(intern("car"), _35reg4953);
-if (True == _35reg4954) {
-Obj _35reg4955 = primCdr(closureRef(co, 0));
-Obj _35reg4956 = primIsCons(_35reg4955);
-if (True == _35reg4956) {
-Obj _35reg4957 = primCdr(closureRef(co, 0));
-Obj _35reg4958 = primCar(_35reg4957);
-Obj x = _35reg4958;
-Obj _35reg4959 = primCdr(closureRef(co, 0));
-Obj _35reg4960 = primCdr(_35reg4959);
-Obj _35reg4961 = primEQ(Nil, _35reg4960);
-if (True == _35reg4961) {
-pushCont(co, _35clofun5231, 0);
+void _35clofun1178(struct Cora* co) {
+Obj _35cc20 = makeNative(_35clofun1179, 0, 1, closureRef(co, 0));
+Obj _35reg918 = primIsCons(closureRef(co, 0));
+if (True == _35reg918) {
+Obj _35reg919 = primCar(closureRef(co, 0));
+Obj _35reg920 = primEQ(intern("car"), _35reg919);
+if (True == _35reg920) {
+Obj _35reg921 = primCdr(closureRef(co, 0));
+Obj _35reg922 = primIsCons(_35reg921);
+if (True == _35reg922) {
+Obj _35reg923 = primCdr(closureRef(co, 0));
+Obj _35reg924 = primCar(_35reg923);
+Obj x = _35reg924;
+Obj _35reg925 = primCdr(closureRef(co, 0));
+Obj _35reg926 = primCdr(_35reg925);
+Obj _35reg927 = primEQ(Nil, _35reg926);
+if (True == _35reg927) {
+pushCont(co, _35clofun1197, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
@@ -1043,7 +1043,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4054;
+co->args[0] = _35cc20;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1054,7 +1054,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4054;
+co->args[0] = _35cc20;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1065,7 +1065,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4054;
+co->args[0] = _35cc20;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1076,7 +1076,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4054;
+co->args[0] = _35cc20;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1087,14 +1087,14 @@ return;
 }
 }
 
-void _35clofun5231(struct Cora* co) {
-Obj _35val4962 = co->args[1];
-Obj x1 = _35val4962;
-Obj _35reg4963 = primCons(x1, Nil);
-Obj _35reg4964 = primCons(intern("car"), _35reg4963);
+void _35clofun1197(struct Cora* co) {
+Obj _35val928 = co->args[1];
+Obj x1 = _35val928;
+Obj _35reg929 = primCons(x1, Nil);
+Obj _35reg930 = primCons(intern("car"), _35reg929);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg4964;
+co->args[1] = _35reg930;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1104,24 +1104,24 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5213(struct Cora* co) {
-Obj _35cc4055 = makeNative(_35clofun5214, 0, 1, closureRef(co, 0));
-Obj _35reg4939 = primIsCons(closureRef(co, 0));
-if (True == _35reg4939) {
-Obj _35reg4940 = primCar(closureRef(co, 0));
-Obj _35reg4941 = primEQ(intern("cdr"), _35reg4940);
-if (True == _35reg4941) {
-Obj _35reg4942 = primCdr(closureRef(co, 0));
-Obj _35reg4943 = primIsCons(_35reg4942);
-if (True == _35reg4943) {
-Obj _35reg4944 = primCdr(closureRef(co, 0));
-Obj _35reg4945 = primCar(_35reg4944);
-Obj x = _35reg4945;
-Obj _35reg4946 = primCdr(closureRef(co, 0));
-Obj _35reg4947 = primCdr(_35reg4946);
-Obj _35reg4948 = primEQ(Nil, _35reg4947);
-if (True == _35reg4948) {
-pushCont(co, _35clofun5230, 0);
+void _35clofun1179(struct Cora* co) {
+Obj _35cc21 = makeNative(_35clofun1180, 0, 1, closureRef(co, 0));
+Obj _35reg905 = primIsCons(closureRef(co, 0));
+if (True == _35reg905) {
+Obj _35reg906 = primCar(closureRef(co, 0));
+Obj _35reg907 = primEQ(intern("cdr"), _35reg906);
+if (True == _35reg907) {
+Obj _35reg908 = primCdr(closureRef(co, 0));
+Obj _35reg909 = primIsCons(_35reg908);
+if (True == _35reg909) {
+Obj _35reg910 = primCdr(closureRef(co, 0));
+Obj _35reg911 = primCar(_35reg910);
+Obj x = _35reg911;
+Obj _35reg912 = primCdr(closureRef(co, 0));
+Obj _35reg913 = primCdr(_35reg912);
+Obj _35reg914 = primEQ(Nil, _35reg913);
+if (True == _35reg914) {
+pushCont(co, _35clofun1196, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
@@ -1134,7 +1134,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4055;
+co->args[0] = _35cc21;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1145,7 +1145,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4055;
+co->args[0] = _35cc21;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1156,7 +1156,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4055;
+co->args[0] = _35cc21;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1167,7 +1167,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4055;
+co->args[0] = _35cc21;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1178,14 +1178,14 @@ return;
 }
 }
 
-void _35clofun5230(struct Cora* co) {
-Obj _35val4949 = co->args[1];
-Obj x1 = _35val4949;
-Obj _35reg4950 = primCons(x1, Nil);
-Obj _35reg4951 = primCons(intern("cdr"), _35reg4950);
+void _35clofun1196(struct Cora* co) {
+Obj _35val915 = co->args[1];
+Obj x1 = _35val915;
+Obj _35reg916 = primCons(x1, Nil);
+Obj _35reg917 = primCons(intern("cdr"), _35reg916);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg4951;
+co->args[1] = _35reg917;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1195,33 +1195,33 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5214(struct Cora* co) {
-Obj _35cc4056 = makeNative(_35clofun5215, 0, 1, closureRef(co, 0));
-Obj _35reg4917 = primIsCons(closureRef(co, 0));
-if (True == _35reg4917) {
-Obj _35reg4918 = primCar(closureRef(co, 0));
-Obj _35reg4919 = primEQ(intern("and"), _35reg4918);
-if (True == _35reg4919) {
-Obj _35reg4920 = primCdr(closureRef(co, 0));
-Obj _35reg4921 = primIsCons(_35reg4920);
-if (True == _35reg4921) {
-Obj _35reg4922 = primCdr(closureRef(co, 0));
-Obj _35reg4923 = primCar(_35reg4922);
-Obj x = _35reg4923;
-Obj _35reg4924 = primCdr(closureRef(co, 0));
-Obj _35reg4925 = primCdr(_35reg4924);
-Obj _35reg4926 = primIsCons(_35reg4925);
-if (True == _35reg4926) {
-Obj _35reg4927 = primCdr(closureRef(co, 0));
-Obj _35reg4928 = primCdr(_35reg4927);
-Obj _35reg4929 = primCar(_35reg4928);
-Obj y = _35reg4929;
-Obj _35reg4930 = primCdr(closureRef(co, 0));
-Obj _35reg4931 = primCdr(_35reg4930);
-Obj _35reg4932 = primCdr(_35reg4931);
-Obj _35reg4933 = primEQ(Nil, _35reg4932);
-if (True == _35reg4933) {
-pushCont(co, _35clofun5228, 1, y);
+void _35clofun1180(struct Cora* co) {
+Obj _35cc22 = makeNative(_35clofun1181, 0, 1, closureRef(co, 0));
+Obj _35reg883 = primIsCons(closureRef(co, 0));
+if (True == _35reg883) {
+Obj _35reg884 = primCar(closureRef(co, 0));
+Obj _35reg885 = primEQ(intern("and"), _35reg884);
+if (True == _35reg885) {
+Obj _35reg886 = primCdr(closureRef(co, 0));
+Obj _35reg887 = primIsCons(_35reg886);
+if (True == _35reg887) {
+Obj _35reg888 = primCdr(closureRef(co, 0));
+Obj _35reg889 = primCar(_35reg888);
+Obj x = _35reg889;
+Obj _35reg890 = primCdr(closureRef(co, 0));
+Obj _35reg891 = primCdr(_35reg890);
+Obj _35reg892 = primIsCons(_35reg891);
+if (True == _35reg892) {
+Obj _35reg893 = primCdr(closureRef(co, 0));
+Obj _35reg894 = primCdr(_35reg893);
+Obj _35reg895 = primCar(_35reg894);
+Obj y = _35reg895;
+Obj _35reg896 = primCdr(closureRef(co, 0));
+Obj _35reg897 = primCdr(_35reg896);
+Obj _35reg898 = primCdr(_35reg897);
+Obj _35reg899 = primEQ(Nil, _35reg898);
+if (True == _35reg899) {
+pushCont(co, _35clofun1194, 1, y);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
@@ -1234,7 +1234,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4056;
+co->args[0] = _35cc22;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1245,7 +1245,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4056;
+co->args[0] = _35cc22;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1256,7 +1256,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4056;
+co->args[0] = _35cc22;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1267,7 +1267,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4056;
+co->args[0] = _35cc22;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1278,7 +1278,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4056;
+co->args[0] = _35cc22;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1289,11 +1289,11 @@ return;
 }
 }
 
-void _35clofun5228(struct Cora* co) {
-Obj _35val4934 = co->args[1];
+void _35clofun1194(struct Cora* co) {
+Obj _35val900 = co->args[1];
 Obj y = co->stack[co->base + 0];
-Obj x1 = _35val4934;
-pushCont(co, _35clofun5229, 1, x1);
+Obj x1 = _35val900;
+pushCont(co, _35clofun1195, 1, x1);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = y;
@@ -1306,16 +1306,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5229(struct Cora* co) {
-Obj _35val4935 = co->args[1];
+void _35clofun1195(struct Cora* co) {
+Obj _35val901 = co->args[1];
 Obj x1 = co->stack[co->base + 0];
-Obj y1 = _35val4935;
-Obj _35reg4936 = primCons(y1, Nil);
-Obj _35reg4937 = primCons(x1, _35reg4936);
-Obj _35reg4938 = primCons(intern("and"), _35reg4937);
+Obj y1 = _35val901;
+Obj _35reg902 = primCons(y1, Nil);
+Obj _35reg903 = primCons(x1, _35reg902);
+Obj _35reg904 = primCons(intern("and"), _35reg903);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg4938;
+co->args[1] = _35reg904;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1325,24 +1325,24 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5215(struct Cora* co) {
-Obj _35cc4057 = makeNative(_35clofun5216, 0, 1, closureRef(co, 0));
-Obj _35reg4904 = primIsCons(closureRef(co, 0));
-if (True == _35reg4904) {
-Obj _35reg4905 = primCar(closureRef(co, 0));
-Obj _35reg4906 = primEQ(intern("null?"), _35reg4905);
-if (True == _35reg4906) {
-Obj _35reg4907 = primCdr(closureRef(co, 0));
-Obj _35reg4908 = primIsCons(_35reg4907);
-if (True == _35reg4908) {
-Obj _35reg4909 = primCdr(closureRef(co, 0));
-Obj _35reg4910 = primCar(_35reg4909);
-Obj x = _35reg4910;
-Obj _35reg4911 = primCdr(closureRef(co, 0));
-Obj _35reg4912 = primCdr(_35reg4911);
-Obj _35reg4913 = primEQ(Nil, _35reg4912);
-if (True == _35reg4913) {
-pushCont(co, _35clofun5227, 0);
+void _35clofun1181(struct Cora* co) {
+Obj _35cc23 = makeNative(_35clofun1182, 0, 1, closureRef(co, 0));
+Obj _35reg870 = primIsCons(closureRef(co, 0));
+if (True == _35reg870) {
+Obj _35reg871 = primCar(closureRef(co, 0));
+Obj _35reg872 = primEQ(intern("null?"), _35reg871);
+if (True == _35reg872) {
+Obj _35reg873 = primCdr(closureRef(co, 0));
+Obj _35reg874 = primIsCons(_35reg873);
+if (True == _35reg874) {
+Obj _35reg875 = primCdr(closureRef(co, 0));
+Obj _35reg876 = primCar(_35reg875);
+Obj x = _35reg876;
+Obj _35reg877 = primCdr(closureRef(co, 0));
+Obj _35reg878 = primCdr(_35reg877);
+Obj _35reg879 = primEQ(Nil, _35reg878);
+if (True == _35reg879) {
+pushCont(co, _35clofun1193, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
@@ -1355,7 +1355,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4057;
+co->args[0] = _35cc23;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1366,7 +1366,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4057;
+co->args[0] = _35cc23;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1377,7 +1377,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4057;
+co->args[0] = _35cc23;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1388,7 +1388,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4057;
+co->args[0] = _35cc23;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1399,14 +1399,14 @@ return;
 }
 }
 
-void _35clofun5227(struct Cora* co) {
-Obj _35val4914 = co->args[1];
-Obj x1 = _35val4914;
-Obj _35reg4915 = primCons(x1, Nil);
-Obj _35reg4916 = primCons(intern("null?"), _35reg4915);
+void _35clofun1193(struct Cora* co) {
+Obj _35val880 = co->args[1];
+Obj x1 = _35val880;
+Obj _35reg881 = primCons(x1, Nil);
+Obj _35reg882 = primCons(intern("null?"), _35reg881);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg4916;
+co->args[1] = _35reg882;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1416,24 +1416,24 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5216(struct Cora* co) {
-Obj _35cc4058 = makeNative(_35clofun5217, 0, 1, closureRef(co, 0));
-Obj _35reg4891 = primIsCons(closureRef(co, 0));
-if (True == _35reg4891) {
-Obj _35reg4892 = primCar(closureRef(co, 0));
-Obj _35reg4893 = primEQ(intern("not"), _35reg4892);
-if (True == _35reg4893) {
-Obj _35reg4894 = primCdr(closureRef(co, 0));
-Obj _35reg4895 = primIsCons(_35reg4894);
-if (True == _35reg4895) {
-Obj _35reg4896 = primCdr(closureRef(co, 0));
-Obj _35reg4897 = primCar(_35reg4896);
-Obj x = _35reg4897;
-Obj _35reg4898 = primCdr(closureRef(co, 0));
-Obj _35reg4899 = primCdr(_35reg4898);
-Obj _35reg4900 = primEQ(Nil, _35reg4899);
-if (True == _35reg4900) {
-pushCont(co, _35clofun5226, 0);
+void _35clofun1182(struct Cora* co) {
+Obj _35cc24 = makeNative(_35clofun1183, 0, 1, closureRef(co, 0));
+Obj _35reg857 = primIsCons(closureRef(co, 0));
+if (True == _35reg857) {
+Obj _35reg858 = primCar(closureRef(co, 0));
+Obj _35reg859 = primEQ(intern("not"), _35reg858);
+if (True == _35reg859) {
+Obj _35reg860 = primCdr(closureRef(co, 0));
+Obj _35reg861 = primIsCons(_35reg860);
+if (True == _35reg861) {
+Obj _35reg862 = primCdr(closureRef(co, 0));
+Obj _35reg863 = primCar(_35reg862);
+Obj x = _35reg863;
+Obj _35reg864 = primCdr(closureRef(co, 0));
+Obj _35reg865 = primCdr(_35reg864);
+Obj _35reg866 = primEQ(Nil, _35reg865);
+if (True == _35reg866) {
+pushCont(co, _35clofun1192, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
@@ -1446,7 +1446,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4058;
+co->args[0] = _35cc24;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1457,7 +1457,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4058;
+co->args[0] = _35cc24;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1468,7 +1468,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4058;
+co->args[0] = _35cc24;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1479,7 +1479,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4058;
+co->args[0] = _35cc24;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1490,14 +1490,14 @@ return;
 }
 }
 
-void _35clofun5226(struct Cora* co) {
-Obj _35val4901 = co->args[1];
-Obj x1 = _35val4901;
-Obj _35reg4902 = primCons(x1, Nil);
-Obj _35reg4903 = primCons(intern("not"), _35reg4902);
+void _35clofun1192(struct Cora* co) {
+Obj _35val867 = co->args[1];
+Obj x1 = _35val867;
+Obj _35reg868 = primCons(x1, Nil);
+Obj _35reg869 = primCons(intern("not"), _35reg868);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg4903;
+co->args[1] = _35reg869;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1507,44 +1507,44 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5217(struct Cora* co) {
-Obj _35cc4059 = makeNative(_35clofun5218, 0, 1, closureRef(co, 0));
-Obj _35reg4858 = primIsCons(closureRef(co, 0));
-if (True == _35reg4858) {
-Obj _35reg4859 = primCar(closureRef(co, 0));
-Obj _35reg4860 = primEQ(intern("if"), _35reg4859);
-if (True == _35reg4860) {
-Obj _35reg4861 = primCdr(closureRef(co, 0));
-Obj _35reg4862 = primIsCons(_35reg4861);
-if (True == _35reg4862) {
-Obj _35reg4863 = primCdr(closureRef(co, 0));
-Obj _35reg4864 = primCar(_35reg4863);
-Obj x = _35reg4864;
-Obj _35reg4865 = primCdr(closureRef(co, 0));
-Obj _35reg4866 = primCdr(_35reg4865);
-Obj _35reg4867 = primIsCons(_35reg4866);
-if (True == _35reg4867) {
-Obj _35reg4868 = primCdr(closureRef(co, 0));
-Obj _35reg4869 = primCdr(_35reg4868);
-Obj _35reg4870 = primCar(_35reg4869);
-Obj y = _35reg4870;
-Obj _35reg4871 = primCdr(closureRef(co, 0));
-Obj _35reg4872 = primCdr(_35reg4871);
-Obj _35reg4873 = primCdr(_35reg4872);
-Obj _35reg4874 = primIsCons(_35reg4873);
-if (True == _35reg4874) {
-Obj _35reg4875 = primCdr(closureRef(co, 0));
-Obj _35reg4876 = primCdr(_35reg4875);
-Obj _35reg4877 = primCdr(_35reg4876);
-Obj _35reg4878 = primCar(_35reg4877);
-Obj z = _35reg4878;
-Obj _35reg4879 = primCdr(closureRef(co, 0));
-Obj _35reg4880 = primCdr(_35reg4879);
-Obj _35reg4881 = primCdr(_35reg4880);
-Obj _35reg4882 = primCdr(_35reg4881);
-Obj _35reg4883 = primEQ(Nil, _35reg4882);
-if (True == _35reg4883) {
-pushCont(co, _35clofun5223, 2, y, z);
+void _35clofun1183(struct Cora* co) {
+Obj _35cc25 = makeNative(_35clofun1184, 0, 1, closureRef(co, 0));
+Obj _35reg824 = primIsCons(closureRef(co, 0));
+if (True == _35reg824) {
+Obj _35reg825 = primCar(closureRef(co, 0));
+Obj _35reg826 = primEQ(intern("if"), _35reg825);
+if (True == _35reg826) {
+Obj _35reg827 = primCdr(closureRef(co, 0));
+Obj _35reg828 = primIsCons(_35reg827);
+if (True == _35reg828) {
+Obj _35reg829 = primCdr(closureRef(co, 0));
+Obj _35reg830 = primCar(_35reg829);
+Obj x = _35reg830;
+Obj _35reg831 = primCdr(closureRef(co, 0));
+Obj _35reg832 = primCdr(_35reg831);
+Obj _35reg833 = primIsCons(_35reg832);
+if (True == _35reg833) {
+Obj _35reg834 = primCdr(closureRef(co, 0));
+Obj _35reg835 = primCdr(_35reg834);
+Obj _35reg836 = primCar(_35reg835);
+Obj y = _35reg836;
+Obj _35reg837 = primCdr(closureRef(co, 0));
+Obj _35reg838 = primCdr(_35reg837);
+Obj _35reg839 = primCdr(_35reg838);
+Obj _35reg840 = primIsCons(_35reg839);
+if (True == _35reg840) {
+Obj _35reg841 = primCdr(closureRef(co, 0));
+Obj _35reg842 = primCdr(_35reg841);
+Obj _35reg843 = primCdr(_35reg842);
+Obj _35reg844 = primCar(_35reg843);
+Obj z = _35reg844;
+Obj _35reg845 = primCdr(closureRef(co, 0));
+Obj _35reg846 = primCdr(_35reg845);
+Obj _35reg847 = primCdr(_35reg846);
+Obj _35reg848 = primCdr(_35reg847);
+Obj _35reg849 = primEQ(Nil, _35reg848);
+if (True == _35reg849) {
+pushCont(co, _35clofun1189, 2, y, z);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = x;
@@ -1557,7 +1557,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4059;
+co->args[0] = _35cc25;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1568,7 +1568,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4059;
+co->args[0] = _35cc25;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1579,7 +1579,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4059;
+co->args[0] = _35cc25;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1590,7 +1590,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4059;
+co->args[0] = _35cc25;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1601,7 +1601,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4059;
+co->args[0] = _35cc25;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1612,7 +1612,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4059;
+co->args[0] = _35cc25;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1623,12 +1623,12 @@ return;
 }
 }
 
-void _35clofun5223(struct Cora* co) {
-Obj _35val4884 = co->args[1];
+void _35clofun1189(struct Cora* co) {
+Obj _35val850 = co->args[1];
 Obj y = co->stack[co->base + 0];
 Obj z = co->stack[co->base + 1];
-Obj x1 = _35val4884;
-pushCont(co, _35clofun5224, 2, z, x1);
+Obj x1 = _35val850;
+pushCont(co, _35clofun1190, 2, z, x1);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = y;
@@ -1641,12 +1641,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5224(struct Cora* co) {
-Obj _35val4885 = co->args[1];
+void _35clofun1190(struct Cora* co) {
+Obj _35val851 = co->args[1];
 Obj z = co->stack[co->base + 0];
 Obj x1 = co->stack[co->base + 1];
-Obj y1 = _35val4885;
-pushCont(co, _35clofun5225, 2, y1, x1);
+Obj y1 = _35val851;
+pushCont(co, _35clofun1191, 2, y1, x1);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = z;
@@ -1659,18 +1659,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5225(struct Cora* co) {
-Obj _35val4886 = co->args[1];
+void _35clofun1191(struct Cora* co) {
+Obj _35val852 = co->args[1];
 Obj y1 = co->stack[co->base + 0];
 Obj x1 = co->stack[co->base + 1];
-Obj z1 = _35val4886;
-Obj _35reg4887 = primCons(z1, Nil);
-Obj _35reg4888 = primCons(y1, _35reg4887);
-Obj _35reg4889 = primCons(x1, _35reg4888);
-Obj _35reg4890 = primCons(intern("if"), _35reg4889);
+Obj z1 = _35val852;
+Obj _35reg853 = primCons(z1, Nil);
+Obj _35reg854 = primCons(y1, _35reg853);
+Obj _35reg855 = primCons(x1, _35reg854);
+Obj _35reg856 = primCons(intern("if"), _35reg855);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean0"));
-co->args[1] = _35reg4890;
+co->args[1] = _35reg856;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1680,33 +1680,33 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5218(struct Cora* co) {
-Obj _35cc4060 = makeNative(_35clofun5219, 0, 1, closureRef(co, 0));
-Obj _35reg4837 = primIsCons(closureRef(co, 0));
-if (True == _35reg4837) {
-Obj _35reg4838 = primCar(closureRef(co, 0));
-Obj _35reg4839 = primEQ(intern("lambda"), _35reg4838);
-if (True == _35reg4839) {
-Obj _35reg4840 = primCdr(closureRef(co, 0));
-Obj _35reg4841 = primIsCons(_35reg4840);
-if (True == _35reg4841) {
-Obj _35reg4842 = primCdr(closureRef(co, 0));
-Obj _35reg4843 = primCar(_35reg4842);
-Obj args = _35reg4843;
-Obj _35reg4844 = primCdr(closureRef(co, 0));
-Obj _35reg4845 = primCdr(_35reg4844);
-Obj _35reg4846 = primIsCons(_35reg4845);
-if (True == _35reg4846) {
-Obj _35reg4847 = primCdr(closureRef(co, 0));
-Obj _35reg4848 = primCdr(_35reg4847);
-Obj _35reg4849 = primCar(_35reg4848);
-Obj body = _35reg4849;
-Obj _35reg4850 = primCdr(closureRef(co, 0));
-Obj _35reg4851 = primCdr(_35reg4850);
-Obj _35reg4852 = primCdr(_35reg4851);
-Obj _35reg4853 = primEQ(Nil, _35reg4852);
-if (True == _35reg4853) {
-pushCont(co, _35clofun5222, 1, args);
+void _35clofun1184(struct Cora* co) {
+Obj _35cc26 = makeNative(_35clofun1185, 0, 1, closureRef(co, 0));
+Obj _35reg803 = primIsCons(closureRef(co, 0));
+if (True == _35reg803) {
+Obj _35reg804 = primCar(closureRef(co, 0));
+Obj _35reg805 = primEQ(intern("lambda"), _35reg804);
+if (True == _35reg805) {
+Obj _35reg806 = primCdr(closureRef(co, 0));
+Obj _35reg807 = primIsCons(_35reg806);
+if (True == _35reg807) {
+Obj _35reg808 = primCdr(closureRef(co, 0));
+Obj _35reg809 = primCar(_35reg808);
+Obj args = _35reg809;
+Obj _35reg810 = primCdr(closureRef(co, 0));
+Obj _35reg811 = primCdr(_35reg810);
+Obj _35reg812 = primIsCons(_35reg811);
+if (True == _35reg812) {
+Obj _35reg813 = primCdr(closureRef(co, 0));
+Obj _35reg814 = primCdr(_35reg813);
+Obj _35reg815 = primCar(_35reg814);
+Obj body = _35reg815;
+Obj _35reg816 = primCdr(closureRef(co, 0));
+Obj _35reg817 = primCdr(_35reg816);
+Obj _35reg818 = primCdr(_35reg817);
+Obj _35reg819 = primEQ(Nil, _35reg818);
+if (True == _35reg819) {
+pushCont(co, _35clofun1188, 1, args);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.propagate-boolean"));
 co->args[1] = body;
@@ -1719,7 +1719,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4060;
+co->args[0] = _35cc26;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1730,7 +1730,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4060;
+co->args[0] = _35cc26;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1741,7 +1741,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4060;
+co->args[0] = _35cc26;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1752,7 +1752,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4060;
+co->args[0] = _35cc26;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1763,7 +1763,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4060;
+co->args[0] = _35cc26;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1774,31 +1774,31 @@ return;
 }
 }
 
-void _35clofun5222(struct Cora* co) {
-Obj _35val4854 = co->args[1];
+void _35clofun1188(struct Cora* co) {
+Obj _35val820 = co->args[1];
 Obj args = co->stack[co->base + 0];
-Obj _35reg4855 = primCons(_35val4854, Nil);
-Obj _35reg4856 = primCons(args, _35reg4855);
-Obj _35reg4857 = primCons(intern("lambda"), _35reg4856);
+Obj _35reg821 = primCons(_35val820, Nil);
+Obj _35reg822 = primCons(args, _35reg821);
+Obj _35reg823 = primCons(intern("lambda"), _35reg822);
 co->nargs = 2;
-co->args[1] = _35reg4857;
+co->args[1] = _35reg823;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5219(struct Cora* co) {
-Obj _35cc4061 = makeNative(_35clofun5220, 0, 1, closureRef(co, 0));
-Obj _35reg4833 = primIsCons(closureRef(co, 0));
-if (True == _35reg4833) {
-Obj _35reg4834 = primCar(closureRef(co, 0));
-Obj f = _35reg4834;
-Obj _35reg4835 = primCdr(closureRef(co, 0));
-Obj args = _35reg4835;
-Obj _35reg4836 = primCons(f, args);
+void _35clofun1185(struct Cora* co) {
+Obj _35cc27 = makeNative(_35clofun1186, 0, 1, closureRef(co, 0));
+Obj _35reg799 = primIsCons(closureRef(co, 0));
+if (True == _35reg799) {
+Obj _35reg800 = primCar(closureRef(co, 0));
+Obj f = _35reg800;
+Obj _35reg801 = primCdr(closureRef(co, 0));
+Obj args = _35reg801;
+Obj _35reg802 = primCons(f, args);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/init.propagate-boolean"));
-co->args[2] = _35reg4836;
+co->args[2] = _35reg802;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1808,7 +1808,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4061;
+co->args[0] = _35cc27;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1819,8 +1819,8 @@ return;
 }
 }
 
-void _35clofun5220(struct Cora* co) {
-Obj _35cc4062 = makeNative(_35clofun5221, 0, 0);
+void _35clofun1186(struct Cora* co) {
+Obj _35cc28 = makeNative(_35clofun1187, 0, 0);
 Obj x = closureRef(co, 0);
 co->nargs = 2;
 co->args[1] = x;
@@ -1828,7 +1828,7 @@ popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5221(struct Cora* co) {
+void _35clofun1187(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -1841,66 +1841,66 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5198(struct Cora* co) {
-Obj _35p4039 = co->args[1];
-Obj _35cc4040 = makeNative(_35clofun5199, 0, 1, _35p4039);
-Obj _35reg4793 = primIsCons(_35p4039);
-if (True == _35reg4793) {
-Obj _35reg4794 = primCar(_35p4039);
-Obj _35reg4795 = primEQ(intern("car"), _35reg4794);
-if (True == _35reg4795) {
-Obj _35reg4796 = primCdr(_35p4039);
-Obj _35reg4797 = primIsCons(_35reg4796);
-if (True == _35reg4797) {
-Obj _35reg4798 = primCdr(_35p4039);
-Obj _35reg4799 = primCar(_35reg4798);
-Obj _35reg4800 = primIsCons(_35reg4799);
-if (True == _35reg4800) {
-Obj _35reg4801 = primCdr(_35p4039);
-Obj _35reg4802 = primCar(_35reg4801);
-Obj _35reg4803 = primCar(_35reg4802);
-Obj _35reg4804 = primEQ(intern("cons"), _35reg4803);
-if (True == _35reg4804) {
-Obj _35reg4805 = primCdr(_35p4039);
-Obj _35reg4806 = primCar(_35reg4805);
-Obj _35reg4807 = primCdr(_35reg4806);
-Obj _35reg4808 = primIsCons(_35reg4807);
-if (True == _35reg4808) {
-Obj _35reg4809 = primCdr(_35p4039);
-Obj _35reg4810 = primCar(_35reg4809);
-Obj _35reg4811 = primCdr(_35reg4810);
-Obj _35reg4812 = primCar(_35reg4811);
-Obj x = _35reg4812;
-Obj _35reg4813 = primCdr(_35p4039);
-Obj _35reg4814 = primCar(_35reg4813);
-Obj _35reg4815 = primCdr(_35reg4814);
-Obj _35reg4816 = primCdr(_35reg4815);
-Obj _35reg4817 = primIsCons(_35reg4816);
-if (True == _35reg4817) {
-Obj _35reg4818 = primCdr(_35p4039);
-Obj _35reg4819 = primCar(_35reg4818);
-Obj _35reg4820 = primCdr(_35reg4819);
-Obj _35reg4821 = primCdr(_35reg4820);
-Obj _35reg4822 = primCar(_35reg4821);
-Obj __ = _35reg4822;
-Obj _35reg4823 = primCdr(_35p4039);
-Obj _35reg4824 = primCar(_35reg4823);
-Obj _35reg4825 = primCdr(_35reg4824);
-Obj _35reg4826 = primCdr(_35reg4825);
-Obj _35reg4827 = primCdr(_35reg4826);
-Obj _35reg4828 = primEQ(Nil, _35reg4827);
-if (True == _35reg4828) {
-Obj _35reg4829 = primCdr(_35p4039);
-Obj _35reg4830 = primCdr(_35reg4829);
-Obj _35reg4831 = primEQ(Nil, _35reg4830);
-if (True == _35reg4831) {
+void _35clofun1164(struct Cora* co) {
+Obj _35p5 = co->args[1];
+Obj _35cc6 = makeNative(_35clofun1165, 0, 1, _35p5);
+Obj _35reg759 = primIsCons(_35p5);
+if (True == _35reg759) {
+Obj _35reg760 = primCar(_35p5);
+Obj _35reg761 = primEQ(intern("car"), _35reg760);
+if (True == _35reg761) {
+Obj _35reg762 = primCdr(_35p5);
+Obj _35reg763 = primIsCons(_35reg762);
+if (True == _35reg763) {
+Obj _35reg764 = primCdr(_35p5);
+Obj _35reg765 = primCar(_35reg764);
+Obj _35reg766 = primIsCons(_35reg765);
+if (True == _35reg766) {
+Obj _35reg767 = primCdr(_35p5);
+Obj _35reg768 = primCar(_35reg767);
+Obj _35reg769 = primCar(_35reg768);
+Obj _35reg770 = primEQ(intern("cons"), _35reg769);
+if (True == _35reg770) {
+Obj _35reg771 = primCdr(_35p5);
+Obj _35reg772 = primCar(_35reg771);
+Obj _35reg773 = primCdr(_35reg772);
+Obj _35reg774 = primIsCons(_35reg773);
+if (True == _35reg774) {
+Obj _35reg775 = primCdr(_35p5);
+Obj _35reg776 = primCar(_35reg775);
+Obj _35reg777 = primCdr(_35reg776);
+Obj _35reg778 = primCar(_35reg777);
+Obj x = _35reg778;
+Obj _35reg779 = primCdr(_35p5);
+Obj _35reg780 = primCar(_35reg779);
+Obj _35reg781 = primCdr(_35reg780);
+Obj _35reg782 = primCdr(_35reg781);
+Obj _35reg783 = primIsCons(_35reg782);
+if (True == _35reg783) {
+Obj _35reg784 = primCdr(_35p5);
+Obj _35reg785 = primCar(_35reg784);
+Obj _35reg786 = primCdr(_35reg785);
+Obj _35reg787 = primCdr(_35reg786);
+Obj _35reg788 = primCar(_35reg787);
+Obj __ = _35reg788;
+Obj _35reg789 = primCdr(_35p5);
+Obj _35reg790 = primCar(_35reg789);
+Obj _35reg791 = primCdr(_35reg790);
+Obj _35reg792 = primCdr(_35reg791);
+Obj _35reg793 = primCdr(_35reg792);
+Obj _35reg794 = primEQ(Nil, _35reg793);
+if (True == _35reg794) {
+Obj _35reg795 = primCdr(_35p5);
+Obj _35reg796 = primCdr(_35reg795);
+Obj _35reg797 = primEQ(Nil, _35reg796);
+if (True == _35reg797) {
 co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4040;
+co->args[0] = _35cc6;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1911,7 +1911,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4040;
+co->args[0] = _35cc6;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1922,7 +1922,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4040;
+co->args[0] = _35cc6;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1933,7 +1933,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4040;
+co->args[0] = _35cc6;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1944,7 +1944,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4040;
+co->args[0] = _35cc6;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1955,7 +1955,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4040;
+co->args[0] = _35cc6;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1966,7 +1966,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4040;
+co->args[0] = _35cc6;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1977,7 +1977,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4040;
+co->args[0] = _35cc6;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1988,7 +1988,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4040;
+co->args[0] = _35cc6;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1999,65 +1999,65 @@ return;
 }
 }
 
-void _35clofun5199(struct Cora* co) {
-Obj _35cc4041 = makeNative(_35clofun5200, 0, 1, closureRef(co, 0));
-Obj _35reg4754 = primIsCons(closureRef(co, 0));
-if (True == _35reg4754) {
-Obj _35reg4755 = primCar(closureRef(co, 0));
-Obj _35reg4756 = primEQ(intern("cdr"), _35reg4755);
-if (True == _35reg4756) {
-Obj _35reg4757 = primCdr(closureRef(co, 0));
-Obj _35reg4758 = primIsCons(_35reg4757);
-if (True == _35reg4758) {
-Obj _35reg4759 = primCdr(closureRef(co, 0));
-Obj _35reg4760 = primCar(_35reg4759);
-Obj _35reg4761 = primIsCons(_35reg4760);
-if (True == _35reg4761) {
-Obj _35reg4762 = primCdr(closureRef(co, 0));
-Obj _35reg4763 = primCar(_35reg4762);
-Obj _35reg4764 = primCar(_35reg4763);
-Obj _35reg4765 = primEQ(intern("cons"), _35reg4764);
-if (True == _35reg4765) {
-Obj _35reg4766 = primCdr(closureRef(co, 0));
-Obj _35reg4767 = primCar(_35reg4766);
-Obj _35reg4768 = primCdr(_35reg4767);
-Obj _35reg4769 = primIsCons(_35reg4768);
-if (True == _35reg4769) {
-Obj _35reg4770 = primCdr(closureRef(co, 0));
-Obj _35reg4771 = primCar(_35reg4770);
-Obj _35reg4772 = primCdr(_35reg4771);
-Obj _35reg4773 = primCar(_35reg4772);
-Obj __ = _35reg4773;
-Obj _35reg4774 = primCdr(closureRef(co, 0));
-Obj _35reg4775 = primCar(_35reg4774);
-Obj _35reg4776 = primCdr(_35reg4775);
-Obj _35reg4777 = primCdr(_35reg4776);
-Obj _35reg4778 = primIsCons(_35reg4777);
-if (True == _35reg4778) {
-Obj _35reg4779 = primCdr(closureRef(co, 0));
-Obj _35reg4780 = primCar(_35reg4779);
-Obj _35reg4781 = primCdr(_35reg4780);
-Obj _35reg4782 = primCdr(_35reg4781);
-Obj _35reg4783 = primCar(_35reg4782);
-Obj x = _35reg4783;
-Obj _35reg4784 = primCdr(closureRef(co, 0));
-Obj _35reg4785 = primCar(_35reg4784);
-Obj _35reg4786 = primCdr(_35reg4785);
-Obj _35reg4787 = primCdr(_35reg4786);
-Obj _35reg4788 = primCdr(_35reg4787);
-Obj _35reg4789 = primEQ(Nil, _35reg4788);
-if (True == _35reg4789) {
-Obj _35reg4790 = primCdr(closureRef(co, 0));
-Obj _35reg4791 = primCdr(_35reg4790);
-Obj _35reg4792 = primEQ(Nil, _35reg4791);
-if (True == _35reg4792) {
+void _35clofun1165(struct Cora* co) {
+Obj _35cc7 = makeNative(_35clofun1166, 0, 1, closureRef(co, 0));
+Obj _35reg720 = primIsCons(closureRef(co, 0));
+if (True == _35reg720) {
+Obj _35reg721 = primCar(closureRef(co, 0));
+Obj _35reg722 = primEQ(intern("cdr"), _35reg721);
+if (True == _35reg722) {
+Obj _35reg723 = primCdr(closureRef(co, 0));
+Obj _35reg724 = primIsCons(_35reg723);
+if (True == _35reg724) {
+Obj _35reg725 = primCdr(closureRef(co, 0));
+Obj _35reg726 = primCar(_35reg725);
+Obj _35reg727 = primIsCons(_35reg726);
+if (True == _35reg727) {
+Obj _35reg728 = primCdr(closureRef(co, 0));
+Obj _35reg729 = primCar(_35reg728);
+Obj _35reg730 = primCar(_35reg729);
+Obj _35reg731 = primEQ(intern("cons"), _35reg730);
+if (True == _35reg731) {
+Obj _35reg732 = primCdr(closureRef(co, 0));
+Obj _35reg733 = primCar(_35reg732);
+Obj _35reg734 = primCdr(_35reg733);
+Obj _35reg735 = primIsCons(_35reg734);
+if (True == _35reg735) {
+Obj _35reg736 = primCdr(closureRef(co, 0));
+Obj _35reg737 = primCar(_35reg736);
+Obj _35reg738 = primCdr(_35reg737);
+Obj _35reg739 = primCar(_35reg738);
+Obj __ = _35reg739;
+Obj _35reg740 = primCdr(closureRef(co, 0));
+Obj _35reg741 = primCar(_35reg740);
+Obj _35reg742 = primCdr(_35reg741);
+Obj _35reg743 = primCdr(_35reg742);
+Obj _35reg744 = primIsCons(_35reg743);
+if (True == _35reg744) {
+Obj _35reg745 = primCdr(closureRef(co, 0));
+Obj _35reg746 = primCar(_35reg745);
+Obj _35reg747 = primCdr(_35reg746);
+Obj _35reg748 = primCdr(_35reg747);
+Obj _35reg749 = primCar(_35reg748);
+Obj x = _35reg749;
+Obj _35reg750 = primCdr(closureRef(co, 0));
+Obj _35reg751 = primCar(_35reg750);
+Obj _35reg752 = primCdr(_35reg751);
+Obj _35reg753 = primCdr(_35reg752);
+Obj _35reg754 = primCdr(_35reg753);
+Obj _35reg755 = primEQ(Nil, _35reg754);
+if (True == _35reg755) {
+Obj _35reg756 = primCdr(closureRef(co, 0));
+Obj _35reg757 = primCdr(_35reg756);
+Obj _35reg758 = primEQ(Nil, _35reg757);
+if (True == _35reg758) {
 co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4041;
+co->args[0] = _35cc7;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2068,7 +2068,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4041;
+co->args[0] = _35cc7;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2079,7 +2079,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4041;
+co->args[0] = _35cc7;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2090,7 +2090,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4041;
+co->args[0] = _35cc7;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2101,7 +2101,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4041;
+co->args[0] = _35cc7;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2112,7 +2112,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4041;
+co->args[0] = _35cc7;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2123,7 +2123,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4041;
+co->args[0] = _35cc7;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2134,7 +2134,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4041;
+co->args[0] = _35cc7;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2145,7 +2145,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4041;
+co->args[0] = _35cc7;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2156,65 +2156,65 @@ return;
 }
 }
 
-void _35clofun5200(struct Cora* co) {
-Obj _35cc4042 = makeNative(_35clofun5201, 0, 1, closureRef(co, 0));
-Obj _35reg4715 = primIsCons(closureRef(co, 0));
-if (True == _35reg4715) {
-Obj _35reg4716 = primCar(closureRef(co, 0));
-Obj _35reg4717 = primEQ(intern("cons?"), _35reg4716);
-if (True == _35reg4717) {
-Obj _35reg4718 = primCdr(closureRef(co, 0));
-Obj _35reg4719 = primIsCons(_35reg4718);
-if (True == _35reg4719) {
-Obj _35reg4720 = primCdr(closureRef(co, 0));
-Obj _35reg4721 = primCar(_35reg4720);
-Obj _35reg4722 = primIsCons(_35reg4721);
-if (True == _35reg4722) {
-Obj _35reg4723 = primCdr(closureRef(co, 0));
-Obj _35reg4724 = primCar(_35reg4723);
-Obj _35reg4725 = primCar(_35reg4724);
-Obj _35reg4726 = primEQ(intern("cons"), _35reg4725);
-if (True == _35reg4726) {
-Obj _35reg4727 = primCdr(closureRef(co, 0));
-Obj _35reg4728 = primCar(_35reg4727);
-Obj _35reg4729 = primCdr(_35reg4728);
-Obj _35reg4730 = primIsCons(_35reg4729);
-if (True == _35reg4730) {
-Obj _35reg4731 = primCdr(closureRef(co, 0));
-Obj _35reg4732 = primCar(_35reg4731);
-Obj _35reg4733 = primCdr(_35reg4732);
-Obj _35reg4734 = primCar(_35reg4733);
-Obj __ = _35reg4734;
-Obj _35reg4735 = primCdr(closureRef(co, 0));
-Obj _35reg4736 = primCar(_35reg4735);
-Obj _35reg4737 = primCdr(_35reg4736);
-Obj _35reg4738 = primCdr(_35reg4737);
-Obj _35reg4739 = primIsCons(_35reg4738);
-if (True == _35reg4739) {
-Obj _35reg4740 = primCdr(closureRef(co, 0));
-Obj _35reg4741 = primCar(_35reg4740);
-Obj _35reg4742 = primCdr(_35reg4741);
-Obj _35reg4743 = primCdr(_35reg4742);
-Obj _35reg4744 = primCar(_35reg4743);
-__ = _35reg4744;
-Obj _35reg4745 = primCdr(closureRef(co, 0));
-Obj _35reg4746 = primCar(_35reg4745);
-Obj _35reg4747 = primCdr(_35reg4746);
-Obj _35reg4748 = primCdr(_35reg4747);
-Obj _35reg4749 = primCdr(_35reg4748);
-Obj _35reg4750 = primEQ(Nil, _35reg4749);
-if (True == _35reg4750) {
-Obj _35reg4751 = primCdr(closureRef(co, 0));
-Obj _35reg4752 = primCdr(_35reg4751);
-Obj _35reg4753 = primEQ(Nil, _35reg4752);
-if (True == _35reg4753) {
+void _35clofun1166(struct Cora* co) {
+Obj _35cc8 = makeNative(_35clofun1167, 0, 1, closureRef(co, 0));
+Obj _35reg681 = primIsCons(closureRef(co, 0));
+if (True == _35reg681) {
+Obj _35reg682 = primCar(closureRef(co, 0));
+Obj _35reg683 = primEQ(intern("cons?"), _35reg682);
+if (True == _35reg683) {
+Obj _35reg684 = primCdr(closureRef(co, 0));
+Obj _35reg685 = primIsCons(_35reg684);
+if (True == _35reg685) {
+Obj _35reg686 = primCdr(closureRef(co, 0));
+Obj _35reg687 = primCar(_35reg686);
+Obj _35reg688 = primIsCons(_35reg687);
+if (True == _35reg688) {
+Obj _35reg689 = primCdr(closureRef(co, 0));
+Obj _35reg690 = primCar(_35reg689);
+Obj _35reg691 = primCar(_35reg690);
+Obj _35reg692 = primEQ(intern("cons"), _35reg691);
+if (True == _35reg692) {
+Obj _35reg693 = primCdr(closureRef(co, 0));
+Obj _35reg694 = primCar(_35reg693);
+Obj _35reg695 = primCdr(_35reg694);
+Obj _35reg696 = primIsCons(_35reg695);
+if (True == _35reg696) {
+Obj _35reg697 = primCdr(closureRef(co, 0));
+Obj _35reg698 = primCar(_35reg697);
+Obj _35reg699 = primCdr(_35reg698);
+Obj _35reg700 = primCar(_35reg699);
+Obj __ = _35reg700;
+Obj _35reg701 = primCdr(closureRef(co, 0));
+Obj _35reg702 = primCar(_35reg701);
+Obj _35reg703 = primCdr(_35reg702);
+Obj _35reg704 = primCdr(_35reg703);
+Obj _35reg705 = primIsCons(_35reg704);
+if (True == _35reg705) {
+Obj _35reg706 = primCdr(closureRef(co, 0));
+Obj _35reg707 = primCar(_35reg706);
+Obj _35reg708 = primCdr(_35reg707);
+Obj _35reg709 = primCdr(_35reg708);
+Obj _35reg710 = primCar(_35reg709);
+__ = _35reg710;
+Obj _35reg711 = primCdr(closureRef(co, 0));
+Obj _35reg712 = primCar(_35reg711);
+Obj _35reg713 = primCdr(_35reg712);
+Obj _35reg714 = primCdr(_35reg713);
+Obj _35reg715 = primCdr(_35reg714);
+Obj _35reg716 = primEQ(Nil, _35reg715);
+if (True == _35reg716) {
+Obj _35reg717 = primCdr(closureRef(co, 0));
+Obj _35reg718 = primCdr(_35reg717);
+Obj _35reg719 = primEQ(Nil, _35reg718);
+if (True == _35reg719) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4042;
+co->args[0] = _35cc8;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2225,7 +2225,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4042;
+co->args[0] = _35cc8;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2236,7 +2236,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4042;
+co->args[0] = _35cc8;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2247,7 +2247,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4042;
+co->args[0] = _35cc8;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2258,7 +2258,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4042;
+co->args[0] = _35cc8;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2269,7 +2269,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4042;
+co->args[0] = _35cc8;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2280,7 +2280,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4042;
+co->args[0] = _35cc8;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2291,7 +2291,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4042;
+co->args[0] = _35cc8;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2302,7 +2302,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4042;
+co->args[0] = _35cc8;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2313,41 +2313,41 @@ return;
 }
 }
 
-void _35clofun5201(struct Cora* co) {
-Obj _35cc4043 = makeNative(_35clofun5202, 0, 1, closureRef(co, 0));
-Obj _35reg4696 = primIsCons(closureRef(co, 0));
-if (True == _35reg4696) {
-Obj _35reg4697 = primCar(closureRef(co, 0));
-Obj _35reg4698 = primEQ(intern("and"), _35reg4697);
-if (True == _35reg4698) {
-Obj _35reg4699 = primCdr(closureRef(co, 0));
-Obj _35reg4700 = primIsCons(_35reg4699);
-if (True == _35reg4700) {
-Obj _35reg4701 = primCdr(closureRef(co, 0));
-Obj _35reg4702 = primCar(_35reg4701);
-Obj _35reg4703 = primEQ(True, _35reg4702);
-if (True == _35reg4703) {
-Obj _35reg4704 = primCdr(closureRef(co, 0));
-Obj _35reg4705 = primCdr(_35reg4704);
-Obj _35reg4706 = primIsCons(_35reg4705);
-if (True == _35reg4706) {
-Obj _35reg4707 = primCdr(closureRef(co, 0));
-Obj _35reg4708 = primCdr(_35reg4707);
-Obj _35reg4709 = primCar(_35reg4708);
-Obj _35reg4710 = primEQ(True, _35reg4709);
-if (True == _35reg4710) {
-Obj _35reg4711 = primCdr(closureRef(co, 0));
-Obj _35reg4712 = primCdr(_35reg4711);
-Obj _35reg4713 = primCdr(_35reg4712);
-Obj _35reg4714 = primEQ(Nil, _35reg4713);
-if (True == _35reg4714) {
+void _35clofun1167(struct Cora* co) {
+Obj _35cc9 = makeNative(_35clofun1168, 0, 1, closureRef(co, 0));
+Obj _35reg662 = primIsCons(closureRef(co, 0));
+if (True == _35reg662) {
+Obj _35reg663 = primCar(closureRef(co, 0));
+Obj _35reg664 = primEQ(intern("and"), _35reg663);
+if (True == _35reg664) {
+Obj _35reg665 = primCdr(closureRef(co, 0));
+Obj _35reg666 = primIsCons(_35reg665);
+if (True == _35reg666) {
+Obj _35reg667 = primCdr(closureRef(co, 0));
+Obj _35reg668 = primCar(_35reg667);
+Obj _35reg669 = primEQ(True, _35reg668);
+if (True == _35reg669) {
+Obj _35reg670 = primCdr(closureRef(co, 0));
+Obj _35reg671 = primCdr(_35reg670);
+Obj _35reg672 = primIsCons(_35reg671);
+if (True == _35reg672) {
+Obj _35reg673 = primCdr(closureRef(co, 0));
+Obj _35reg674 = primCdr(_35reg673);
+Obj _35reg675 = primCar(_35reg674);
+Obj _35reg676 = primEQ(True, _35reg675);
+if (True == _35reg676) {
+Obj _35reg677 = primCdr(closureRef(co, 0));
+Obj _35reg678 = primCdr(_35reg677);
+Obj _35reg679 = primCdr(_35reg678);
+Obj _35reg680 = primEQ(Nil, _35reg679);
+if (True == _35reg680) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4043;
+co->args[0] = _35cc9;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2358,7 +2358,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4043;
+co->args[0] = _35cc9;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2369,7 +2369,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4043;
+co->args[0] = _35cc9;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2380,7 +2380,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4043;
+co->args[0] = _35cc9;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2391,7 +2391,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4043;
+co->args[0] = _35cc9;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2402,7 +2402,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4043;
+co->args[0] = _35cc9;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2413,7 +2413,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4043;
+co->args[0] = _35cc9;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2424,31 +2424,31 @@ return;
 }
 }
 
-void _35clofun5202(struct Cora* co) {
-Obj _35cc4044 = makeNative(_35clofun5203, 0, 1, closureRef(co, 0));
-Obj _35reg4685 = primIsCons(closureRef(co, 0));
-if (True == _35reg4685) {
-Obj _35reg4686 = primCar(closureRef(co, 0));
-Obj _35reg4687 = primEQ(intern("null?"), _35reg4686);
-if (True == _35reg4687) {
-Obj _35reg4688 = primCdr(closureRef(co, 0));
-Obj _35reg4689 = primIsCons(_35reg4688);
-if (True == _35reg4689) {
-Obj _35reg4690 = primCdr(closureRef(co, 0));
-Obj _35reg4691 = primCar(_35reg4690);
-Obj _35reg4692 = primEQ(Nil, _35reg4691);
-if (True == _35reg4692) {
-Obj _35reg4693 = primCdr(closureRef(co, 0));
-Obj _35reg4694 = primCdr(_35reg4693);
-Obj _35reg4695 = primEQ(Nil, _35reg4694);
-if (True == _35reg4695) {
+void _35clofun1168(struct Cora* co) {
+Obj _35cc10 = makeNative(_35clofun1169, 0, 1, closureRef(co, 0));
+Obj _35reg651 = primIsCons(closureRef(co, 0));
+if (True == _35reg651) {
+Obj _35reg652 = primCar(closureRef(co, 0));
+Obj _35reg653 = primEQ(intern("null?"), _35reg652);
+if (True == _35reg653) {
+Obj _35reg654 = primCdr(closureRef(co, 0));
+Obj _35reg655 = primIsCons(_35reg654);
+if (True == _35reg655) {
+Obj _35reg656 = primCdr(closureRef(co, 0));
+Obj _35reg657 = primCar(_35reg656);
+Obj _35reg658 = primEQ(Nil, _35reg657);
+if (True == _35reg658) {
+Obj _35reg659 = primCdr(closureRef(co, 0));
+Obj _35reg660 = primCdr(_35reg659);
+Obj _35reg661 = primEQ(Nil, _35reg660);
+if (True == _35reg661) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4044;
+co->args[0] = _35cc10;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2459,7 +2459,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4044;
+co->args[0] = _35cc10;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2470,7 +2470,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4044;
+co->args[0] = _35cc10;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2481,7 +2481,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4044;
+co->args[0] = _35cc10;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2492,7 +2492,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4044;
+co->args[0] = _35cc10;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2503,65 +2503,65 @@ return;
 }
 }
 
-void _35clofun5203(struct Cora* co) {
-Obj _35cc4045 = makeNative(_35clofun5204, 0, 1, closureRef(co, 0));
-Obj _35reg4646 = primIsCons(closureRef(co, 0));
-if (True == _35reg4646) {
-Obj _35reg4647 = primCar(closureRef(co, 0));
-Obj _35reg4648 = primEQ(intern("null?"), _35reg4647);
-if (True == _35reg4648) {
-Obj _35reg4649 = primCdr(closureRef(co, 0));
-Obj _35reg4650 = primIsCons(_35reg4649);
-if (True == _35reg4650) {
-Obj _35reg4651 = primCdr(closureRef(co, 0));
-Obj _35reg4652 = primCar(_35reg4651);
-Obj _35reg4653 = primIsCons(_35reg4652);
-if (True == _35reg4653) {
-Obj _35reg4654 = primCdr(closureRef(co, 0));
-Obj _35reg4655 = primCar(_35reg4654);
-Obj _35reg4656 = primCar(_35reg4655);
-Obj _35reg4657 = primEQ(intern("cons"), _35reg4656);
-if (True == _35reg4657) {
-Obj _35reg4658 = primCdr(closureRef(co, 0));
-Obj _35reg4659 = primCar(_35reg4658);
-Obj _35reg4660 = primCdr(_35reg4659);
-Obj _35reg4661 = primIsCons(_35reg4660);
-if (True == _35reg4661) {
-Obj _35reg4662 = primCdr(closureRef(co, 0));
-Obj _35reg4663 = primCar(_35reg4662);
-Obj _35reg4664 = primCdr(_35reg4663);
-Obj _35reg4665 = primCar(_35reg4664);
-Obj __ = _35reg4665;
-Obj _35reg4666 = primCdr(closureRef(co, 0));
-Obj _35reg4667 = primCar(_35reg4666);
-Obj _35reg4668 = primCdr(_35reg4667);
-Obj _35reg4669 = primCdr(_35reg4668);
-Obj _35reg4670 = primIsCons(_35reg4669);
-if (True == _35reg4670) {
-Obj _35reg4671 = primCdr(closureRef(co, 0));
-Obj _35reg4672 = primCar(_35reg4671);
-Obj _35reg4673 = primCdr(_35reg4672);
-Obj _35reg4674 = primCdr(_35reg4673);
-Obj _35reg4675 = primCar(_35reg4674);
-__ = _35reg4675;
-Obj _35reg4676 = primCdr(closureRef(co, 0));
-Obj _35reg4677 = primCar(_35reg4676);
-Obj _35reg4678 = primCdr(_35reg4677);
-Obj _35reg4679 = primCdr(_35reg4678);
-Obj _35reg4680 = primCdr(_35reg4679);
-Obj _35reg4681 = primEQ(Nil, _35reg4680);
-if (True == _35reg4681) {
-Obj _35reg4682 = primCdr(closureRef(co, 0));
-Obj _35reg4683 = primCdr(_35reg4682);
-Obj _35reg4684 = primEQ(Nil, _35reg4683);
-if (True == _35reg4684) {
+void _35clofun1169(struct Cora* co) {
+Obj _35cc11 = makeNative(_35clofun1170, 0, 1, closureRef(co, 0));
+Obj _35reg612 = primIsCons(closureRef(co, 0));
+if (True == _35reg612) {
+Obj _35reg613 = primCar(closureRef(co, 0));
+Obj _35reg614 = primEQ(intern("null?"), _35reg613);
+if (True == _35reg614) {
+Obj _35reg615 = primCdr(closureRef(co, 0));
+Obj _35reg616 = primIsCons(_35reg615);
+if (True == _35reg616) {
+Obj _35reg617 = primCdr(closureRef(co, 0));
+Obj _35reg618 = primCar(_35reg617);
+Obj _35reg619 = primIsCons(_35reg618);
+if (True == _35reg619) {
+Obj _35reg620 = primCdr(closureRef(co, 0));
+Obj _35reg621 = primCar(_35reg620);
+Obj _35reg622 = primCar(_35reg621);
+Obj _35reg623 = primEQ(intern("cons"), _35reg622);
+if (True == _35reg623) {
+Obj _35reg624 = primCdr(closureRef(co, 0));
+Obj _35reg625 = primCar(_35reg624);
+Obj _35reg626 = primCdr(_35reg625);
+Obj _35reg627 = primIsCons(_35reg626);
+if (True == _35reg627) {
+Obj _35reg628 = primCdr(closureRef(co, 0));
+Obj _35reg629 = primCar(_35reg628);
+Obj _35reg630 = primCdr(_35reg629);
+Obj _35reg631 = primCar(_35reg630);
+Obj __ = _35reg631;
+Obj _35reg632 = primCdr(closureRef(co, 0));
+Obj _35reg633 = primCar(_35reg632);
+Obj _35reg634 = primCdr(_35reg633);
+Obj _35reg635 = primCdr(_35reg634);
+Obj _35reg636 = primIsCons(_35reg635);
+if (True == _35reg636) {
+Obj _35reg637 = primCdr(closureRef(co, 0));
+Obj _35reg638 = primCar(_35reg637);
+Obj _35reg639 = primCdr(_35reg638);
+Obj _35reg640 = primCdr(_35reg639);
+Obj _35reg641 = primCar(_35reg640);
+__ = _35reg641;
+Obj _35reg642 = primCdr(closureRef(co, 0));
+Obj _35reg643 = primCar(_35reg642);
+Obj _35reg644 = primCdr(_35reg643);
+Obj _35reg645 = primCdr(_35reg644);
+Obj _35reg646 = primCdr(_35reg645);
+Obj _35reg647 = primEQ(Nil, _35reg646);
+if (True == _35reg647) {
+Obj _35reg648 = primCdr(closureRef(co, 0));
+Obj _35reg649 = primCdr(_35reg648);
+Obj _35reg650 = primEQ(Nil, _35reg649);
+if (True == _35reg650) {
 co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4045;
+co->args[0] = _35cc11;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2572,7 +2572,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4045;
+co->args[0] = _35cc11;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2583,7 +2583,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4045;
+co->args[0] = _35cc11;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2594,7 +2594,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4045;
+co->args[0] = _35cc11;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2605,7 +2605,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4045;
+co->args[0] = _35cc11;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2616,7 +2616,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4045;
+co->args[0] = _35cc11;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2627,7 +2627,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4045;
+co->args[0] = _35cc11;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2638,7 +2638,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4045;
+co->args[0] = _35cc11;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2649,7 +2649,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4045;
+co->args[0] = _35cc11;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2660,31 +2660,31 @@ return;
 }
 }
 
-void _35clofun5204(struct Cora* co) {
-Obj _35cc4046 = makeNative(_35clofun5205, 0, 1, closureRef(co, 0));
-Obj _35reg4635 = primIsCons(closureRef(co, 0));
-if (True == _35reg4635) {
-Obj _35reg4636 = primCar(closureRef(co, 0));
-Obj _35reg4637 = primEQ(intern("not"), _35reg4636);
-if (True == _35reg4637) {
-Obj _35reg4638 = primCdr(closureRef(co, 0));
-Obj _35reg4639 = primIsCons(_35reg4638);
-if (True == _35reg4639) {
-Obj _35reg4640 = primCdr(closureRef(co, 0));
-Obj _35reg4641 = primCar(_35reg4640);
-Obj _35reg4642 = primEQ(True, _35reg4641);
-if (True == _35reg4642) {
-Obj _35reg4643 = primCdr(closureRef(co, 0));
-Obj _35reg4644 = primCdr(_35reg4643);
-Obj _35reg4645 = primEQ(Nil, _35reg4644);
-if (True == _35reg4645) {
+void _35clofun1170(struct Cora* co) {
+Obj _35cc12 = makeNative(_35clofun1171, 0, 1, closureRef(co, 0));
+Obj _35reg601 = primIsCons(closureRef(co, 0));
+if (True == _35reg601) {
+Obj _35reg602 = primCar(closureRef(co, 0));
+Obj _35reg603 = primEQ(intern("not"), _35reg602);
+if (True == _35reg603) {
+Obj _35reg604 = primCdr(closureRef(co, 0));
+Obj _35reg605 = primIsCons(_35reg604);
+if (True == _35reg605) {
+Obj _35reg606 = primCdr(closureRef(co, 0));
+Obj _35reg607 = primCar(_35reg606);
+Obj _35reg608 = primEQ(True, _35reg607);
+if (True == _35reg608) {
+Obj _35reg609 = primCdr(closureRef(co, 0));
+Obj _35reg610 = primCdr(_35reg609);
+Obj _35reg611 = primEQ(Nil, _35reg610);
+if (True == _35reg611) {
 co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4046;
+co->args[0] = _35cc12;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2695,7 +2695,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4046;
+co->args[0] = _35cc12;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2706,7 +2706,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4046;
+co->args[0] = _35cc12;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2717,7 +2717,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4046;
+co->args[0] = _35cc12;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2728,7 +2728,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4046;
+co->args[0] = _35cc12;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2739,31 +2739,31 @@ return;
 }
 }
 
-void _35clofun5205(struct Cora* co) {
-Obj _35cc4047 = makeNative(_35clofun5206, 0, 1, closureRef(co, 0));
-Obj _35reg4624 = primIsCons(closureRef(co, 0));
-if (True == _35reg4624) {
-Obj _35reg4625 = primCar(closureRef(co, 0));
-Obj _35reg4626 = primEQ(intern("not"), _35reg4625);
-if (True == _35reg4626) {
-Obj _35reg4627 = primCdr(closureRef(co, 0));
-Obj _35reg4628 = primIsCons(_35reg4627);
-if (True == _35reg4628) {
-Obj _35reg4629 = primCdr(closureRef(co, 0));
-Obj _35reg4630 = primCar(_35reg4629);
-Obj _35reg4631 = primEQ(False, _35reg4630);
-if (True == _35reg4631) {
-Obj _35reg4632 = primCdr(closureRef(co, 0));
-Obj _35reg4633 = primCdr(_35reg4632);
-Obj _35reg4634 = primEQ(Nil, _35reg4633);
-if (True == _35reg4634) {
+void _35clofun1171(struct Cora* co) {
+Obj _35cc13 = makeNative(_35clofun1172, 0, 1, closureRef(co, 0));
+Obj _35reg590 = primIsCons(closureRef(co, 0));
+if (True == _35reg590) {
+Obj _35reg591 = primCar(closureRef(co, 0));
+Obj _35reg592 = primEQ(intern("not"), _35reg591);
+if (True == _35reg592) {
+Obj _35reg593 = primCdr(closureRef(co, 0));
+Obj _35reg594 = primIsCons(_35reg593);
+if (True == _35reg594) {
+Obj _35reg595 = primCdr(closureRef(co, 0));
+Obj _35reg596 = primCar(_35reg595);
+Obj _35reg597 = primEQ(False, _35reg596);
+if (True == _35reg597) {
+Obj _35reg598 = primCdr(closureRef(co, 0));
+Obj _35reg599 = primCdr(_35reg598);
+Obj _35reg600 = primEQ(Nil, _35reg599);
+if (True == _35reg600) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4047;
+co->args[0] = _35cc13;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2774,7 +2774,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4047;
+co->args[0] = _35cc13;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2785,7 +2785,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4047;
+co->args[0] = _35cc13;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2796,7 +2796,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4047;
+co->args[0] = _35cc13;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2807,7 +2807,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4047;
+co->args[0] = _35cc13;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2818,51 +2818,51 @@ return;
 }
 }
 
-void _35clofun5206(struct Cora* co) {
-Obj _35cc4048 = makeNative(_35clofun5207, 0, 1, closureRef(co, 0));
-Obj _35reg4597 = primIsCons(closureRef(co, 0));
-if (True == _35reg4597) {
-Obj _35reg4598 = primCar(closureRef(co, 0));
-Obj _35reg4599 = primEQ(intern("if"), _35reg4598);
-if (True == _35reg4599) {
-Obj _35reg4600 = primCdr(closureRef(co, 0));
-Obj _35reg4601 = primIsCons(_35reg4600);
-if (True == _35reg4601) {
-Obj _35reg4602 = primCdr(closureRef(co, 0));
-Obj _35reg4603 = primCar(_35reg4602);
-Obj _35reg4604 = primEQ(True, _35reg4603);
-if (True == _35reg4604) {
-Obj _35reg4605 = primCdr(closureRef(co, 0));
-Obj _35reg4606 = primCdr(_35reg4605);
-Obj _35reg4607 = primIsCons(_35reg4606);
-if (True == _35reg4607) {
-Obj _35reg4608 = primCdr(closureRef(co, 0));
-Obj _35reg4609 = primCdr(_35reg4608);
-Obj _35reg4610 = primCar(_35reg4609);
-Obj y = _35reg4610;
-Obj _35reg4611 = primCdr(closureRef(co, 0));
-Obj _35reg4612 = primCdr(_35reg4611);
-Obj _35reg4613 = primCdr(_35reg4612);
-Obj _35reg4614 = primIsCons(_35reg4613);
-if (True == _35reg4614) {
-Obj _35reg4615 = primCdr(closureRef(co, 0));
-Obj _35reg4616 = primCdr(_35reg4615);
-Obj _35reg4617 = primCdr(_35reg4616);
-Obj _35reg4618 = primCar(_35reg4617);
-Obj z = _35reg4618;
-Obj _35reg4619 = primCdr(closureRef(co, 0));
-Obj _35reg4620 = primCdr(_35reg4619);
-Obj _35reg4621 = primCdr(_35reg4620);
-Obj _35reg4622 = primCdr(_35reg4621);
-Obj _35reg4623 = primEQ(Nil, _35reg4622);
-if (True == _35reg4623) {
+void _35clofun1172(struct Cora* co) {
+Obj _35cc14 = makeNative(_35clofun1173, 0, 1, closureRef(co, 0));
+Obj _35reg563 = primIsCons(closureRef(co, 0));
+if (True == _35reg563) {
+Obj _35reg564 = primCar(closureRef(co, 0));
+Obj _35reg565 = primEQ(intern("if"), _35reg564);
+if (True == _35reg565) {
+Obj _35reg566 = primCdr(closureRef(co, 0));
+Obj _35reg567 = primIsCons(_35reg566);
+if (True == _35reg567) {
+Obj _35reg568 = primCdr(closureRef(co, 0));
+Obj _35reg569 = primCar(_35reg568);
+Obj _35reg570 = primEQ(True, _35reg569);
+if (True == _35reg570) {
+Obj _35reg571 = primCdr(closureRef(co, 0));
+Obj _35reg572 = primCdr(_35reg571);
+Obj _35reg573 = primIsCons(_35reg572);
+if (True == _35reg573) {
+Obj _35reg574 = primCdr(closureRef(co, 0));
+Obj _35reg575 = primCdr(_35reg574);
+Obj _35reg576 = primCar(_35reg575);
+Obj y = _35reg576;
+Obj _35reg577 = primCdr(closureRef(co, 0));
+Obj _35reg578 = primCdr(_35reg577);
+Obj _35reg579 = primCdr(_35reg578);
+Obj _35reg580 = primIsCons(_35reg579);
+if (True == _35reg580) {
+Obj _35reg581 = primCdr(closureRef(co, 0));
+Obj _35reg582 = primCdr(_35reg581);
+Obj _35reg583 = primCdr(_35reg582);
+Obj _35reg584 = primCar(_35reg583);
+Obj z = _35reg584;
+Obj _35reg585 = primCdr(closureRef(co, 0));
+Obj _35reg586 = primCdr(_35reg585);
+Obj _35reg587 = primCdr(_35reg586);
+Obj _35reg588 = primCdr(_35reg587);
+Obj _35reg589 = primEQ(Nil, _35reg588);
+if (True == _35reg589) {
 co->nargs = 2;
 co->args[1] = y;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4048;
+co->args[0] = _35cc14;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2873,7 +2873,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4048;
+co->args[0] = _35cc14;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2884,7 +2884,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4048;
+co->args[0] = _35cc14;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2895,7 +2895,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4048;
+co->args[0] = _35cc14;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2906,7 +2906,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4048;
+co->args[0] = _35cc14;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2917,7 +2917,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4048;
+co->args[0] = _35cc14;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2928,7 +2928,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4048;
+co->args[0] = _35cc14;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2939,51 +2939,51 @@ return;
 }
 }
 
-void _35clofun5207(struct Cora* co) {
-Obj _35cc4049 = makeNative(_35clofun5208, 0, 1, closureRef(co, 0));
-Obj _35reg4570 = primIsCons(closureRef(co, 0));
-if (True == _35reg4570) {
-Obj _35reg4571 = primCar(closureRef(co, 0));
-Obj _35reg4572 = primEQ(intern("if"), _35reg4571);
-if (True == _35reg4572) {
-Obj _35reg4573 = primCdr(closureRef(co, 0));
-Obj _35reg4574 = primIsCons(_35reg4573);
-if (True == _35reg4574) {
-Obj _35reg4575 = primCdr(closureRef(co, 0));
-Obj _35reg4576 = primCar(_35reg4575);
-Obj _35reg4577 = primEQ(False, _35reg4576);
-if (True == _35reg4577) {
-Obj _35reg4578 = primCdr(closureRef(co, 0));
-Obj _35reg4579 = primCdr(_35reg4578);
-Obj _35reg4580 = primIsCons(_35reg4579);
-if (True == _35reg4580) {
-Obj _35reg4581 = primCdr(closureRef(co, 0));
-Obj _35reg4582 = primCdr(_35reg4581);
-Obj _35reg4583 = primCar(_35reg4582);
-Obj y = _35reg4583;
-Obj _35reg4584 = primCdr(closureRef(co, 0));
-Obj _35reg4585 = primCdr(_35reg4584);
-Obj _35reg4586 = primCdr(_35reg4585);
-Obj _35reg4587 = primIsCons(_35reg4586);
-if (True == _35reg4587) {
-Obj _35reg4588 = primCdr(closureRef(co, 0));
-Obj _35reg4589 = primCdr(_35reg4588);
-Obj _35reg4590 = primCdr(_35reg4589);
-Obj _35reg4591 = primCar(_35reg4590);
-Obj z = _35reg4591;
-Obj _35reg4592 = primCdr(closureRef(co, 0));
-Obj _35reg4593 = primCdr(_35reg4592);
-Obj _35reg4594 = primCdr(_35reg4593);
-Obj _35reg4595 = primCdr(_35reg4594);
-Obj _35reg4596 = primEQ(Nil, _35reg4595);
-if (True == _35reg4596) {
+void _35clofun1173(struct Cora* co) {
+Obj _35cc15 = makeNative(_35clofun1174, 0, 1, closureRef(co, 0));
+Obj _35reg536 = primIsCons(closureRef(co, 0));
+if (True == _35reg536) {
+Obj _35reg537 = primCar(closureRef(co, 0));
+Obj _35reg538 = primEQ(intern("if"), _35reg537);
+if (True == _35reg538) {
+Obj _35reg539 = primCdr(closureRef(co, 0));
+Obj _35reg540 = primIsCons(_35reg539);
+if (True == _35reg540) {
+Obj _35reg541 = primCdr(closureRef(co, 0));
+Obj _35reg542 = primCar(_35reg541);
+Obj _35reg543 = primEQ(False, _35reg542);
+if (True == _35reg543) {
+Obj _35reg544 = primCdr(closureRef(co, 0));
+Obj _35reg545 = primCdr(_35reg544);
+Obj _35reg546 = primIsCons(_35reg545);
+if (True == _35reg546) {
+Obj _35reg547 = primCdr(closureRef(co, 0));
+Obj _35reg548 = primCdr(_35reg547);
+Obj _35reg549 = primCar(_35reg548);
+Obj y = _35reg549;
+Obj _35reg550 = primCdr(closureRef(co, 0));
+Obj _35reg551 = primCdr(_35reg550);
+Obj _35reg552 = primCdr(_35reg551);
+Obj _35reg553 = primIsCons(_35reg552);
+if (True == _35reg553) {
+Obj _35reg554 = primCdr(closureRef(co, 0));
+Obj _35reg555 = primCdr(_35reg554);
+Obj _35reg556 = primCdr(_35reg555);
+Obj _35reg557 = primCar(_35reg556);
+Obj z = _35reg557;
+Obj _35reg558 = primCdr(closureRef(co, 0));
+Obj _35reg559 = primCdr(_35reg558);
+Obj _35reg560 = primCdr(_35reg559);
+Obj _35reg561 = primCdr(_35reg560);
+Obj _35reg562 = primEQ(Nil, _35reg561);
+if (True == _35reg562) {
 co->nargs = 2;
 co->args[1] = z;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4049;
+co->args[0] = _35cc15;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2994,7 +2994,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4049;
+co->args[0] = _35cc15;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3005,7 +3005,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4049;
+co->args[0] = _35cc15;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3016,7 +3016,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4049;
+co->args[0] = _35cc15;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3027,7 +3027,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4049;
+co->args[0] = _35cc15;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3038,7 +3038,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4049;
+co->args[0] = _35cc15;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3049,7 +3049,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4049;
+co->args[0] = _35cc15;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3060,8 +3060,8 @@ return;
 }
 }
 
-void _35clofun5208(struct Cora* co) {
-Obj _35cc4050 = makeNative(_35clofun5209, 0, 0);
+void _35clofun1174(struct Cora* co) {
+Obj _35cc16 = makeNative(_35clofun1175, 0, 0);
 Obj x = closureRef(co, 0);
 co->nargs = 2;
 co->args[1] = x;
@@ -3069,7 +3069,7 @@ popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5209(struct Cora* co) {
+void _35clofun1175(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -3082,9 +3082,9 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5191(struct Cora* co) {
+void _35clofun1157(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun5192, 1, exp);
+pushCont(co, _35clofun1158, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cddr"));
 co->args[1] = exp;
@@ -3097,13 +3097,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5192(struct Cora* co) {
-Obj _35val4557 = co->args[1];
+void _35clofun1158(struct Cora* co) {
+Obj _35val523 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-pushCont(co, _35clofun5193, 1, exp);
+pushCont(co, _35clofun1159, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.extract-rules"));
-co->args[1] = _35val4557;
+co->args[1] = _35val523;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3113,11 +3113,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5193(struct Cora* co) {
-Obj _35val4558 = co->args[1];
+void _35clofun1159(struct Cora* co) {
+Obj _35val524 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj body = _35val4558;
-pushCont(co, _35clofun5194, 2, exp, body);
+Obj body = _35val524;
+pushCont(co, _35clofun1160, 2, exp, body);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rules-arg-count"));
 co->args[1] = body;
@@ -3130,12 +3130,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5194(struct Cora* co) {
-Obj _35val4559 = co->args[1];
+void _35clofun1160(struct Cora* co) {
+Obj _35val525 = co->args[1];
 Obj exp = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
-Obj nargs = _35val4559;
-pushCont(co, _35clofun5195, 2, exp, body);
+Obj nargs = _35val525;
+pushCont(co, _35clofun1161, 2, exp, body);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.gen-parameters"));
 co->args[1] = nargs;
@@ -3148,12 +3148,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5195(struct Cora* co) {
-Obj _35val4560 = co->args[1];
+void _35clofun1161(struct Cora* co) {
+Obj _35val526 = co->args[1];
 Obj exp = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
-Obj args = _35val4560;
-pushCont(co, _35clofun5196, 2, body, args);
+Obj args = _35val526;
+pushCont(co, _35clofun1162, 2, body, args);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -3166,38 +3166,38 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5196(struct Cora* co) {
-Obj _35val4561 = co->args[1];
+void _35clofun1162(struct Cora* co) {
+Obj _35val527 = co->args[1];
 Obj body = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
-Obj _35reg4562 = primCons(intern("list"), args);
-Obj _35reg4563 = primCons(_35reg4562, body);
-Obj _35reg4564 = primCons(intern("match"), _35reg4563);
-Obj _35reg4565 = primCons(_35reg4564, Nil);
-Obj _35reg4566 = primCons(args, _35reg4565);
-Obj _35reg4567 = primCons(_35val4561, _35reg4566);
-Obj _35reg4568 = primCons(intern("defun"), _35reg4567);
+Obj _35reg528 = primCons(intern("list"), args);
+Obj _35reg529 = primCons(_35reg528, body);
+Obj _35reg530 = primCons(intern("match"), _35reg529);
+Obj _35reg531 = primCons(_35reg530, Nil);
+Obj _35reg532 = primCons(args, _35reg531);
+Obj _35reg533 = primCons(_35val527, _35reg532);
+Obj _35reg534 = primCons(intern("defun"), _35reg533);
 co->nargs = 2;
-co->args[1] = _35reg4568;
+co->args[1] = _35reg534;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5189(struct Cora* co) {
+void _35clofun1155(struct Cora* co) {
 Obj n = co->args[1];
-Obj _35reg4551 = primEQ(n, makeNumber(0));
-if (True == _35reg4551) {
+Obj _35reg517 = primEQ(n, makeNumber(0));
+if (True == _35reg517) {
 co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4552 = primGenSym(intern("p"));
-Obj _35reg4553 = primSub(n, makeNumber(1));
-pushCont(co, _35clofun5190, 1, _35reg4552);
+Obj _35reg518 = primGenSym(intern("p"));
+Obj _35reg519 = primSub(n, makeNumber(1));
+pushCont(co, _35clofun1156, 1, _35reg518);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.gen-parameters"));
-co->args[1] = _35reg4553;
+co->args[1] = _35reg519;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3208,19 +3208,19 @@ return;
 }
 }
 
-void _35clofun5190(struct Cora* co) {
-Obj _35val4554 = co->args[1];
-Obj _35reg4552 = co->stack[co->base + 0];
-Obj _35reg4555 = primCons(_35reg4552, _35val4554);
+void _35clofun1156(struct Cora* co) {
+Obj _35val520 = co->args[1];
+Obj _35reg518 = co->stack[co->base + 0];
+Obj _35reg521 = primCons(_35reg518, _35val520);
 co->nargs = 2;
-co->args[1] = _35reg4555;
+co->args[1] = _35reg521;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5182(struct Cora* co) {
+void _35clofun1148(struct Cora* co) {
 Obj rules = co->args[1];
-pushCont(co, _35clofun5183, 0);
+pushCont(co, _35clofun1149, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.rules-patterns"));
 co->args[1] = Nil;
@@ -3234,11 +3234,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5183(struct Cora* co) {
-Obj _35val4540 = co->args[1];
-Obj pats = _35val4540;
-Obj len = makeNative(_35clofun5184, 1, 0);
-pushCont(co, _35clofun5185, 0);
+void _35clofun1149(struct Cora* co) {
+Obj _35val506 = co->args[1];
+Obj pats = _35val506;
+Obj len = makeNative(_35clofun1150, 1, 0);
+pushCont(co, _35clofun1151, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = len;
@@ -3252,18 +3252,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5185(struct Cora* co) {
-Obj _35val4542 = co->args[1];
-Obj counts = _35val4542;
-Obj _35reg4543 = primCar(counts);
-Obj n = _35reg4543;
-Obj dif = makeNative(_35clofun5186, 1, 1, n);
-Obj _35reg4546 = primCdr(counts);
-pushCont(co, _35clofun5187, 1, n);
+void _35clofun1151(struct Cora* co) {
+Obj _35val508 = co->args[1];
+Obj counts = _35val508;
+Obj _35reg509 = primCar(counts);
+Obj n = _35reg509;
+Obj dif = makeNative(_35clofun1152, 1, 1, n);
+Obj _35reg512 = primCdr(counts);
+pushCont(co, _35clofun1153, 1, n);
 co->nargs = 3;
 co->args[0] = globalRef(intern("filter"));
 co->args[1] = dif;
-co->args[2] = _35reg4546;
+co->args[2] = _35reg512;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3273,13 +3273,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5187(struct Cora* co) {
-Obj _35val4547 = co->args[1];
+void _35clofun1153(struct Cora* co) {
+Obj _35val513 = co->args[1];
 Obj n = co->stack[co->base + 0];
-pushCont(co, _35clofun5188, 1, n);
+pushCont(co, _35clofun1154, 1, n);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
-co->args[1] = _35val4547;
+co->args[1] = _35val513;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3289,11 +3289,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5188(struct Cora* co) {
-Obj _35val4548 = co->args[1];
+void _35clofun1154(struct Cora* co) {
+Obj _35val514 = co->args[1];
 Obj n = co->stack[co->base + 0];
-Obj _35reg4549 = primNot(_35val4548);
-if (True == _35reg4549) {
+Obj _35reg515 = primNot(_35val514);
+if (True == _35reg515) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("inconsistent func rule args count");
@@ -3312,22 +3312,22 @@ return;
 }
 }
 
-void _35clofun5186(struct Cora* co) {
+void _35clofun1152(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4544 = primEQ(closureRef(co, 0), x);
-Obj _35reg4545 = primNot(_35reg4544);
+Obj _35reg510 = primEQ(closureRef(co, 0), x);
+Obj _35reg511 = primNot(_35reg510);
 co->nargs = 2;
-co->args[1] = _35reg4545;
+co->args[1] = _35reg511;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5184(struct Cora* co) {
+void _35clofun1150(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4541 = primCdr(x);
+Obj _35reg507 = primCdr(x);
 co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
-co->args[1] = _35reg4541;
+co->args[1] = _35reg507;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3337,22 +3337,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5180(struct Cora* co) {
+void _35clofun1146(struct Cora* co) {
 Obj l1 = co->args[1];
 Obj l2 = co->args[2];
-Obj _35reg4534 = primEQ(l1, Nil);
-if (True == _35reg4534) {
+Obj _35reg500 = primEQ(l1, Nil);
+if (True == _35reg500) {
 co->nargs = 2;
 co->args[1] = l2;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4535 = primCar(l1);
-Obj _35reg4536 = primCdr(l1);
-pushCont(co, _35clofun5181, 1, _35reg4535);
+Obj _35reg501 = primCar(l1);
+Obj _35reg502 = primCdr(l1);
+pushCont(co, _35clofun1147, 1, _35reg501);
 co->nargs = 3;
 co->args[0] = globalRef(intern("append"));
-co->args[1] = _35reg4536;
+co->args[1] = _35reg502;
 co->args[2] = l2;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -3364,17 +3364,17 @@ return;
 }
 }
 
-void _35clofun5181(struct Cora* co) {
-Obj _35val4537 = co->args[1];
-Obj _35reg4535 = co->stack[co->base + 0];
-Obj _35reg4538 = primCons(_35reg4535, _35val4537);
+void _35clofun1147(struct Cora* co) {
+Obj _35val503 = co->args[1];
+Obj _35reg501 = co->stack[co->base + 0];
+Obj _35reg504 = primCons(_35reg501, _35val503);
 co->nargs = 2;
-co->args[1] = _35reg4538;
+co->args[1] = _35reg504;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5179(struct Cora* co) {
+void _35clofun1145(struct Cora* co) {
 Obj fn = co->args[1];
 Obj l = co->args[2];
 co->nargs = 4;
@@ -3391,17 +3391,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5177(struct Cora* co) {
+void _35clofun1143(struct Cora* co) {
 Obj res = co->args[1];
 Obj fn = co->args[2];
 Obj l = co->args[3];
-Obj _35reg4525 = primIsCons(l);
-if (True == _35reg4525) {
-Obj _35reg4526 = primCar(l);
-pushCont(co, _35clofun5178, 3, l, res, fn);
+Obj _35reg491 = primIsCons(l);
+if (True == _35reg491) {
+Obj _35reg492 = primCar(l);
+pushCont(co, _35clofun1144, 3, l, res, fn);
 co->nargs = 2;
 co->args[0] = fn;
-co->args[1] = _35reg4526;
+co->args[1] = _35reg492;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3423,20 +3423,20 @@ return;
 }
 }
 
-void _35clofun5178(struct Cora* co) {
-Obj _35val4527 = co->args[1];
+void _35clofun1144(struct Cora* co) {
+Obj _35val493 = co->args[1];
 Obj l = co->stack[co->base + 0];
 Obj res = co->stack[co->base + 1];
 Obj fn = co->stack[co->base + 2];
-if (True == _35val4527) {
-Obj _35reg4528 = primCar(l);
-Obj _35reg4529 = primCons(_35reg4528, res);
-Obj _35reg4530 = primCdr(l);
+if (True == _35val493) {
+Obj _35reg494 = primCar(l);
+Obj _35reg495 = primCons(_35reg494, res);
+Obj _35reg496 = primCdr(l);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/init.filter-h"));
-co->args[1] = _35reg4529;
+co->args[1] = _35reg495;
 co->args[2] = fn;
-co->args[3] = _35reg4530;
+co->args[3] = _35reg496;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3445,12 +3445,12 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg4531 = primCdr(l);
+Obj _35reg497 = primCdr(l);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/init.filter-h"));
 co->args[1] = res;
 co->args[2] = fn;
-co->args[3] = _35reg4531;
+co->args[3] = _35reg497;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3461,7 +3461,7 @@ return;
 }
 }
 
-void _35clofun5176(struct Cora* co) {
+void _35clofun1142(struct Cora* co) {
 Obj l = co->args[1];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.length-h"));
@@ -3476,22 +3476,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5175(struct Cora* co) {
+void _35clofun1141(struct Cora* co) {
 Obj i = co->args[1];
 Obj l = co->args[2];
-Obj _35reg4520 = primEQ(l, Nil);
-if (True == _35reg4520) {
+Obj _35reg486 = primEQ(l, Nil);
+if (True == _35reg486) {
 co->nargs = 2;
 co->args[1] = i;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4521 = primAdd(i, makeNumber(1));
-Obj _35reg4522 = primCdr(l);
+Obj _35reg487 = primAdd(i, makeNumber(1));
+Obj _35reg488 = primCdr(l);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.length-h"));
-co->args[1] = _35reg4521;
-co->args[2] = _35reg4522;
+co->args[1] = _35reg487;
+co->args[2] = _35reg488;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3502,10 +3502,10 @@ return;
 }
 }
 
-void _35clofun5172(struct Cora* co) {
+void _35clofun1138(struct Cora* co) {
 Obj res = co->args[1];
 Obj rules = co->args[2];
-pushCont(co, _35clofun5173, 2, res, rules);
+pushCont(co, _35clofun1139, 2, res, rules);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = rules;
@@ -3518,11 +3518,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5173(struct Cora* co) {
-Obj _35val4515 = co->args[1];
+void _35clofun1139(struct Cora* co) {
+Obj _35val481 = co->args[1];
 Obj res = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
-if (True == _35val4515) {
+if (True == _35val481) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = res;
@@ -3534,9 +3534,9 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg4516 = primCar(rules);
-Obj _35reg4517 = primCons(_35reg4516, res);
-pushCont(co, _35clofun5174, 1, _35reg4517);
+Obj _35reg482 = primCar(rules);
+Obj _35reg483 = primCons(_35reg482, res);
+pushCont(co, _35clofun1140, 1, _35reg483);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cddr"));
 co->args[1] = rules;
@@ -3550,13 +3550,13 @@ return;
 }
 }
 
-void _35clofun5174(struct Cora* co) {
-Obj _35val4518 = co->args[1];
-Obj _35reg4517 = co->stack[co->base + 0];
+void _35clofun1140(struct Cora* co) {
+Obj _35val484 = co->args[1];
+Obj _35reg483 = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.rules-patterns"));
-co->args[1] = _35reg4517;
-co->args[2] = _35val4518;
+co->args[1] = _35reg483;
+co->args[2] = _35val484;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3566,7 +3566,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5171(struct Cora* co) {
+void _35clofun1137(struct Cora* co) {
 Obj input = co->args[1];
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/init.extract-rules1"));
@@ -3582,13 +3582,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5164(struct Cora* co) {
+void _35clofun1130(struct Cora* co) {
 Obj input = co->args[1];
 Obj current = co->args[2];
 Obj result = co->args[3];
-Obj _35cc4035 = makeNative(_35clofun5165, 0, 3, input, current, result);
-Obj _35reg4512 = primEQ(Nil, input);
-if (True == _35reg4512) {
+Obj _35cc1 = makeNative(_35clofun1131, 0, 3, input, current, result);
+Obj _35reg478 = primEQ(Nil, input);
+if (True == _35reg478) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = result;
@@ -3601,7 +3601,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4035;
+co->args[0] = _35cc1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3612,44 +3612,44 @@ return;
 }
 }
 
-void _35clofun5165(struct Cora* co) {
-Obj _35cc4036 = makeNative(_35clofun5166, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj _35reg4479 = primIsCons(closureRef(co, 0));
-if (True == _35reg4479) {
-Obj _35reg4480 = primCar(closureRef(co, 0));
-Obj _35reg4481 = primEQ(intern("=>"), _35reg4480);
-if (True == _35reg4481) {
-Obj _35reg4482 = primCdr(closureRef(co, 0));
-Obj _35reg4483 = primIsCons(_35reg4482);
-if (True == _35reg4483) {
-Obj _35reg4484 = primCdr(closureRef(co, 0));
-Obj _35reg4485 = primCar(_35reg4484);
-Obj act = _35reg4485;
-Obj _35reg4486 = primCdr(closureRef(co, 0));
-Obj _35reg4487 = primCdr(_35reg4486);
-Obj _35reg4488 = primIsCons(_35reg4487);
-if (True == _35reg4488) {
-Obj _35reg4489 = primCdr(closureRef(co, 0));
-Obj _35reg4490 = primCdr(_35reg4489);
-Obj _35reg4491 = primCar(_35reg4490);
-Obj _35reg4492 = primEQ(intern("where"), _35reg4491);
-if (True == _35reg4492) {
-Obj _35reg4493 = primCdr(closureRef(co, 0));
-Obj _35reg4494 = primCdr(_35reg4493);
-Obj _35reg4495 = primCdr(_35reg4494);
-Obj _35reg4496 = primIsCons(_35reg4495);
-if (True == _35reg4496) {
-Obj _35reg4497 = primCdr(closureRef(co, 0));
-Obj _35reg4498 = primCdr(_35reg4497);
-Obj _35reg4499 = primCdr(_35reg4498);
-Obj _35reg4500 = primCar(_35reg4499);
-Obj pred = _35reg4500;
-Obj _35reg4501 = primCdr(closureRef(co, 0));
-Obj _35reg4502 = primCdr(_35reg4501);
-Obj _35reg4503 = primCdr(_35reg4502);
-Obj _35reg4504 = primCdr(_35reg4503);
-Obj remain = _35reg4504;
-pushCont(co, _35clofun5170, 3, act, pred, remain);
+void _35clofun1131(struct Cora* co) {
+Obj _35cc2 = makeNative(_35clofun1132, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35reg445 = primIsCons(closureRef(co, 0));
+if (True == _35reg445) {
+Obj _35reg446 = primCar(closureRef(co, 0));
+Obj _35reg447 = primEQ(intern("=>"), _35reg446);
+if (True == _35reg447) {
+Obj _35reg448 = primCdr(closureRef(co, 0));
+Obj _35reg449 = primIsCons(_35reg448);
+if (True == _35reg449) {
+Obj _35reg450 = primCdr(closureRef(co, 0));
+Obj _35reg451 = primCar(_35reg450);
+Obj act = _35reg451;
+Obj _35reg452 = primCdr(closureRef(co, 0));
+Obj _35reg453 = primCdr(_35reg452);
+Obj _35reg454 = primIsCons(_35reg453);
+if (True == _35reg454) {
+Obj _35reg455 = primCdr(closureRef(co, 0));
+Obj _35reg456 = primCdr(_35reg455);
+Obj _35reg457 = primCar(_35reg456);
+Obj _35reg458 = primEQ(intern("where"), _35reg457);
+if (True == _35reg458) {
+Obj _35reg459 = primCdr(closureRef(co, 0));
+Obj _35reg460 = primCdr(_35reg459);
+Obj _35reg461 = primCdr(_35reg460);
+Obj _35reg462 = primIsCons(_35reg461);
+if (True == _35reg462) {
+Obj _35reg463 = primCdr(closureRef(co, 0));
+Obj _35reg464 = primCdr(_35reg463);
+Obj _35reg465 = primCdr(_35reg464);
+Obj _35reg466 = primCar(_35reg465);
+Obj pred = _35reg466;
+Obj _35reg467 = primCdr(closureRef(co, 0));
+Obj _35reg468 = primCdr(_35reg467);
+Obj _35reg469 = primCdr(_35reg468);
+Obj _35reg470 = primCdr(_35reg469);
+Obj remain = _35reg470;
+pushCont(co, _35clofun1136, 3, act, pred, remain);
 co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = closureRef(co, 1);
@@ -3662,7 +3662,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4036;
+co->args[0] = _35cc2;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3673,7 +3673,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4036;
+co->args[0] = _35cc2;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3684,7 +3684,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4036;
+co->args[0] = _35cc2;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3695,7 +3695,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4036;
+co->args[0] = _35cc2;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3706,7 +3706,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4036;
+co->args[0] = _35cc2;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3717,7 +3717,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4036;
+co->args[0] = _35cc2;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3728,23 +3728,23 @@ return;
 }
 }
 
-void _35clofun5170(struct Cora* co) {
-Obj _35val4505 = co->args[1];
+void _35clofun1136(struct Cora* co) {
+Obj _35val471 = co->args[1];
 Obj act = co->stack[co->base + 0];
 Obj pred = co->stack[co->base + 1];
 Obj remain = co->stack[co->base + 2];
-Obj _35reg4506 = primCons(intern("list"), _35val4505);
-Obj pat = _35reg4506;
-Obj _35reg4507 = primCons(act, Nil);
-Obj _35reg4508 = primCons(pred, _35reg4507);
-Obj _35reg4509 = primCons(intern("where"), _35reg4508);
-Obj _35reg4510 = primCons(pat, closureRef(co, 2));
-Obj _35reg4511 = primCons(_35reg4509, _35reg4510);
+Obj _35reg472 = primCons(intern("list"), _35val471);
+Obj pat = _35reg472;
+Obj _35reg473 = primCons(act, Nil);
+Obj _35reg474 = primCons(pred, _35reg473);
+Obj _35reg475 = primCons(intern("where"), _35reg474);
+Obj _35reg476 = primCons(pat, closureRef(co, 2));
+Obj _35reg477 = primCons(_35reg475, _35reg476);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/init.extract-rules1"));
 co->args[1] = remain;
 co->args[2] = Nil;
-co->args[3] = _35reg4511;
+co->args[3] = _35reg477;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3754,23 +3754,23 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5166(struct Cora* co) {
-Obj _35cc4037 = makeNative(_35clofun5167, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj _35reg4466 = primIsCons(closureRef(co, 0));
-if (True == _35reg4466) {
-Obj _35reg4467 = primCar(closureRef(co, 0));
-Obj _35reg4468 = primEQ(intern("=>"), _35reg4467);
-if (True == _35reg4468) {
-Obj _35reg4469 = primCdr(closureRef(co, 0));
-Obj _35reg4470 = primIsCons(_35reg4469);
-if (True == _35reg4470) {
-Obj _35reg4471 = primCdr(closureRef(co, 0));
-Obj _35reg4472 = primCar(_35reg4471);
-Obj act = _35reg4472;
-Obj _35reg4473 = primCdr(closureRef(co, 0));
-Obj _35reg4474 = primCdr(_35reg4473);
-Obj remain = _35reg4474;
-pushCont(co, _35clofun5169, 2, act, remain);
+void _35clofun1132(struct Cora* co) {
+Obj _35cc3 = makeNative(_35clofun1133, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35reg432 = primIsCons(closureRef(co, 0));
+if (True == _35reg432) {
+Obj _35reg433 = primCar(closureRef(co, 0));
+Obj _35reg434 = primEQ(intern("=>"), _35reg433);
+if (True == _35reg434) {
+Obj _35reg435 = primCdr(closureRef(co, 0));
+Obj _35reg436 = primIsCons(_35reg435);
+if (True == _35reg436) {
+Obj _35reg437 = primCdr(closureRef(co, 0));
+Obj _35reg438 = primCar(_35reg437);
+Obj act = _35reg438;
+Obj _35reg439 = primCdr(closureRef(co, 0));
+Obj _35reg440 = primCdr(_35reg439);
+Obj remain = _35reg440;
+pushCont(co, _35clofun1135, 2, act, remain);
 co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = closureRef(co, 1);
@@ -3783,7 +3783,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4037;
+co->args[0] = _35cc3;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3794,7 +3794,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4037;
+co->args[0] = _35cc3;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3805,7 +3805,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4037;
+co->args[0] = _35cc3;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3816,19 +3816,19 @@ return;
 }
 }
 
-void _35clofun5169(struct Cora* co) {
-Obj _35val4475 = co->args[1];
+void _35clofun1135(struct Cora* co) {
+Obj _35val441 = co->args[1];
 Obj act = co->stack[co->base + 0];
 Obj remain = co->stack[co->base + 1];
-Obj _35reg4476 = primCons(intern("list"), _35val4475);
-Obj pat = _35reg4476;
-Obj _35reg4477 = primCons(pat, closureRef(co, 2));
-Obj _35reg4478 = primCons(act, _35reg4477);
+Obj _35reg442 = primCons(intern("list"), _35val441);
+Obj pat = _35reg442;
+Obj _35reg443 = primCons(pat, closureRef(co, 2));
+Obj _35reg444 = primCons(act, _35reg443);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/init.extract-rules1"));
 co->args[1] = remain;
 co->args[2] = Nil;
-co->args[3] = _35reg4478;
+co->args[3] = _35reg444;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3838,19 +3838,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5167(struct Cora* co) {
-Obj _35cc4038 = makeNative(_35clofun5168, 0, 0);
-Obj _35reg4462 = primIsCons(closureRef(co, 0));
-if (True == _35reg4462) {
-Obj _35reg4463 = primCar(closureRef(co, 0));
-Obj x = _35reg4463;
-Obj _35reg4464 = primCdr(closureRef(co, 0));
-Obj y = _35reg4464;
-Obj _35reg4465 = primCons(x, closureRef(co, 1));
+void _35clofun1133(struct Cora* co) {
+Obj _35cc4 = makeNative(_35clofun1134, 0, 0);
+Obj _35reg428 = primIsCons(closureRef(co, 0));
+if (True == _35reg428) {
+Obj _35reg429 = primCar(closureRef(co, 0));
+Obj x = _35reg429;
+Obj _35reg430 = primCdr(closureRef(co, 0));
+Obj y = _35reg430;
+Obj _35reg431 = primCons(x, closureRef(co, 1));
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/init.extract-rules1"));
 co->args[1] = y;
-co->args[2] = _35reg4465;
+co->args[2] = _35reg431;
 co->args[3] = closureRef(co, 2);
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -3861,7 +3861,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc4038;
+co->args[0] = _35cc4;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3872,7 +3872,7 @@ return;
 }
 }
 
-void _35clofun5168(struct Cora* co) {
+void _35clofun1134(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -3885,7 +3885,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5162(struct Cora* co) {
+void _35clofun1128(struct Cora* co) {
 Obj exp = co->args[1];
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-match"));
@@ -3899,9 +3899,9 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5155(struct Cora* co) {
+void _35clofun1121(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun5156, 1, exp);
+pushCont(co, _35clofun1122, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -3914,13 +3914,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5156(struct Cora* co) {
-Obj _35val4435 = co->args[1];
+void _35clofun1122(struct Cora* co) {
+Obj _35val401 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-pushCont(co, _35clofun5157, 1, exp);
+pushCont(co, _35clofun1123, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("macroexpand"));
-co->args[1] = _35val4435;
+co->args[1] = _35val401;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3930,11 +3930,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5157(struct Cora* co) {
-Obj _35val4436 = co->args[1];
+void _35clofun1123(struct Cora* co) {
+Obj _35val402 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj value = _35val4436;
-pushCont(co, _35clofun5158, 1, value);
+Obj value = _35val402;
+pushCont(co, _35clofun1124, 1, value);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cddr"));
 co->args[1] = exp;
@@ -3947,20 +3947,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5158(struct Cora* co) {
-Obj _35val4437 = co->args[1];
+void _35clofun1124(struct Cora* co) {
+Obj _35val403 = co->args[1];
 Obj value = co->stack[co->base + 0];
-Obj rules = _35val4437;
-Obj _35reg4438 = primIsCons(value);
-if (True == _35reg4438) {
-Obj _35reg4439 = primCar(value);
-Obj _35reg4440 = primEQ(intern("cons"), _35reg4439);
-Obj _35reg4441 = primNot(_35reg4440);
-if (True == _35reg4441) {
+Obj rules = _35val403;
+Obj _35reg404 = primIsCons(value);
+if (True == _35reg404) {
+Obj _35reg405 = primCar(value);
+Obj _35reg406 = primEQ(intern("cons"), _35reg405);
+Obj _35reg407 = primNot(_35reg406);
+if (True == _35reg407) {
 if (True == True) {
-Obj _35reg4442 = primGenSym(intern("val"));
-Obj val = _35reg4442;
-pushCont(co, _35clofun5159, 2, value, val);
+Obj _35reg408 = primGenSym(intern("val"));
+Obj val = _35reg408;
+pushCont(co, _35clofun1125, 2, value, val);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = val;
@@ -3987,9 +3987,9 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg4448 = primGenSym(intern("val"));
-Obj val = _35reg4448;
-pushCont(co, _35clofun5160, 2, value, val);
+Obj _35reg414 = primGenSym(intern("val"));
+Obj val = _35reg414;
+pushCont(co, _35clofun1126, 2, value, val);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = val;
@@ -4017,9 +4017,9 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg4454 = primGenSym(intern("val"));
-Obj val = _35reg4454;
-pushCont(co, _35clofun5161, 2, value, val);
+Obj _35reg420 = primGenSym(intern("val"));
+Obj val = _35reg420;
+pushCont(co, _35clofun1127, 2, value, val);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = val;
@@ -4047,52 +4047,52 @@ return;
 }
 }
 
-void _35clofun5161(struct Cora* co) {
-Obj _35val4455 = co->args[1];
+void _35clofun1127(struct Cora* co) {
+Obj _35val421 = co->args[1];
 Obj value = co->stack[co->base + 0];
 Obj val = co->stack[co->base + 1];
-Obj _35reg4456 = primCons(_35val4455, Nil);
-Obj _35reg4457 = primCons(value, _35reg4456);
-Obj _35reg4458 = primCons(val, _35reg4457);
-Obj _35reg4459 = primCons(intern("let"), _35reg4458);
+Obj _35reg422 = primCons(_35val421, Nil);
+Obj _35reg423 = primCons(value, _35reg422);
+Obj _35reg424 = primCons(val, _35reg423);
+Obj _35reg425 = primCons(intern("let"), _35reg424);
 co->nargs = 2;
-co->args[1] = _35reg4459;
+co->args[1] = _35reg425;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5160(struct Cora* co) {
-Obj _35val4449 = co->args[1];
+void _35clofun1126(struct Cora* co) {
+Obj _35val415 = co->args[1];
 Obj value = co->stack[co->base + 0];
 Obj val = co->stack[co->base + 1];
-Obj _35reg4450 = primCons(_35val4449, Nil);
-Obj _35reg4451 = primCons(value, _35reg4450);
-Obj _35reg4452 = primCons(val, _35reg4451);
-Obj _35reg4453 = primCons(intern("let"), _35reg4452);
+Obj _35reg416 = primCons(_35val415, Nil);
+Obj _35reg417 = primCons(value, _35reg416);
+Obj _35reg418 = primCons(val, _35reg417);
+Obj _35reg419 = primCons(intern("let"), _35reg418);
 co->nargs = 2;
-co->args[1] = _35reg4453;
+co->args[1] = _35reg419;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5159(struct Cora* co) {
-Obj _35val4443 = co->args[1];
+void _35clofun1125(struct Cora* co) {
+Obj _35val409 = co->args[1];
 Obj value = co->stack[co->base + 0];
 Obj val = co->stack[co->base + 1];
-Obj _35reg4444 = primCons(_35val4443, Nil);
-Obj _35reg4445 = primCons(value, _35reg4444);
-Obj _35reg4446 = primCons(val, _35reg4445);
-Obj _35reg4447 = primCons(intern("let"), _35reg4446);
+Obj _35reg410 = primCons(_35val409, Nil);
+Obj _35reg411 = primCons(value, _35reg410);
+Obj _35reg412 = primCons(val, _35reg411);
+Obj _35reg413 = primCons(intern("let"), _35reg412);
 co->nargs = 2;
-co->args[1] = _35reg4447;
+co->args[1] = _35reg413;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5139(struct Cora* co) {
+void _35clofun1105(struct Cora* co) {
 Obj value = co->args[1];
 Obj rules = co->args[2];
-pushCont(co, _35clofun5140, 2, rules, value);
+pushCont(co, _35clofun1106, 2, rules, value);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = rules;
@@ -4105,19 +4105,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5140(struct Cora* co) {
-Obj _35val4383 = co->args[1];
+void _35clofun1106(struct Cora* co) {
+Obj _35val349 = co->args[1];
 Obj rules = co->stack[co->base + 0];
 Obj value = co->stack[co->base + 1];
-if (True == _35val4383) {
-Obj _35reg4384 = primCons(makeString1("no match-help found!"), Nil);
-Obj _35reg4385 = primCons(intern("error"), _35reg4384);
+if (True == _35val349) {
+Obj _35reg350 = primCons(makeString1("no match-help found!"), Nil);
+Obj _35reg351 = primCons(intern("error"), _35reg350);
 co->nargs = 2;
-co->args[1] = _35reg4385;
+co->args[1] = _35reg351;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-pushCont(co, _35clofun5141, 2, rules, value);
+pushCont(co, _35clofun1107, 2, rules, value);
 co->nargs = 2;
 co->args[0] = globalRef(intern("pair?"));
 co->args[1] = rules;
@@ -4131,16 +4131,16 @@ return;
 }
 }
 
-void _35clofun5141(struct Cora* co) {
-Obj _35val4386 = co->args[1];
+void _35clofun1107(struct Cora* co) {
+Obj _35val352 = co->args[1];
 Obj rules = co->stack[co->base + 0];
 Obj value = co->stack[co->base + 1];
-if (True == _35val4386) {
-Obj _35reg4387 = primCdr(rules);
-pushCont(co, _35clofun5142, 2, rules, value);
+if (True == _35val352) {
+Obj _35reg353 = primCdr(rules);
+pushCont(co, _35clofun1108, 2, rules, value);
 co->nargs = 2;
 co->args[0] = globalRef(intern("pair?"));
-co->args[1] = _35reg4387;
+co->args[1] = _35reg353;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4150,11 +4150,11 @@ co->pc = coraCall;
 return;
 } else {
 if (True == False) {
-Obj _35reg4419 = primCar(rules);
-Obj pat = _35reg4419;
-Obj _35reg4420 = primGenSym(intern("cc"));
-Obj cc = _35reg4420;
-pushCont(co, _35clofun5151, 4, pat, rules, value, cc);
+Obj _35reg385 = primCar(rules);
+Obj pat = _35reg385;
+Obj _35reg386 = primGenSym(intern("cc"));
+Obj cc = _35reg386;
+pushCont(co, _35clofun1117, 4, pat, rules, value, cc);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.extract-rule-action"));
 co->args[1] = rules;
@@ -4181,14 +4181,14 @@ return;
 }
 }
 
-void _35clofun5151(struct Cora* co) {
-Obj _35val4421 = co->args[1];
+void _35clofun1117(struct Cora* co) {
+Obj _35val387 = co->args[1];
 Obj pat = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
 Obj value = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-Obj action = _35val4421;
-pushCont(co, _35clofun5152, 4, action, rules, value, cc);
+Obj action = _35val387;
+pushCont(co, _35clofun1118, 4, action, rules, value, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("macroexpand"));
 co->args[1] = pat;
@@ -4201,16 +4201,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5152(struct Cora* co) {
-Obj _35val4422 = co->args[1];
+void _35clofun1118(struct Cora* co) {
+Obj _35val388 = co->args[1];
 Obj action = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
 Obj value = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-pushCont(co, _35clofun5153, 3, rules, value, cc);
+pushCont(co, _35clofun1119, 3, rules, value, cc);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
-co->args[1] = _35val4422;
+co->args[1] = _35val388;
 co->args[2] = value;
 co->args[3] = action;
 co->args[4] = cc;
@@ -4223,19 +4223,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5153(struct Cora* co) {
-Obj _35val4423 = co->args[1];
+void _35clofun1119(struct Cora* co) {
+Obj _35val389 = co->args[1];
 Obj rules = co->stack[co->base + 0];
 Obj value = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
-Obj curr = _35val4423;
-Obj _35reg4424 = primCdr(rules);
-Obj _35reg4425 = primCdr(_35reg4424);
-pushCont(co, _35clofun5154, 2, curr, cc);
+Obj curr = _35val389;
+Obj _35reg390 = primCdr(rules);
+Obj _35reg391 = primCdr(_35reg390);
+pushCont(co, _35clofun1120, 2, curr, cc);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = value;
-co->args[2] = _35reg4425;
+co->args[2] = _35reg391;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4245,35 +4245,35 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5154(struct Cora* co) {
-Obj _35val4426 = co->args[1];
+void _35clofun1120(struct Cora* co) {
+Obj _35val392 = co->args[1];
 Obj curr = co->stack[co->base + 0];
 Obj cc = co->stack[co->base + 1];
-Obj rest = _35val4426;
-Obj _35reg4427 = primCons(rest, Nil);
-Obj _35reg4428 = primCons(Nil, _35reg4427);
-Obj _35reg4429 = primCons(intern("lambda"), _35reg4428);
-Obj _35reg4430 = primCons(curr, Nil);
-Obj _35reg4431 = primCons(_35reg4429, _35reg4430);
-Obj _35reg4432 = primCons(cc, _35reg4431);
-Obj _35reg4433 = primCons(intern("let"), _35reg4432);
+Obj rest = _35val392;
+Obj _35reg393 = primCons(rest, Nil);
+Obj _35reg394 = primCons(Nil, _35reg393);
+Obj _35reg395 = primCons(intern("lambda"), _35reg394);
+Obj _35reg396 = primCons(curr, Nil);
+Obj _35reg397 = primCons(_35reg395, _35reg396);
+Obj _35reg398 = primCons(cc, _35reg397);
+Obj _35reg399 = primCons(intern("let"), _35reg398);
 co->nargs = 2;
-co->args[1] = _35reg4433;
+co->args[1] = _35reg399;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5142(struct Cora* co) {
-Obj _35val4388 = co->args[1];
+void _35clofun1108(struct Cora* co) {
+Obj _35val354 = co->args[1];
 Obj rules = co->stack[co->base + 0];
 Obj value = co->stack[co->base + 1];
-if (True == _35val4388) {
+if (True == _35val354) {
 if (True == True) {
-Obj _35reg4389 = primCar(rules);
-Obj pat = _35reg4389;
-Obj _35reg4390 = primGenSym(intern("cc"));
-Obj cc = _35reg4390;
-pushCont(co, _35clofun5143, 4, pat, rules, value, cc);
+Obj _35reg355 = primCar(rules);
+Obj pat = _35reg355;
+Obj _35reg356 = primGenSym(intern("cc"));
+Obj cc = _35reg356;
+pushCont(co, _35clofun1109, 4, pat, rules, value, cc);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.extract-rule-action"));
 co->args[1] = rules;
@@ -4299,11 +4299,11 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg4404 = primCar(rules);
-Obj pat = _35reg4404;
-Obj _35reg4405 = primGenSym(intern("cc"));
-Obj cc = _35reg4405;
-pushCont(co, _35clofun5147, 4, pat, rules, value, cc);
+Obj _35reg370 = primCar(rules);
+Obj pat = _35reg370;
+Obj _35reg371 = primGenSym(intern("cc"));
+Obj cc = _35reg371;
+pushCont(co, _35clofun1113, 4, pat, rules, value, cc);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.extract-rule-action"));
 co->args[1] = rules;
@@ -4330,14 +4330,14 @@ return;
 }
 }
 
-void _35clofun5147(struct Cora* co) {
-Obj _35val4406 = co->args[1];
+void _35clofun1113(struct Cora* co) {
+Obj _35val372 = co->args[1];
 Obj pat = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
 Obj value = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-Obj action = _35val4406;
-pushCont(co, _35clofun5148, 4, action, rules, value, cc);
+Obj action = _35val372;
+pushCont(co, _35clofun1114, 4, action, rules, value, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("macroexpand"));
 co->args[1] = pat;
@@ -4350,16 +4350,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5148(struct Cora* co) {
-Obj _35val4407 = co->args[1];
+void _35clofun1114(struct Cora* co) {
+Obj _35val373 = co->args[1];
 Obj action = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
 Obj value = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-pushCont(co, _35clofun5149, 3, rules, value, cc);
+pushCont(co, _35clofun1115, 3, rules, value, cc);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
-co->args[1] = _35val4407;
+co->args[1] = _35val373;
 co->args[2] = value;
 co->args[3] = action;
 co->args[4] = cc;
@@ -4372,19 +4372,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5149(struct Cora* co) {
-Obj _35val4408 = co->args[1];
+void _35clofun1115(struct Cora* co) {
+Obj _35val374 = co->args[1];
 Obj rules = co->stack[co->base + 0];
 Obj value = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
-Obj curr = _35val4408;
-Obj _35reg4409 = primCdr(rules);
-Obj _35reg4410 = primCdr(_35reg4409);
-pushCont(co, _35clofun5150, 2, curr, cc);
+Obj curr = _35val374;
+Obj _35reg375 = primCdr(rules);
+Obj _35reg376 = primCdr(_35reg375);
+pushCont(co, _35clofun1116, 2, curr, cc);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = value;
-co->args[2] = _35reg4410;
+co->args[2] = _35reg376;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4394,32 +4394,32 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5150(struct Cora* co) {
-Obj _35val4411 = co->args[1];
+void _35clofun1116(struct Cora* co) {
+Obj _35val377 = co->args[1];
 Obj curr = co->stack[co->base + 0];
 Obj cc = co->stack[co->base + 1];
-Obj rest = _35val4411;
-Obj _35reg4412 = primCons(rest, Nil);
-Obj _35reg4413 = primCons(Nil, _35reg4412);
-Obj _35reg4414 = primCons(intern("lambda"), _35reg4413);
-Obj _35reg4415 = primCons(curr, Nil);
-Obj _35reg4416 = primCons(_35reg4414, _35reg4415);
-Obj _35reg4417 = primCons(cc, _35reg4416);
-Obj _35reg4418 = primCons(intern("let"), _35reg4417);
+Obj rest = _35val377;
+Obj _35reg378 = primCons(rest, Nil);
+Obj _35reg379 = primCons(Nil, _35reg378);
+Obj _35reg380 = primCons(intern("lambda"), _35reg379);
+Obj _35reg381 = primCons(curr, Nil);
+Obj _35reg382 = primCons(_35reg380, _35reg381);
+Obj _35reg383 = primCons(cc, _35reg382);
+Obj _35reg384 = primCons(intern("let"), _35reg383);
 co->nargs = 2;
-co->args[1] = _35reg4418;
+co->args[1] = _35reg384;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5143(struct Cora* co) {
-Obj _35val4391 = co->args[1];
+void _35clofun1109(struct Cora* co) {
+Obj _35val357 = co->args[1];
 Obj pat = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
 Obj value = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-Obj action = _35val4391;
-pushCont(co, _35clofun5144, 4, action, rules, value, cc);
+Obj action = _35val357;
+pushCont(co, _35clofun1110, 4, action, rules, value, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("macroexpand"));
 co->args[1] = pat;
@@ -4432,16 +4432,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5144(struct Cora* co) {
-Obj _35val4392 = co->args[1];
+void _35clofun1110(struct Cora* co) {
+Obj _35val358 = co->args[1];
 Obj action = co->stack[co->base + 0];
 Obj rules = co->stack[co->base + 1];
 Obj value = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-pushCont(co, _35clofun5145, 3, rules, value, cc);
+pushCont(co, _35clofun1111, 3, rules, value, cc);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
-co->args[1] = _35val4392;
+co->args[1] = _35val358;
 co->args[2] = value;
 co->args[3] = action;
 co->args[4] = cc;
@@ -4454,19 +4454,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5145(struct Cora* co) {
-Obj _35val4393 = co->args[1];
+void _35clofun1111(struct Cora* co) {
+Obj _35val359 = co->args[1];
 Obj rules = co->stack[co->base + 0];
 Obj value = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
-Obj curr = _35val4393;
-Obj _35reg4394 = primCdr(rules);
-Obj _35reg4395 = primCdr(_35reg4394);
-pushCont(co, _35clofun5146, 2, curr, cc);
+Obj curr = _35val359;
+Obj _35reg360 = primCdr(rules);
+Obj _35reg361 = primCdr(_35reg360);
+pushCont(co, _35clofun1112, 2, curr, cc);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.match-helper"));
 co->args[1] = value;
-co->args[2] = _35reg4395;
+co->args[2] = _35reg361;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4476,31 +4476,31 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5146(struct Cora* co) {
-Obj _35val4396 = co->args[1];
+void _35clofun1112(struct Cora* co) {
+Obj _35val362 = co->args[1];
 Obj curr = co->stack[co->base + 0];
 Obj cc = co->stack[co->base + 1];
-Obj rest = _35val4396;
-Obj _35reg4397 = primCons(rest, Nil);
-Obj _35reg4398 = primCons(Nil, _35reg4397);
-Obj _35reg4399 = primCons(intern("lambda"), _35reg4398);
-Obj _35reg4400 = primCons(curr, Nil);
-Obj _35reg4401 = primCons(_35reg4399, _35reg4400);
-Obj _35reg4402 = primCons(cc, _35reg4401);
-Obj _35reg4403 = primCons(intern("let"), _35reg4402);
+Obj rest = _35val362;
+Obj _35reg363 = primCons(rest, Nil);
+Obj _35reg364 = primCons(Nil, _35reg363);
+Obj _35reg365 = primCons(intern("lambda"), _35reg364);
+Obj _35reg366 = primCons(curr, Nil);
+Obj _35reg367 = primCons(_35reg365, _35reg366);
+Obj _35reg368 = primCons(cc, _35reg367);
+Obj _35reg369 = primCons(intern("let"), _35reg368);
 co->nargs = 2;
-co->args[1] = _35reg4403;
+co->args[1] = _35reg369;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5131(struct Cora* co) {
+void _35clofun1097(struct Cora* co) {
 Obj rules = co->args[1];
 Obj cc = co->args[2];
-Obj _35reg4356 = primCdr(rules);
-Obj _35reg4357 = primCar(_35reg4356);
-Obj action = _35reg4357;
-pushCont(co, _35clofun5132, 2, cc, action);
+Obj _35reg322 = primCdr(rules);
+Obj _35reg323 = primCar(_35reg322);
+Obj action = _35reg323;
+pushCont(co, _35clofun1098, 2, cc, action);
 co->nargs = 2;
 co->args[0] = globalRef(intern("pair?"));
 co->args[1] = action;
@@ -4513,16 +4513,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5132(struct Cora* co) {
-Obj _35val4358 = co->args[1];
+void _35clofun1098(struct Cora* co) {
+Obj _35val324 = co->args[1];
 Obj cc = co->stack[co->base + 0];
 Obj action = co->stack[co->base + 1];
-if (True == _35val4358) {
-Obj _35reg4359 = primCar(action);
-Obj _35reg4360 = primEQ(_35reg4359, intern("where"));
-if (True == _35reg4360) {
+if (True == _35val324) {
+Obj _35reg325 = primCar(action);
+Obj _35reg326 = primEQ(_35reg325, intern("where"));
+if (True == _35reg326) {
 if (True == True) {
-pushCont(co, _35clofun5133, 2, action, cc);
+pushCont(co, _35clofun1099, 2, action, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = action;
@@ -4541,7 +4541,7 @@ return;
 }
 } else {
 if (True == False) {
-pushCont(co, _35clofun5135, 2, action, cc);
+pushCont(co, _35clofun1101, 2, action, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = action;
@@ -4561,7 +4561,7 @@ return;
 }
 } else {
 if (True == False) {
-pushCont(co, _35clofun5137, 2, action, cc);
+pushCont(co, _35clofun1103, 2, action, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = action;
@@ -4581,11 +4581,11 @@ return;
 }
 }
 
-void _35clofun5137(struct Cora* co) {
-Obj _35val4375 = co->args[1];
+void _35clofun1103(struct Cora* co) {
+Obj _35val341 = co->args[1];
 Obj action = co->stack[co->base + 0];
 Obj cc = co->stack[co->base + 1];
-pushCont(co, _35clofun5138, 2, cc, _35val4375);
+pushCont(co, _35clofun1104, 2, cc, _35val341);
 co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = action;
@@ -4598,26 +4598,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5138(struct Cora* co) {
-Obj _35val4376 = co->args[1];
+void _35clofun1104(struct Cora* co) {
+Obj _35val342 = co->args[1];
 Obj cc = co->stack[co->base + 0];
-Obj _35val4375 = co->stack[co->base + 1];
-Obj _35reg4377 = primCons(cc, Nil);
-Obj _35reg4378 = primCons(_35reg4377, Nil);
-Obj _35reg4379 = primCons(_35val4376, _35reg4378);
-Obj _35reg4380 = primCons(_35val4375, _35reg4379);
-Obj _35reg4381 = primCons(intern("if"), _35reg4380);
+Obj _35val341 = co->stack[co->base + 1];
+Obj _35reg343 = primCons(cc, Nil);
+Obj _35reg344 = primCons(_35reg343, Nil);
+Obj _35reg345 = primCons(_35val342, _35reg344);
+Obj _35reg346 = primCons(_35val341, _35reg345);
+Obj _35reg347 = primCons(intern("if"), _35reg346);
 co->nargs = 2;
-co->args[1] = _35reg4381;
+co->args[1] = _35reg347;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5135(struct Cora* co) {
-Obj _35val4368 = co->args[1];
+void _35clofun1101(struct Cora* co) {
+Obj _35val334 = co->args[1];
 Obj action = co->stack[co->base + 0];
 Obj cc = co->stack[co->base + 1];
-pushCont(co, _35clofun5136, 2, cc, _35val4368);
+pushCont(co, _35clofun1102, 2, cc, _35val334);
 co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = action;
@@ -4630,26 +4630,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5136(struct Cora* co) {
-Obj _35val4369 = co->args[1];
+void _35clofun1102(struct Cora* co) {
+Obj _35val335 = co->args[1];
 Obj cc = co->stack[co->base + 0];
-Obj _35val4368 = co->stack[co->base + 1];
-Obj _35reg4370 = primCons(cc, Nil);
-Obj _35reg4371 = primCons(_35reg4370, Nil);
-Obj _35reg4372 = primCons(_35val4369, _35reg4371);
-Obj _35reg4373 = primCons(_35val4368, _35reg4372);
-Obj _35reg4374 = primCons(intern("if"), _35reg4373);
+Obj _35val334 = co->stack[co->base + 1];
+Obj _35reg336 = primCons(cc, Nil);
+Obj _35reg337 = primCons(_35reg336, Nil);
+Obj _35reg338 = primCons(_35val335, _35reg337);
+Obj _35reg339 = primCons(_35val334, _35reg338);
+Obj _35reg340 = primCons(intern("if"), _35reg339);
 co->nargs = 2;
-co->args[1] = _35reg4374;
+co->args[1] = _35reg340;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5133(struct Cora* co) {
-Obj _35val4361 = co->args[1];
+void _35clofun1099(struct Cora* co) {
+Obj _35val327 = co->args[1];
 Obj action = co->stack[co->base + 0];
 Obj cc = co->stack[co->base + 1];
-pushCont(co, _35clofun5134, 2, cc, _35val4361);
+pushCont(co, _35clofun1100, 2, cc, _35val327);
 co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = action;
@@ -4662,28 +4662,28 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5134(struct Cora* co) {
-Obj _35val4362 = co->args[1];
+void _35clofun1100(struct Cora* co) {
+Obj _35val328 = co->args[1];
 Obj cc = co->stack[co->base + 0];
-Obj _35val4361 = co->stack[co->base + 1];
-Obj _35reg4363 = primCons(cc, Nil);
-Obj _35reg4364 = primCons(_35reg4363, Nil);
-Obj _35reg4365 = primCons(_35val4362, _35reg4364);
-Obj _35reg4366 = primCons(_35val4361, _35reg4365);
-Obj _35reg4367 = primCons(intern("if"), _35reg4366);
+Obj _35val327 = co->stack[co->base + 1];
+Obj _35reg329 = primCons(cc, Nil);
+Obj _35reg330 = primCons(_35reg329, Nil);
+Obj _35reg331 = primCons(_35val328, _35reg330);
+Obj _35reg332 = primCons(_35val327, _35reg331);
+Obj _35reg333 = primCons(intern("if"), _35reg332);
 co->nargs = 2;
-co->args[1] = _35reg4367;
+co->args[1] = _35reg333;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5125(struct Cora* co) {
+void _35clofun1091(struct Cora* co) {
 Obj pat = co->args[1];
 Obj expr = co->args[2];
 Obj body = co->args[3];
 Obj cc = co->args[4];
-Obj literal_63 = makeNative(_35clofun5126, 1, 0);
-pushCont(co, _35clofun5128, 4, expr, body, cc, pat);
+Obj literal_63 = makeNative(_35clofun1092, 1, 0);
+pushCont(co, _35clofun1094, 4, expr, body, cc, pat);
 co->nargs = 2;
 co->args[0] = literal_63;
 co->args[1] = pat;
@@ -4696,46 +4696,46 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5128(struct Cora* co) {
-Obj _35val4326 = co->args[1];
+void _35clofun1094(struct Cora* co) {
+Obj _35val292 = co->args[1];
 Obj expr = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
 Obj pat = co->stack[co->base + 3];
-if (True == _35val4326) {
-Obj _35reg4327 = primEQ(pat, expr);
-if (True == _35reg4327) {
+if (True == _35val292) {
+Obj _35reg293 = primEQ(pat, expr);
+if (True == _35reg293) {
 co->nargs = 2;
 co->args[1] = body;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4328 = primCons(expr, Nil);
-Obj _35reg4329 = primCons(pat, _35reg4328);
-Obj _35reg4330 = primCons(intern("="), _35reg4329);
-Obj _35reg4331 = primCons(cc, Nil);
-Obj _35reg4332 = primCons(_35reg4331, Nil);
-Obj _35reg4333 = primCons(body, _35reg4332);
-Obj _35reg4334 = primCons(_35reg4330, _35reg4333);
-Obj _35reg4335 = primCons(intern("if"), _35reg4334);
+Obj _35reg294 = primCons(expr, Nil);
+Obj _35reg295 = primCons(pat, _35reg294);
+Obj _35reg296 = primCons(intern("="), _35reg295);
+Obj _35reg297 = primCons(cc, Nil);
+Obj _35reg298 = primCons(_35reg297, Nil);
+Obj _35reg299 = primCons(body, _35reg298);
+Obj _35reg300 = primCons(_35reg296, _35reg299);
+Obj _35reg301 = primCons(intern("if"), _35reg300);
 co->nargs = 2;
-co->args[1] = _35reg4335;
+co->args[1] = _35reg301;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 } else {
-Obj _35reg4336 = primIsSymbol(pat);
-if (True == _35reg4336) {
-Obj _35reg4337 = primCons(body, Nil);
-Obj _35reg4338 = primCons(expr, _35reg4337);
-Obj _35reg4339 = primCons(pat, _35reg4338);
-Obj _35reg4340 = primCons(intern("let"), _35reg4339);
+Obj _35reg302 = primIsSymbol(pat);
+if (True == _35reg302) {
+Obj _35reg303 = primCons(body, Nil);
+Obj _35reg304 = primCons(expr, _35reg303);
+Obj _35reg305 = primCons(pat, _35reg304);
+Obj _35reg306 = primCons(intern("let"), _35reg305);
 co->nargs = 2;
-co->args[1] = _35reg4340;
+co->args[1] = _35reg306;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-pushCont(co, _35clofun5129, 4, expr, body, cc, pat);
+pushCont(co, _35clofun1095, 4, expr, body, cc, pat);
 co->nargs = 2;
 co->args[0] = globalRef(intern("pair?"));
 co->args[1] = pat;
@@ -4750,32 +4750,32 @@ return;
 }
 }
 
-void _35clofun5129(struct Cora* co) {
-Obj _35val4341 = co->args[1];
+void _35clofun1095(struct Cora* co) {
+Obj _35val307 = co->args[1];
 Obj expr = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
 Obj pat = co->stack[co->base + 3];
-if (True == _35val4341) {
-Obj _35reg4342 = primCar(pat);
-Obj _35reg4343 = primEQ(_35reg4342, intern("quote"));
-if (True == _35reg4343) {
-Obj _35reg4344 = primCons(expr, Nil);
-Obj _35reg4345 = primCons(pat, _35reg4344);
-Obj _35reg4346 = primCons(intern("="), _35reg4345);
-Obj _35reg4347 = primCons(cc, Nil);
-Obj _35reg4348 = primCons(_35reg4347, Nil);
-Obj _35reg4349 = primCons(body, _35reg4348);
-Obj _35reg4350 = primCons(_35reg4346, _35reg4349);
-Obj _35reg4351 = primCons(intern("if"), _35reg4350);
+if (True == _35val307) {
+Obj _35reg308 = primCar(pat);
+Obj _35reg309 = primEQ(_35reg308, intern("quote"));
+if (True == _35reg309) {
+Obj _35reg310 = primCons(expr, Nil);
+Obj _35reg311 = primCons(pat, _35reg310);
+Obj _35reg312 = primCons(intern("="), _35reg311);
+Obj _35reg313 = primCons(cc, Nil);
+Obj _35reg314 = primCons(_35reg313, Nil);
+Obj _35reg315 = primCons(body, _35reg314);
+Obj _35reg316 = primCons(_35reg312, _35reg315);
+Obj _35reg317 = primCons(intern("if"), _35reg316);
 co->nargs = 2;
-co->args[1] = _35reg4351;
+co->args[1] = _35reg317;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4352 = primCar(pat);
-Obj _35reg4353 = primEQ(_35reg4352, intern("cons"));
-if (True == _35reg4353) {
+Obj _35reg318 = primCar(pat);
+Obj _35reg319 = primEQ(_35reg318, intern("cons"));
+if (True == _35reg319) {
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match-cons-expander"));
 co->args[1] = pat;
@@ -4803,7 +4803,7 @@ return;
 }
 }
 } else {
-pushCont(co, _35clofun5130, 0);
+pushCont(co, _35clofun1096, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("str"));
 co->args[1] = makeString1("match fail ");
@@ -4818,11 +4818,11 @@ return;
 }
 }
 
-void _35clofun5130(struct Cora* co) {
-Obj _35val4354 = co->args[1];
+void _35clofun1096(struct Cora* co) {
+Obj _35val320 = co->args[1];
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
-co->args[1] = _35val4354;
+co->args[1] = _35val320;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4832,9 +4832,9 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5126(struct Cora* co) {
+void _35clofun1092(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun5127, 1, x);
+pushCont(co, _35clofun1093, 1, x);
 co->nargs = 2;
 co->args[0] = globalRef(intern("atom?"));
 co->args[1] = x;
@@ -4847,13 +4847,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5127(struct Cora* co) {
-Obj _35val4323 = co->args[1];
+void _35clofun1093(struct Cora* co) {
+Obj _35val289 = co->args[1];
 Obj x = co->stack[co->base + 0];
-if (True == _35val4323) {
-Obj _35reg4324 = primIsSymbol(x);
-Obj _35reg4325 = primNot(_35reg4324);
-if (True == _35reg4325) {
+if (True == _35val289) {
+Obj _35reg290 = primIsSymbol(x);
+Obj _35reg291 = primNot(_35reg290);
+if (True == _35reg291) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
@@ -4872,12 +4872,12 @@ return;
 }
 }
 
-void _35clofun5107(struct Cora* co) {
+void _35clofun1073(struct Cora* co) {
 Obj pat = co->args[1];
 Obj expr = co->args[2];
 Obj body = co->args[3];
 Obj cc = co->args[4];
-pushCont(co, _35clofun5108, 4, pat, expr, body, cc);
+pushCont(co, _35clofun1074, 4, pat, expr, body, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = pat;
@@ -4890,14 +4890,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5108(struct Cora* co) {
-Obj _35val4269 = co->args[1];
+void _35clofun1074(struct Cora* co) {
+Obj _35val235 = co->args[1];
 Obj pat = co->stack[co->base + 0];
 Obj expr = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-Obj x = _35val4269;
-pushCont(co, _35clofun5109, 4, expr, body, x, cc);
+Obj x = _35val235;
+pushCont(co, _35clofun1075, 4, expr, body, x, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = pat;
@@ -4910,20 +4910,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5109(struct Cora* co) {
-Obj _35val4270 = co->args[1];
+void _35clofun1075(struct Cora* co) {
+Obj _35val236 = co->args[1];
 Obj expr = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj x = co->stack[co->base + 2];
 Obj cc = co->stack[co->base + 3];
-Obj y = _35val4270;
-Obj _35reg4271 = primIsCons(expr);
-if (True == _35reg4271) {
-Obj _35reg4272 = primCar(expr);
-Obj _35reg4273 = primEQ(_35reg4272, intern("cons"));
-if (True == _35reg4273) {
+Obj y = _35val236;
+Obj _35reg237 = primIsCons(expr);
+if (True == _35reg237) {
+Obj _35reg238 = primCar(expr);
+Obj _35reg239 = primEQ(_35reg238, intern("cons"));
+if (True == _35reg239) {
 if (True == True) {
-pushCont(co, _35clofun5110, 5, expr, y, body, x, cc);
+pushCont(co, _35clofun1076, 5, expr, y, body, x, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = expr;
@@ -4935,17 +4935,17 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg4277 = primCons(expr, Nil);
-Obj _35reg4278 = primCons(intern("cons?"), _35reg4277);
-Obj _35reg4279 = primCons(expr, Nil);
-Obj _35reg4280 = primCons(intern("car"), _35reg4279);
-Obj _35reg4281 = primCons(expr, Nil);
-Obj _35reg4282 = primCons(intern("cdr"), _35reg4281);
-pushCont(co, _35clofun5113, 4, x, _35reg4280, cc, _35reg4278);
+Obj _35reg243 = primCons(expr, Nil);
+Obj _35reg244 = primCons(intern("cons?"), _35reg243);
+Obj _35reg245 = primCons(expr, Nil);
+Obj _35reg246 = primCons(intern("car"), _35reg245);
+Obj _35reg247 = primCons(expr, Nil);
+Obj _35reg248 = primCons(intern("cdr"), _35reg247);
+pushCont(co, _35clofun1079, 4, x, _35reg246, cc, _35reg244);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = y;
-co->args[2] = _35reg4282;
+co->args[2] = _35reg248;
 co->args[3] = body;
 co->args[4] = cc;
 if (nativeRequired(co->args[0]) == 4) {
@@ -4958,7 +4958,7 @@ return;
 }
 } else {
 if (True == False) {
-pushCont(co, _35clofun5115, 5, expr, y, body, x, cc);
+pushCont(co, _35clofun1081, 5, expr, y, body, x, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = expr;
@@ -4970,17 +4970,17 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg4293 = primCons(expr, Nil);
-Obj _35reg4294 = primCons(intern("cons?"), _35reg4293);
-Obj _35reg4295 = primCons(expr, Nil);
-Obj _35reg4296 = primCons(intern("car"), _35reg4295);
-Obj _35reg4297 = primCons(expr, Nil);
-Obj _35reg4298 = primCons(intern("cdr"), _35reg4297);
-pushCont(co, _35clofun5118, 4, x, _35reg4296, cc, _35reg4294);
+Obj _35reg259 = primCons(expr, Nil);
+Obj _35reg260 = primCons(intern("cons?"), _35reg259);
+Obj _35reg261 = primCons(expr, Nil);
+Obj _35reg262 = primCons(intern("car"), _35reg261);
+Obj _35reg263 = primCons(expr, Nil);
+Obj _35reg264 = primCons(intern("cdr"), _35reg263);
+pushCont(co, _35clofun1084, 4, x, _35reg262, cc, _35reg260);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = y;
-co->args[2] = _35reg4298;
+co->args[2] = _35reg264;
 co->args[3] = body;
 co->args[4] = cc;
 if (nativeRequired(co->args[0]) == 4) {
@@ -4994,7 +4994,7 @@ return;
 }
 } else {
 if (True == False) {
-pushCont(co, _35clofun5120, 5, expr, y, body, x, cc);
+pushCont(co, _35clofun1086, 5, expr, y, body, x, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = expr;
@@ -5006,17 +5006,17 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg4309 = primCons(expr, Nil);
-Obj _35reg4310 = primCons(intern("cons?"), _35reg4309);
-Obj _35reg4311 = primCons(expr, Nil);
-Obj _35reg4312 = primCons(intern("car"), _35reg4311);
-Obj _35reg4313 = primCons(expr, Nil);
-Obj _35reg4314 = primCons(intern("cdr"), _35reg4313);
-pushCont(co, _35clofun5123, 4, x, _35reg4312, cc, _35reg4310);
+Obj _35reg275 = primCons(expr, Nil);
+Obj _35reg276 = primCons(intern("cons?"), _35reg275);
+Obj _35reg277 = primCons(expr, Nil);
+Obj _35reg278 = primCons(intern("car"), _35reg277);
+Obj _35reg279 = primCons(expr, Nil);
+Obj _35reg280 = primCons(intern("cdr"), _35reg279);
+pushCont(co, _35clofun1089, 4, x, _35reg278, cc, _35reg276);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = y;
-co->args[2] = _35reg4314;
+co->args[2] = _35reg280;
 co->args[3] = body;
 co->args[4] = cc;
 if (nativeRequired(co->args[0]) == 4) {
@@ -5030,18 +5030,18 @@ return;
 }
 }
 
-void _35clofun5123(struct Cora* co) {
-Obj _35val4315 = co->args[1];
+void _35clofun1089(struct Cora* co) {
+Obj _35val281 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35reg4312 = co->stack[co->base + 1];
+Obj _35reg278 = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
-Obj _35reg4310 = co->stack[co->base + 3];
-pushCont(co, _35clofun5124, 2, cc, _35reg4310);
+Obj _35reg276 = co->stack[co->base + 3];
+pushCont(co, _35clofun1090, 2, cc, _35reg276);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = x;
-co->args[2] = _35reg4312;
-co->args[3] = _35val4315;
+co->args[2] = _35reg278;
+co->args[3] = _35val281;
 co->args[4] = cc;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -5052,30 +5052,30 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5124(struct Cora* co) {
-Obj _35val4316 = co->args[1];
+void _35clofun1090(struct Cora* co) {
+Obj _35val282 = co->args[1];
 Obj cc = co->stack[co->base + 0];
-Obj _35reg4310 = co->stack[co->base + 1];
-Obj _35reg4317 = primCons(cc, Nil);
-Obj _35reg4318 = primCons(_35reg4317, Nil);
-Obj _35reg4319 = primCons(_35val4316, _35reg4318);
-Obj _35reg4320 = primCons(_35reg4310, _35reg4319);
-Obj _35reg4321 = primCons(intern("if"), _35reg4320);
+Obj _35reg276 = co->stack[co->base + 1];
+Obj _35reg283 = primCons(cc, Nil);
+Obj _35reg284 = primCons(_35reg283, Nil);
+Obj _35reg285 = primCons(_35val282, _35reg284);
+Obj _35reg286 = primCons(_35reg276, _35reg285);
+Obj _35reg287 = primCons(intern("if"), _35reg286);
 co->nargs = 2;
-co->args[1] = _35reg4321;
+co->args[1] = _35reg287;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5120(struct Cora* co) {
-Obj _35val4306 = co->args[1];
+void _35clofun1086(struct Cora* co) {
+Obj _35val272 = co->args[1];
 Obj expr = co->stack[co->base + 0];
 Obj y = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj x = co->stack[co->base + 3];
 Obj cc = co->stack[co->base + 4];
-Obj e1 = _35val4306;
-pushCont(co, _35clofun5121, 5, y, body, x, e1, cc);
+Obj e1 = _35val272;
+pushCont(co, _35clofun1087, 5, y, body, x, e1, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = expr;
@@ -5088,15 +5088,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5121(struct Cora* co) {
-Obj _35val4307 = co->args[1];
+void _35clofun1087(struct Cora* co) {
+Obj _35val273 = co->args[1];
 Obj y = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj x = co->stack[co->base + 2];
 Obj e1 = co->stack[co->base + 3];
 Obj cc = co->stack[co->base + 4];
-Obj e2 = _35val4307;
-pushCont(co, _35clofun5122, 3, x, e1, cc);
+Obj e2 = _35val273;
+pushCont(co, _35clofun1088, 3, x, e1, cc);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = y;
@@ -5112,8 +5112,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5122(struct Cora* co) {
-Obj _35val4308 = co->args[1];
+void _35clofun1088(struct Cora* co) {
+Obj _35val274 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj e1 = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
@@ -5121,7 +5121,7 @@ co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = x;
 co->args[2] = e1;
-co->args[3] = _35val4308;
+co->args[3] = _35val274;
 co->args[4] = cc;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -5132,18 +5132,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5118(struct Cora* co) {
-Obj _35val4299 = co->args[1];
+void _35clofun1084(struct Cora* co) {
+Obj _35val265 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35reg4296 = co->stack[co->base + 1];
+Obj _35reg262 = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
-Obj _35reg4294 = co->stack[co->base + 3];
-pushCont(co, _35clofun5119, 2, cc, _35reg4294);
+Obj _35reg260 = co->stack[co->base + 3];
+pushCont(co, _35clofun1085, 2, cc, _35reg260);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = x;
-co->args[2] = _35reg4296;
-co->args[3] = _35val4299;
+co->args[2] = _35reg262;
+co->args[3] = _35val265;
 co->args[4] = cc;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -5154,30 +5154,30 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5119(struct Cora* co) {
-Obj _35val4300 = co->args[1];
+void _35clofun1085(struct Cora* co) {
+Obj _35val266 = co->args[1];
 Obj cc = co->stack[co->base + 0];
-Obj _35reg4294 = co->stack[co->base + 1];
-Obj _35reg4301 = primCons(cc, Nil);
-Obj _35reg4302 = primCons(_35reg4301, Nil);
-Obj _35reg4303 = primCons(_35val4300, _35reg4302);
-Obj _35reg4304 = primCons(_35reg4294, _35reg4303);
-Obj _35reg4305 = primCons(intern("if"), _35reg4304);
+Obj _35reg260 = co->stack[co->base + 1];
+Obj _35reg267 = primCons(cc, Nil);
+Obj _35reg268 = primCons(_35reg267, Nil);
+Obj _35reg269 = primCons(_35val266, _35reg268);
+Obj _35reg270 = primCons(_35reg260, _35reg269);
+Obj _35reg271 = primCons(intern("if"), _35reg270);
 co->nargs = 2;
-co->args[1] = _35reg4305;
+co->args[1] = _35reg271;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5115(struct Cora* co) {
-Obj _35val4290 = co->args[1];
+void _35clofun1081(struct Cora* co) {
+Obj _35val256 = co->args[1];
 Obj expr = co->stack[co->base + 0];
 Obj y = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj x = co->stack[co->base + 3];
 Obj cc = co->stack[co->base + 4];
-Obj e1 = _35val4290;
-pushCont(co, _35clofun5116, 5, y, body, x, e1, cc);
+Obj e1 = _35val256;
+pushCont(co, _35clofun1082, 5, y, body, x, e1, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = expr;
@@ -5190,15 +5190,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5116(struct Cora* co) {
-Obj _35val4291 = co->args[1];
+void _35clofun1082(struct Cora* co) {
+Obj _35val257 = co->args[1];
 Obj y = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj x = co->stack[co->base + 2];
 Obj e1 = co->stack[co->base + 3];
 Obj cc = co->stack[co->base + 4];
-Obj e2 = _35val4291;
-pushCont(co, _35clofun5117, 3, x, e1, cc);
+Obj e2 = _35val257;
+pushCont(co, _35clofun1083, 3, x, e1, cc);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = y;
@@ -5214,8 +5214,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5117(struct Cora* co) {
-Obj _35val4292 = co->args[1];
+void _35clofun1083(struct Cora* co) {
+Obj _35val258 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj e1 = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
@@ -5223,7 +5223,7 @@ co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = x;
 co->args[2] = e1;
-co->args[3] = _35val4292;
+co->args[3] = _35val258;
 co->args[4] = cc;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -5234,18 +5234,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5113(struct Cora* co) {
-Obj _35val4283 = co->args[1];
+void _35clofun1079(struct Cora* co) {
+Obj _35val249 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35reg4280 = co->stack[co->base + 1];
+Obj _35reg246 = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
-Obj _35reg4278 = co->stack[co->base + 3];
-pushCont(co, _35clofun5114, 2, cc, _35reg4278);
+Obj _35reg244 = co->stack[co->base + 3];
+pushCont(co, _35clofun1080, 2, cc, _35reg244);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = x;
-co->args[2] = _35reg4280;
-co->args[3] = _35val4283;
+co->args[2] = _35reg246;
+co->args[3] = _35val249;
 co->args[4] = cc;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -5256,30 +5256,30 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5114(struct Cora* co) {
-Obj _35val4284 = co->args[1];
+void _35clofun1080(struct Cora* co) {
+Obj _35val250 = co->args[1];
 Obj cc = co->stack[co->base + 0];
-Obj _35reg4278 = co->stack[co->base + 1];
-Obj _35reg4285 = primCons(cc, Nil);
-Obj _35reg4286 = primCons(_35reg4285, Nil);
-Obj _35reg4287 = primCons(_35val4284, _35reg4286);
-Obj _35reg4288 = primCons(_35reg4278, _35reg4287);
-Obj _35reg4289 = primCons(intern("if"), _35reg4288);
+Obj _35reg244 = co->stack[co->base + 1];
+Obj _35reg251 = primCons(cc, Nil);
+Obj _35reg252 = primCons(_35reg251, Nil);
+Obj _35reg253 = primCons(_35val250, _35reg252);
+Obj _35reg254 = primCons(_35reg244, _35reg253);
+Obj _35reg255 = primCons(intern("if"), _35reg254);
 co->nargs = 2;
-co->args[1] = _35reg4289;
+co->args[1] = _35reg255;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5110(struct Cora* co) {
-Obj _35val4274 = co->args[1];
+void _35clofun1076(struct Cora* co) {
+Obj _35val240 = co->args[1];
 Obj expr = co->stack[co->base + 0];
 Obj y = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj x = co->stack[co->base + 3];
 Obj cc = co->stack[co->base + 4];
-Obj e1 = _35val4274;
-pushCont(co, _35clofun5111, 5, y, body, x, e1, cc);
+Obj e1 = _35val240;
+pushCont(co, _35clofun1077, 5, y, body, x, e1, cc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = expr;
@@ -5292,15 +5292,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5111(struct Cora* co) {
-Obj _35val4275 = co->args[1];
+void _35clofun1077(struct Cora* co) {
+Obj _35val241 = co->args[1];
 Obj y = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj x = co->stack[co->base + 2];
 Obj e1 = co->stack[co->base + 3];
 Obj cc = co->stack[co->base + 4];
-Obj e2 = _35val4275;
-pushCont(co, _35clofun5112, 3, x, e1, cc);
+Obj e2 = _35val241;
+pushCont(co, _35clofun1078, 3, x, e1, cc);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = y;
@@ -5316,8 +5316,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5112(struct Cora* co) {
-Obj _35val4276 = co->args[1];
+void _35clofun1078(struct Cora* co) {
+Obj _35val242 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj e1 = co->stack[co->base + 1];
 Obj cc = co->stack[co->base + 2];
@@ -5325,7 +5325,7 @@ co->nargs = 5;
 co->args[0] = globalRef(intern("cora/init.match1"));
 co->args[1] = x;
 co->args[2] = e1;
-co->args[3] = _35val4276;
+co->args[3] = _35val242;
 co->args[4] = cc;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -5336,12 +5336,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5105(struct Cora* co) {
+void _35clofun1071(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg4267 = primCdr(exp);
+Obj _35reg233 = primCdr(exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rcons1"));
-co->args[1] = _35reg4267;
+co->args[1] = _35reg233;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5351,13 +5351,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5102(struct Cora* co) {
+void _35clofun1068(struct Cora* co) {
 Obj pat = co->args[1];
-Obj _35reg4257 = primCdr(pat);
-pushCont(co, _35clofun5103, 1, pat);
+Obj _35reg223 = primCdr(pat);
+pushCont(co, _35clofun1069, 1, pat);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
-co->args[1] = _35reg4257;
+co->args[1] = _35reg223;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5367,22 +5367,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5103(struct Cora* co) {
-Obj _35val4258 = co->args[1];
+void _35clofun1069(struct Cora* co) {
+Obj _35val224 = co->args[1];
 Obj pat = co->stack[co->base + 0];
-if (True == _35val4258) {
-Obj _35reg4259 = primCar(pat);
+if (True == _35val224) {
+Obj _35reg225 = primCar(pat);
 co->nargs = 2;
-co->args[1] = _35reg4259;
+co->args[1] = _35reg225;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4260 = primCar(pat);
-Obj _35reg4261 = primCdr(pat);
-pushCont(co, _35clofun5104, 1, _35reg4260);
+Obj _35reg226 = primCar(pat);
+Obj _35reg227 = primCdr(pat);
+pushCont(co, _35clofun1070, 1, _35reg226);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rcons1"));
-co->args[1] = _35reg4261;
+co->args[1] = _35reg227;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5393,29 +5393,29 @@ return;
 }
 }
 
-void _35clofun5104(struct Cora* co) {
-Obj _35val4262 = co->args[1];
-Obj _35reg4260 = co->stack[co->base + 0];
-Obj _35reg4263 = primCons(_35val4262, Nil);
-Obj _35reg4264 = primCons(_35reg4260, _35reg4263);
-Obj _35reg4265 = primCons(intern("cons"), _35reg4264);
+void _35clofun1070(struct Cora* co) {
+Obj _35val228 = co->args[1];
+Obj _35reg226 = co->stack[co->base + 0];
+Obj _35reg229 = primCons(_35val228, Nil);
+Obj _35reg230 = primCons(_35reg226, _35reg229);
+Obj _35reg231 = primCons(intern("cons"), _35reg230);
 co->nargs = 2;
-co->args[1] = _35reg4265;
+co->args[1] = _35reg231;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5101(struct Cora* co) {
+void _35clofun1067(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4254 = primEQ(x, True);
-if (True == _35reg4254) {
+Obj _35reg220 = primEQ(x, True);
+if (True == _35reg220) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4255 = primEQ(x, False);
-if (True == _35reg4255) {
+Obj _35reg221 = primEQ(x, False);
+if (True == _35reg221) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
@@ -5429,12 +5429,12 @@ return;
 }
 }
 
-void _35clofun5099(struct Cora* co) {
+void _35clofun1065(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg4252 = primCdr(exp);
+Obj _35reg218 = primCdr(exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-and"));
-co->args[1] = _35reg4252;
+co->args[1] = _35reg218;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5444,28 +5444,28 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5097(struct Cora* co) {
+void _35clofun1063(struct Cora* co) {
 Obj l = co->args[1];
-Obj _35reg4240 = primEQ(Nil, l);
-if (True == _35reg4240) {
+Obj _35reg206 = primEQ(Nil, l);
+if (True == _35reg206) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4241 = primCar(l);
-Obj _35reg4242 = primEQ(_35reg4241, False);
-if (True == _35reg4242) {
+Obj _35reg207 = primCar(l);
+Obj _35reg208 = primEQ(_35reg207, False);
+if (True == _35reg208) {
 co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4243 = primCdr(l);
-pushCont(co, _35clofun5098, 1, l);
+Obj _35reg209 = primCdr(l);
+pushCont(co, _35clofun1064, 1, l);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-and"));
-co->args[1] = _35reg4243;
+co->args[1] = _35reg209;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5477,35 +5477,35 @@ return;
 }
 }
 
-void _35clofun5098(struct Cora* co) {
-Obj _35val4244 = co->args[1];
+void _35clofun1064(struct Cora* co) {
+Obj _35val210 = co->args[1];
 Obj l = co->stack[co->base + 0];
-Obj more = _35val4244;
-Obj _35reg4245 = primEQ(more, False);
-if (True == _35reg4245) {
+Obj more = _35val210;
+Obj _35reg211 = primEQ(more, False);
+if (True == _35reg211) {
 co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4246 = primCar(l);
-Obj _35reg4247 = primCons(False, Nil);
-Obj _35reg4248 = primCons(more, _35reg4247);
-Obj _35reg4249 = primCons(_35reg4246, _35reg4248);
-Obj _35reg4250 = primCons(intern("if"), _35reg4249);
+Obj _35reg212 = primCar(l);
+Obj _35reg213 = primCons(False, Nil);
+Obj _35reg214 = primCons(more, _35reg213);
+Obj _35reg215 = primCons(_35reg212, _35reg214);
+Obj _35reg216 = primCons(intern("if"), _35reg215);
 co->nargs = 2;
-co->args[1] = _35reg4250;
+co->args[1] = _35reg216;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun5095(struct Cora* co) {
+void _35clofun1061(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg4238 = primCdr(exp);
+Obj _35reg204 = primCdr(exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-or"));
-co->args[1] = _35reg4238;
+co->args[1] = _35reg204;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5515,28 +5515,28 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5093(struct Cora* co) {
+void _35clofun1059(struct Cora* co) {
 Obj l = co->args[1];
-Obj _35reg4226 = primEQ(l, Nil);
-if (True == _35reg4226) {
+Obj _35reg192 = primEQ(l, Nil);
+if (True == _35reg192) {
 co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4227 = primCar(l);
-Obj _35reg4228 = primEQ(_35reg4227, True);
-if (True == _35reg4228) {
+Obj _35reg193 = primCar(l);
+Obj _35reg194 = primEQ(_35reg193, True);
+if (True == _35reg194) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4229 = primCdr(l);
-pushCont(co, _35clofun5094, 1, l);
+Obj _35reg195 = primCdr(l);
+pushCont(co, _35clofun1060, 1, l);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-or"));
-co->args[1] = _35reg4229;
+co->args[1] = _35reg195;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5548,42 +5548,42 @@ return;
 }
 }
 
-void _35clofun5094(struct Cora* co) {
-Obj _35val4230 = co->args[1];
+void _35clofun1060(struct Cora* co) {
+Obj _35val196 = co->args[1];
 Obj l = co->stack[co->base + 0];
-Obj more = _35val4230;
-Obj _35reg4231 = primEQ(more, True);
-if (True == _35reg4231) {
+Obj more = _35val196;
+Obj _35reg197 = primEQ(more, True);
+if (True == _35reg197) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4232 = primCar(l);
-Obj _35reg4233 = primCons(more, Nil);
-Obj _35reg4234 = primCons(True, _35reg4233);
-Obj _35reg4235 = primCons(_35reg4232, _35reg4234);
-Obj _35reg4236 = primCons(intern("if"), _35reg4235);
+Obj _35reg198 = primCar(l);
+Obj _35reg199 = primCons(more, Nil);
+Obj _35reg200 = primCons(True, _35reg199);
+Obj _35reg201 = primCons(_35reg198, _35reg200);
+Obj _35reg202 = primCons(intern("if"), _35reg201);
 co->nargs = 2;
-co->args[1] = _35reg4236;
+co->args[1] = _35reg202;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun5088(struct Cora* co) {
+void _35clofun1054(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg4212 = primCdr(exp);
-Obj _35reg4213 = primEQ(Nil, _35reg4212);
-if (True == _35reg4213) {
-Obj _35reg4214 = primCons(makeString1("no cond match"), Nil);
-Obj _35reg4215 = primCons(intern("error"), _35reg4214);
+Obj _35reg178 = primCdr(exp);
+Obj _35reg179 = primEQ(Nil, _35reg178);
+if (True == _35reg179) {
+Obj _35reg180 = primCons(makeString1("no cond match"), Nil);
+Obj _35reg181 = primCons(intern("error"), _35reg180);
 co->nargs = 2;
-co->args[1] = _35reg4215;
+co->args[1] = _35reg181;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-pushCont(co, _35clofun5089, 1, exp);
+pushCont(co, _35clofun1055, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -5597,12 +5597,12 @@ return;
 }
 }
 
-void _35clofun5089(struct Cora* co) {
-Obj _35val4216 = co->args[1];
+void _35clofun1055(struct Cora* co) {
+Obj _35val182 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj curr = _35val4216;
-Obj _35reg4217 = primCar(curr);
-pushCont(co, _35clofun5090, 2, exp, _35reg4217);
+Obj curr = _35val182;
+Obj _35reg183 = primCar(curr);
+pushCont(co, _35clofun1056, 2, exp, _35reg183);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = curr;
@@ -5615,11 +5615,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5090(struct Cora* co) {
-Obj _35val4218 = co->args[1];
+void _35clofun1056(struct Cora* co) {
+Obj _35val184 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg4217 = co->stack[co->base + 1];
-pushCont(co, _35clofun5091, 2, _35val4218, _35reg4217);
+Obj _35reg183 = co->stack[co->base + 1];
+pushCont(co, _35clofun1057, 2, _35val184, _35reg183);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cddr"));
 co->args[1] = exp;
@@ -5632,27 +5632,27 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5091(struct Cora* co) {
-Obj _35val4219 = co->args[1];
-Obj _35val4218 = co->stack[co->base + 0];
-Obj _35reg4217 = co->stack[co->base + 1];
-Obj _35reg4220 = primCons(intern("cond"), _35val4219);
-Obj _35reg4221 = primCons(_35reg4220, Nil);
-Obj _35reg4222 = primCons(_35val4218, _35reg4221);
-Obj _35reg4223 = primCons(_35reg4217, _35reg4222);
-Obj _35reg4224 = primCons(intern("if"), _35reg4223);
+void _35clofun1057(struct Cora* co) {
+Obj _35val185 = co->args[1];
+Obj _35val184 = co->stack[co->base + 0];
+Obj _35reg183 = co->stack[co->base + 1];
+Obj _35reg186 = primCons(intern("cond"), _35val185);
+Obj _35reg187 = primCons(_35reg186, Nil);
+Obj _35reg188 = primCons(_35val184, _35reg187);
+Obj _35reg189 = primCons(_35reg183, _35reg188);
+Obj _35reg190 = primCons(intern("if"), _35reg189);
 co->nargs = 2;
-co->args[1] = _35reg4224;
+co->args[1] = _35reg190;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5086(struct Cora* co) {
+void _35clofun1052(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg4210 = primCdr(exp);
+Obj _35reg176 = primCdr(exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-let"));
-co->args[1] = _35reg4210;
+co->args[1] = _35reg176;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5662,13 +5662,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5081(struct Cora* co) {
+void _35clofun1047(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg4198 = primCdr(exp);
-pushCont(co, _35clofun5082, 1, exp);
+Obj _35reg164 = primCdr(exp);
+pushCont(co, _35clofun1048, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
-co->args[1] = _35reg4198;
+co->args[1] = _35reg164;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5678,18 +5678,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5082(struct Cora* co) {
-Obj _35val4199 = co->args[1];
+void _35clofun1048(struct Cora* co) {
+Obj _35val165 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-if (True == _35val4199) {
-Obj _35reg4200 = primCar(exp);
+if (True == _35val165) {
+Obj _35reg166 = primCar(exp);
 co->nargs = 2;
-co->args[1] = _35reg4200;
+co->args[1] = _35reg166;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4201 = primCar(exp);
-pushCont(co, _35clofun5083, 2, exp, _35reg4201);
+Obj _35reg167 = primCar(exp);
+pushCont(co, _35clofun1049, 2, exp, _35reg167);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -5703,11 +5703,11 @@ return;
 }
 }
 
-void _35clofun5083(struct Cora* co) {
-Obj _35val4202 = co->args[1];
+void _35clofun1049(struct Cora* co) {
+Obj _35val168 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg4201 = co->stack[co->base + 1];
-pushCont(co, _35clofun5084, 2, _35val4202, _35reg4201);
+Obj _35reg167 = co->stack[co->base + 1];
+pushCont(co, _35clofun1050, 2, _35val168, _35reg167);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cddr"));
 co->args[1] = exp;
@@ -5720,14 +5720,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5084(struct Cora* co) {
-Obj _35val4203 = co->args[1];
-Obj _35val4202 = co->stack[co->base + 0];
-Obj _35reg4201 = co->stack[co->base + 1];
-pushCont(co, _35clofun5085, 2, _35val4202, _35reg4201);
+void _35clofun1050(struct Cora* co) {
+Obj _35val169 = co->args[1];
+Obj _35val168 = co->stack[co->base + 0];
+Obj _35reg167 = co->stack[co->base + 1];
+pushCont(co, _35clofun1051, 2, _35val168, _35reg167);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.rewrite-let"));
-co->args[1] = _35val4203;
+co->args[1] = _35val169;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5737,48 +5737,48 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5085(struct Cora* co) {
-Obj _35val4204 = co->args[1];
-Obj _35val4202 = co->stack[co->base + 0];
-Obj _35reg4201 = co->stack[co->base + 1];
-Obj _35reg4205 = primCons(_35val4204, Nil);
-Obj _35reg4206 = primCons(_35val4202, _35reg4205);
-Obj _35reg4207 = primCons(_35reg4201, _35reg4206);
-Obj _35reg4208 = primCons(intern("let"), _35reg4207);
+void _35clofun1051(struct Cora* co) {
+Obj _35val170 = co->args[1];
+Obj _35val168 = co->stack[co->base + 0];
+Obj _35reg167 = co->stack[co->base + 1];
+Obj _35reg171 = primCons(_35val170, Nil);
+Obj _35reg172 = primCons(_35val168, _35reg171);
+Obj _35reg173 = primCons(_35reg167, _35reg172);
+Obj _35reg174 = primCons(intern("let"), _35reg173);
 co->nargs = 2;
-co->args[1] = _35reg4208;
+co->args[1] = _35reg174;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5080(struct Cora* co) {
+void _35clofun1046(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4195 = primIsCons(x);
-Obj _35reg4196 = primNot(_35reg4195);
+Obj _35reg161 = primIsCons(x);
+Obj _35reg162 = primNot(_35reg161);
 co->nargs = 2;
-co->args[1] = _35reg4196;
+co->args[1] = _35reg162;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5079(struct Cora* co) {
+void _35clofun1045(struct Cora* co) {
 Obj x = co->args[1];
 Obj l = co->args[2];
-Obj _35reg4190 = primIsCons(l);
-if (True == _35reg4190) {
-Obj _35reg4191 = primCar(l);
-Obj _35reg4192 = primEQ(_35reg4191, x);
-if (True == _35reg4192) {
+Obj _35reg156 = primIsCons(l);
+if (True == _35reg156) {
+Obj _35reg157 = primCar(l);
+Obj _35reg158 = primEQ(_35reg157, x);
+if (True == _35reg158) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4193 = primCdr(l);
+Obj _35reg159 = primCdr(l);
 co->nargs = 3;
 co->args[0] = globalRef(intern("elem?"));
 co->args[1] = x;
-co->args[2] = _35reg4193;
+co->args[2] = _35reg159;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5795,9 +5795,9 @@ return;
 }
 }
 
-void _35clofun5074(struct Cora* co) {
+void _35clofun1040(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun5075, 1, exp);
+pushCont(co, _35clofun1041, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -5810,12 +5810,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5075(struct Cora* co) {
-Obj _35val4178 = co->args[1];
+void _35clofun1041(struct Cora* co) {
+Obj _35val144 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg4179 = primCons(_35val4178, Nil);
-Obj _35reg4180 = primCons(intern("quote"), _35reg4179);
-pushCont(co, _35clofun5076, 2, exp, _35reg4180);
+Obj _35reg145 = primCons(_35val144, Nil);
+Obj _35reg146 = primCons(intern("quote"), _35reg145);
+pushCont(co, _35clofun1042, 2, exp, _35reg146);
 co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = exp;
@@ -5828,11 +5828,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5076(struct Cora* co) {
-Obj _35val4181 = co->args[1];
+void _35clofun1042(struct Cora* co) {
+Obj _35val147 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg4180 = co->stack[co->base + 1];
-pushCont(co, _35clofun5077, 2, _35val4181, _35reg4180);
+Obj _35reg146 = co->stack[co->base + 1];
+pushCont(co, _35clofun1043, 2, _35val147, _35reg146);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadddr"));
 co->args[1] = exp;
@@ -5845,28 +5845,28 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5077(struct Cora* co) {
-Obj _35val4182 = co->args[1];
-Obj _35val4181 = co->stack[co->base + 0];
-Obj _35reg4180 = co->stack[co->base + 1];
-Obj _35reg4183 = primCons(_35val4182, Nil);
-Obj _35reg4184 = primCons(_35val4181, _35reg4183);
-Obj _35reg4185 = primCons(intern("lambda"), _35reg4184);
-Obj _35reg4186 = primCons(_35reg4185, Nil);
-Obj _35reg4187 = primCons(_35reg4180, _35reg4186);
-Obj _35reg4188 = primCons(intern("set"), _35reg4187);
+void _35clofun1043(struct Cora* co) {
+Obj _35val148 = co->args[1];
+Obj _35val147 = co->stack[co->base + 0];
+Obj _35reg146 = co->stack[co->base + 1];
+Obj _35reg149 = primCons(_35val148, Nil);
+Obj _35reg150 = primCons(_35val147, _35reg149);
+Obj _35reg151 = primCons(intern("lambda"), _35reg150);
+Obj _35reg152 = primCons(_35reg151, Nil);
+Obj _35reg153 = primCons(_35reg146, _35reg152);
+Obj _35reg154 = primCons(intern("set"), _35reg153);
 co->nargs = 2;
-co->args[1] = _35reg4188;
+co->args[1] = _35reg154;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5072(struct Cora* co) {
+void _35clofun1038(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg4176 = primCdr(exp);
+Obj _35reg142 = primCdr(exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("rcons"));
-co->args[1] = _35reg4176;
+co->args[1] = _35reg142;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5876,9 +5876,9 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5067(struct Cora* co) {
+void _35clofun1033(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun5068, 1, exp);
+pushCont(co, _35clofun1034, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -5891,12 +5891,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5068(struct Cora* co) {
-Obj _35val4164 = co->args[1];
+void _35clofun1034(struct Cora* co) {
+Obj _35val130 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg4165 = primCons(_35val4164, Nil);
-Obj _35reg4166 = primCons(intern("quote"), _35reg4165);
-pushCont(co, _35clofun5069, 2, exp, _35reg4166);
+Obj _35reg131 = primCons(_35val130, Nil);
+Obj _35reg132 = primCons(intern("quote"), _35reg131);
+pushCont(co, _35clofun1035, 2, exp, _35reg132);
 co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = exp;
@@ -5909,11 +5909,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5069(struct Cora* co) {
-Obj _35val4167 = co->args[1];
+void _35clofun1035(struct Cora* co) {
+Obj _35val133 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg4166 = co->stack[co->base + 1];
-pushCont(co, _35clofun5070, 2, _35val4167, _35reg4166);
+Obj _35reg132 = co->stack[co->base + 1];
+pushCont(co, _35clofun1036, 2, _35val133, _35reg132);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cdddr"));
 co->args[1] = exp;
@@ -5926,38 +5926,38 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5070(struct Cora* co) {
-Obj _35val4168 = co->args[1];
-Obj _35val4167 = co->stack[co->base + 0];
-Obj _35reg4166 = co->stack[co->base + 1];
-Obj _35reg4169 = primCons(_35val4167, _35val4168);
-Obj _35reg4170 = primCons(intern("lambda"), _35reg4169);
-Obj _35reg4171 = primCons(_35reg4170, Nil);
-Obj _35reg4172 = primCons(_35reg4166, _35reg4171);
-Obj _35reg4173 = primCons(intern("cora/init.add-to-*macros*"), _35reg4172);
+void _35clofun1036(struct Cora* co) {
+Obj _35val134 = co->args[1];
+Obj _35val133 = co->stack[co->base + 0];
+Obj _35reg132 = co->stack[co->base + 1];
+Obj _35reg135 = primCons(_35val133, _35val134);
+Obj _35reg136 = primCons(intern("lambda"), _35reg135);
+Obj _35reg137 = primCons(_35reg136, Nil);
+Obj _35reg138 = primCons(_35reg132, _35reg137);
+Obj _35reg139 = primCons(intern("cora/init.add-to-*macros*"), _35reg138);
 co->nargs = 2;
-co->args[1] = _35reg4173;
+co->args[1] = _35reg139;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5061(struct Cora* co) {
+void _35clofun1027(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg4146 = primIsCons(exp);
-if (True == _35reg4146) {
-Obj _35reg4147 = primCar(exp);
-Obj _35reg4148 = primEQ(_35reg4147, globalRef(intern("*protect-symbol*")));
-if (True == _35reg4148) {
-Obj _35reg4149 = primCdr(exp);
+Obj _35reg112 = primIsCons(exp);
+if (True == _35reg112) {
+Obj _35reg113 = primCar(exp);
+Obj _35reg114 = primEQ(_35reg113, globalRef(intern("*protect-symbol*")));
+if (True == _35reg114) {
+Obj _35reg115 = primCdr(exp);
 co->nargs = 2;
-co->args[1] = _35reg4149;
+co->args[1] = _35reg115;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4150 = primCar(exp);
-Obj _35reg4151 = primEQ(_35reg4150, intern("lambda"));
-if (True == _35reg4151) {
-pushCont(co, _35clofun5062, 1, exp);
+Obj _35reg116 = primCar(exp);
+Obj _35reg117 = primEQ(_35reg116, intern("lambda"));
+if (True == _35reg117) {
+pushCont(co, _35clofun1028, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -5969,15 +5969,15 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg4158 = primCar(exp);
-Obj _35reg4159 = primEQ(_35reg4158, intern("quote"));
-if (True == _35reg4159) {
+Obj _35reg124 = primCar(exp);
+Obj _35reg125 = primEQ(_35reg124, intern("quote"));
+if (True == _35reg125) {
 co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-pushCont(co, _35clofun5065, 1, exp);
+pushCont(co, _35clofun1031, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.macroexpand1"));
 co->args[1] = exp;
@@ -5999,12 +5999,12 @@ return;
 }
 }
 
-void _35clofun5065(struct Cora* co) {
-Obj _35val4161 = co->args[1];
+void _35clofun1031(struct Cora* co) {
+Obj _35val127 = co->args[1];
 Obj exp = co->stack[co->base + 0];
 co->nargs = 2;
-co->args[0] = makeNative(_35clofun5066, 1, 1, exp);
-co->args[1] = _35val4161;
+co->args[0] = makeNative(_35clofun1032, 1, 1, exp);
+co->args[1] = _35val127;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6014,10 +6014,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5066(struct Cora* co) {
+void _35clofun1032(struct Cora* co) {
 Obj exp1 = co->args[1];
-Obj _35reg4160 = primEQ(exp1, closureRef(co, 0));
-if (True == _35reg4160) {
+Obj _35reg126 = primEQ(exp1, closureRef(co, 0));
+if (True == _35reg126) {
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/init.macroexpand-boot"));
@@ -6043,10 +6043,10 @@ return;
 }
 }
 
-void _35clofun5062(struct Cora* co) {
-Obj _35val4152 = co->args[1];
+void _35clofun1028(struct Cora* co) {
+Obj _35val118 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-pushCont(co, _35clofun5063, 1, _35val4152);
+pushCont(co, _35clofun1029, 1, _35val118);
 co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = exp;
@@ -6059,13 +6059,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5063(struct Cora* co) {
-Obj _35val4153 = co->args[1];
-Obj _35val4152 = co->stack[co->base + 0];
-pushCont(co, _35clofun5064, 1, _35val4152);
+void _35clofun1029(struct Cora* co) {
+Obj _35val119 = co->args[1];
+Obj _35val118 = co->stack[co->base + 0];
+pushCont(co, _35clofun1030, 1, _35val118);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/init.macroexpand-boot"));
-co->args[1] = _35val4153;
+co->args[1] = _35val119;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6075,19 +6075,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5064(struct Cora* co) {
-Obj _35val4154 = co->args[1];
-Obj _35val4152 = co->stack[co->base + 0];
-Obj _35reg4155 = primCons(_35val4154, Nil);
-Obj _35reg4156 = primCons(_35val4152, _35reg4155);
-Obj _35reg4157 = primCons(intern("lambda"), _35reg4156);
+void _35clofun1030(struct Cora* co) {
+Obj _35val120 = co->args[1];
+Obj _35val118 = co->stack[co->base + 0];
+Obj _35reg121 = primCons(_35val120, Nil);
+Obj _35reg122 = primCons(_35val118, _35reg121);
+Obj _35reg123 = primCons(intern("lambda"), _35reg122);
 co->nargs = 2;
-co->args[1] = _35reg4157;
+co->args[1] = _35reg123;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5060(struct Cora* co) {
+void _35clofun1026(struct Cora* co) {
 Obj exp = co->args[1];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.macroexpand1-h"));
@@ -6102,20 +6102,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5058(struct Cora* co) {
+void _35clofun1024(struct Cora* co) {
 Obj exp = co->args[1];
 Obj macros = co->args[2];
-Obj _35reg4132 = primEQ(Nil, macros);
-if (True == _35reg4132) {
+Obj _35reg98 = primEQ(Nil, macros);
+if (True == _35reg98) {
 co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg4143 = primCar(macros);
+Obj _35reg109 = primCar(macros);
 co->nargs = 2;
-co->args[0] = makeNative(_35clofun5059, 1, 2, exp, macros);
-co->args[1] = _35reg4143;
+co->args[0] = makeNative(_35clofun1025, 1, 2, exp, macros);
+co->args[1] = _35reg109;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6126,18 +6126,18 @@ return;
 }
 }
 
-void _35clofun5059(struct Cora* co) {
+void _35clofun1025(struct Cora* co) {
 Obj item = co->args[1];
-Obj _35reg4133 = primIsCons(closureRef(co, 0));
-if (True == _35reg4133) {
-Obj _35reg4134 = primCar(closureRef(co, 0));
-Obj _35reg4135 = primCar(item);
-Obj _35reg4136 = primEQ(_35reg4134, _35reg4135);
-if (True == _35reg4136) {
+Obj _35reg99 = primIsCons(closureRef(co, 0));
+if (True == _35reg99) {
+Obj _35reg100 = primCar(closureRef(co, 0));
+Obj _35reg101 = primCar(item);
+Obj _35reg102 = primEQ(_35reg100, _35reg101);
+if (True == _35reg102) {
 if (True == True) {
-Obj _35reg4137 = primCdr(item);
+Obj _35reg103 = primCdr(item);
 co->nargs = 2;
-co->args[0] = _35reg4137;
+co->args[0] = _35reg103;
 co->args[1] = closureRef(co, 0);
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -6147,11 +6147,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg4138 = primCdr(closureRef(co, 1));
+Obj _35reg104 = primCdr(closureRef(co, 1));
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.macroexpand1-h"));
 co->args[1] = closureRef(co, 0);
-co->args[2] = _35reg4138;
+co->args[2] = _35reg104;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6162,9 +6162,9 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg4139 = primCdr(item);
+Obj _35reg105 = primCdr(item);
 co->nargs = 2;
-co->args[0] = _35reg4139;
+co->args[0] = _35reg105;
 co->args[1] = closureRef(co, 0);
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -6174,11 +6174,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg4140 = primCdr(closureRef(co, 1));
+Obj _35reg106 = primCdr(closureRef(co, 1));
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.macroexpand1-h"));
 co->args[1] = closureRef(co, 0);
-co->args[2] = _35reg4140;
+co->args[2] = _35reg106;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6190,9 +6190,9 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg4141 = primCdr(item);
+Obj _35reg107 = primCdr(item);
 co->nargs = 2;
-co->args[0] = _35reg4141;
+co->args[0] = _35reg107;
 co->args[1] = closureRef(co, 0);
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -6202,11 +6202,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg4142 = primCdr(closureRef(co, 1));
+Obj _35reg108 = primCdr(closureRef(co, 1));
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.macroexpand1-h"));
 co->args[1] = closureRef(co, 0);
-co->args[2] = _35reg4142;
+co->args[2] = _35reg108;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6218,28 +6218,28 @@ return;
 }
 }
 
-void _35clofun5057(struct Cora* co) {
+void _35clofun1023(struct Cora* co) {
 Obj n = co->args[1];
 Obj v = co->args[2];
-Obj _35reg4128 = primCons(n, v);
-Obj _35reg4129 = primCons(_35reg4128, globalRef(intern("*macros*")));
-Obj _35reg4130 = primSet(intern("*macros*"), _35reg4129);
+Obj _35reg94 = primCons(n, v);
+Obj _35reg95 = primCons(_35reg94, globalRef(intern("*macros*")));
+Obj _35reg96 = primSet(intern("*macros*"), _35reg95);
 co->nargs = 2;
-co->args[1] = _35reg4130;
+co->args[1] = _35reg96;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5056(struct Cora* co) {
+void _35clofun1022(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4126 = primCons(globalRef(intern("*protect-symbol*")), x);
+Obj _35reg92 = primCons(globalRef(intern("*protect-symbol*")), x);
 co->nargs = 2;
-co->args[1] = _35reg4126;
+co->args[1] = _35reg92;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5055(struct Cora* co) {
+void _35clofun1021(struct Cora* co) {
 Obj f = co->args[1];
 Obj l = co->args[2];
 co->nargs = 4;
@@ -6256,17 +6256,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5053(struct Cora* co) {
+void _35clofun1019(struct Cora* co) {
 Obj res = co->args[1];
 Obj f = co->args[2];
 Obj l = co->args[3];
-Obj _35reg4116 = primIsCons(l);
-if (True == _35reg4116) {
-Obj _35reg4117 = primCar(l);
-pushCont(co, _35clofun5054, 3, res, l, f);
+Obj _35reg82 = primIsCons(l);
+if (True == _35reg82) {
+Obj _35reg83 = primCar(l);
+pushCont(co, _35clofun1020, 3, res, l, f);
 co->nargs = 2;
 co->args[0] = f;
-co->args[1] = _35reg4117;
+co->args[1] = _35reg83;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6288,18 +6288,18 @@ return;
 }
 }
 
-void _35clofun5054(struct Cora* co) {
-Obj _35val4118 = co->args[1];
+void _35clofun1020(struct Cora* co) {
+Obj _35val84 = co->args[1];
 Obj res = co->stack[co->base + 0];
 Obj l = co->stack[co->base + 1];
 Obj f = co->stack[co->base + 2];
-Obj _35reg4119 = primCons(_35val4118, res);
-Obj _35reg4120 = primCdr(l);
+Obj _35reg85 = primCons(_35val84, res);
+Obj _35reg86 = primCdr(l);
 co->nargs = 4;
 co->args[0] = globalRef(intern("map-h"));
-co->args[1] = _35reg4119;
+co->args[1] = _35reg85;
 co->args[2] = f;
-co->args[3] = _35reg4120;
+co->args[3] = _35reg86;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6309,18 +6309,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun5051(struct Cora* co) {
+void _35clofun1017(struct Cora* co) {
 Obj res = co->args[1];
 Obj l = co->args[2];
-Obj _35reg4109 = primIsCons(l);
-if (True == _35reg4109) {
-Obj _35reg4110 = primCar(l);
-Obj _35reg4111 = primCons(_35reg4110, res);
-Obj _35reg4112 = primCdr(l);
+Obj _35reg75 = primIsCons(l);
+if (True == _35reg75) {
+Obj _35reg76 = primCar(l);
+Obj _35reg77 = primCons(_35reg76, res);
+Obj _35reg78 = primCdr(l);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.reverse-h"));
-co->args[1] = _35reg4111;
-co->args[2] = _35reg4112;
+co->args[1] = _35reg77;
+co->args[2] = _35reg78;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6336,25 +6336,25 @@ return;
 }
 }
 
-void _35clofun5050(struct Cora* co) {
+void _35clofun1016(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4107 = primIsCons(x);
+Obj _35reg73 = primIsCons(x);
 co->nargs = 2;
-co->args[1] = _35reg4107;
+co->args[1] = _35reg73;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5048(struct Cora* co) {
+void _35clofun1014(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg4099 = primIsCons(exp);
-if (True == _35reg4099) {
-Obj _35reg4100 = primCar(exp);
-Obj _35reg4101 = primCdr(exp);
-pushCont(co, _35clofun5049, 1, _35reg4100);
+Obj _35reg65 = primIsCons(exp);
+if (True == _35reg65) {
+Obj _35reg66 = primCar(exp);
+Obj _35reg67 = primCdr(exp);
+pushCont(co, _35clofun1015, 1, _35reg66);
 co->nargs = 2;
 co->args[0] = globalRef(intern("rcons"));
-co->args[1] = _35reg4101;
+co->args[1] = _35reg67;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6370,97 +6370,97 @@ return;
 }
 }
 
-void _35clofun5049(struct Cora* co) {
-Obj _35val4102 = co->args[1];
-Obj _35reg4100 = co->stack[co->base + 0];
-Obj _35reg4103 = primCons(_35val4102, Nil);
-Obj _35reg4104 = primCons(_35reg4100, _35reg4103);
-Obj _35reg4105 = primCons(intern("cons"), _35reg4104);
+void _35clofun1015(struct Cora* co) {
+Obj _35val68 = co->args[1];
+Obj _35reg66 = co->stack[co->base + 0];
+Obj _35reg69 = primCons(_35val68, Nil);
+Obj _35reg70 = primCons(_35reg66, _35reg69);
+Obj _35reg71 = primCons(intern("cons"), _35reg70);
 co->nargs = 2;
-co->args[1] = _35reg4105;
+co->args[1] = _35reg71;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5047(struct Cora* co) {
+void _35clofun1013(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4095 = primCdr(x);
-Obj _35reg4096 = primCdr(_35reg4095);
-Obj _35reg4097 = primCdr(_35reg4096);
+Obj _35reg61 = primCdr(x);
+Obj _35reg62 = primCdr(_35reg61);
+Obj _35reg63 = primCdr(_35reg62);
 co->nargs = 2;
-co->args[1] = _35reg4097;
+co->args[1] = _35reg63;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5046(struct Cora* co) {
+void _35clofun1012(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4090 = primCdr(x);
-Obj _35reg4091 = primCdr(_35reg4090);
-Obj _35reg4092 = primCdr(_35reg4091);
-Obj _35reg4093 = primCar(_35reg4092);
+Obj _35reg56 = primCdr(x);
+Obj _35reg57 = primCdr(_35reg56);
+Obj _35reg58 = primCdr(_35reg57);
+Obj _35reg59 = primCar(_35reg58);
 co->nargs = 2;
-co->args[1] = _35reg4093;
+co->args[1] = _35reg59;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5045(struct Cora* co) {
+void _35clofun1011(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4086 = primCdr(x);
-Obj _35reg4087 = primCdr(_35reg4086);
-Obj _35reg4088 = primCar(_35reg4087);
+Obj _35reg52 = primCdr(x);
+Obj _35reg53 = primCdr(_35reg52);
+Obj _35reg54 = primCar(_35reg53);
 co->nargs = 2;
-co->args[1] = _35reg4088;
+co->args[1] = _35reg54;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5044(struct Cora* co) {
+void _35clofun1010(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4083 = primCdr(x);
-Obj _35reg4084 = primCdr(_35reg4083);
+Obj _35reg49 = primCdr(x);
+Obj _35reg50 = primCdr(_35reg49);
 co->nargs = 2;
-co->args[1] = _35reg4084;
+co->args[1] = _35reg50;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5043(struct Cora* co) {
+void _35clofun1009(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4080 = primCar(x);
-Obj _35reg4081 = primCdr(_35reg4080);
+Obj _35reg46 = primCar(x);
+Obj _35reg47 = primCdr(_35reg46);
 co->nargs = 2;
-co->args[1] = _35reg4081;
+co->args[1] = _35reg47;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5042(struct Cora* co) {
+void _35clofun1008(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4077 = primCar(x);
-Obj _35reg4078 = primCar(_35reg4077);
+Obj _35reg43 = primCar(x);
+Obj _35reg44 = primCar(_35reg43);
 co->nargs = 2;
-co->args[1] = _35reg4078;
+co->args[1] = _35reg44;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5041(struct Cora* co) {
+void _35clofun1007(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4074 = primCdr(x);
-Obj _35reg4075 = primCar(_35reg4074);
+Obj _35reg40 = primCdr(x);
+Obj _35reg41 = primCar(_35reg40);
 co->nargs = 2;
-co->args[1] = _35reg4075;
+co->args[1] = _35reg41;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun5040(struct Cora* co) {
+void _35clofun1006(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg4072 = primEQ(x, Nil);
+Obj _35reg38 = primEQ(x, Nil);
 co->nargs = 2;
-co->args[1] = _35reg4072;
+co->args[1] = _35reg38;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }

--- a/lib/io.c
+++ b/lib/io.c
@@ -6,6 +6,7 @@ static void
 builtinDisplay(struct Cora *co) {
   Obj arg = co->args[1];
   sexpWrite(stdout, arg);
+  co->nargs = 2;
   co->args[1] = Nil;
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 }
@@ -16,6 +17,7 @@ builtinOpenOutputFile(struct Cora *co) {
   strBuf filePath = stringStr(arg1);
   FILE* f = fopen(toCStr(filePath), "w");
 
+  co->nargs = 2;
   co->args[1] = makeCObj(f);
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 }
@@ -26,6 +28,7 @@ builtinCloseOutputFile(struct Cora *co) {
   FILE *f = mustCObj(arg1);
   int errno = fclose(f);
 
+  co->nargs = 2;
   co->args[1] = makeNumber(errno);
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 }
@@ -47,6 +50,7 @@ ioReadAll(struct Cora *co) {
     }
   }
   Obj ret = makeString(toCStr(dest), strLen(toStr(dest)));
+  co->nargs = 2;
   co->args[1] = ret;
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 }
@@ -67,6 +71,7 @@ ioCopy(struct Cora *co) {
       break;
     }
   }
+  co->nargs = 2;
   co->args[1] = feof(from);
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 }
@@ -87,6 +92,7 @@ void
 entry(struct Cora *co) {
   Obj pkg = co->args[2];
   registerAPI(&ioModule, toStr(stringStr(pkg)));
+  co->nargs = 2;
   co->args[1] = intern("io");
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 }

--- a/lib/os.c
+++ b/lib/os.c
@@ -22,6 +22,7 @@ exec(struct Cora *co) {
   Obj args = co->args[1];
   strBuf cmd = cmdListStr(args);
   int exitCode = system(toCStr(cmd));
+  co->nargs = 2;
   co->args[1] = makeNumber(exitCode);
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
   return;
@@ -36,6 +37,7 @@ popenFn(struct Cora *co) {
   strBuf cmdStr = cmdListStr(cmd);
   FILE* f = popen(toCStr(cmdStr), type);
 
+  co->nargs = 2;
   co->args[1] = makeCObj(f);
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
   return;
@@ -46,6 +48,7 @@ pcloseFn(struct Cora *co) {
   Obj arg = co->args[1];
   FILE *f = mustCObj(arg);
   int res = pclose(f);
+  co->nargs = 2;
   co->args[1] = res;
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
   return;
@@ -64,6 +67,7 @@ void
 entry(struct Cora *co) {
   Obj pkg = co->args[2];
   registerAPI(&osModule, toStr(stringStr(pkg)));
+  co->nargs = 2;
   co->args[1] = intern("os");
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
   return;

--- a/lib/string.c
+++ b/lib/string.c
@@ -18,6 +18,7 @@ stringSlice(struct Cora *co) {
     strBuf s = stringStr(str);
     ret = makeString(toCStr(s)+pos, len-pos);
   }
+  co->nargs = 2;
   co->args[1] = ret;
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 }
@@ -32,6 +33,7 @@ stringHasPrefix(struct Cora *co) {
 
   int lPrefix = stringLen(prefix);
   if (lPrefix > stringLen(str)) {
+    co->nargs = 2;
     co->args[1] = False;
     popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
     return;
@@ -39,12 +41,14 @@ stringHasPrefix(struct Cora *co) {
 
   for(int i=0; i<lPrefix; i++) {
     if (toCStr(prefix1)[i] != toCStr(str1)[i]) {
+      co->nargs = 2;
       co->args[1] = False;
       popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
       return;
     }
   }
 
+  co->nargs = 2;
   co->args[1] = True;
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
   return;
@@ -55,6 +59,7 @@ stringLength(struct Cora *co) {
   Obj o = co->args[1];
   int l = stringLen(o);
 
+  co->nargs = 2;
   co->args[1] = makeNumber(l);
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
   return;
@@ -68,6 +73,7 @@ stringIndex(struct Cora *co) {
   strBuf str = stringStr(x);
   int idx = fixnum(y);
   Obj ret =  makeString(toCStr(str)+idx, 1);
+  co->nargs = 2;
   co->args[1] = ret;
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
   return;
@@ -81,6 +87,7 @@ stringCompare(struct Cora *co) {
   strBuf x1 = stringStr(x);
   strBuf y1 = stringStr(y);
   int ret = strCmp(toStr(x1), toStr(y1));
+  co->nargs = 2;
   co->args[1] = makeNumber(ret);
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
   return;
@@ -93,6 +100,7 @@ numberToString(struct Cora *co) {
 
   char tmp[32];
   int l = snprintf(tmp, 32, "%ld", fixnum(n));
+  co->nargs = 2;
   co->args[1] = makeString(tmp, l);
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
   return;
@@ -110,6 +118,7 @@ stringReplace(struct Cora *co) {
 
   int pos = strStr(toStr(raw), toStr(from));
   if (pos < 0) {
+    co->nargs = 2;
     co->args[1] = arg1;
     popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
     return;
@@ -122,6 +131,7 @@ stringReplace(struct Cora *co) {
   buf = strCat(buf, strSub(toStr(raw), pos+strLen(toStr(from)), strLen(toStr(raw))));
   str s = toStr(buf);
   Obj res = makeString(s.str, s.len);
+  co->nargs = 2;
   co->args[1] = res;
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
   return;
@@ -149,6 +159,7 @@ stringSplit(struct Cora *co) {
     break;
   }
 
+  co->nargs = 2;
   co->args[1] = reverse(res);
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 }
@@ -187,6 +198,7 @@ void
 entry(struct Cora *co) {
   Obj pkg = co->args[2];
   registerAPI(&stringModule, toStr(stringStr(pkg)));
+  co->nargs = 2;
   co->args[1] = intern("string");
   popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 }

--- a/lib/toc/include.cora
+++ b/lib/toc/include.cora
@@ -279,7 +279,7 @@
 			   (c.generate-num w (length args))
 			   (c.generate-str w ") {\n")
 			   (c.generate-str w "co->pc = nativeFuncPtr(co->args[0]);\n")
-			   (c.generate-str w "co->frees = nativeData(co->args[0]);\n")
+			   (c.generate-str w "co->frees = co->args[0];\n")
 			   (c.generate-str w "} else {\n")
 			   (c.generate-str w "co->pc = coraCall;\n}\n")
 			   (c.generate-str w "return;\n")))

--- a/lib/toc/include.cora
+++ b/lib/toc/include.cora
@@ -261,20 +261,20 @@
 			  (c.generate-str w ";\n")
 			  (.generate-inst env w b))
       env w ['return x] => (begin
+			    (c.generate-str w "co->nargs = 2;\n")
 			    (c.generate-str w "co->args[1] = ")
 			    (.generate-inst env w x)
 			    (c.generate-str w ";\npopStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);")
-			    ;; (c.generate-str w ";\npopStack(&co->callstack, &co->pc, &co->base, &co->stack, &co->frees);")
 			    (c.generate-str w "\nreturn;\n"))
       env w ['tailcall exp] => (.generate-inst env w exp)
       env w ['call exp cont] => (begin
 				 (.generate-cont w cont)
 				 (.generate-inst env w exp))
       env w [f . args] => (begin
-			   (.generate-call-args env w 0 [f . args])
 			   (c.generate-str w "co->nargs = ")
 			   (c.generate-num w (length [f . args]))
 			   (c.generate-str w ";\n")
+			   (.generate-call-args env w 0 [f . args])
 			   (c.generate-str w "if (nativeRequired(co->args[0]) == ")
 			   (c.generate-num w (length args))
 			   (c.generate-str w ") {\n")

--- a/main.c
+++ b/main.c
@@ -45,10 +45,10 @@ int main(int argc, char *argv[]) {
     trampoline(co, coraCall);
     exp = co->args[1];
 
-    printf("after macro expand ==");
-    sexpWrite(stdout, exp);
-    printf(" --- %d %d\n", co->base, co->pos);
-    printf("\n");
+    /* printf("after macro expand =="); */
+    /* sexpWrite(stdout, exp); */
+    /* printf(" --- %d %d\n", co->base, co->pos); */
+    /* printf("\n"); */
 
     co->args[0] = globalRef(intern("cora/lib/toc/include.eval0"));
     co->args[1] = exp;

--- a/main.c
+++ b/main.c
@@ -1,11 +1,11 @@
 #include "runtime.h"
 
 
-extern void coraInit();
 extern void builtinLoadSo(struct Cora *co);
 
 int main(int argc, char *argv[]) {
-  coraInit();
+  void* dummy;
+  coraInit(&dummy);
   struct Cora* co = coraNew();
   Obj imported = intern("*imported*");
 
@@ -45,10 +45,10 @@ int main(int argc, char *argv[]) {
     trampoline(co, coraCall);
     exp = co->args[1];
 
-    /* printf("after macro expand =="); */
-    /* sexpWrite(stdout, exp); */
-    /* printf(" --- %d %d\n", co->base, co->pos); */
-    /* printf("\n"); */
+    printf("after macro expand ==");
+    sexpWrite(stdout, exp);
+    printf(" --- %d %d\n", co->base, co->pos);
+    printf("\n");
 
     co->args[0] = globalRef(intern("cora/lib/toc/include.eval0"));
     co->args[1] = exp;

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,13 +1,13 @@
 .POSIX:
 .SUFFIXES:
 
-SRCS = str.c types.c reader.c runtime.c reader_test.c eval_test.c bootstrap_test.c
+SRCS = str.c gc.c types.c reader.c runtime.c reader_test.c eval_test.c bootstrap_test.c
 OBJS = $(SRCS:%.c=%.o)
 CC = gcc
 CFLAGS = -g -Wall -fPIC
 # CFLAGS = -Wall -O2
 
-all: libcora.so libcora.a
+all: libcora.so
 
 # test: reader_test bootstrap_test
 test: reader_test
@@ -30,7 +30,7 @@ reader_test: reader.test
 # bootstrap.test: bootstrap_test.o libcora.a
 # 	$(CC) -o $@ $^ -ldl
 
-LIBOBJS = str.o types.o reader.o runtime.o
+LIBOBJS = str.o gc.o types.o reader.o runtime.o
 
 libcora.a: $(LIBOBJS)
 	ar -rc $@ $^

--- a/src/gc.c
+++ b/src/gc.c
@@ -21,7 +21,7 @@ blockInit(struct Block *block) {
 
 static void
 blockReset(struct Block *block) {
-  printf("reset data in rage [%p, %p]\n", block->data, block->data + MEM_BLOCK_SIZE);
+  /* printf("reset data in rage [%p, %p]\n", block->data, block->data + MEM_BLOCK_SIZE); */
   // For easy debug ... not really a MUST
   memset(block->data, 0, MEM_BLOCK_SIZE);
   free(block->data);
@@ -202,7 +202,7 @@ gcCopy(struct GC *gc, uintptr_t p) {
   memcpy(to, from, from->size);
   from->forwarding = (uintptr_t)to | tag(p);
 
-  printf("gcCopy from %p to %p ==%ld, sz=%d tp=%d\n", from, to, p, from->size, from->type);
+  /* printf("gcCopy from %p to %p ==%ld, sz=%d tp=%d\n", from, to, p, from->size, from->type); */
 
   // Copy the children to the new place.
   // And update the reference of the new object.
@@ -216,7 +216,7 @@ gcCopy(struct GC *gc, uintptr_t p) {
 
 static void
 gcStack(struct GC* gc, uintptr_t* from, uintptr_t* to) {
-  printf("gcStack -- from %p to %p\n", from, to);
+  /* printf("gcStack -- from %p to %p\n", from, to); */
   assert(from < to);
   assert(((uintptr_t)from & 0x7) == 0);
   assert(((uintptr_t)to & 0x7) == 0);
@@ -225,9 +225,9 @@ gcStack(struct GC* gc, uintptr_t* from, uintptr_t* to) {
     uintptr_t stackValue = *p;
     if (areaContains(gc->curr, ptr(stackValue))) {
       *p = gcCopy(gc, stackValue);
-      printf("gcStack update == %p to %ld\n", p, *p);
+      /* printf("gcStack update == %p to %ld\n", p, *p); */
     } else {
-      printf("gcStack skip == %p\n", p);
+      /* printf("gcStack skip == %p\n", p); */
     }
   }
 }

--- a/src/gc.c
+++ b/src/gc.c
@@ -250,7 +250,7 @@ gcRun(struct GC *gc) {
   gc->curr = gcGetNextArea(gc);
 
   int sz2 = areaSize(gc->curr);
-  printf("after run gc, current size = %d, after gc = %d\n", sz1, sz2);
+  /* printf("after run gc, current size = %d, after gc = %d\n", sz1, sz2); */
   gc->nextSize = 2 * sz2;
   if (gc->nextSize < MEM_BLOCK_SIZE) {
     // Because a block is at least that size, GC smaller then this is meanless.

--- a/src/gc.c
+++ b/src/gc.c
@@ -1,549 +1,253 @@
-#include "gc.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <setjmp.h>
 #include <string.h>
+#include <setjmp.h>
+#include <stddef.h>
+#include <assert.h>
+#include "gc.h"
 
-struct GC *g;
+const int MEM_BLOCK_SIZE = 4*1024*1024;
 
-const int PAGE_SIZE = 4<<10;
-
-struct Allocator {
-  void** pages;
-  int len;
-  int cap;
-
-  void* curr;
+struct Block {
+  int offset;
+  char *data;
 };
 
-
 static void
-newPage(struct Allocator *alloc) {
-  void *page = malloc(PAGE_SIZE);
-  alloc->pages[alloc->len] = page;
-  alloc->len++;
-  alloc->curr = page;
+blockInit(struct Block *block) {
+  block->data = malloc(MEM_BLOCK_SIZE);
+  block->offset = 0;
 }
 
 static void
-expandPages(struct Allocator *alloc) {
-  if (alloc->len == 0) {
-    alloc->pages = malloc(sizeof(void*) * 16);
-    alloc->cap = 16;
-    newPage(alloc);
-  } else {
-    alloc->pages = realloc(alloc->pages, sizeof(void*) * alloc->cap * 2);
-    alloc->cap *= 2;
+blockReset(struct Block *block) {
+  free(block->data);
+  block->offset = 0;
+}
+
+static bool
+blockContains(struct Block *block, void *p) {
+  if (p < (void*)block->data || p >= (void*)&block->data[block->offset]) {
+    return false;
   }
-  return;
+  return true;
 }
 
 #define alignto(p, bits)      (((p) >> bits) << bits)
 #define aligntonext(p, bits)  alignto(((p) + (1 << bits) - 1), bits)
 
-void*
-allocFn(struct Allocator *alloc, int sz) {
-  if (alloc->len >= alloc->cap) {
-    expandPages(alloc);
+static scmHead*
+blockAlloc(struct Block *block, int size) {
+  if (block->offset + size > MEM_BLOCK_SIZE) {
+    return NULL;
   }
-
-  void *page = alloc->pages[alloc->len-1];
-  if (alloc->curr + sz >= page + PAGE_SIZE) {
-    newPage(alloc);
-  }
-
-  void *ret = alloc->curr;
-  alloc->curr += sz;
-  alloc->curr = (void*)aligntonext((uintptr_t)(alloc->curr), 3);
-  /* printf("alloc fn return %p sz=%d new_curr= %p\n", ret, sz, alloc->curr); */
-  return ret;
+  size = aligntonext(size, TAG_SHIFT);
+  scmHead *head = (void*)&block->data[block->offset];
+  head->size = size;
+  head->forwarding = 0;
+  block->offset += size;
+  return head;
 }
 
-void
-recycleFn(struct Allocator *alloc, void *ptr) {
+struct Area {
+  struct Block *blocks;
+  int len;
+  int cap;
+};
+
+static void
+areaInit(struct Area *area) {
+  area->len = 0;
+  area->cap = 8;
+  area->blocks = malloc(sizeof(struct Block) * area->cap);
 }
 
-bool
-managed(struct Allocator *alloc, void *ptr) {
-  for (int i=0; i<alloc->len; i++) {
-    void *page = alloc->pages[i];
-    if (ptr >= page && ptr < page+PAGE_SIZE) {
+static bool
+areaContains(struct Area *area, void *p) {
+  for (int i=0; i<area->len; i++) {
+    struct Block *b = &area->blocks[i];
+    if (blockContains(b, p)) {
       return true;
     }
   }
   return false;
 }
 
-/* void gcDisable(struct GC *gc) { */
-/*   gc->disable = true; */
-/* } */
-
-/* void gcEnable(struct GC *gc) { */
-/*   gc->disable = false; */
-/* } */
-
-static void
-unlink(scmHead *h) {
-  if (h->prev != NULL) {
-    h->prev->next = h->next;
+static scmHead*
+areaAlloc(struct Area *area, int size) {
+  assert(size > sizeof(scmHead));
+  // Lazy initialize the first block.
+  if (area->len == 0) {
+    area->len = 1;
+    blockInit(&area->blocks[0]);
   }
-  if (h->next != NULL) {
-    h->next->prev = h->prev;
+
+  struct Block *curr = &area->blocks[area->len - 1];
+  scmHead *res = blockAlloc(curr, size);
+  if (res != NULL) {
+    return res;
   }
-  h->prev = NULL;
-  h->next = NULL;
+
+  if (area->len == area->cap) {
+    struct Block *tmp = malloc(sizeof(struct Block) * area->cap * 2);
+    if (tmp == NULL) {
+      abort();
+    }
+    memcpy(tmp, area->blocks, sizeof(struct Block) * area->len);
+    free(area->blocks);
+    area->blocks = tmp;
+    area->cap = area->cap * 2;
+  }
+  curr = &area->blocks[area->len];
+  blockInit(curr);
+  area->len++;
+
+  return areaAlloc(area, size);
 }
 
 static void
-link(scmHead *from, scmHead *to) {
-  assert(to != NULL);
-  from->next = to->next;
-  if (to->next != NULL) {
-    to->next->prev = from;
+areaReset(struct Area *area) {
+  for (int i=0; i<area->len; i++) {
+    struct Block *b = &area->blocks[i];
+    blockReset(b);
   }
-
-  to->next = from;
-  from->prev = to;
+  area->len = 0;
 }
 
-bool
-ecru(struct GC *gc, scmHead *obj) {
-  return gc->color == obj->color;
-}
-
-// The caller should assume gc->gray is not an empty list.
-static void
-advance(struct GC *gc) {
-  scmHead *obj = gc->gray.next;
-  gcFunc fn = gc->registry[obj->type];
-
-  // collect all its fields.
-  if (fn != NULL) {
-    fn(gc, obj);
+static int
+areaSize(struct Area *area) {
+  int size = 0;
+  for (int i=0; i<area->len - 1; i++) {
+    size += MEM_BLOCK_SIZE;
   }
-
-  // unlink obj from gray and link to black.
-  unlink(obj);
-  link(obj, &gc->black);
-
-  /* printf("advance: gray -> black: %p\n", obj); */
+  if (area->len > 0) {
+    struct Block *b = &area->blocks[area->len - 1];
+    size += b->offset;
+  }
+  return size;
 }
+
+struct GC {
+  struct Area area1;
+  struct Area area2;
+  struct Area *curr;
+  int nextSize;
+};
+
+struct GC gc;
+
+void* baseStackAddr = NULL;
 
 void
-postGCFlip(struct GC *gc) {
-  assert(gc->white.next == NULL);
-
-  // After GC, the ecru list become the new white list.
-  gc->white.next = gc->ecru.next;
-  if (gc->white.next != NULL) {
-    gc->white.next->prev = &gc->white;
-  }
-
-  for(scmHead* p = gc->white.next; p != NULL; p = p->next) {
-    printf("post flip recycle %p\n", p);
-  }
-
-  // And black become the ecru.
-  gc->ecru.next = gc->black.next;
-  if (gc->ecru.next != NULL) {
-    gc->ecru.next->prev = &gc->ecru;
-  }
-
-  gc->black.prev = NULL;
-  gc->black.next = NULL;
-
-  // And also turn the ecru color
-  gc->color = ~gc->color;
+gcInit(struct GC *gc) {
+  void* dummy;
+  baseStackAddr = &dummy;
+  areaInit(&gc->area1);
+  areaInit(&gc->area2);
+  gc->curr = &gc->area1;
+  gc->nextSize = MEM_BLOCK_SIZE;
 }
 
-/* static char *typeName[] = { */
-/*   "bool", */
-/*   "null", */
-/*   "number", */
-/*   "cons", */
-/*   "curry", */
-/*   "string", */
-/*   "vector", */
-/*   "closure", */
-/*   "continuation", */
-/* }; */
-
-void gcFull(struct GC *gc, struct VM *vm, int pos);
-
-// ----- exposed API ---------- //
-scmHead*
-gcAlloc(struct GC *gc, struct VM *vm, int pos, int sz) {
-  if (gc->count >= gc->nextGC) {
-    /* gcFull(gc, vm, pos); */
-    gc->count = 0;
-  }
-  gc->count++;
-
-  scmHead* tmp = NULL;
-  if (gc->white.next != NULL)  {
-    tmp = gc->white.next;
-    unlink(tmp);
-    if (tmp->size != sz) {
-      // GC only manage the lifecycle, the memory alloc/free is the work of the allocator.
-      // The allocator can reuse the memory by, for example, object pools.
-      gc->recycleFn(gc->allocator, tmp);
-      printf("gc recycle object:%p\n", tmp);
-      tmp = NULL;
-    }
-  }
-
-  if (tmp == NULL) {
-    tmp = gc->allocFn(gc->allocator, sz);
-    tmp->size = sz;
-  }
-
-  /* if (gc->gray.next == NULL && gc->black.next == NULL) { */
-  if (gc->gray.next == NULL) {
-    // No GC related things, just put the obj to ecru list.
-    tmp->color = gc->color;
-    link(tmp, &gc->ecru);
-  } else {
-    // Maybe GC-ing, the black list will become the next ecru list eventually.
-    // If the color of an object is ecru, it's move to gray and then black.
-    // So the new allocated is black directly.
-    assert(false);  // TODO not now
-    tmp->color = ~gc->color;
-    link(tmp, &gc->black);
-  }
-
-  return tmp;
-}
+static gcFunc registry[256] = {};
 
 bool
-gcStep(struct GC *gc, int n) {
-  while (gc->gray.next != NULL && n > 0) {
-    advance(gc);
-    n--;
-  }
-  return gc->gray.next == NULL;
-}
-
-bool
-gcRegistForType(struct GC *gc, uint8_t idx, gcFunc fn) {
-  if (gc->registry[idx] != NULL) {
+gcRegistForType(uint8_t idx, gcFunc fn) {
+  if (registry[idx] != NULL) {
     return false;
   }
-  gc->registry[idx] = fn;
+  registry[idx] = fn;
   return true;
 }
 
-void
-gcMark(struct GC *gc, scmHead *obj) {
-  if (obj == NULL) {
-    return;
+static struct Area*
+gcGetNextArea(struct GC *gc) {
+  struct Area *area;
+  if (gc->curr == &gc->area1) {
+    area = &gc->area2;
+  } else {
+    area = &gc->area1;
   }
-
-  if (ecru(gc, obj)) {
-    unlink(obj);
-    obj->color = ~obj->color;
-    link(obj, &gc->gray);
-    /* printf("gcObj, ecru obj -> gray: %p\n", obj); */
-  }
+  return area;
 }
 
-struct GC*
-gcInit() {
-  void* dummy;
-  struct Allocator *alloc =  malloc(sizeof(struct Allocator));
-  memset(alloc, 0, sizeof(struct Allocator));
-
-  struct GC *gc = (struct GC*)malloc(sizeof(struct GC));
-  gc->baseStackAddr = &dummy;
-
-  gc->allocator = alloc;
-  gc->allocFn = allocFn;
-  gc->recycleFn = recycleFn;
-  gc->managed = managed;
-
-  gc->color = 0;
-  gc->white.next = NULL;
-  gc->white.prev = NULL;
-
-  gc->ecru.next = NULL;
-  gc->ecru.prev = NULL;
-
-  gc->gray.next = NULL;
-  gc->gray.prev = NULL;
-
-  gc->black.next = NULL;
-  gc->black.prev = NULL;
-
-  memset(gc->registry, 0, GC_REGISTRY_MAX*sizeof(gcFunc));
-
-  /* gc->disable = false; */
-  gc->count = 0;
-  gc->nextGC = 64;
-
-  return gc;
-}
-
-/* void */
-/* gcMarkRoot(struct GC *gc, scmHead *rootObj) { */
-/*   // rootObj should be in the ecru list, before GC. */
-/*   /\* assert(ecru(gc, rootObj)); *\/ */
-
-/*   if (ecru(gc, rootObj)) { */
-/*     /\* printf("markroot %p %d\n", rootObj, rootObj->color); *\/ */
-/*     unlink(rootObj); */
-/*     rootObj->color = ~rootObj->color; */
-/*     link(rootObj, &gc->gray); */
-/*   } */
-/* } */
-
-
-bool
-gcIng(struct GC *gc) {
-  return gc->gray.next != NULL;
-}
-
-void
-printGC(struct GC *gc) {
-  printf("printGC ... begin\n");
-  if (gc->gray.next == NULL) {
-    printf("no gray objects\n");
-  } else {
-    for (scmHead *p = gc->gray.next; p != NULL; p=p->next) {
-      printf("gray object: %p\n", p);
-    }
+uintptr_t
+gcCopy(struct GC *gc, uintptr_t p) {
+  // p is not gc alloced, skip it.
+  // This magic number kinda dirty, see types.h
+  if ((p&0x3) != 0x3) {
+    return p;
   }
 
-  if (gc->ecru.next == NULL) {
-    printf("no ecru objects\n");
-  } else {
-    for (scmHead *p = gc->ecru.next; p != NULL; p=p->next) {
-      printf("ecru object: %p\n", p);
-    }
+  if (!areaContains(gc->curr, ptr(p))) {
+    return p;
   }
 
-  if (gc->white.next == NULL) {
-    printf("no white objects\n");
-  } else {
-    for (scmHead *p = gc->white.next; p != NULL; p=p->next) {
-      printf("white object: %p\n", p);
-    }
+  scmHead *from = ptr(p);
+  if (from->forwarding != 0) {
+    return from->forwarding;
+  }
+  assert(from->size > 0);
+
+  // Copy the data of itself to the new place.
+  struct Area *area = gcGetNextArea(gc);
+  void* to = areaAlloc(area, from->size);
+  memcpy(to, from, from->size);
+  from->forwarding = (uintptr_t)to | tag(p);
+
+  /* printf("gccopy from %p to %p ==%ld\n", from, to, p); */
+
+  // Copy the children to the new place.
+  // And update the reference of the new object.
+  gcFunc copyChildren = registry[from->type];
+  if (copyChildren != NULL) {
+    copyChildren(gc, from, to);
   }
 
-  if (gc->black.next == NULL) {
-    printf("no black objects\n");
-  } else {
-    for (scmHead *p = gc->black.next; p != NULL; p=p->next) {
-      printf("black object: %p\n", p);
-    }
-  }
-  printf("printGC ... end\n");
-}
-
-static int gcIdx = 0;
-
-/* void */
-/* checkList(scmHead *p, scmHead *q) { */
-/*   while(p->next != NULL) { */
-/*     p = p->next; */
-/*   } */
-/*   while(q->next != NULL) { */
-/*     q = q->next; */
-/*   } */
-/*   assert((p != q) || (p == NULL && q == NULL)); */
-/* } */
-
-static int
-listCount(scmHead *p) {
-  int ret = 0;
-  while(p->next != NULL) {
-    ret++;
-    p = p->next;
-  }
-  return ret;
+  return from->forwarding;
 }
 
 static void
-gcCStack(struct GC* gc, uintptr_t* from, uintptr_t* to) {
+gcStack(struct GC* gc, uintptr_t* from, uintptr_t* to) {
   assert(from < to);
   assert(((uintptr_t)from & 0x7) == 0);
   assert(((uintptr_t)to & 0x7) == 0);
 
   for (uintptr_t *p = from; p<to; p++) {
     uintptr_t stackValue = *p;
-    void *stackPtr = ptr(stackValue);
-    if (gc->managed(gc->allocator, stackPtr)) {
-      gcMark(gc, stackPtr);
+    if (areaContains(gc->curr, ptr(stackValue))) {
+      *p = gcCopy(gc, stackValue);
     }
   }
 }
 
-struct VM;
-/* extern void gcVM(struct GC *gc, struct VM *vm, int pos); */
+extern void gcGlobal(struct GC *gc);
 
-void
-gcFull(struct GC *gc, struct VM *vm, int pos) {
+static void
+gcRun(struct GC *gc) {
+  void* stackAddr = &stackAddr;
   // Dump registers onto stack and scan the stack.
   jmp_buf ctx;
   memset(&ctx, 0, sizeof(jmp_buf));
   setjmp(ctx);
-  void* stackAddr = &stackAddr;
-  gcCStack(gc, stackAddr, gc->baseStackAddr);
-  /* gcVM(gc, vm, pos); */
+  gcStack(gc, stackAddr, baseStackAddr);
+  gcGlobal(gc);
 
-  printf("==== before full gc %d=========\n", gcIdx++);
-  /* if (gcIdx == 177) { */
-  /*   printf("before full gc %d=========\n", gcIdx); */
-  /*   printGC(gc); */
-  /* } */
-  /* checkList(&gc->gray, &gc->ecru); */
-
-  while(!gcStep(gc, 10)) {}
-
-  assert (gc->gray.next == NULL && gc->black.next != NULL);
-  /* if (gcIdx == 177) { */
-  /*   printf("after full gc =========\n"); */
-  /*   printGC(gc); */
-  /* } */
-
-  while(gc->white.next != NULL) {
-    scmHead *tmp = gc->white.next;
-    printf("recycle white obj %p\n", tmp);
-    unlink(tmp);
-    gc->recycleFn(gc->allocator, tmp);
-  }
-  assert(gc->white.next == NULL);
-
-  /* checkList(&gc->black, &gc->ecru); */
-
-  assert (gc->gray.next == NULL && gc->black.next != NULL && gc->white.next == NULL);
-  // After a round of GC, there are only ecru and black, flip then.
-  postGCFlip(gc);
-
-  int count = listCount(&gc->ecru);
-  gc->nextGC = count;
-
-  /* checkList(&gc->white, &gc->ecru); */
-  /* if (gcIdx == 177) { */
-  /*   printf("post gc ~~~\n"); */
-  /*   printGC(g); */
-  /* } */
+  areaReset(gc->curr);
+  gc->curr = gcGetNextArea(gc);
 }
 
-
-// unit test for the code
-// gcc -g -D_GC_TEST gc.c -o a.out
-
-/* #ifdef _GC_TEST */
-
-/* struct Cons { */
-/*   scmHead head; */
-/*   struct Cons* car; */
-/*   struct Cons* cdr; */
-/* }; */
-
-/* scmHead* */
-/* getCarField(scmHead* p) { */
-/*   struct Cons* pair = (struct Cons*)p; */
-/*   return (scmHead*)(pair->car); */
-/* } */
-
-/* static void */
-/* consGCFunc(struct GC* gc, void *obj) { */
-/*   struct Cons *p = obj; */
-/*   gcMark(gc, &p->car->head); */
-/*   gcMark(gc, &p->cdr->head); */
-/* } */
-
-/* scmHead* */
-/* readBarrier(struct GC *gc, scmHead* obj, scmHead* (*getField)(scmHead*)) { */
-/*   if (ecru(gc, obj)) { */
-/*     unlink(obj); */
-/*     link(obj, &gc->gray); */
-/*   } */
-/*   return getField(obj); */
-/* } */
-
-/* void* */
-/* newObj(scmHeadType tp, int sz) { */
-/*   scmHead *p = gcAlloc(g, sz); */
-/*   p->size = sz; */
-/*   p->type = tp; */
-/*   return p; */
-/* } */
-
-/* struct Atom { */
-/*   scmHead head; */
-/*   int v; */
-/* }; */
-
-/* static scmHead* */
-/* cons(scmHead* car, scmHead* cdr) { */
-/*   void* p = newObj(0, sizeof(struct Cons)); */
-/*   struct Cons* ret = p; */
-/*   ret->car = (struct Cons*)car; */
-/*   ret->cdr = (struct Cons*)cdr; */
-/*   return (scmHead*)p; */
-/* } */
-
-/* static scmHead* */
-/* atom(int x) { */
-/*   void *p = newObj(1, sizeof(struct Atom)); */
-/*   struct Atom* o = p; */
-/*   o->v = x; */
-/*   return p; */
-/* } */
-
-/* void* allocFn(void *allocator, int sz) { */
-/*   return malloc(sz); */
-/* } */
-
-/* void recycleFn(void *allocator, void *ptr) { */
-/*   return free(ptr); */
-/* } */
-
-/* bool managed(void *allocator, void *ptr) { */
-/* } */
-
-
-/* int */
-/* main(int argc, char *argv[]) { */
-/*   struct GC *gc = gcInit(NULL, allocFn, recycleFn); */
-/*   gcRegistForType(gc, 0, consGCFunc); */
-/*   g = gc; */
-
-/*   scmHead* x1 = cons(atom(1), cons(atom(2), atom(3))); */
-/*   scmHead* x2 = cons(x1, atom(5)); */
-/*   scmHead* x3 = cons(atom(1), cons(atom(2), atom(3))); */
-/*   scmHead* x4 = cons(x1, x3); */
-/*   scmHead* x5 = cons(x1, atom(6)); */
-/*   scmHead* x6 = cons(x1, cons(x2, cons(x3, cons(x4, cons(x5, x6))))); */
-
-/*   // Try to GC something. */
-/*   gcMarkRoot(g, x3); */
-/*   gcStep(g, 1); */
-/*   gcStep(g, 3); */
-/*   gcStep(g, 5); */
-  
-/*   // Test allocating during GC. */
-/*   x2 = cons(x1, atom(5)); */
-/*   x3 = cons(atom(1), cons(atom(2), atom(3))); */
-/*   x4 = cons(x1, x3); */
-  
-/*   // Finish this round of GC */
-/*   while(!gcStep(g, 7)) {} */
-
-/*   // Now whitelist is not null, test object reuse. */
-/*   x4 = cons(x1, x3); */
-/*   x5 = cons(x1, atom(6)); */
-/*   x6 = cons(x1, cons(x2, cons(x3, cons(x4, cons(x5, x6))))); */
-
-/*   // Cover read barrier. */
-/*   if (gc->gray.next != NULL) { */
-/*     x4 = readBarrier(g, x5, getCarField); */
-/*   } */
-
-/*   // And GC another round. */
-/*   gcMarkRoot(g, x4); */
-/*   while(!gcStep(g, 7)) {} */
-/* } */
-
-/* #endif */
+void*
+gcAlloc(struct GC* gc, int size) {
+  int sz1 = areaSize(gc->curr);
+  if (sz1 >= gc->nextSize) {
+    gcRun(gc);
+    int sz2 = areaSize(gc->curr);
+    /* printf("run gc, current size = %d, after gc = %d\n", sz1, sz2); */
+    gc->nextSize = 2 * sz2;
+    if (gc->nextSize < MEM_BLOCK_SIZE) {
+      // Because a block is at least that size, GC smaller then this is meanless.
+      gc->nextSize = MEM_BLOCK_SIZE;
+    }
+  }
+  return areaAlloc(gc->curr, size);
+}

--- a/src/gc.c
+++ b/src/gc.c
@@ -21,6 +21,9 @@ blockInit(struct Block *block) {
 
 static void
 blockReset(struct Block *block) {
+  printf("reset data in rage [%p, %p]\n", block->data, block->data + MEM_BLOCK_SIZE);
+  // For easy debug ... not really a MUST
+  memset(block->data, 0, MEM_BLOCK_SIZE);
   free(block->data);
   block->offset = 0;
 }
@@ -75,6 +78,9 @@ areaContains(struct Area *area, void *p) {
 
 static scmHead*
 areaAlloc(struct Area *area, int size) {
+  if (size > 500) {
+    printf("what the fuck??\n");
+  }
   assert(size > sizeof(scmHead));
   // Lazy initialize the first block.
   if (area->len == 0) {
@@ -186,6 +192,7 @@ gcCopy(struct GC *gc, uintptr_t p) {
     return from->forwarding;
   }
   assert(from->size > 0);
+  assert(from->type <= 6);
 
   // Copy the data of itself to the new place.
   struct Area *area = gcGetNextArea(gc);

--- a/src/gc.h
+++ b/src/gc.h
@@ -1,94 +1,30 @@
-#ifndef _GC_H
-#define _GC_H
+#ifndef _GC_H_
+#define _GC_H_
 
 #include <stdbool.h>
 #include <stdint.h>
 
-// The GC algorithm is inspired by the paper <The Treadmill: Real-Time Garbage Collection Without Motion Sickness>
-// The basic idea is the same -- like the "tricolor marking" and the "in-place garbage collection".
-// The "treadmill optimization" is not adopted, white/gray/black/ecru four lists are used, instead of making them cyclic.
-// See also http://www.cofault.com/2022/07/treadmill.html
+typedef uint8_t scmHeadType;
 
+typedef struct {
+  scmHeadType type;
+  uint16_t size;
+  uintptr_t forwarding;
+} scmHead;
+
+#define TAG_SHIFT 3
+#define TAG_MASK 0x7
 #define TAG_PTR 0x7
 
 #define ptr(x) ((void*)((x)&~TAG_PTR))
+#define tag(x) ((x) & TAG_MASK)
 
-struct GC;
+extern struct GC gc;
+void gcInit(struct GC* gc);
+uintptr_t gcCopy(struct GC *gc, uintptr_t head);
+void* gcAlloc(struct GC* gc, int size);
 
-typedef uint8_t scmHeadType;
-
-typedef struct _scmHead {
-  scmHeadType type;
-  struct _scmHead* prev;
-  struct _scmHead* next;
-  uint16_t size;
-  uint8_t color;
-} scmHead;
-
-extern struct GC *g;
-
-typedef void (*gcFunc)(struct GC* gc, void *obj);
-
-#define GC_REGISTRY_MAX 256
-
-struct Allocator;
-struct GC {
-  void* baseStackAddr;
-
-  void *allocator;
-  void* (*allocFn)(struct Allocator* allocator, int sz);
-  void (*recycleFn)(struct Allocator* allocator, void *ptr);
-  bool (*managed)(struct Allocator *allocator, void *ptr);
-
-  // color is the color of ecru list.
-  uint8_t color;
-
-  // state change:
-  /* | stage |                   | gray     | black    | white    | ecru     | comment                                         | */
-  /* |-------|-------------------|----------|----------|----------|----------|-------------------------------------------------| */
-  /* | 0     | Init              | NULL     | NULL     |          | Not NULL | ecru list means to be Scanned                   | */
-  /* | 1     | GCing             | Not NULL |          |          |          | gray list means to be GCed                      | */
-  /* | 2     | GC finish         | NULL     | Not NULL |          |          | all reachable become black, no gray anymore     | */
-  /* | 2     | Before next round | NULL     | Not NULL | NULL     |          | when white list is used up, prepare the flip    | */
-  /* | 0     | Post GC flip      | NULL     | NULL     | Not NULL | Not NULL | black become ecru and ecru become the new white | */
-  //
-  // stage0 = !gray && !black
-  // stage1 = gray
-  // stage2 = !gray && black
-  //
-  // In stage 1, read barrier should be set.
-  // In stage 2, alloc object become black directly?
-  scmHead white;
-  scmHead ecru;
-  scmHead gray;
-  scmHead black;
-
-  gcFunc registry[GC_REGISTRY_MAX];
-
-  /* bool disable; */
-  int count;
-  int nextGC;
-};
-
-struct GC* gcInit();
-
-void gcMark(struct GC *gc, scmHead *obj);
-bool gcRegistForType(struct GC *gc, uint8_t type, gcFunc fn);
-
-bool gcIng(struct GC *gc);
-
-struct VM;
-scmHead* gcAlloc(struct GC *gc, struct VM *vm, int pos, int sz);
-/* void gcMarkRoot(struct GC *gc, scmHead *obj); */
-bool gcStep(struct GC *gc, int n);
-
-/* void gcDisable(struct GC *gc); */
-/* void gcEnable(struct GC *gc); */
-
-void gcFull(struct GC *gc, struct VM *vm, int pos);
-void postGCFlip(struct GC *gc);
-
-
-void printGC(struct GC *gc);
+typedef void (*gcFunc)(struct GC *gc, void* from, void* to);
+bool gcRegistForType(uint8_t type, gcFunc fn);
 
 #endif

--- a/src/gc.h
+++ b/src/gc.h
@@ -24,7 +24,12 @@ void gcInit(struct GC* gc, void* mark);
 uintptr_t gcCopy(struct GC *gc, uintptr_t head);
 void* gcAlloc(struct GC* gc, int size);
 
+bool gcCheck(struct GC* gc);
+void gcRun(struct GC *gc);
+
 typedef void (*gcFunc)(struct GC *gc, void* from, void* to);
 bool gcRegistForType(uint8_t type, gcFunc fn);
+
+extern struct GC gc;
 
 #endif

--- a/src/gc.h
+++ b/src/gc.h
@@ -20,7 +20,7 @@ typedef struct {
 #define tag(x) ((x) & TAG_MASK)
 
 extern struct GC gc;
-void gcInit(struct GC* gc);
+void gcInit(struct GC* gc, void* mark);
 uintptr_t gcCopy(struct GC *gc, uintptr_t head);
 void* gcAlloc(struct GC* gc, int size);
 

--- a/src/reader.c
+++ b/src/reader.c
@@ -361,18 +361,9 @@ printObj(FILE *to, Obj o) {
     case scmHeadNative:
       fprintf(to, "native");
       break;
-    /* case scmHeadCurry: */
-    /*   fprintf(to, "curry"); */
-    /*   break; */
-    case scmHeadClosure:
-      fprintf(to, "closure");
-      break;
     /* case scmHeadContinuation: */
     /*   fprintf(to, "continuation"); */
     /*   break; */
-    case scmHeadPrimitive:
-      fprintf(to, "primitive");
-      break;
     default:
       fprintf(to, "ptr unknown type = %d\n", h->type);
     };

--- a/src/reader.c
+++ b/src/reader.c
@@ -8,7 +8,10 @@
 
 static void
 addPkgMapping(struct SexpReader *r, Obj sym, Obj path) {
-  r->pkgMapping = cons(cons(sym, path), r->pkgMapping);
+  Obj var = intern("*package-mapping*");
+  Obj pkgMapping = symbolGet(var);
+  symbolSet(var, cons(cons(sym, path), pkgMapping));
+  /* r->pkgMapping = cons(cons(sym, path), r->pkgMapping); */
 }
 
 static bool
@@ -257,7 +260,8 @@ sexpRead(struct SexpReader* r, FILE *in, int *errCode) {
 	  buffer[firstDot] = 0;
 	  Obj pkg = makeSymbol(buffer);
 
-	  Obj p = r->pkgMapping;
+	  Obj p = symbolGet(intern("*package-mapping*"));
+	  /* Obj p = r->pkgMapping; */
 	  for (; p != Nil; p = cdr(p)) {
 	    Obj item = car(p);
 	    if (car(item) == pkg) {

--- a/src/reader.h
+++ b/src/reader.h
@@ -6,7 +6,7 @@
 
 struct SexpReader {
   // associate list ((pkg . path1) (pkg2 . path2) ...)
-  Obj pkgMapping;
+  /* Obj pkgMapping; */
   char *selfPath;
 };
 

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -205,6 +205,7 @@ coraNew() {
 
 void
 trampoline(struct Cora *co, basicBlock pc) {
+  int mark;
   saveStack(&co->callstack, NULL, co->base, co->pos, co->frees); 
   co->pc = pc;
   while(co->pc != NULL) {

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -787,7 +787,7 @@ builtinReadFileAsSexp(struct Cora *co) {
 
   Obj pkg = co->args[2];
   char *selfPath = toCStr(stringStr(pkg));
-  struct SexpReader r = {.pkgMapping = Nil, .selfPath = selfPath};
+  struct SexpReader r = {.selfPath = selfPath};
   int err = 0;
   int count = 0;
   while(true) {
@@ -870,6 +870,7 @@ coraInit(void *mark) {
   symQuote = intern("quote");
   symBackQuote = intern("backquote");
   symUnQuote = intern("unquote");
+  primSet(intern("*package-mapping*"), Nil);
   primSet(intern("symbol->string"), makeNative(symbolToString, 1, 0));
   primSet(intern("string-append"), makeNative(stringAppend, 2, 0));
   primSet(intern("intern"), makeNative(builtinIntern, 1, 0));

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -8,9 +8,6 @@
 #include "types.h"
 #include "reader.h"
 
-struct Cora;
-typedef void (*basicBlock)(struct Cora *co);
-
 struct returnAddr {
   basicBlock pc;
   Obj *frees;
@@ -40,30 +37,9 @@ struct Cora {
 };
 
 void trampoline(struct Cora *co, basicBlock pc);
-
-struct scmNative {
-  scmHead head;
-  basicBlock fn;
-  // required is the argument number of the nativeFunc.
-  int required;
-  // captured is the size of the data, it's immutable after makeNative.
-  int captured;
-  Obj data[];
-};
-
 void coraCall(struct Cora *co);
-Obj makeNative(basicBlock fn, int required, int captured, ...);
-Obj* nativeData(Obj o);
-int nativeCaptured(Obj o);
-int nativeRequired(Obj o);
-basicBlock nativeFuncPtr(Obj o);
-
-Obj makeString1(char *x);
-
-void push(struct Cora *co, Obj v);
 void pushCont(struct Cora *co, basicBlock cb, int nstack, ...);
 void popStack(struct callStack *cs, basicBlock *pc, int *base, int *pos, Obj **stack, Obj **frees);
-/* void popStack(struct callStack *cs, basicBlock *pc, int *base, Obj **stack, Obj **frees); */
 Obj globalRef(Obj sym);
 Obj closureRef(struct Cora *co, int idx);
 Obj stackRef(struct Cora *co, int idx);
@@ -101,5 +77,6 @@ void registerAPI(struct registerModule* m, str pkg);
 
 
 struct Cora* coraNew();
+void coraInit(void *mark);
 
 #endif

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -10,7 +10,7 @@
 
 struct returnAddr {
   basicBlock pc;
-  Obj *frees;
+  Obj frees;
   int base;
   int pos;
   Obj *stack;
@@ -30,7 +30,7 @@ struct Cora {
 
   struct callStack callstack;
 
-  Obj *frees;
+  Obj frees;
   Obj args[32];
   int nargs;
   basicBlock pc;
@@ -39,7 +39,7 @@ struct Cora {
 void trampoline(struct Cora *co, basicBlock pc);
 void coraCall(struct Cora *co);
 void pushCont(struct Cora *co, basicBlock cb, int nstack, ...);
-void popStack(struct callStack *cs, basicBlock *pc, int *base, int *pos, Obj **stack, Obj **frees);
+void popStack(struct callStack *cs, basicBlock *pc, int *base, int *pos, Obj **stack, Obj *frees);
 Obj globalRef(Obj sym);
 Obj closureRef(struct Cora *co, int idx);
 Obj stackRef(struct Cora *co, int idx);

--- a/src/types.c
+++ b/src/types.c
@@ -11,24 +11,31 @@ const Obj False = ((2 << (TAG_SHIFT+1)) | TAG_BOOLEAN);
 const Obj Nil = ((666 << (TAG_SHIFT+1)) | TAG_IMMEDIATE_CONST);
 const Obj Undef = ((42 << TAG_SHIFT) | TAG_IMMEDIATE_CONST);
 
-/* uintptr_t gcCopy(struct GC *gc, uintptr_t head) { return 42; }; */
-
-
 struct scmString {
   scmHead head;
   strBuf str;
 };
 
 
-extern struct GC *g;
+extern struct GC gc;
+
+const char* typeNameX[7] = {
+  "boolean",
+  "null",
+  "number",
+  "cons",
+  "string",
+  "vector",
+  "native",
+};
 
 void*
 newObj(scmHeadType tp, int sz) {
-  scmHead* p = malloc(sz);
-  /* scmHead* p = gcAlloc(g, vm, pos, sz); */
+  /* scmHead* p = malloc(sz); */
+  scmHead* p = gcAlloc(&gc, sz);
   assert(((Obj)p & TAG_PTR) == 0);
   p->type = tp;
-  /* printf("alloc object -- %p %s\n", p, typeNameX[tp]); */
+  printf("alloc object -- %p %s\n", p, typeNameX[tp]);
   return (void*)p;
 }
 
@@ -68,12 +75,13 @@ bool iscons(Obj o) {
   return h->type == scmHeadCons;
 }
 
-/* static void */
-/* consGCFunc(struct GC *gc, void *obj) { */
-/*   struct scmCons *p = obj; */
-/*   gcField(gc, getScmHead(p->car)); */
-/*   gcField(gc, getScmHead(p->cdr)); */
-/* } */
+static void
+consGCFunc(struct GC *gc, void* f, void* t) {
+  struct scmCons *from = f;
+  struct scmCons *to = t;
+  to->car = gcCopy(gc, from->car);
+  to->cdr = gcCopy(gc, from->cdr);
+}
 
 Obj
 consp(Obj x) {
@@ -97,115 +105,6 @@ Obj
 cdddr(Obj x) {
   return cdr(cdr(cdr(x)));
 }
-
-Obj
-makeClosure(int required, int nfrees, void *closed, Obj code, nativeFn *fn) {
-  struct scmClosure* clo = newObj(scmHeadClosure, sizeof(struct scmClosure));
-  clo->required = required;
-  clo->nfrees = nfrees;
-  clo->closed = closed;
-  clo->code = code;
-  clo->fn = fn;
-
-  return ((Obj)(&clo->head) | TAG_PTR);
-}
-
-/* extern void instrGCFunc(struct GC *gc, void *obj); */
-
-/* static void */
-/* closureGCFunc(struct GC *gc, void *obj) { */
-/*   struct scmClosure* clo = obj; */
-/*   gcField(gc, getScmHead(clo->parent)); */
-/*   for (int i=0; i<clo->slot.size; i++) { */
-/*     struct hashForObjItem *item = clo->slot.ptr+i; */
-/*     if (item->value != 0) { */
-/*       gcField(gc, getScmHead(item->value)); */
-/*     } */
-/*   } */
-  
-/*   gcField(gc, &(((Instr)clo->codeData)->head)); */
-/* } */
-
-bool
-isclosure(Obj c) {
-  if ((c & TAG_MASK) != TAG_PTR) {
-    return false;
-  }
-  scmHead *h = ptr(c);
-  return h->type == scmHeadClosure;
-}
-
-struct scmClosure*
-mustClosure(Obj o) {
-  struct scmClosure* c = ptr(o);
-  assert(c->head.type == scmHeadClosure);
-  return c;
-}
-
-Obj
-closureCode(Obj o) {
-  struct scmClosure* c = mustClosure(o);
-  return c->code;
-}
-
-nativeFn*
-closurePC(Obj o) {
-  struct scmClosure* c = mustClosure(o);
-  return c->fn;
-}
-
-Obj
-closureSlot(Obj o, int idx) {
-  struct scmClosure* c = mustClosure(o);
-  return ((Obj*)c->closed)[idx];
-}
-
-int
-closureRequired(Obj o) {
-  struct scmClosure* c = mustClosure(o);
-  return c->required;
-}
-
-Obj
-makePrimitive(nativeFn *fn, int nargs) {
-  Obj tmp = makeClosure(nargs, 0, NULL, Nil, fn);
-  /* struct scmClosure* clo = mustClosure(tmp); */
-  /* clo->fn = fn; */
-  /* clo->required = nargs; */
-  /* clo->code = &clo->fn; */
-  return tmp;
-}
-
-
-/* extern void resumeCurry(void *pc, Obj val, struct VM *vm, int pos); */
-
-/* static struct hashForObjItem* */
-/* hashGet(struct hashForObj *h, int key) { */
-/*   int pos = key % h->size; */
-/*   int avoidDeadLoop = pos; */
-/*   do { */
-/*     if (h->ptr[pos].key == key) { */
-/*       return h->ptr+pos; */
-/*     } */
-/*     if (h->ptr[pos].value == 0) { */
-/*       break; */
-/*     } */
-/*     pos = (pos + 1) % h->size; */
-/*   } while (pos != avoidDeadLoop); */
-
-/*   return NULL; */
-/* } */
-
-/* static void */
-/* continuationGCFunc(struct GC *gc, void *obj) { */
-/*   struct continuation *cont = obj; */
-/*   struct stack *s = &cont->s; */
-/*   /\* printf("cont gc func, stack = %d %d\n", s->base, s->pos); *\/ */
-/*   for (int i=s->base; i<s->pos; i++) { */
-/*     gcField(gc, getScmHead(s->data[i])); */
-/*   } */
-/*   gcField(gc, &cont->codeData->head); */
-/* } */
 
 Obj
 makeNumber(int v) {
@@ -242,6 +141,10 @@ makeString(const char *s, int len) {
   return ((Obj)(&str->head) | TAG_PTR);
 }
 
+Obj makeString1(char *x) {
+  return makeString(x, strlen(x));
+}
+
 Obj
 makeCString(const char *s) {
   return makeString(s, strlen(s));
@@ -271,33 +174,28 @@ isstring(Obj o) {
   return false;
 }
 
-/* static void */
-/* stringGCFunc(struct GC *gc, void *obj) { */
-/*   // TODO: */
-/* } */
+static void
+stringGCFunc(struct GC *gc, void* f, void* t) {
+  // TODO:
+}
 
 
-static struct trieNode root = {};
+struct trieNode gRoot = {};
 
-/* static void */
-/* trieNodeGCFunc(struct GC* gc, struct trieNode *node) { */
-/*   gcMark(gc, getScmHead(node->value)); */
-/*   for (int i=0; i<256; i++) { */
-/*     if (node->child[i] != NULL) { */
-/*       trieNodeGCFunc(gc, node->child[i]); */
-/*     } */
-/*   } */
-/* } */
-
-/* void */
-/* gcGlobal(struct GC *gc) { */
-/*   trieNodeGCFunc(gc, &root); */
-/* } */
+void
+trieNodeGCFunc(struct GC* gc, struct trieNode *node) {
+  node->value = gcCopy(gc, node->value);
+  for (int i=0; i<256; i++) {
+    if (node->child[i] != NULL) {
+      trieNodeGCFunc(gc, node->child[i]);
+    }
+  }
+}
 
 Obj
 makeSymbol(char *s) {
   char *old = s;
-  struct trieNode* p = &root;
+  struct trieNode* p = &gRoot;
   for(; *s; s++) {
     int offset = *s;
     if (p->child[offset] == NULL) {
@@ -340,89 +238,73 @@ symbolStr(Obj sym) {
   return s->sym;
 }
 
-struct scmCurry {
-  scmHead head;
+Obj
+makeNative(basicBlock fn, int required, int captured, ...) {
+  int sz = sizeof(struct scmNative) + captured*sizeof(Obj);
+  struct scmNative* clo = newObj(scmHeadNative, sz);
+  clo->fn = fn;
+  clo->required = required;
+  clo->captured = captured;
+  if (captured > 0) {
+    va_list ap;
+    va_start(ap, captured);
+    for (int i=0; i<captured; i++) {
+      clo->data[i] = va_arg(ap, Obj);
+    }
+    va_end(ap);
+  }
 
-  int required;
-  int captured;
-  // The first element is scmNative and the remain is arguments.
-  Obj *data;
-};
+  return ((Obj)(&clo->head) | TAG_PTR);
+}
 
-/* Obj */
-/* makeCurry(int required, int captured, Obj *data) { */
-/*   int sz = sizeof(struct scmCurry) + captured*sizeof(Obj); */
-/*   struct scmCurry* clo = newObj(scmHeadCurry, sz); */
-/*   clo->required = required; */
-/*   clo->captured = captured; */
-/*   clo->data = data; */
-/*   /\* assert(captured > 0); *\/ */
-/*   return ((Obj)(&clo->head) | TAG_PTR); */
-/* } */
+static void
+nativeGCFunc(struct GC *gc, void* f, void* t) {
+  struct scmNative *from = f;
+  struct scmNative *to = t;
+  for (int i=0; i<from->captured; i++) {
+    to->data[i] = gcCopy(gc, from->data[i]);
+  }
+}
 
-/* static void */
-/* curryGCFunc(struct GC *gc, void* obj) { */
-/*   struct scmCurry *curry = obj; */
-/*   /\* gcField(gc, getScmHead(curry->prim)); *\/ */
-/*   for (int i=0; i<curry->captured; i++) { */
-/*     gcField(gc, getScmHead(curry->data[i])); */
-/*   } */
-/* } */
+bool
+isNative(Obj c) {
+  if ((c & TAG_MASK) != TAG_PTR) {
+    return false;
+  }
+  scmHead *h = ptr(c);
+  return h->type == scmHeadNative;
+}
 
-/* int */
-/* curryRequired(Obj o) { */
-/*   struct scmCurry *curry = ptr(o); */
-/*   return curry->required; */
-/* } */
+Obj*
+nativeData(Obj o) {
+  struct scmNative* native = ptr(o);
+  assert(native->head.type == scmHeadNative);
+  if (native->captured == 0) {
+    return NULL;
+  }
+  return native->data;
+}
 
-/* Obj */
-/* curryCaptured(Obj o) { */
-/*   struct scmCurry *curry = ptr(o); */
-/*   return curry->captured; */
-/* } */
+int
+nativeCaptured(Obj o) {
+  struct scmNative* native = ptr(o);
+  assert(native->head.type == scmHeadNative);
+  return native->captured;
+}
 
-/* Obj* */
-/* curryData(Obj o) { */
-/*   struct scmCurry *curry = ptr(o); */
-/*   return curry->data; */
-/* } */
+basicBlock
+nativeFuncPtr(Obj o) {
+  struct scmNative* native = ptr(o);
+  assert(native->head.type == scmHeadNative);
+  return native->fn;
+}
 
-/* bool */
-/* iscurry(Obj c) { */
-/*   if ((c & TAG_MASK) != TAG_PTR) { */
-/*     return false; */
-/*   } */
-/*   scmHead *h = ptr(c); */
-/*   return h->type == scmHeadCurry; */
-/* } */
-
-/* static void */
-/* nativeGCFunc(struct GC *gc, void* f, void* t) { */
-/*   struct scmNative *from = f; */
-/*   struct scmNative *to = t; */
-/*   for (int i=0; i<from->captured; i++) { */
-/*     to->data[i] = gcCopy(gc, from->data[i]); */
-/*   } */
-/* } */
-
-/* int */
-/* nativeCaptured(Obj o) { */
-/*   struct scmNative* native = ptr(o); */
-/*   assert(native->head.type == scmHeadNative); */
-/*   return native->captured; */
-/* } */
-
-/* Obj */
-/* nativeRef(Obj o, int idx) { */
-/*   struct scmNative* native = ptr(o); */
-/*   assert(native->head.type == scmHeadNative); */
-/*   return native->data[idx]; */
-/* } */
-
-/* Obj */
-/* makeBuiltin(nativeFuncPtr fn, int required) { */
-/*   return makeNative(fn, required+1, 0); */
-/* } */
+int
+nativeRequired(Obj o) {
+  struct scmNative* native = ptr(o);
+  assert(native->head.type == scmHeadNative);
+  return native->required;
+}
 
 struct scmVector {
   scmHead head;
@@ -464,13 +346,15 @@ isvector(Obj o) {
   return false;
 }
 
-/* static void */
-/* vectorGCFunc(struct GC *gc, void* obj) { */
-/*   struct scmVector *from = obj; */
-/*   for (int i=0; i<from->size; i++) { */
-/*     gcField(gc, getScmHead(from->data[i])); */
-/*   } */
-/* } */
+
+static void
+vectorGCFunc(struct GC *gc, void* f, void* t) {
+  struct scmVector *from = f;
+  struct scmVector *to = t;
+  for (int i=0; i<from->size; i++) {
+    to->data[i] = gcCopy(gc, from->data[i]);
+  }
+}
 
 bool
 eq(Obj x, Obj y) {
@@ -494,14 +378,11 @@ eq(Obj x, Obj y) {
   return false;
 }
 
-/* void */
-/* typesInit(struct GC *gc) { */
-  /* gcRegistForType(gc, scmHeadCons, consGCFunc); */
-  /* gcRegistForType(gc, scmHeadClosure, closureGCFunc); */
-  /* gcRegistForType(gc, scmHeadCurry, curryGCFunc); */
-  /* gcRegistForType(gc, scmHeadString, stringGCFunc); */
-  /* gcRegistForType(gc, scmHeadPrimitive, primitiveGCFunc); */
-  /* gcRegistForType(gc, scmHeadVector, vectorGCFunc); */
+void
+typesInit() {
+  gcRegistForType(scmHeadCons, consGCFunc);
+  gcRegistForType(scmHeadString, stringGCFunc);
+  gcRegistForType(scmHeadVector, vectorGCFunc);
+  gcRegistForType(scmHeadNative, nativeGCFunc);
   /* gcRegistForType(gc, scmHeadContinuation, continuationGCFunc); */
-  /* gcRegistForType(gc, scmHeadInstr, instrGCFunc); */
-/* } */
+}

--- a/src/types.c
+++ b/src/types.c
@@ -16,9 +16,6 @@ struct scmString {
   strBuf str;
 };
 
-
-extern struct GC gc;
-
 const char* typeNameX[7] = {
   "boolean",
   "null",
@@ -35,7 +32,7 @@ newObj(scmHeadType tp, int sz) {
   scmHead* p = gcAlloc(&gc, sz);
   assert(((Obj)p & TAG_PTR) == 0);
   p->type = tp;
-  printf("alloc object -- %p %s\n", p, typeNameX[tp]);
+  /* printf("alloc object -- %p %s\n", p, typeNameX[tp]); */
   return (void*)p;
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -53,17 +53,13 @@ enum {
       // The followings are all pointer types.
       // Except cons, all the others are general pointer.
       scmHeadCons,
-      /* scmHeadCurry, */
       scmHeadString,
       scmHeadVector,
-      scmHeadClosure,
-      /* scmHeadContinuation, */
-      scmHeadPrimitive,
-
       scmHeadNative,
+      /* scmHeadContinuation, */
 };
 
-/* void typesInit(); */
+void typesInit();
 
 struct VM;
 
@@ -100,30 +96,7 @@ Obj cdddr(Obj v);
 
 Obj makeCObj(void *ptr);
 
-typedef void (nativeFn)(struct VM*);
-
-struct scmClosure {
-  scmHead head;
-  int required;
-  Obj code;
-  void *closed;
-  int nfrees;
-  nativeFn *fn;
-};
-
-Obj makeClosure(int requred, int nfrees, void *closed, Obj code, nativeFn *pc);
-struct scmClosure* mustClosure(Obj o);
-Obj closureCode(Obj);
-bool isclosure(Obj o);
-Obj closureSlot(Obj, int);
-int closureRequired(Obj);
-nativeFn* closurePC(Obj o);
-
-/* Obj makePrimitive(nativeFn *fn, int nargs); */
-Obj makeCurry(int required, Obj *closed, int nfrees);
-
-struct tagbstring;
-typedef struct tagbstring * bstring;
+Obj makeString1(char *x);
 
 Obj makeString(const char *s, int len);
 Obj makeCString(const char *s);
@@ -132,6 +105,26 @@ int stringLen(Obj o);
 Obj makeNumber(int v);
 bool isstring(Obj o);
 bool isNumber(Obj o);
+
+struct Cora;
+
+typedef void (*basicBlock)(struct Cora *co);
+
+struct scmNative {
+  scmHead head;
+  basicBlock fn;
+  // required is the argument number of the nativeFunc.
+  int required;
+  // captured is the size of the data, it's immutable after makeNative.
+  int captured;
+  Obj data[];
+};
+
+Obj makeNative(basicBlock fn, int required, int captured, ...);
+Obj* nativeData(Obj o);
+int nativeCaptured(Obj o);
+int nativeRequired(Obj o);
+basicBlock nativeFuncPtr(Obj o);
 
 struct stack {
   Obj *data;
@@ -151,5 +144,8 @@ struct trieNode {
   char *sym;
   struct trieNode* child[256];
 };
+
+
+void trieNodeGCFunc(struct GC* gc, struct trieNode *node);
 
 #endif

--- a/test/run-all-test.cora
+++ b/test/run-all-test.cora
@@ -26,7 +26,7 @@
        outfile-path (get-exec-file file-path)
        (begin
 	(toc.compile-to-c file-path c-file-path "")
-	(os.exec ["gcc" "-DForTest -Isrc src/runtime.c ./src/str.c ./src/types.c ./src/reader.c" c-file-path
+	(os.exec ["gcc" "-g" "-DForTest -Isrc src/runtime.c src/gc.c ./src/str.c ./src/types.c ./src/reader.c" c-file-path
 		 "-o" outfile-path "-ldl"]))))
 
 (defun run (file-path)

--- a/toc.c
+++ b/toc.c
@@ -2,383 +2,383 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun3661(struct Cora* co);
-void _35clofun3662(struct Cora* co);
-void _35clofun3981(struct Cora* co);
-void _35clofun4021(struct Cora* co);
-void _35clofun4022(struct Cora* co);
-void _35clofun4027(struct Cora* co);
-void _35clofun4030(struct Cora* co);
-void _35clofun4033(struct Cora* co);
-void _35clofun4034(struct Cora* co);
-void _35clofun4031(struct Cora* co);
-void _35clofun4032(struct Cora* co);
-void _35clofun4028(struct Cora* co);
-void _35clofun4029(struct Cora* co);
-void _35clofun4025(struct Cora* co);
-void _35clofun4026(struct Cora* co);
-void _35clofun4023(struct Cora* co);
-void _35clofun4024(struct Cora* co);
-void _35clofun4020(struct Cora* co);
-void _35clofun4019(struct Cora* co);
-void _35clofun4018(struct Cora* co);
-void _35clofun4017(struct Cora* co);
-void _35clofun4016(struct Cora* co);
-void _35clofun4015(struct Cora* co);
-void _35clofun4014(struct Cora* co);
-void _35clofun4013(struct Cora* co);
-void _35clofun4012(struct Cora* co);
-void _35clofun4011(struct Cora* co);
-void _35clofun4010(struct Cora* co);
-void _35clofun4009(struct Cora* co);
-void _35clofun4008(struct Cora* co);
-void _35clofun4007(struct Cora* co);
-void _35clofun4006(struct Cora* co);
-void _35clofun4005(struct Cora* co);
-void _35clofun3999(struct Cora* co);
-void _35clofun4000(struct Cora* co);
-void _35clofun4001(struct Cora* co);
-void _35clofun4002(struct Cora* co);
-void _35clofun4003(struct Cora* co);
-void _35clofun4004(struct Cora* co);
-void _35clofun3991(struct Cora* co);
-void _35clofun3992(struct Cora* co);
-void _35clofun3993(struct Cora* co);
-void _35clofun3996(struct Cora* co);
-void _35clofun3997(struct Cora* co);
-void _35clofun3998(struct Cora* co);
-void _35clofun3994(struct Cora* co);
-void _35clofun3995(struct Cora* co);
-void _35clofun3987(struct Cora* co);
-void _35clofun3988(struct Cora* co);
-void _35clofun3990(struct Cora* co);
-void _35clofun3989(struct Cora* co);
-void _35clofun3982(struct Cora* co);
-void _35clofun3983(struct Cora* co);
-void _35clofun3984(struct Cora* co);
-void _35clofun3985(struct Cora* co);
-void _35clofun3986(struct Cora* co);
-void _35clofun3978(struct Cora* co);
-void _35clofun3979(struct Cora* co);
-void _35clofun3980(struct Cora* co);
-void _35clofun3975(struct Cora* co);
-void _35clofun3976(struct Cora* co);
-void _35clofun3977(struct Cora* co);
-void _35clofun3973(struct Cora* co);
-void _35clofun3974(struct Cora* co);
-void _35clofun3972(struct Cora* co);
-void _35clofun3971(struct Cora* co);
-void _35clofun3970(struct Cora* co);
-void _35clofun3969(struct Cora* co);
-void _35clofun3962(struct Cora* co);
-void _35clofun3964(struct Cora* co);
-void _35clofun3965(struct Cora* co);
-void _35clofun3966(struct Cora* co);
-void _35clofun3967(struct Cora* co);
-void _35clofun3968(struct Cora* co);
-void _35clofun3963(struct Cora* co);
-void _35clofun3954(struct Cora* co);
-void _35clofun3955(struct Cora* co);
-void _35clofun3957(struct Cora* co);
-void _35clofun3958(struct Cora* co);
-void _35clofun3959(struct Cora* co);
-void _35clofun3960(struct Cora* co);
-void _35clofun3961(struct Cora* co);
-void _35clofun3956(struct Cora* co);
-void _35clofun3950(struct Cora* co);
-void _35clofun3951(struct Cora* co);
-void _35clofun3952(struct Cora* co);
-void _35clofun3953(struct Cora* co);
-void _35clofun3949(struct Cora* co);
-void _35clofun3943(struct Cora* co);
-void _35clofun3944(struct Cora* co);
-void _35clofun3946(struct Cora* co);
-void _35clofun3947(struct Cora* co);
-void _35clofun3948(struct Cora* co);
-void _35clofun3945(struct Cora* co);
-void _35clofun3932(struct Cora* co);
-void _35clofun3934(struct Cora* co);
-void _35clofun3935(struct Cora* co);
-void _35clofun3936(struct Cora* co);
-void _35clofun3937(struct Cora* co);
-void _35clofun3938(struct Cora* co);
-void _35clofun3939(struct Cora* co);
-void _35clofun3942(struct Cora* co);
-void _35clofun3940(struct Cora* co);
-void _35clofun3941(struct Cora* co);
-void _35clofun3933(struct Cora* co);
-void _35clofun3924(struct Cora* co);
-void _35clofun3925(struct Cora* co);
-void _35clofun3927(struct Cora* co);
-void _35clofun3928(struct Cora* co);
-void _35clofun3929(struct Cora* co);
-void _35clofun3930(struct Cora* co);
-void _35clofun3931(struct Cora* co);
-void _35clofun3926(struct Cora* co);
-void _35clofun3843(struct Cora* co);
-void _35clofun3844(struct Cora* co);
-void _35clofun3921(struct Cora* co);
-void _35clofun3922(struct Cora* co);
-void _35clofun3923(struct Cora* co);
-void _35clofun3845(struct Cora* co);
-void _35clofun3919(struct Cora* co);
-void _35clofun3920(struct Cora* co);
-void _35clofun3846(struct Cora* co);
-void _35clofun3917(struct Cora* co);
-void _35clofun3918(struct Cora* co);
-void _35clofun3847(struct Cora* co);
-void _35clofun3911(struct Cora* co);
-void _35clofun3914(struct Cora* co);
-void _35clofun3915(struct Cora* co);
-void _35clofun3916(struct Cora* co);
-void _35clofun3912(struct Cora* co);
-void _35clofun3913(struct Cora* co);
-void _35clofun3908(struct Cora* co);
-void _35clofun3909(struct Cora* co);
-void _35clofun3910(struct Cora* co);
-void _35clofun3848(struct Cora* co);
-void _35clofun3898(struct Cora* co);
-void _35clofun3904(struct Cora* co);
-void _35clofun3905(struct Cora* co);
-void _35clofun3906(struct Cora* co);
-void _35clofun3907(struct Cora* co);
-void _35clofun3899(struct Cora* co);
-void _35clofun3900(struct Cora* co);
-void _35clofun3901(struct Cora* co);
-void _35clofun3902(struct Cora* co);
-void _35clofun3903(struct Cora* co);
-void _35clofun3849(struct Cora* co);
-void _35clofun3894(struct Cora* co);
-void _35clofun3895(struct Cora* co);
-void _35clofun3896(struct Cora* co);
-void _35clofun3897(struct Cora* co);
-void _35clofun3850(struct Cora* co);
-void _35clofun3888(struct Cora* co);
-void _35clofun3889(struct Cora* co);
-void _35clofun3890(struct Cora* co);
-void _35clofun3891(struct Cora* co);
-void _35clofun3892(struct Cora* co);
-void _35clofun3893(struct Cora* co);
-void _35clofun3851(struct Cora* co);
-void _35clofun3878(struct Cora* co);
-void _35clofun3879(struct Cora* co);
-void _35clofun3880(struct Cora* co);
-void _35clofun3881(struct Cora* co);
-void _35clofun3882(struct Cora* co);
-void _35clofun3883(struct Cora* co);
-void _35clofun3884(struct Cora* co);
-void _35clofun3885(struct Cora* co);
-void _35clofun3886(struct Cora* co);
-void _35clofun3887(struct Cora* co);
-void _35clofun3852(struct Cora* co);
-void _35clofun3876(struct Cora* co);
-void _35clofun3877(struct Cora* co);
-void _35clofun3853(struct Cora* co);
-void _35clofun3872(struct Cora* co);
-void _35clofun3873(struct Cora* co);
-void _35clofun3874(struct Cora* co);
-void _35clofun3875(struct Cora* co);
-void _35clofun3854(struct Cora* co);
-void _35clofun3855(struct Cora* co);
-void _35clofun3871(struct Cora* co);
-void _35clofun3856(struct Cora* co);
-void _35clofun3858(struct Cora* co);
-void _35clofun3859(struct Cora* co);
-void _35clofun3860(struct Cora* co);
-void _35clofun3861(struct Cora* co);
-void _35clofun3862(struct Cora* co);
-void _35clofun3863(struct Cora* co);
-void _35clofun3864(struct Cora* co);
-void _35clofun3865(struct Cora* co);
-void _35clofun3866(struct Cora* co);
-void _35clofun3867(struct Cora* co);
-void _35clofun3868(struct Cora* co);
-void _35clofun3869(struct Cora* co);
-void _35clofun3870(struct Cora* co);
-void _35clofun3857(struct Cora* co);
-void _35clofun3841(struct Cora* co);
-void _35clofun3842(struct Cora* co);
-void _35clofun3836(struct Cora* co);
-void _35clofun3840(struct Cora* co);
-void _35clofun3837(struct Cora* co);
-void _35clofun3839(struct Cora* co);
-void _35clofun3838(struct Cora* co);
-void _35clofun3826(struct Cora* co);
-void _35clofun3834(struct Cora* co);
-void _35clofun3835(struct Cora* co);
-void _35clofun3832(struct Cora* co);
-void _35clofun3833(struct Cora* co);
-void _35clofun3830(struct Cora* co);
-void _35clofun3831(struct Cora* co);
-void _35clofun3827(struct Cora* co);
-void _35clofun3828(struct Cora* co);
-void _35clofun3829(struct Cora* co);
-void _35clofun3808(struct Cora* co);
-void _35clofun3825(struct Cora* co);
-void _35clofun3809(struct Cora* co);
-void _35clofun3810(struct Cora* co);
-void _35clofun3824(struct Cora* co);
-void _35clofun3811(struct Cora* co);
-void _35clofun3819(struct Cora* co);
-void _35clofun3820(struct Cora* co);
-void _35clofun3821(struct Cora* co);
-void _35clofun3822(struct Cora* co);
-void _35clofun3823(struct Cora* co);
-void _35clofun3812(struct Cora* co);
-void _35clofun3816(struct Cora* co);
-void _35clofun3817(struct Cora* co);
-void _35clofun3818(struct Cora* co);
-void _35clofun3813(struct Cora* co);
-void _35clofun3815(struct Cora* co);
-void _35clofun3814(struct Cora* co);
-void _35clofun3798(struct Cora* co);
-void _35clofun3802(struct Cora* co);
-void _35clofun3803(struct Cora* co);
-void _35clofun3807(struct Cora* co);
-void _35clofun3804(struct Cora* co);
-void _35clofun3806(struct Cora* co);
-void _35clofun3805(struct Cora* co);
-void _35clofun3799(struct Cora* co);
-void _35clofun3801(struct Cora* co);
-void _35clofun3800(struct Cora* co);
-void _35clofun3780(struct Cora* co);
-void _35clofun3797(struct Cora* co);
-void _35clofun3781(struct Cora* co);
-void _35clofun3796(struct Cora* co);
-void _35clofun3782(struct Cora* co);
-void _35clofun3793(struct Cora* co);
-void _35clofun3794(struct Cora* co);
-void _35clofun3795(struct Cora* co);
-void _35clofun3783(struct Cora* co);
-void _35clofun3791(struct Cora* co);
-void _35clofun3792(struct Cora* co);
-void _35clofun3784(struct Cora* co);
-void _35clofun3789(struct Cora* co);
-void _35clofun3790(struct Cora* co);
-void _35clofun3785(struct Cora* co);
-void _35clofun3788(struct Cora* co);
-void _35clofun3786(struct Cora* co);
-void _35clofun3787(struct Cora* co);
-void _35clofun3779(struct Cora* co);
-void _35clofun3764(struct Cora* co);
-void _35clofun3778(struct Cora* co);
-void _35clofun3765(struct Cora* co);
-void _35clofun3777(struct Cora* co);
-void _35clofun3766(struct Cora* co);
-void _35clofun3773(struct Cora* co);
-void _35clofun3774(struct Cora* co);
-void _35clofun3775(struct Cora* co);
-void _35clofun3776(struct Cora* co);
-void _35clofun3767(struct Cora* co);
-void _35clofun3771(struct Cora* co);
-void _35clofun3772(struct Cora* co);
-void _35clofun3768(struct Cora* co);
-void _35clofun3770(struct Cora* co);
-void _35clofun3769(struct Cora* co);
-void _35clofun3741(struct Cora* co);
-void _35clofun3763(struct Cora* co);
-void _35clofun3742(struct Cora* co);
-void _35clofun3743(struct Cora* co);
-void _35clofun3762(struct Cora* co);
-void _35clofun3744(struct Cora* co);
-void _35clofun3761(struct Cora* co);
-void _35clofun3745(struct Cora* co);
-void _35clofun3760(struct Cora* co);
-void _35clofun3746(struct Cora* co);
-void _35clofun3757(struct Cora* co);
-void _35clofun3758(struct Cora* co);
-void _35clofun3759(struct Cora* co);
-void _35clofun3747(struct Cora* co);
-void _35clofun3748(struct Cora* co);
-void _35clofun3749(struct Cora* co);
-void _35clofun3756(struct Cora* co);
-void _35clofun3750(struct Cora* co);
-void _35clofun3751(struct Cora* co);
-void _35clofun3755(struct Cora* co);
-void _35clofun3752(struct Cora* co);
-void _35clofun3754(struct Cora* co);
-void _35clofun3753(struct Cora* co);
-void _35clofun3734(struct Cora* co);
-void _35clofun3735(struct Cora* co);
-void _35clofun3736(struct Cora* co);
-void _35clofun3737(struct Cora* co);
-void _35clofun3738(struct Cora* co);
-void _35clofun3739(struct Cora* co);
-void _35clofun3740(struct Cora* co);
-void _35clofun3728(struct Cora* co);
-void _35clofun3729(struct Cora* co);
-void _35clofun3733(struct Cora* co);
-void _35clofun3730(struct Cora* co);
-void _35clofun3732(struct Cora* co);
-void _35clofun3731(struct Cora* co);
-void _35clofun3722(struct Cora* co);
-void _35clofun3723(struct Cora* co);
-void _35clofun3727(struct Cora* co);
-void _35clofun3724(struct Cora* co);
-void _35clofun3726(struct Cora* co);
-void _35clofun3725(struct Cora* co);
-void _35clofun3692(struct Cora* co);
-void _35clofun3719(struct Cora* co);
-void _35clofun3720(struct Cora* co);
-void _35clofun3721(struct Cora* co);
-void _35clofun3693(struct Cora* co);
-void _35clofun3694(struct Cora* co);
-void _35clofun3718(struct Cora* co);
-void _35clofun3695(struct Cora* co);
-void _35clofun3716(struct Cora* co);
-void _35clofun3717(struct Cora* co);
-void _35clofun3696(struct Cora* co);
-void _35clofun3714(struct Cora* co);
-void _35clofun3715(struct Cora* co);
-void _35clofun3697(struct Cora* co);
-void _35clofun3712(struct Cora* co);
-void _35clofun3713(struct Cora* co);
-void _35clofun3698(struct Cora* co);
-void _35clofun3710(struct Cora* co);
-void _35clofun3711(struct Cora* co);
-void _35clofun3699(struct Cora* co);
-void _35clofun3703(struct Cora* co);
-void _35clofun3704(struct Cora* co);
-void _35clofun3705(struct Cora* co);
-void _35clofun3708(struct Cora* co);
-void _35clofun3709(struct Cora* co);
-void _35clofun3706(struct Cora* co);
-void _35clofun3707(struct Cora* co);
-void _35clofun3700(struct Cora* co);
-void _35clofun3702(struct Cora* co);
-void _35clofun3701(struct Cora* co);
-void _35clofun3689(struct Cora* co);
-void _35clofun3690(struct Cora* co);
-void _35clofun3691(struct Cora* co);
-void _35clofun3686(struct Cora* co);
-void _35clofun3687(struct Cora* co);
-void _35clofun3688(struct Cora* co);
-void _35clofun3683(struct Cora* co);
-void _35clofun3684(struct Cora* co);
-void _35clofun3685(struct Cora* co);
-void _35clofun3680(struct Cora* co);
-void _35clofun3681(struct Cora* co);
-void _35clofun3682(struct Cora* co);
-void _35clofun3676(struct Cora* co);
-void _35clofun3677(struct Cora* co);
-void _35clofun3679(struct Cora* co);
-void _35clofun3678(struct Cora* co);
-void _35clofun3675(struct Cora* co);
-void _35clofun3671(struct Cora* co);
-void _35clofun3672(struct Cora* co);
-void _35clofun3673(struct Cora* co);
-void _35clofun3674(struct Cora* co);
-void _35clofun3667(struct Cora* co);
-void _35clofun3668(struct Cora* co);
-void _35clofun3670(struct Cora* co);
-void _35clofun3669(struct Cora* co);
-void _35clofun3663(struct Cora* co);
-void _35clofun3664(struct Cora* co);
-void _35clofun3665(struct Cora* co);
-void _35clofun3666(struct Cora* co);
+void _35clofun2859(struct Cora* co);
+void _35clofun2860(struct Cora* co);
+void _35clofun3179(struct Cora* co);
+void _35clofun3219(struct Cora* co);
+void _35clofun3220(struct Cora* co);
+void _35clofun3225(struct Cora* co);
+void _35clofun3228(struct Cora* co);
+void _35clofun3231(struct Cora* co);
+void _35clofun3232(struct Cora* co);
+void _35clofun3229(struct Cora* co);
+void _35clofun3230(struct Cora* co);
+void _35clofun3226(struct Cora* co);
+void _35clofun3227(struct Cora* co);
+void _35clofun3223(struct Cora* co);
+void _35clofun3224(struct Cora* co);
+void _35clofun3221(struct Cora* co);
+void _35clofun3222(struct Cora* co);
+void _35clofun3218(struct Cora* co);
+void _35clofun3217(struct Cora* co);
+void _35clofun3216(struct Cora* co);
+void _35clofun3215(struct Cora* co);
+void _35clofun3214(struct Cora* co);
+void _35clofun3213(struct Cora* co);
+void _35clofun3212(struct Cora* co);
+void _35clofun3211(struct Cora* co);
+void _35clofun3210(struct Cora* co);
+void _35clofun3209(struct Cora* co);
+void _35clofun3208(struct Cora* co);
+void _35clofun3207(struct Cora* co);
+void _35clofun3206(struct Cora* co);
+void _35clofun3205(struct Cora* co);
+void _35clofun3204(struct Cora* co);
+void _35clofun3203(struct Cora* co);
+void _35clofun3197(struct Cora* co);
+void _35clofun3198(struct Cora* co);
+void _35clofun3199(struct Cora* co);
+void _35clofun3200(struct Cora* co);
+void _35clofun3201(struct Cora* co);
+void _35clofun3202(struct Cora* co);
+void _35clofun3189(struct Cora* co);
+void _35clofun3190(struct Cora* co);
+void _35clofun3191(struct Cora* co);
+void _35clofun3194(struct Cora* co);
+void _35clofun3195(struct Cora* co);
+void _35clofun3196(struct Cora* co);
+void _35clofun3192(struct Cora* co);
+void _35clofun3193(struct Cora* co);
+void _35clofun3185(struct Cora* co);
+void _35clofun3186(struct Cora* co);
+void _35clofun3188(struct Cora* co);
+void _35clofun3187(struct Cora* co);
+void _35clofun3180(struct Cora* co);
+void _35clofun3181(struct Cora* co);
+void _35clofun3182(struct Cora* co);
+void _35clofun3183(struct Cora* co);
+void _35clofun3184(struct Cora* co);
+void _35clofun3176(struct Cora* co);
+void _35clofun3177(struct Cora* co);
+void _35clofun3178(struct Cora* co);
+void _35clofun3173(struct Cora* co);
+void _35clofun3174(struct Cora* co);
+void _35clofun3175(struct Cora* co);
+void _35clofun3171(struct Cora* co);
+void _35clofun3172(struct Cora* co);
+void _35clofun3170(struct Cora* co);
+void _35clofun3169(struct Cora* co);
+void _35clofun3168(struct Cora* co);
+void _35clofun3167(struct Cora* co);
+void _35clofun3160(struct Cora* co);
+void _35clofun3162(struct Cora* co);
+void _35clofun3163(struct Cora* co);
+void _35clofun3164(struct Cora* co);
+void _35clofun3165(struct Cora* co);
+void _35clofun3166(struct Cora* co);
+void _35clofun3161(struct Cora* co);
+void _35clofun3152(struct Cora* co);
+void _35clofun3153(struct Cora* co);
+void _35clofun3155(struct Cora* co);
+void _35clofun3156(struct Cora* co);
+void _35clofun3157(struct Cora* co);
+void _35clofun3158(struct Cora* co);
+void _35clofun3159(struct Cora* co);
+void _35clofun3154(struct Cora* co);
+void _35clofun3148(struct Cora* co);
+void _35clofun3149(struct Cora* co);
+void _35clofun3150(struct Cora* co);
+void _35clofun3151(struct Cora* co);
+void _35clofun3147(struct Cora* co);
+void _35clofun3141(struct Cora* co);
+void _35clofun3142(struct Cora* co);
+void _35clofun3144(struct Cora* co);
+void _35clofun3145(struct Cora* co);
+void _35clofun3146(struct Cora* co);
+void _35clofun3143(struct Cora* co);
+void _35clofun3130(struct Cora* co);
+void _35clofun3132(struct Cora* co);
+void _35clofun3133(struct Cora* co);
+void _35clofun3134(struct Cora* co);
+void _35clofun3135(struct Cora* co);
+void _35clofun3136(struct Cora* co);
+void _35clofun3137(struct Cora* co);
+void _35clofun3140(struct Cora* co);
+void _35clofun3138(struct Cora* co);
+void _35clofun3139(struct Cora* co);
+void _35clofun3131(struct Cora* co);
+void _35clofun3122(struct Cora* co);
+void _35clofun3123(struct Cora* co);
+void _35clofun3125(struct Cora* co);
+void _35clofun3126(struct Cora* co);
+void _35clofun3127(struct Cora* co);
+void _35clofun3128(struct Cora* co);
+void _35clofun3129(struct Cora* co);
+void _35clofun3124(struct Cora* co);
+void _35clofun3041(struct Cora* co);
+void _35clofun3042(struct Cora* co);
+void _35clofun3119(struct Cora* co);
+void _35clofun3120(struct Cora* co);
+void _35clofun3121(struct Cora* co);
+void _35clofun3043(struct Cora* co);
+void _35clofun3117(struct Cora* co);
+void _35clofun3118(struct Cora* co);
+void _35clofun3044(struct Cora* co);
+void _35clofun3115(struct Cora* co);
+void _35clofun3116(struct Cora* co);
+void _35clofun3045(struct Cora* co);
+void _35clofun3109(struct Cora* co);
+void _35clofun3112(struct Cora* co);
+void _35clofun3113(struct Cora* co);
+void _35clofun3114(struct Cora* co);
+void _35clofun3110(struct Cora* co);
+void _35clofun3111(struct Cora* co);
+void _35clofun3106(struct Cora* co);
+void _35clofun3107(struct Cora* co);
+void _35clofun3108(struct Cora* co);
+void _35clofun3046(struct Cora* co);
+void _35clofun3096(struct Cora* co);
+void _35clofun3102(struct Cora* co);
+void _35clofun3103(struct Cora* co);
+void _35clofun3104(struct Cora* co);
+void _35clofun3105(struct Cora* co);
+void _35clofun3097(struct Cora* co);
+void _35clofun3098(struct Cora* co);
+void _35clofun3099(struct Cora* co);
+void _35clofun3100(struct Cora* co);
+void _35clofun3101(struct Cora* co);
+void _35clofun3047(struct Cora* co);
+void _35clofun3092(struct Cora* co);
+void _35clofun3093(struct Cora* co);
+void _35clofun3094(struct Cora* co);
+void _35clofun3095(struct Cora* co);
+void _35clofun3048(struct Cora* co);
+void _35clofun3086(struct Cora* co);
+void _35clofun3087(struct Cora* co);
+void _35clofun3088(struct Cora* co);
+void _35clofun3089(struct Cora* co);
+void _35clofun3090(struct Cora* co);
+void _35clofun3091(struct Cora* co);
+void _35clofun3049(struct Cora* co);
+void _35clofun3076(struct Cora* co);
+void _35clofun3077(struct Cora* co);
+void _35clofun3078(struct Cora* co);
+void _35clofun3079(struct Cora* co);
+void _35clofun3080(struct Cora* co);
+void _35clofun3081(struct Cora* co);
+void _35clofun3082(struct Cora* co);
+void _35clofun3083(struct Cora* co);
+void _35clofun3084(struct Cora* co);
+void _35clofun3085(struct Cora* co);
+void _35clofun3050(struct Cora* co);
+void _35clofun3074(struct Cora* co);
+void _35clofun3075(struct Cora* co);
+void _35clofun3051(struct Cora* co);
+void _35clofun3070(struct Cora* co);
+void _35clofun3071(struct Cora* co);
+void _35clofun3072(struct Cora* co);
+void _35clofun3073(struct Cora* co);
+void _35clofun3052(struct Cora* co);
+void _35clofun3053(struct Cora* co);
+void _35clofun3069(struct Cora* co);
+void _35clofun3054(struct Cora* co);
+void _35clofun3056(struct Cora* co);
+void _35clofun3057(struct Cora* co);
+void _35clofun3058(struct Cora* co);
+void _35clofun3059(struct Cora* co);
+void _35clofun3060(struct Cora* co);
+void _35clofun3061(struct Cora* co);
+void _35clofun3062(struct Cora* co);
+void _35clofun3063(struct Cora* co);
+void _35clofun3064(struct Cora* co);
+void _35clofun3065(struct Cora* co);
+void _35clofun3066(struct Cora* co);
+void _35clofun3067(struct Cora* co);
+void _35clofun3068(struct Cora* co);
+void _35clofun3055(struct Cora* co);
+void _35clofun3039(struct Cora* co);
+void _35clofun3040(struct Cora* co);
+void _35clofun3034(struct Cora* co);
+void _35clofun3038(struct Cora* co);
+void _35clofun3035(struct Cora* co);
+void _35clofun3037(struct Cora* co);
+void _35clofun3036(struct Cora* co);
+void _35clofun3024(struct Cora* co);
+void _35clofun3032(struct Cora* co);
+void _35clofun3033(struct Cora* co);
+void _35clofun3030(struct Cora* co);
+void _35clofun3031(struct Cora* co);
+void _35clofun3028(struct Cora* co);
+void _35clofun3029(struct Cora* co);
+void _35clofun3025(struct Cora* co);
+void _35clofun3026(struct Cora* co);
+void _35clofun3027(struct Cora* co);
+void _35clofun3006(struct Cora* co);
+void _35clofun3023(struct Cora* co);
+void _35clofun3007(struct Cora* co);
+void _35clofun3008(struct Cora* co);
+void _35clofun3022(struct Cora* co);
+void _35clofun3009(struct Cora* co);
+void _35clofun3017(struct Cora* co);
+void _35clofun3018(struct Cora* co);
+void _35clofun3019(struct Cora* co);
+void _35clofun3020(struct Cora* co);
+void _35clofun3021(struct Cora* co);
+void _35clofun3010(struct Cora* co);
+void _35clofun3014(struct Cora* co);
+void _35clofun3015(struct Cora* co);
+void _35clofun3016(struct Cora* co);
+void _35clofun3011(struct Cora* co);
+void _35clofun3013(struct Cora* co);
+void _35clofun3012(struct Cora* co);
+void _35clofun2996(struct Cora* co);
+void _35clofun3000(struct Cora* co);
+void _35clofun3001(struct Cora* co);
+void _35clofun3005(struct Cora* co);
+void _35clofun3002(struct Cora* co);
+void _35clofun3004(struct Cora* co);
+void _35clofun3003(struct Cora* co);
+void _35clofun2997(struct Cora* co);
+void _35clofun2999(struct Cora* co);
+void _35clofun2998(struct Cora* co);
+void _35clofun2978(struct Cora* co);
+void _35clofun2995(struct Cora* co);
+void _35clofun2979(struct Cora* co);
+void _35clofun2994(struct Cora* co);
+void _35clofun2980(struct Cora* co);
+void _35clofun2991(struct Cora* co);
+void _35clofun2992(struct Cora* co);
+void _35clofun2993(struct Cora* co);
+void _35clofun2981(struct Cora* co);
+void _35clofun2989(struct Cora* co);
+void _35clofun2990(struct Cora* co);
+void _35clofun2982(struct Cora* co);
+void _35clofun2987(struct Cora* co);
+void _35clofun2988(struct Cora* co);
+void _35clofun2983(struct Cora* co);
+void _35clofun2986(struct Cora* co);
+void _35clofun2984(struct Cora* co);
+void _35clofun2985(struct Cora* co);
+void _35clofun2977(struct Cora* co);
+void _35clofun2962(struct Cora* co);
+void _35clofun2976(struct Cora* co);
+void _35clofun2963(struct Cora* co);
+void _35clofun2975(struct Cora* co);
+void _35clofun2964(struct Cora* co);
+void _35clofun2971(struct Cora* co);
+void _35clofun2972(struct Cora* co);
+void _35clofun2973(struct Cora* co);
+void _35clofun2974(struct Cora* co);
+void _35clofun2965(struct Cora* co);
+void _35clofun2969(struct Cora* co);
+void _35clofun2970(struct Cora* co);
+void _35clofun2966(struct Cora* co);
+void _35clofun2968(struct Cora* co);
+void _35clofun2967(struct Cora* co);
+void _35clofun2939(struct Cora* co);
+void _35clofun2961(struct Cora* co);
+void _35clofun2940(struct Cora* co);
+void _35clofun2941(struct Cora* co);
+void _35clofun2960(struct Cora* co);
+void _35clofun2942(struct Cora* co);
+void _35clofun2959(struct Cora* co);
+void _35clofun2943(struct Cora* co);
+void _35clofun2958(struct Cora* co);
+void _35clofun2944(struct Cora* co);
+void _35clofun2955(struct Cora* co);
+void _35clofun2956(struct Cora* co);
+void _35clofun2957(struct Cora* co);
+void _35clofun2945(struct Cora* co);
+void _35clofun2946(struct Cora* co);
+void _35clofun2947(struct Cora* co);
+void _35clofun2954(struct Cora* co);
+void _35clofun2948(struct Cora* co);
+void _35clofun2949(struct Cora* co);
+void _35clofun2953(struct Cora* co);
+void _35clofun2950(struct Cora* co);
+void _35clofun2952(struct Cora* co);
+void _35clofun2951(struct Cora* co);
+void _35clofun2932(struct Cora* co);
+void _35clofun2933(struct Cora* co);
+void _35clofun2934(struct Cora* co);
+void _35clofun2935(struct Cora* co);
+void _35clofun2936(struct Cora* co);
+void _35clofun2937(struct Cora* co);
+void _35clofun2938(struct Cora* co);
+void _35clofun2926(struct Cora* co);
+void _35clofun2927(struct Cora* co);
+void _35clofun2931(struct Cora* co);
+void _35clofun2928(struct Cora* co);
+void _35clofun2930(struct Cora* co);
+void _35clofun2929(struct Cora* co);
+void _35clofun2920(struct Cora* co);
+void _35clofun2921(struct Cora* co);
+void _35clofun2925(struct Cora* co);
+void _35clofun2922(struct Cora* co);
+void _35clofun2924(struct Cora* co);
+void _35clofun2923(struct Cora* co);
+void _35clofun2890(struct Cora* co);
+void _35clofun2917(struct Cora* co);
+void _35clofun2918(struct Cora* co);
+void _35clofun2919(struct Cora* co);
+void _35clofun2891(struct Cora* co);
+void _35clofun2892(struct Cora* co);
+void _35clofun2916(struct Cora* co);
+void _35clofun2893(struct Cora* co);
+void _35clofun2914(struct Cora* co);
+void _35clofun2915(struct Cora* co);
+void _35clofun2894(struct Cora* co);
+void _35clofun2912(struct Cora* co);
+void _35clofun2913(struct Cora* co);
+void _35clofun2895(struct Cora* co);
+void _35clofun2910(struct Cora* co);
+void _35clofun2911(struct Cora* co);
+void _35clofun2896(struct Cora* co);
+void _35clofun2908(struct Cora* co);
+void _35clofun2909(struct Cora* co);
+void _35clofun2897(struct Cora* co);
+void _35clofun2901(struct Cora* co);
+void _35clofun2902(struct Cora* co);
+void _35clofun2903(struct Cora* co);
+void _35clofun2906(struct Cora* co);
+void _35clofun2907(struct Cora* co);
+void _35clofun2904(struct Cora* co);
+void _35clofun2905(struct Cora* co);
+void _35clofun2898(struct Cora* co);
+void _35clofun2900(struct Cora* co);
+void _35clofun2899(struct Cora* co);
+void _35clofun2887(struct Cora* co);
+void _35clofun2888(struct Cora* co);
+void _35clofun2889(struct Cora* co);
+void _35clofun2884(struct Cora* co);
+void _35clofun2885(struct Cora* co);
+void _35clofun2886(struct Cora* co);
+void _35clofun2881(struct Cora* co);
+void _35clofun2882(struct Cora* co);
+void _35clofun2883(struct Cora* co);
+void _35clofun2878(struct Cora* co);
+void _35clofun2879(struct Cora* co);
+void _35clofun2880(struct Cora* co);
+void _35clofun2874(struct Cora* co);
+void _35clofun2875(struct Cora* co);
+void _35clofun2877(struct Cora* co);
+void _35clofun2876(struct Cora* co);
+void _35clofun2873(struct Cora* co);
+void _35clofun2869(struct Cora* co);
+void _35clofun2870(struct Cora* co);
+void _35clofun2871(struct Cora* co);
+void _35clofun2872(struct Cora* co);
+void _35clofun2865(struct Cora* co);
+void _35clofun2866(struct Cora* co);
+void _35clofun2868(struct Cora* co);
+void _35clofun2867(struct Cora* co);
+void _35clofun2861(struct Cora* co);
+void _35clofun2862(struct Cora* co);
+void _35clofun2863(struct Cora* co);
+void _35clofun2864(struct Cora* co);
 
 void entry(struct Cora* co) {
-pushCont(co, _35clofun3661, 0);
+pushCont(co, _35clofun2859, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("import"));
 co->args[1] = makeString1("cora/lib/toc/internal");
@@ -391,9 +391,9 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3661(struct Cora* co) {
-Obj _35val2200 = co->args[1];
-pushCont(co, _35clofun3662, 0);
+void _35clofun2859(struct Cora* co) {
+Obj _35val1398 = co->args[1];
+pushCont(co, _35clofun2860, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("import"));
 co->args[1] = makeString1("cora/lib/io");
@@ -406,118 +406,118 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3662(struct Cora* co) {
-Obj _35val2201 = co->args[1];
-Obj _35reg2216 = primSet(intern("cora/lib/toc/include.assq"), makeNative(_35clofun3663, 2, 0));
-Obj _35reg2222 = primSet(intern("cora/lib/toc/include.foldl"), makeNative(_35clofun3667, 3, 0));
-Obj _35reg2232 = primSet(intern("cora/lib/toc/include.pos-in-list0"), makeNative(_35clofun3671, 3, 0));
-Obj _35reg2233 = primSet(intern("cora/lib/toc/include.index"), makeNative(_35clofun3675, 2, 0));
-Obj _35reg2240 = primSet(intern("cora/lib/toc/include.exist-in-env"), makeNative(_35clofun3676, 2, 0));
-Obj _35reg2241 = primCons(intern("primSet"), Nil);
-Obj _35reg2242 = primCons(makeNumber(2), _35reg2241);
-Obj _35reg2243 = primCons(intern("set"), _35reg2242);
-Obj _35reg2244 = primCons(intern("primCar"), Nil);
-Obj _35reg2245 = primCons(makeNumber(1), _35reg2244);
-Obj _35reg2246 = primCons(intern("car"), _35reg2245);
-Obj _35reg2247 = primCons(intern("primCdr"), Nil);
-Obj _35reg2248 = primCons(makeNumber(1), _35reg2247);
-Obj _35reg2249 = primCons(intern("cdr"), _35reg2248);
-Obj _35reg2250 = primCons(intern("primCons"), Nil);
-Obj _35reg2251 = primCons(makeNumber(2), _35reg2250);
-Obj _35reg2252 = primCons(intern("cons"), _35reg2251);
-Obj _35reg2253 = primCons(intern("primIsCons"), Nil);
-Obj _35reg2254 = primCons(makeNumber(1), _35reg2253);
-Obj _35reg2255 = primCons(intern("cons?"), _35reg2254);
-Obj _35reg2256 = primCons(intern("primAdd"), Nil);
-Obj _35reg2257 = primCons(makeNumber(2), _35reg2256);
-Obj _35reg2258 = primCons(intern("+"), _35reg2257);
-Obj _35reg2259 = primCons(intern("primSub"), Nil);
-Obj _35reg2260 = primCons(makeNumber(2), _35reg2259);
-Obj _35reg2261 = primCons(intern("-"), _35reg2260);
-Obj _35reg2262 = primCons(intern("primMul"), Nil);
-Obj _35reg2263 = primCons(makeNumber(2), _35reg2262);
-Obj _35reg2264 = primCons(intern("*"), _35reg2263);
-Obj _35reg2265 = primCons(intern("primDiv"), Nil);
-Obj _35reg2266 = primCons(makeNumber(2), _35reg2265);
-Obj _35reg2267 = primCons(intern("/"), _35reg2266);
-Obj _35reg2268 = primCons(intern("primEQ"), Nil);
-Obj _35reg2269 = primCons(makeNumber(2), _35reg2268);
-Obj _35reg2270 = primCons(intern("="), _35reg2269);
-Obj _35reg2271 = primCons(intern("primGT"), Nil);
-Obj _35reg2272 = primCons(makeNumber(2), _35reg2271);
-Obj _35reg2273 = primCons(intern(">"), _35reg2272);
-Obj _35reg2274 = primCons(intern("primLT"), Nil);
-Obj _35reg2275 = primCons(makeNumber(2), _35reg2274);
-Obj _35reg2276 = primCons(intern("<"), _35reg2275);
-Obj _35reg2277 = primCons(intern("primGenSym"), Nil);
-Obj _35reg2278 = primCons(makeNumber(1), _35reg2277);
-Obj _35reg2279 = primCons(intern("gensym"), _35reg2278);
-Obj _35reg2280 = primCons(intern("primIsSymbol"), Nil);
-Obj _35reg2281 = primCons(makeNumber(1), _35reg2280);
-Obj _35reg2282 = primCons(intern("symbol?"), _35reg2281);
-Obj _35reg2283 = primCons(intern("primNot"), Nil);
-Obj _35reg2284 = primCons(makeNumber(1), _35reg2283);
-Obj _35reg2285 = primCons(intern("not"), _35reg2284);
-Obj _35reg2286 = primCons(intern("primIsNumber"), Nil);
-Obj _35reg2287 = primCons(makeNumber(1), _35reg2286);
-Obj _35reg2288 = primCons(intern("integer?"), _35reg2287);
-Obj _35reg2289 = primCons(intern("primIsString"), Nil);
-Obj _35reg2290 = primCons(makeNumber(1), _35reg2289);
-Obj _35reg2291 = primCons(intern("string?"), _35reg2290);
-Obj _35reg2292 = primCons(_35reg2291, Nil);
-Obj _35reg2293 = primCons(_35reg2288, _35reg2292);
-Obj _35reg2294 = primCons(_35reg2285, _35reg2293);
-Obj _35reg2295 = primCons(_35reg2282, _35reg2294);
-Obj _35reg2296 = primCons(_35reg2279, _35reg2295);
-Obj _35reg2297 = primCons(_35reg2276, _35reg2296);
-Obj _35reg2298 = primCons(_35reg2273, _35reg2297);
-Obj _35reg2299 = primCons(_35reg2270, _35reg2298);
-Obj _35reg2300 = primCons(_35reg2267, _35reg2299);
-Obj _35reg2301 = primCons(_35reg2264, _35reg2300);
-Obj _35reg2302 = primCons(_35reg2261, _35reg2301);
-Obj _35reg2303 = primCons(_35reg2258, _35reg2302);
-Obj _35reg2304 = primCons(_35reg2255, _35reg2303);
-Obj _35reg2305 = primCons(_35reg2252, _35reg2304);
-Obj _35reg2306 = primCons(_35reg2249, _35reg2305);
-Obj _35reg2307 = primCons(_35reg2246, _35reg2306);
-Obj _35reg2308 = primCons(_35reg2243, _35reg2307);
-Obj _35reg2309 = primSet(intern("cora/lib/toc/include.*builtin-prims*"), _35reg2308);
-Obj _35reg2313 = primSet(intern("builtin?"), makeNative(_35clofun3680, 1, 0));
-Obj _35reg2316 = primSet(intern("cora/lib/toc/include.builtin->name"), makeNative(_35clofun3683, 1, 0));
-Obj _35reg2319 = primSet(intern("cora/lib/toc/include.builtin->args"), makeNative(_35clofun3686, 1, 0));
-Obj _35reg2324 = primSet(intern("cora/lib/toc/include.temp-list"), makeNative(_35clofun3689, 2, 0));
-Obj _35reg2460 = primSet(intern("cora/lib/toc/include.parse"), makeNative(_35clofun3692, 2, 0));
-Obj _35reg2471 = primSet(intern("cora/lib/toc/include.union"), makeNative(_35clofun3722, 2, 0));
-Obj _35reg2482 = primSet(intern("cora/lib/toc/include.diff"), makeNative(_35clofun3728, 2, 0));
-Obj _35reg2533 = primSet(intern("cora/lib/toc/include.convert-protect?"), makeNative(_35clofun3734, 1, 0));
-Obj _35reg2708 = primSet(intern("cora/lib/toc/include.free-vars"), makeNative(_35clofun3741, 1, 0));
-Obj _35reg2781 = primSet(intern("cora/lib/toc/include.closure-convert"), makeNative(_35clofun3764, 2, 0));
-Obj _35reg2784 = primSet(intern("cora/lib/toc/include.id"), makeNative(_35clofun3779, 1, 0));
-Obj _35reg2921 = primSet(intern("cora/lib/toc/include.tailify"), makeNative(_35clofun3780, 2, 0));
-Obj _35reg2968 = primSet(intern("cora/lib/toc/include.tailify-list"), makeNative(_35clofun3798, 3, 0));
-Obj _35reg3047 = primSet(intern("cora/lib/toc/include.explicit-stack"), makeNative(_35clofun3808, 2, 0));
-Obj _35reg3154 = primSet(intern("cora/lib/toc/include.collect-lambda"), makeNative(_35clofun3826, 3, 0));
-Obj _35reg3161 = primSet(intern("cora/lib/toc/include.collect-lambda-list"), makeNative(_35clofun3836, 4, 0));
-Obj _35reg3168 = primSet(intern("cora/lib/toc/include.wrap-var"), makeNative(_35clofun3841, 2, 0));
-Obj _35reg3429 = primSet(intern("cora/lib/toc/include.generate-inst"), makeNative(_35clofun3843, 3, 0));
-Obj _35reg3440 = primSet(intern("cora/lib/toc/include.generate-call-args"), makeNative(_35clofun3924, 4, 0));
-Obj _35reg3459 = primSet(intern("cora/lib/toc/include.generate-cont"), makeNative(_35clofun3932, 2, 0));
-Obj _35reg3468 = primSet(intern("cora/lib/toc/include.generate-inst-list-h"), makeNative(_35clofun3943, 4, 0));
-Obj _35reg3469 = primSet(intern("cora/lib/toc/include.generate-inst-list"), makeNative(_35clofun3949, 3, 0));
-Obj _35reg3473 = primSet(intern("cora/lib/toc/include.code-gen-func-declare"), makeNative(_35clofun3950, 2, 0));
-Obj _35reg3484 = primSet(intern("cora/lib/toc/include.generate-call-args-reverse"), makeNative(_35clofun3954, 5, 0));
-Obj _35reg3541 = primSet(intern("cora/lib/toc/include.code-gen-toplevel"), makeNative(_35clofun3962, 2, 0));
-Obj _35reg3542 = primSet(intern("cora/lib/toc/include.parse-pass"), makeNative(_35clofun3969, 1, 0));
-Obj _35reg3543 = primSet(intern("cora/lib/toc/include.closure-convert-pass"), makeNative(_35clofun3970, 1, 0));
-Obj _35reg3544 = primSet(intern("cora/lib/toc/include.tailify-pass"), makeNative(_35clofun3971, 1, 0));
-Obj _35reg3545 = primSet(intern("cora/lib/toc/include.explicit-stack-pass"), makeNative(_35clofun3972, 1, 0));
-Obj _35reg3553 = primSet(intern("cora/lib/toc/include.collect-lambda-pass"), makeNative(_35clofun3973, 1, 0));
-Obj _35reg3560 = primSet(intern("cora/lib/toc/include.rewrite-->macro"), makeNative(_35clofun3975, 2, 0));
-pushCont(co, _35clofun3981, 0);
+void _35clofun2860(struct Cora* co) {
+Obj _35val1399 = co->args[1];
+Obj _35reg1414 = primSet(intern("cora/lib/toc/include.assq"), makeNative(_35clofun2861, 2, 0));
+Obj _35reg1420 = primSet(intern("cora/lib/toc/include.foldl"), makeNative(_35clofun2865, 3, 0));
+Obj _35reg1430 = primSet(intern("cora/lib/toc/include.pos-in-list0"), makeNative(_35clofun2869, 3, 0));
+Obj _35reg1431 = primSet(intern("cora/lib/toc/include.index"), makeNative(_35clofun2873, 2, 0));
+Obj _35reg1438 = primSet(intern("cora/lib/toc/include.exist-in-env"), makeNative(_35clofun2874, 2, 0));
+Obj _35reg1439 = primCons(intern("primSet"), Nil);
+Obj _35reg1440 = primCons(makeNumber(2), _35reg1439);
+Obj _35reg1441 = primCons(intern("set"), _35reg1440);
+Obj _35reg1442 = primCons(intern("primCar"), Nil);
+Obj _35reg1443 = primCons(makeNumber(1), _35reg1442);
+Obj _35reg1444 = primCons(intern("car"), _35reg1443);
+Obj _35reg1445 = primCons(intern("primCdr"), Nil);
+Obj _35reg1446 = primCons(makeNumber(1), _35reg1445);
+Obj _35reg1447 = primCons(intern("cdr"), _35reg1446);
+Obj _35reg1448 = primCons(intern("primCons"), Nil);
+Obj _35reg1449 = primCons(makeNumber(2), _35reg1448);
+Obj _35reg1450 = primCons(intern("cons"), _35reg1449);
+Obj _35reg1451 = primCons(intern("primIsCons"), Nil);
+Obj _35reg1452 = primCons(makeNumber(1), _35reg1451);
+Obj _35reg1453 = primCons(intern("cons?"), _35reg1452);
+Obj _35reg1454 = primCons(intern("primAdd"), Nil);
+Obj _35reg1455 = primCons(makeNumber(2), _35reg1454);
+Obj _35reg1456 = primCons(intern("+"), _35reg1455);
+Obj _35reg1457 = primCons(intern("primSub"), Nil);
+Obj _35reg1458 = primCons(makeNumber(2), _35reg1457);
+Obj _35reg1459 = primCons(intern("-"), _35reg1458);
+Obj _35reg1460 = primCons(intern("primMul"), Nil);
+Obj _35reg1461 = primCons(makeNumber(2), _35reg1460);
+Obj _35reg1462 = primCons(intern("*"), _35reg1461);
+Obj _35reg1463 = primCons(intern("primDiv"), Nil);
+Obj _35reg1464 = primCons(makeNumber(2), _35reg1463);
+Obj _35reg1465 = primCons(intern("/"), _35reg1464);
+Obj _35reg1466 = primCons(intern("primEQ"), Nil);
+Obj _35reg1467 = primCons(makeNumber(2), _35reg1466);
+Obj _35reg1468 = primCons(intern("="), _35reg1467);
+Obj _35reg1469 = primCons(intern("primGT"), Nil);
+Obj _35reg1470 = primCons(makeNumber(2), _35reg1469);
+Obj _35reg1471 = primCons(intern(">"), _35reg1470);
+Obj _35reg1472 = primCons(intern("primLT"), Nil);
+Obj _35reg1473 = primCons(makeNumber(2), _35reg1472);
+Obj _35reg1474 = primCons(intern("<"), _35reg1473);
+Obj _35reg1475 = primCons(intern("primGenSym"), Nil);
+Obj _35reg1476 = primCons(makeNumber(1), _35reg1475);
+Obj _35reg1477 = primCons(intern("gensym"), _35reg1476);
+Obj _35reg1478 = primCons(intern("primIsSymbol"), Nil);
+Obj _35reg1479 = primCons(makeNumber(1), _35reg1478);
+Obj _35reg1480 = primCons(intern("symbol?"), _35reg1479);
+Obj _35reg1481 = primCons(intern("primNot"), Nil);
+Obj _35reg1482 = primCons(makeNumber(1), _35reg1481);
+Obj _35reg1483 = primCons(intern("not"), _35reg1482);
+Obj _35reg1484 = primCons(intern("primIsNumber"), Nil);
+Obj _35reg1485 = primCons(makeNumber(1), _35reg1484);
+Obj _35reg1486 = primCons(intern("integer?"), _35reg1485);
+Obj _35reg1487 = primCons(intern("primIsString"), Nil);
+Obj _35reg1488 = primCons(makeNumber(1), _35reg1487);
+Obj _35reg1489 = primCons(intern("string?"), _35reg1488);
+Obj _35reg1490 = primCons(_35reg1489, Nil);
+Obj _35reg1491 = primCons(_35reg1486, _35reg1490);
+Obj _35reg1492 = primCons(_35reg1483, _35reg1491);
+Obj _35reg1493 = primCons(_35reg1480, _35reg1492);
+Obj _35reg1494 = primCons(_35reg1477, _35reg1493);
+Obj _35reg1495 = primCons(_35reg1474, _35reg1494);
+Obj _35reg1496 = primCons(_35reg1471, _35reg1495);
+Obj _35reg1497 = primCons(_35reg1468, _35reg1496);
+Obj _35reg1498 = primCons(_35reg1465, _35reg1497);
+Obj _35reg1499 = primCons(_35reg1462, _35reg1498);
+Obj _35reg1500 = primCons(_35reg1459, _35reg1499);
+Obj _35reg1501 = primCons(_35reg1456, _35reg1500);
+Obj _35reg1502 = primCons(_35reg1453, _35reg1501);
+Obj _35reg1503 = primCons(_35reg1450, _35reg1502);
+Obj _35reg1504 = primCons(_35reg1447, _35reg1503);
+Obj _35reg1505 = primCons(_35reg1444, _35reg1504);
+Obj _35reg1506 = primCons(_35reg1441, _35reg1505);
+Obj _35reg1507 = primSet(intern("cora/lib/toc/include.*builtin-prims*"), _35reg1506);
+Obj _35reg1511 = primSet(intern("builtin?"), makeNative(_35clofun2878, 1, 0));
+Obj _35reg1514 = primSet(intern("cora/lib/toc/include.builtin->name"), makeNative(_35clofun2881, 1, 0));
+Obj _35reg1517 = primSet(intern("cora/lib/toc/include.builtin->args"), makeNative(_35clofun2884, 1, 0));
+Obj _35reg1522 = primSet(intern("cora/lib/toc/include.temp-list"), makeNative(_35clofun2887, 2, 0));
+Obj _35reg1658 = primSet(intern("cora/lib/toc/include.parse"), makeNative(_35clofun2890, 2, 0));
+Obj _35reg1669 = primSet(intern("cora/lib/toc/include.union"), makeNative(_35clofun2920, 2, 0));
+Obj _35reg1680 = primSet(intern("cora/lib/toc/include.diff"), makeNative(_35clofun2926, 2, 0));
+Obj _35reg1731 = primSet(intern("cora/lib/toc/include.convert-protect?"), makeNative(_35clofun2932, 1, 0));
+Obj _35reg1906 = primSet(intern("cora/lib/toc/include.free-vars"), makeNative(_35clofun2939, 1, 0));
+Obj _35reg1979 = primSet(intern("cora/lib/toc/include.closure-convert"), makeNative(_35clofun2962, 2, 0));
+Obj _35reg1982 = primSet(intern("cora/lib/toc/include.id"), makeNative(_35clofun2977, 1, 0));
+Obj _35reg2119 = primSet(intern("cora/lib/toc/include.tailify"), makeNative(_35clofun2978, 2, 0));
+Obj _35reg2166 = primSet(intern("cora/lib/toc/include.tailify-list"), makeNative(_35clofun2996, 3, 0));
+Obj _35reg2245 = primSet(intern("cora/lib/toc/include.explicit-stack"), makeNative(_35clofun3006, 2, 0));
+Obj _35reg2352 = primSet(intern("cora/lib/toc/include.collect-lambda"), makeNative(_35clofun3024, 3, 0));
+Obj _35reg2359 = primSet(intern("cora/lib/toc/include.collect-lambda-list"), makeNative(_35clofun3034, 4, 0));
+Obj _35reg2366 = primSet(intern("cora/lib/toc/include.wrap-var"), makeNative(_35clofun3039, 2, 0));
+Obj _35reg2627 = primSet(intern("cora/lib/toc/include.generate-inst"), makeNative(_35clofun3041, 3, 0));
+Obj _35reg2638 = primSet(intern("cora/lib/toc/include.generate-call-args"), makeNative(_35clofun3122, 4, 0));
+Obj _35reg2657 = primSet(intern("cora/lib/toc/include.generate-cont"), makeNative(_35clofun3130, 2, 0));
+Obj _35reg2666 = primSet(intern("cora/lib/toc/include.generate-inst-list-h"), makeNative(_35clofun3141, 4, 0));
+Obj _35reg2667 = primSet(intern("cora/lib/toc/include.generate-inst-list"), makeNative(_35clofun3147, 3, 0));
+Obj _35reg2671 = primSet(intern("cora/lib/toc/include.code-gen-func-declare"), makeNative(_35clofun3148, 2, 0));
+Obj _35reg2682 = primSet(intern("cora/lib/toc/include.generate-call-args-reverse"), makeNative(_35clofun3152, 5, 0));
+Obj _35reg2739 = primSet(intern("cora/lib/toc/include.code-gen-toplevel"), makeNative(_35clofun3160, 2, 0));
+Obj _35reg2740 = primSet(intern("cora/lib/toc/include.parse-pass"), makeNative(_35clofun3167, 1, 0));
+Obj _35reg2741 = primSet(intern("cora/lib/toc/include.closure-convert-pass"), makeNative(_35clofun3168, 1, 0));
+Obj _35reg2742 = primSet(intern("cora/lib/toc/include.tailify-pass"), makeNative(_35clofun3169, 1, 0));
+Obj _35reg2743 = primSet(intern("cora/lib/toc/include.explicit-stack-pass"), makeNative(_35clofun3170, 1, 0));
+Obj _35reg2751 = primSet(intern("cora/lib/toc/include.collect-lambda-pass"), makeNative(_35clofun3171, 1, 0));
+Obj _35reg2758 = primSet(intern("cora/lib/toc/include.rewrite-->macro"), makeNative(_35clofun3173, 2, 0));
+pushCont(co, _35clofun3179, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("->");
-co->args[2] = makeNative(_35clofun3978, 1, 0);
+co->args[2] = makeNative(_35clofun3176, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -527,39 +527,39 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3981(struct Cora* co) {
-Obj _35val3563 = co->args[1];
-Obj _35reg3568 = primSet(intern("cora/lib/toc/include.compile"), makeNative(_35clofun3982, 1, 0));
-Obj _35reg3574 = primSet(intern("for-each"), makeNative(_35clofun3987, 2, 0));
-Obj _35reg3581 = primSet(intern("cora/lib/toc/include.generate-c"), makeNative(_35clofun3991, 2, 0));
-Obj _35reg3587 = primSet(intern("cora/lib/toc/include.compile-to-c"), makeNative(_35clofun3999, 3, 0));
-Obj _35reg3589 = primSet(intern("set"), makeNative(_35clofun4005, 2, 0));
-Obj _35reg3591 = primSet(intern("car"), makeNative(_35clofun4006, 1, 0));
-Obj _35reg3593 = primSet(intern("cdr"), makeNative(_35clofun4007, 1, 0));
-Obj _35reg3595 = primSet(intern("cons"), makeNative(_35clofun4008, 2, 0));
-Obj _35reg3597 = primSet(intern("cons"), makeNative(_35clofun4009, 2, 0));
-Obj _35reg3599 = primSet(intern("+"), makeNative(_35clofun4010, 2, 0));
-Obj _35reg3601 = primSet(intern("-"), makeNative(_35clofun4011, 2, 0));
-Obj _35reg3603 = primSet(intern("*"), makeNative(_35clofun4012, 2, 0));
-Obj _35reg3605 = primSet(intern("/"), makeNative(_35clofun4013, 2, 0));
-Obj _35reg3607 = primSet(intern("="), makeNative(_35clofun4014, 2, 0));
-Obj _35reg3609 = primSet(intern(">"), makeNative(_35clofun4015, 2, 0));
-Obj _35reg3611 = primSet(intern("<"), makeNative(_35clofun4016, 2, 0));
-Obj _35reg3613 = primSet(intern("gensym"), makeNative(_35clofun4017, 1, 0));
-Obj _35reg3615 = primSet(intern("symbol?"), makeNative(_35clofun4018, 1, 0));
-Obj _35reg3617 = primSet(intern("not"), makeNative(_35clofun4019, 1, 0));
-Obj _35reg3619 = primSet(intern("string?"), makeNative(_35clofun4020, 1, 0));
-Obj _35reg3660 = primSet(intern("cora/lib/toc/include.eval0"), makeNative(_35clofun4021, 1, 0));
+void _35clofun3179(struct Cora* co) {
+Obj _35val2761 = co->args[1];
+Obj _35reg2766 = primSet(intern("cora/lib/toc/include.compile"), makeNative(_35clofun3180, 1, 0));
+Obj _35reg2772 = primSet(intern("for-each"), makeNative(_35clofun3185, 2, 0));
+Obj _35reg2779 = primSet(intern("cora/lib/toc/include.generate-c"), makeNative(_35clofun3189, 2, 0));
+Obj _35reg2785 = primSet(intern("cora/lib/toc/include.compile-to-c"), makeNative(_35clofun3197, 3, 0));
+Obj _35reg2787 = primSet(intern("set"), makeNative(_35clofun3203, 2, 0));
+Obj _35reg2789 = primSet(intern("car"), makeNative(_35clofun3204, 1, 0));
+Obj _35reg2791 = primSet(intern("cdr"), makeNative(_35clofun3205, 1, 0));
+Obj _35reg2793 = primSet(intern("cons"), makeNative(_35clofun3206, 2, 0));
+Obj _35reg2795 = primSet(intern("cons"), makeNative(_35clofun3207, 2, 0));
+Obj _35reg2797 = primSet(intern("+"), makeNative(_35clofun3208, 2, 0));
+Obj _35reg2799 = primSet(intern("-"), makeNative(_35clofun3209, 2, 0));
+Obj _35reg2801 = primSet(intern("*"), makeNative(_35clofun3210, 2, 0));
+Obj _35reg2803 = primSet(intern("/"), makeNative(_35clofun3211, 2, 0));
+Obj _35reg2805 = primSet(intern("="), makeNative(_35clofun3212, 2, 0));
+Obj _35reg2807 = primSet(intern(">"), makeNative(_35clofun3213, 2, 0));
+Obj _35reg2809 = primSet(intern("<"), makeNative(_35clofun3214, 2, 0));
+Obj _35reg2811 = primSet(intern("gensym"), makeNative(_35clofun3215, 1, 0));
+Obj _35reg2813 = primSet(intern("symbol?"), makeNative(_35clofun3216, 1, 0));
+Obj _35reg2815 = primSet(intern("not"), makeNative(_35clofun3217, 1, 0));
+Obj _35reg2817 = primSet(intern("string?"), makeNative(_35clofun3218, 1, 0));
+Obj _35reg2858 = primSet(intern("cora/lib/toc/include.eval0"), makeNative(_35clofun3219, 1, 0));
 co->nargs = 2;
-co->args[1] = _35reg3660;
+co->args[1] = _35reg2858;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4021(struct Cora* co) {
+void _35clofun3219(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg3620 = primIsSymbol(exp);
-if (True == _35reg3620) {
+Obj _35reg2818 = primIsSymbol(exp);
+if (True == _35reg2818) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("value"));
 co->args[1] = exp;
@@ -571,7 +571,7 @@ co->pc = coraCall;
 }
 return;
 } else {
-pushCont(co, _35clofun4022, 1, exp);
+pushCont(co, _35clofun3220, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("number?"));
 co->args[1] = exp;
@@ -585,21 +585,21 @@ return;
 }
 }
 
-void _35clofun4022(struct Cora* co) {
-Obj _35val3621 = co->args[1];
+void _35clofun3220(struct Cora* co) {
+Obj _35val2819 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-if (True == _35val3621) {
+if (True == _35val2819) {
 if (True == True) {
 co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg3622 = primIsCons(exp);
-if (True == _35reg3622) {
-Obj _35reg3623 = primCar(exp);
-Obj _35reg3624 = primEQ(_35reg3623, intern("quote"));
-if (True == _35reg3624) {
+Obj _35reg2820 = primIsCons(exp);
+if (True == _35reg2820) {
+Obj _35reg2821 = primCar(exp);
+Obj _35reg2822 = primEQ(_35reg2821, intern("quote"));
+if (True == _35reg2822) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -611,11 +611,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg3625 = primCar(exp);
-pushCont(co, _35clofun4023, 1, exp);
+Obj _35reg2823 = primCar(exp);
+pushCont(co, _35clofun3221, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[1] = _35reg3625;
+co->args[1] = _35reg2823;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -638,19 +638,19 @@ return;
 }
 }
 } else {
-Obj _35reg3629 = primIsString(exp);
-if (True == _35reg3629) {
+Obj _35reg2827 = primIsString(exp);
+if (True == _35reg2827) {
 if (True == True) {
 co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg3630 = primIsCons(exp);
-if (True == _35reg3630) {
-Obj _35reg3631 = primCar(exp);
-Obj _35reg3632 = primEQ(_35reg3631, intern("quote"));
-if (True == _35reg3632) {
+Obj _35reg2828 = primIsCons(exp);
+if (True == _35reg2828) {
+Obj _35reg2829 = primCar(exp);
+Obj _35reg2830 = primEQ(_35reg2829, intern("quote"));
+if (True == _35reg2830) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -662,11 +662,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg3633 = primCar(exp);
-pushCont(co, _35clofun4025, 1, exp);
+Obj _35reg2831 = primCar(exp);
+pushCont(co, _35clofun3223, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[1] = _35reg3633;
+co->args[1] = _35reg2831;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -689,7 +689,7 @@ return;
 }
 }
 } else {
-pushCont(co, _35clofun4027, 1, exp);
+pushCont(co, _35clofun3225, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("boolean?"));
 co->args[1] = exp;
@@ -704,21 +704,21 @@ return;
 }
 }
 
-void _35clofun4027(struct Cora* co) {
-Obj _35val3637 = co->args[1];
+void _35clofun3225(struct Cora* co) {
+Obj _35val2835 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-if (True == _35val3637) {
+if (True == _35val2835) {
 if (True == True) {
 co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg3638 = primIsCons(exp);
-if (True == _35reg3638) {
-Obj _35reg3639 = primCar(exp);
-Obj _35reg3640 = primEQ(_35reg3639, intern("quote"));
-if (True == _35reg3640) {
+Obj _35reg2836 = primIsCons(exp);
+if (True == _35reg2836) {
+Obj _35reg2837 = primCar(exp);
+Obj _35reg2838 = primEQ(_35reg2837, intern("quote"));
+if (True == _35reg2838) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -730,11 +730,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg3641 = primCar(exp);
-pushCont(co, _35clofun4028, 1, exp);
+Obj _35reg2839 = primCar(exp);
+pushCont(co, _35clofun3226, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[1] = _35reg3641;
+co->args[1] = _35reg2839;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -757,7 +757,7 @@ return;
 }
 }
 } else {
-pushCont(co, _35clofun4030, 1, exp);
+pushCont(co, _35clofun3228, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = exp;
@@ -771,21 +771,21 @@ return;
 }
 }
 
-void _35clofun4030(struct Cora* co) {
-Obj _35val3645 = co->args[1];
+void _35clofun3228(struct Cora* co) {
+Obj _35val2843 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-if (True == _35val3645) {
+if (True == _35val2843) {
 if (True == True) {
 co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg3646 = primIsCons(exp);
-if (True == _35reg3646) {
-Obj _35reg3647 = primCar(exp);
-Obj _35reg3648 = primEQ(_35reg3647, intern("quote"));
-if (True == _35reg3648) {
+Obj _35reg2844 = primIsCons(exp);
+if (True == _35reg2844) {
+Obj _35reg2845 = primCar(exp);
+Obj _35reg2846 = primEQ(_35reg2845, intern("quote"));
+if (True == _35reg2846) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -797,11 +797,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg3649 = primCar(exp);
-pushCont(co, _35clofun4031, 1, exp);
+Obj _35reg2847 = primCar(exp);
+pushCont(co, _35clofun3229, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[1] = _35reg3649;
+co->args[1] = _35reg2847;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -830,11 +830,11 @@ co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg3653 = primIsCons(exp);
-if (True == _35reg3653) {
-Obj _35reg3654 = primCar(exp);
-Obj _35reg3655 = primEQ(_35reg3654, intern("quote"));
-if (True == _35reg3655) {
+Obj _35reg2851 = primIsCons(exp);
+if (True == _35reg2851) {
+Obj _35reg2852 = primCar(exp);
+Obj _35reg2853 = primEQ(_35reg2852, intern("quote"));
+if (True == _35reg2853) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -846,11 +846,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg3656 = primCar(exp);
-pushCont(co, _35clofun4033, 1, exp);
+Obj _35reg2854 = primCar(exp);
+pushCont(co, _35clofun3231, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[1] = _35reg3656;
+co->args[1] = _35reg2854;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -875,15 +875,15 @@ return;
 }
 }
 
-void _35clofun4033(struct Cora* co) {
-Obj _35val3657 = co->args[1];
+void _35clofun3231(struct Cora* co) {
+Obj _35val2855 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg3658 = primCdr(exp);
-pushCont(co, _35clofun4034, 1, _35val3657);
+Obj _35reg2856 = primCdr(exp);
+pushCont(co, _35clofun3232, 1, _35val2855);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[2] = _35reg3658;
+co->args[2] = _35reg2856;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -893,13 +893,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4034(struct Cora* co) {
-Obj _35val3659 = co->args[1];
-Obj _35val3657 = co->stack[co->base + 0];
+void _35clofun3232(struct Cora* co) {
+Obj _35val2857 = co->args[1];
+Obj _35val2855 = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("apply"));
-co->args[1] = _35val3657;
-co->args[2] = _35val3659;
+co->args[1] = _35val2855;
+co->args[2] = _35val2857;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -909,15 +909,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4031(struct Cora* co) {
-Obj _35val3650 = co->args[1];
+void _35clofun3229(struct Cora* co) {
+Obj _35val2848 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg3651 = primCdr(exp);
-pushCont(co, _35clofun4032, 1, _35val3650);
+Obj _35reg2849 = primCdr(exp);
+pushCont(co, _35clofun3230, 1, _35val2848);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[2] = _35reg3651;
+co->args[2] = _35reg2849;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -927,13 +927,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4032(struct Cora* co) {
-Obj _35val3652 = co->args[1];
-Obj _35val3650 = co->stack[co->base + 0];
+void _35clofun3230(struct Cora* co) {
+Obj _35val2850 = co->args[1];
+Obj _35val2848 = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("apply"));
-co->args[1] = _35val3650;
-co->args[2] = _35val3652;
+co->args[1] = _35val2848;
+co->args[2] = _35val2850;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -943,15 +943,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4028(struct Cora* co) {
-Obj _35val3642 = co->args[1];
+void _35clofun3226(struct Cora* co) {
+Obj _35val2840 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg3643 = primCdr(exp);
-pushCont(co, _35clofun4029, 1, _35val3642);
+Obj _35reg2841 = primCdr(exp);
+pushCont(co, _35clofun3227, 1, _35val2840);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[2] = _35reg3643;
+co->args[2] = _35reg2841;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -961,13 +961,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4029(struct Cora* co) {
-Obj _35val3644 = co->args[1];
-Obj _35val3642 = co->stack[co->base + 0];
+void _35clofun3227(struct Cora* co) {
+Obj _35val2842 = co->args[1];
+Obj _35val2840 = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("apply"));
-co->args[1] = _35val3642;
-co->args[2] = _35val3644;
+co->args[1] = _35val2840;
+co->args[2] = _35val2842;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -977,15 +977,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4025(struct Cora* co) {
-Obj _35val3634 = co->args[1];
+void _35clofun3223(struct Cora* co) {
+Obj _35val2832 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg3635 = primCdr(exp);
-pushCont(co, _35clofun4026, 1, _35val3634);
+Obj _35reg2833 = primCdr(exp);
+pushCont(co, _35clofun3224, 1, _35val2832);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[2] = _35reg3635;
+co->args[2] = _35reg2833;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -995,13 +995,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4026(struct Cora* co) {
-Obj _35val3636 = co->args[1];
-Obj _35val3634 = co->stack[co->base + 0];
+void _35clofun3224(struct Cora* co) {
+Obj _35val2834 = co->args[1];
+Obj _35val2832 = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("apply"));
-co->args[1] = _35val3634;
-co->args[2] = _35val3636;
+co->args[1] = _35val2832;
+co->args[2] = _35val2834;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1011,15 +1011,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4023(struct Cora* co) {
-Obj _35val3626 = co->args[1];
+void _35clofun3221(struct Cora* co) {
+Obj _35val2824 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg3627 = primCdr(exp);
-pushCont(co, _35clofun4024, 1, _35val3626);
+Obj _35reg2825 = primCdr(exp);
+pushCont(co, _35clofun3222, 1, _35val2824);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[2] = _35reg3627;
+co->args[2] = _35reg2825;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1029,13 +1029,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4024(struct Cora* co) {
-Obj _35val3628 = co->args[1];
-Obj _35val3626 = co->stack[co->base + 0];
+void _35clofun3222(struct Cora* co) {
+Obj _35val2826 = co->args[1];
+Obj _35val2824 = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("apply"));
-co->args[1] = _35val3626;
-co->args[2] = _35val3628;
+co->args[1] = _35val2824;
+co->args[2] = _35val2826;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1045,165 +1045,165 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4020(struct Cora* co) {
-Obj _35tmp2199 = co->args[1];
-Obj _35reg3618 = primIsString(_35tmp2199);
+void _35clofun3218(struct Cora* co) {
+Obj _35tmp1397 = co->args[1];
+Obj _35reg2816 = primIsString(_35tmp1397);
 co->nargs = 2;
-co->args[1] = _35reg3618;
+co->args[1] = _35reg2816;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4019(struct Cora* co) {
-Obj _35tmp2198 = co->args[1];
-Obj _35reg3616 = primNot(_35tmp2198);
+void _35clofun3217(struct Cora* co) {
+Obj _35tmp1396 = co->args[1];
+Obj _35reg2814 = primNot(_35tmp1396);
 co->nargs = 2;
-co->args[1] = _35reg3616;
+co->args[1] = _35reg2814;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4018(struct Cora* co) {
-Obj _35tmp2197 = co->args[1];
-Obj _35reg3614 = primIsSymbol(_35tmp2197);
+void _35clofun3216(struct Cora* co) {
+Obj _35tmp1395 = co->args[1];
+Obj _35reg2812 = primIsSymbol(_35tmp1395);
 co->nargs = 2;
-co->args[1] = _35reg3614;
+co->args[1] = _35reg2812;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4017(struct Cora* co) {
-Obj _35tmp2196 = co->args[1];
-Obj _35reg3612 = primGenSym(_35tmp2196);
+void _35clofun3215(struct Cora* co) {
+Obj _35tmp1394 = co->args[1];
+Obj _35reg2810 = primGenSym(_35tmp1394);
 co->nargs = 2;
-co->args[1] = _35reg3612;
+co->args[1] = _35reg2810;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4016(struct Cora* co) {
-Obj _35tmp2195 = co->args[1];
-Obj _35tmp2194 = co->args[2];
-Obj _35reg3610 = primLT(_35tmp2195, _35tmp2194);
+void _35clofun3214(struct Cora* co) {
+Obj _35tmp1393 = co->args[1];
+Obj _35tmp1392 = co->args[2];
+Obj _35reg2808 = primLT(_35tmp1393, _35tmp1392);
 co->nargs = 2;
-co->args[1] = _35reg3610;
+co->args[1] = _35reg2808;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4015(struct Cora* co) {
-Obj _35tmp2193 = co->args[1];
-Obj _35tmp2192 = co->args[2];
-Obj _35reg3608 = primGT(_35tmp2193, _35tmp2192);
+void _35clofun3213(struct Cora* co) {
+Obj _35tmp1391 = co->args[1];
+Obj _35tmp1390 = co->args[2];
+Obj _35reg2806 = primGT(_35tmp1391, _35tmp1390);
 co->nargs = 2;
-co->args[1] = _35reg3608;
+co->args[1] = _35reg2806;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4014(struct Cora* co) {
-Obj _35tmp2191 = co->args[1];
-Obj _35tmp2190 = co->args[2];
-Obj _35reg3606 = primEQ(_35tmp2191, _35tmp2190);
+void _35clofun3212(struct Cora* co) {
+Obj _35tmp1389 = co->args[1];
+Obj _35tmp1388 = co->args[2];
+Obj _35reg2804 = primEQ(_35tmp1389, _35tmp1388);
 co->nargs = 2;
-co->args[1] = _35reg3606;
+co->args[1] = _35reg2804;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4013(struct Cora* co) {
-Obj _35tmp2189 = co->args[1];
-Obj _35tmp2188 = co->args[2];
-Obj _35reg3604 = primDiv(_35tmp2189, _35tmp2188);
+void _35clofun3211(struct Cora* co) {
+Obj _35tmp1387 = co->args[1];
+Obj _35tmp1386 = co->args[2];
+Obj _35reg2802 = primDiv(_35tmp1387, _35tmp1386);
 co->nargs = 2;
-co->args[1] = _35reg3604;
+co->args[1] = _35reg2802;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4012(struct Cora* co) {
-Obj _35tmp2187 = co->args[1];
-Obj _35tmp2186 = co->args[2];
-Obj _35reg3602 = primMul(_35tmp2187, _35tmp2186);
+void _35clofun3210(struct Cora* co) {
+Obj _35tmp1385 = co->args[1];
+Obj _35tmp1384 = co->args[2];
+Obj _35reg2800 = primMul(_35tmp1385, _35tmp1384);
 co->nargs = 2;
-co->args[1] = _35reg3602;
+co->args[1] = _35reg2800;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4011(struct Cora* co) {
-Obj _35tmp2185 = co->args[1];
-Obj _35tmp2184 = co->args[2];
-Obj _35reg3600 = primSub(_35tmp2185, _35tmp2184);
+void _35clofun3209(struct Cora* co) {
+Obj _35tmp1383 = co->args[1];
+Obj _35tmp1382 = co->args[2];
+Obj _35reg2798 = primSub(_35tmp1383, _35tmp1382);
 co->nargs = 2;
-co->args[1] = _35reg3600;
+co->args[1] = _35reg2798;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4010(struct Cora* co) {
-Obj _35tmp2183 = co->args[1];
-Obj _35tmp2182 = co->args[2];
-Obj _35reg3598 = primAdd(_35tmp2183, _35tmp2182);
+void _35clofun3208(struct Cora* co) {
+Obj _35tmp1381 = co->args[1];
+Obj _35tmp1380 = co->args[2];
+Obj _35reg2796 = primAdd(_35tmp1381, _35tmp1380);
 co->nargs = 2;
-co->args[1] = _35reg3598;
+co->args[1] = _35reg2796;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4009(struct Cora* co) {
-Obj _35tmp2181 = co->args[1];
-Obj _35tmp2180 = co->args[2];
-Obj _35reg3596 = primCons(_35tmp2181, _35tmp2180);
+void _35clofun3207(struct Cora* co) {
+Obj _35tmp1379 = co->args[1];
+Obj _35tmp1378 = co->args[2];
+Obj _35reg2794 = primCons(_35tmp1379, _35tmp1378);
 co->nargs = 2;
-co->args[1] = _35reg3596;
+co->args[1] = _35reg2794;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4008(struct Cora* co) {
-Obj _35tmp2179 = co->args[1];
-Obj _35tmp2178 = co->args[2];
-Obj _35reg3594 = primCons(_35tmp2179, _35tmp2178);
+void _35clofun3206(struct Cora* co) {
+Obj _35tmp1377 = co->args[1];
+Obj _35tmp1376 = co->args[2];
+Obj _35reg2792 = primCons(_35tmp1377, _35tmp1376);
 co->nargs = 2;
-co->args[1] = _35reg3594;
+co->args[1] = _35reg2792;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4007(struct Cora* co) {
-Obj _35tmp2177 = co->args[1];
-Obj _35reg3592 = primCdr(_35tmp2177);
+void _35clofun3205(struct Cora* co) {
+Obj _35tmp1375 = co->args[1];
+Obj _35reg2790 = primCdr(_35tmp1375);
 co->nargs = 2;
-co->args[1] = _35reg3592;
+co->args[1] = _35reg2790;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4006(struct Cora* co) {
-Obj _35tmp2176 = co->args[1];
-Obj _35reg3590 = primCar(_35tmp2176);
+void _35clofun3204(struct Cora* co) {
+Obj _35tmp1374 = co->args[1];
+Obj _35reg2788 = primCar(_35tmp1374);
 co->nargs = 2;
-co->args[1] = _35reg3590;
+co->args[1] = _35reg2788;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun4005(struct Cora* co) {
-Obj _35tmp2175 = co->args[1];
-Obj _35tmp2174 = co->args[2];
-Obj _35reg3588 = primSet(_35tmp2175, _35tmp2174);
+void _35clofun3203(struct Cora* co) {
+Obj _35tmp1373 = co->args[1];
+Obj _35tmp1372 = co->args[2];
+Obj _35reg2786 = primSet(_35tmp1373, _35tmp1372);
 co->nargs = 2;
-co->args[1] = _35reg3588;
+co->args[1] = _35reg2786;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3999(struct Cora* co) {
+void _35clofun3197(struct Cora* co) {
 Obj from = co->args[1];
 Obj to = co->args[2];
 Obj pkg_45str = co->args[3];
-pushCont(co, _35clofun4000, 1, to);
+pushCont(co, _35clofun3198, 1, to);
 co->nargs = 3;
 co->args[0] = globalRef(intern("read-file-as-sexp"));
 co->args[1] = from;
@@ -1217,11 +1217,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4000(struct Cora* co) {
-Obj _35val3582 = co->args[1];
+void _35clofun3198(struct Cora* co) {
+Obj _35val2780 = co->args[1];
 Obj to = co->stack[co->base + 0];
-Obj sexp = _35val3582;
-pushCont(co, _35clofun4001, 1, to);
+Obj sexp = _35val2780;
+pushCont(co, _35clofun3199, 1, to);
 co->nargs = 2;
 co->args[0] = globalRef(intern("macroexpand"));
 co->args[1] = sexp;
@@ -1234,11 +1234,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4001(struct Cora* co) {
-Obj _35val3583 = co->args[1];
+void _35clofun3199(struct Cora* co) {
+Obj _35val2781 = co->args[1];
 Obj to = co->stack[co->base + 0];
-Obj input = _35val3583;
-pushCont(co, _35clofun4002, 1, to);
+Obj input = _35val2781;
+pushCont(co, _35clofun3200, 1, to);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.compile"));
 co->args[1] = input;
@@ -1251,11 +1251,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4002(struct Cora* co) {
-Obj _35val3584 = co->args[1];
+void _35clofun3200(struct Cora* co) {
+Obj _35val2782 = co->args[1];
 Obj to = co->stack[co->base + 0];
-Obj bc = _35val3584;
-pushCont(co, _35clofun4003, 1, bc);
+Obj bc = _35val2782;
+pushCont(co, _35clofun3201, 1, bc);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/io.open-output-file"));
 co->args[1] = to;
@@ -1268,11 +1268,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4003(struct Cora* co) {
-Obj _35val3585 = co->args[1];
+void _35clofun3201(struct Cora* co) {
+Obj _35val2783 = co->args[1];
 Obj bc = co->stack[co->base + 0];
-Obj stream = _35val3585;
-pushCont(co, _35clofun4004, 1, stream);
+Obj stream = _35val2783;
+pushCont(co, _35clofun3202, 1, stream);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-c"));
 co->args[1] = stream;
@@ -1286,8 +1286,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun4004(struct Cora* co) {
-Obj _35val3586 = co->args[1];
+void _35clofun3202(struct Cora* co) {
+Obj _35val2784 = co->args[1];
 Obj stream = co->stack[co->base + 0];
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/io.close-output-file"));
@@ -1301,10 +1301,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3991(struct Cora* co) {
+void _35clofun3189(struct Cora* co) {
 Obj to = co->args[1];
 Obj bc = co->args[2];
-pushCont(co, _35clofun3992, 2, to, bc);
+pushCont(co, _35clofun3190, 2, to, bc);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = to;
@@ -1318,11 +1318,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3992(struct Cora* co) {
-Obj _35val3575 = co->args[1];
+void _35clofun3190(struct Cora* co) {
+Obj _35val2773 = co->args[1];
 Obj to = co->stack[co->base + 0];
 Obj bc = co->stack[co->base + 1];
-pushCont(co, _35clofun3993, 2, to, bc);
+pushCont(co, _35clofun3191, 2, to, bc);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = to;
@@ -1336,14 +1336,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3993(struct Cora* co) {
-Obj _35val3576 = co->args[1];
+void _35clofun3191(struct Cora* co) {
+Obj _35val2774 = co->args[1];
 Obj to = co->stack[co->base + 0];
 Obj bc = co->stack[co->base + 1];
-pushCont(co, _35clofun3996, 2, to, bc);
+pushCont(co, _35clofun3194, 2, to, bc);
 co->nargs = 3;
 co->args[0] = globalRef(intern("for-each"));
-co->args[1] = makeNative(_35clofun3994, 1, 1, to);
+co->args[1] = makeNative(_35clofun3192, 1, 1, to);
 co->args[2] = bc;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -1354,11 +1354,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3996(struct Cora* co) {
-Obj _35val3579 = co->args[1];
+void _35clofun3194(struct Cora* co) {
+Obj _35val2777 = co->args[1];
 Obj to = co->stack[co->base + 0];
 Obj bc = co->stack[co->base + 1];
-pushCont(co, _35clofun3997, 2, to, bc);
+pushCont(co, _35clofun3195, 2, to, bc);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = to;
@@ -1372,13 +1372,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3997(struct Cora* co) {
-Obj _35val3580 = co->args[1];
+void _35clofun3195(struct Cora* co) {
+Obj _35val2778 = co->args[1];
 Obj to = co->stack[co->base + 0];
 Obj bc = co->stack[co->base + 1];
 co->nargs = 3;
 co->args[0] = globalRef(intern("for-each"));
-co->args[1] = makeNative(_35clofun3998, 1, 1, to);
+co->args[1] = makeNative(_35clofun3196, 1, 1, to);
 co->args[2] = bc;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -1389,7 +1389,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3998(struct Cora* co) {
+void _35clofun3196(struct Cora* co) {
 Obj x = co->args[1];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.code-gen-toplevel"));
@@ -1404,14 +1404,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3994(struct Cora* co) {
+void _35clofun3192(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg3577 = primCar(x);
-pushCont(co, _35clofun3995, 0);
+Obj _35reg2775 = primCar(x);
+pushCont(co, _35clofun3193, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.code-gen-func-declare"));
 co->args[1] = closureRef(co, 0);
-co->args[2] = _35reg3577;
+co->args[2] = _35reg2775;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1421,8 +1421,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3995(struct Cora* co) {
-Obj _35val3578 = co->args[1];
+void _35clofun3193(struct Cora* co) {
+Obj _35val2776 = co->args[1];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = closureRef(co, 0);
@@ -1436,20 +1436,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3987(struct Cora* co) {
-Obj _35p2170 = co->args[1];
-Obj _35p2171 = co->args[2];
-Obj _35cc2172 = makeNative(_35clofun3988, 0, 2, _35p2170, _35p2171);
-Obj fn = _35p2170;
-Obj _35reg3573 = primEQ(Nil, _35p2171);
-if (True == _35reg3573) {
+void _35clofun3185(struct Cora* co) {
+Obj _35p1368 = co->args[1];
+Obj _35p1369 = co->args[2];
+Obj _35cc1370 = makeNative(_35clofun3186, 0, 2, _35p1368, _35p1369);
+Obj fn = _35p1368;
+Obj _35reg2771 = primEQ(Nil, _35p1369);
+if (True == _35reg2771) {
 co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2172;
+co->args[0] = _35cc1370;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1460,16 +1460,16 @@ return;
 }
 }
 
-void _35clofun3988(struct Cora* co) {
-Obj _35cc2173 = makeNative(_35clofun3989, 0, 0);
+void _35clofun3186(struct Cora* co) {
+Obj _35cc1371 = makeNative(_35clofun3187, 0, 0);
 Obj fn = closureRef(co, 0);
-Obj _35reg3569 = primIsCons(closureRef(co, 1));
-if (True == _35reg3569) {
-Obj _35reg3570 = primCar(closureRef(co, 1));
-Obj x = _35reg3570;
-Obj _35reg3571 = primCdr(closureRef(co, 1));
-Obj y = _35reg3571;
-pushCont(co, _35clofun3990, 2, fn, y);
+Obj _35reg2767 = primIsCons(closureRef(co, 1));
+if (True == _35reg2767) {
+Obj _35reg2768 = primCar(closureRef(co, 1));
+Obj x = _35reg2768;
+Obj _35reg2769 = primCdr(closureRef(co, 1));
+Obj y = _35reg2769;
+pushCont(co, _35clofun3188, 2, fn, y);
 co->nargs = 2;
 co->args[0] = fn;
 co->args[1] = x;
@@ -1482,7 +1482,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2173;
+co->args[0] = _35cc1371;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1493,8 +1493,8 @@ return;
 }
 }
 
-void _35clofun3990(struct Cora* co) {
-Obj _35val3572 = co->args[1];
+void _35clofun3188(struct Cora* co) {
+Obj _35val2770 = co->args[1];
 Obj fn = co->stack[co->base + 0];
 Obj y = co->stack[co->base + 1];
 co->nargs = 3;
@@ -1510,7 +1510,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3989(struct Cora* co) {
+void _35clofun3187(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -1523,9 +1523,9 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3982(struct Cora* co) {
+void _35clofun3180(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun3983, 0);
+pushCont(co, _35clofun3181, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse-pass"));
 co->args[1] = exp;
@@ -1538,12 +1538,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3983(struct Cora* co) {
-Obj _35val3564 = co->args[1];
-pushCont(co, _35clofun3984, 0);
+void _35clofun3181(struct Cora* co) {
+Obj _35val2762 = co->args[1];
+pushCont(co, _35clofun3182, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert-pass"));
-co->args[1] = _35val3564;
+co->args[1] = _35val2762;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1553,12 +1553,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3984(struct Cora* co) {
-Obj _35val3565 = co->args[1];
-pushCont(co, _35clofun3985, 0);
+void _35clofun3182(struct Cora* co) {
+Obj _35val2763 = co->args[1];
+pushCont(co, _35clofun3183, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify-pass"));
-co->args[1] = _35val3565;
+co->args[1] = _35val2763;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1568,12 +1568,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3985(struct Cora* co) {
-Obj _35val3566 = co->args[1];
-pushCont(co, _35clofun3986, 0);
+void _35clofun3183(struct Cora* co) {
+Obj _35val2764 = co->args[1];
+pushCont(co, _35clofun3184, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack-pass"));
-co->args[1] = _35val3566;
+co->args[1] = _35val2764;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1583,11 +1583,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3986(struct Cora* co) {
-Obj _35val3567 = co->args[1];
+void _35clofun3184(struct Cora* co) {
+Obj _35val2765 = co->args[1];
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda-pass"));
-co->args[1] = _35val3567;
+co->args[1] = _35val2765;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1597,9 +1597,9 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3978(struct Cora* co) {
+void _35clofun3176(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun3979, 1, exp);
+pushCont(co, _35clofun3177, 1, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
@@ -1612,11 +1612,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3979(struct Cora* co) {
-Obj _35val3561 = co->args[1];
+void _35clofun3177(struct Cora* co) {
+Obj _35val2759 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj obj = _35val3561;
-pushCont(co, _35clofun3980, 1, obj);
+Obj obj = _35val2759;
+pushCont(co, _35clofun3178, 1, obj);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cddr"));
 co->args[1] = exp;
@@ -1629,10 +1629,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3980(struct Cora* co) {
-Obj _35val3562 = co->args[1];
+void _35clofun3178(struct Cora* co) {
+Obj _35val2760 = co->args[1];
 Obj obj = co->stack[co->base + 0];
-Obj fns = _35val3562;
+Obj fns = _35val2760;
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.rewrite-->macro"));
 co->args[1] = obj;
@@ -1646,20 +1646,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3975(struct Cora* co) {
-Obj _35p2166 = co->args[1];
-Obj _35p2167 = co->args[2];
-Obj _35cc2168 = makeNative(_35clofun3976, 0, 2, _35p2166, _35p2167);
-Obj obj = _35p2166;
-Obj _35reg3559 = primEQ(Nil, _35p2167);
-if (True == _35reg3559) {
+void _35clofun3173(struct Cora* co) {
+Obj _35p1364 = co->args[1];
+Obj _35p1365 = co->args[2];
+Obj _35cc1366 = makeNative(_35clofun3174, 0, 2, _35p1364, _35p1365);
+Obj obj = _35p1364;
+Obj _35reg2757 = primEQ(Nil, _35p1365);
+if (True == _35reg2757) {
 co->nargs = 2;
 co->args[1] = obj;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2168;
+co->args[0] = _35cc1366;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1670,20 +1670,20 @@ return;
 }
 }
 
-void _35clofun3976(struct Cora* co) {
-Obj _35cc2169 = makeNative(_35clofun3977, 0, 0);
+void _35clofun3174(struct Cora* co) {
+Obj _35cc1367 = makeNative(_35clofun3175, 0, 0);
 Obj obj = closureRef(co, 0);
-Obj _35reg3554 = primIsCons(closureRef(co, 1));
-if (True == _35reg3554) {
-Obj _35reg3555 = primCar(closureRef(co, 1));
-Obj hd = _35reg3555;
-Obj _35reg3556 = primCdr(closureRef(co, 1));
-Obj more = _35reg3556;
-Obj _35reg3557 = primCons(obj, Nil);
-Obj _35reg3558 = primCons(hd, _35reg3557);
+Obj _35reg2752 = primIsCons(closureRef(co, 1));
+if (True == _35reg2752) {
+Obj _35reg2753 = primCar(closureRef(co, 1));
+Obj hd = _35reg2753;
+Obj _35reg2754 = primCdr(closureRef(co, 1));
+Obj more = _35reg2754;
+Obj _35reg2755 = primCons(obj, Nil);
+Obj _35reg2756 = primCons(hd, _35reg2755);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.rewrite-->macro"));
-co->args[1] = _35reg3558;
+co->args[1] = _35reg2756;
 co->args[2] = more;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -1694,7 +1694,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2169;
+co->args[0] = _35cc1367;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1705,7 +1705,7 @@ return;
 }
 }
 
-void _35clofun3977(struct Cora* co) {
+void _35clofun3175(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -1718,13 +1718,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3973(struct Cora* co) {
+void _35clofun3171(struct Cora* co) {
 Obj exp = co->args[1];
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda"));
 co->args[1] = Nil;
 co->args[2] = exp;
-co->args[3] = makeNative(_35clofun3974, 2, 0);
+co->args[3] = makeNative(_35clofun3172, 2, 0);
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1734,23 +1734,23 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3974(struct Cora* co) {
+void _35clofun3172(struct Cora* co) {
 Obj ls = co->args[1];
 Obj e1 = co->args[2];
-Obj _35reg3546 = primCons(e1, Nil);
-Obj _35reg3547 = primCons(Nil, _35reg3546);
-Obj _35reg3548 = primCons(Nil, _35reg3547);
-Obj _35reg3549 = primCons(intern("lambda"), _35reg3548);
-Obj _35reg3550 = primCons(_35reg3549, Nil);
-Obj _35reg3551 = primCons(intern("entry"), _35reg3550);
-Obj _35reg3552 = primCons(_35reg3551, ls);
+Obj _35reg2744 = primCons(e1, Nil);
+Obj _35reg2745 = primCons(Nil, _35reg2744);
+Obj _35reg2746 = primCons(Nil, _35reg2745);
+Obj _35reg2747 = primCons(intern("lambda"), _35reg2746);
+Obj _35reg2748 = primCons(_35reg2747, Nil);
+Obj _35reg2749 = primCons(intern("entry"), _35reg2748);
+Obj _35reg2750 = primCons(_35reg2749, ls);
 co->nargs = 2;
-co->args[1] = _35reg3552;
+co->args[1] = _35reg2750;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3972(struct Cora* co) {
+void _35clofun3170(struct Cora* co) {
 Obj exp = co->args[1];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
@@ -1765,7 +1765,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3971(struct Cora* co) {
+void _35clofun3169(struct Cora* co) {
 Obj exp = co->args[1];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
@@ -1780,7 +1780,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3970(struct Cora* co) {
+void _35clofun3168(struct Cora* co) {
 Obj exp = co->args[1];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert"));
@@ -1795,7 +1795,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3969(struct Cora* co) {
+void _35clofun3167(struct Cora* co) {
 Obj exp = co->args[1];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
@@ -1810,76 +1810,76 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3962(struct Cora* co) {
-Obj _35p2163 = co->args[1];
-Obj _35p2164 = co->args[2];
-Obj _35cc2165 = makeNative(_35clofun3963, 0, 0);
-Obj w = _35p2163;
-Obj _35reg3485 = primIsCons(_35p2164);
-if (True == _35reg3485) {
-Obj _35reg3486 = primCar(_35p2164);
-Obj name = _35reg3486;
-Obj _35reg3487 = primCdr(_35p2164);
-Obj _35reg3488 = primIsCons(_35reg3487);
-if (True == _35reg3488) {
-Obj _35reg3489 = primCdr(_35p2164);
-Obj _35reg3490 = primCar(_35reg3489);
-Obj _35reg3491 = primIsCons(_35reg3490);
-if (True == _35reg3491) {
-Obj _35reg3492 = primCdr(_35p2164);
-Obj _35reg3493 = primCar(_35reg3492);
-Obj _35reg3494 = primCar(_35reg3493);
-Obj _35reg3495 = primEQ(intern("lambda"), _35reg3494);
-if (True == _35reg3495) {
-Obj _35reg3496 = primCdr(_35p2164);
-Obj _35reg3497 = primCar(_35reg3496);
-Obj _35reg3498 = primCdr(_35reg3497);
-Obj _35reg3499 = primIsCons(_35reg3498);
-if (True == _35reg3499) {
-Obj _35reg3500 = primCdr(_35p2164);
-Obj _35reg3501 = primCar(_35reg3500);
-Obj _35reg3502 = primCdr(_35reg3501);
-Obj _35reg3503 = primCar(_35reg3502);
-Obj params = _35reg3503;
-Obj _35reg3504 = primCdr(_35p2164);
-Obj _35reg3505 = primCar(_35reg3504);
-Obj _35reg3506 = primCdr(_35reg3505);
-Obj _35reg3507 = primCdr(_35reg3506);
-Obj _35reg3508 = primIsCons(_35reg3507);
-if (True == _35reg3508) {
-Obj _35reg3509 = primCdr(_35p2164);
-Obj _35reg3510 = primCar(_35reg3509);
-Obj _35reg3511 = primCdr(_35reg3510);
-Obj _35reg3512 = primCdr(_35reg3511);
-Obj _35reg3513 = primCar(_35reg3512);
-Obj actives = _35reg3513;
-Obj _35reg3514 = primCdr(_35p2164);
-Obj _35reg3515 = primCar(_35reg3514);
-Obj _35reg3516 = primCdr(_35reg3515);
-Obj _35reg3517 = primCdr(_35reg3516);
-Obj _35reg3518 = primCdr(_35reg3517);
-Obj _35reg3519 = primIsCons(_35reg3518);
-if (True == _35reg3519) {
-Obj _35reg3520 = primCdr(_35p2164);
-Obj _35reg3521 = primCar(_35reg3520);
-Obj _35reg3522 = primCdr(_35reg3521);
-Obj _35reg3523 = primCdr(_35reg3522);
-Obj _35reg3524 = primCdr(_35reg3523);
-Obj _35reg3525 = primCar(_35reg3524);
-Obj body = _35reg3525;
-Obj _35reg3526 = primCdr(_35p2164);
-Obj _35reg3527 = primCar(_35reg3526);
-Obj _35reg3528 = primCdr(_35reg3527);
-Obj _35reg3529 = primCdr(_35reg3528);
-Obj _35reg3530 = primCdr(_35reg3529);
-Obj _35reg3531 = primCdr(_35reg3530);
-Obj _35reg3532 = primEQ(Nil, _35reg3531);
-if (True == _35reg3532) {
-Obj _35reg3533 = primCdr(_35p2164);
-Obj _35reg3534 = primCdr(_35reg3533);
-Obj _35reg3535 = primEQ(Nil, _35reg3534);
-if (True == _35reg3535) {
-pushCont(co, _35clofun3964, 4, actives, params, body, w);
+void _35clofun3160(struct Cora* co) {
+Obj _35p1361 = co->args[1];
+Obj _35p1362 = co->args[2];
+Obj _35cc1363 = makeNative(_35clofun3161, 0, 0);
+Obj w = _35p1361;
+Obj _35reg2683 = primIsCons(_35p1362);
+if (True == _35reg2683) {
+Obj _35reg2684 = primCar(_35p1362);
+Obj name = _35reg2684;
+Obj _35reg2685 = primCdr(_35p1362);
+Obj _35reg2686 = primIsCons(_35reg2685);
+if (True == _35reg2686) {
+Obj _35reg2687 = primCdr(_35p1362);
+Obj _35reg2688 = primCar(_35reg2687);
+Obj _35reg2689 = primIsCons(_35reg2688);
+if (True == _35reg2689) {
+Obj _35reg2690 = primCdr(_35p1362);
+Obj _35reg2691 = primCar(_35reg2690);
+Obj _35reg2692 = primCar(_35reg2691);
+Obj _35reg2693 = primEQ(intern("lambda"), _35reg2692);
+if (True == _35reg2693) {
+Obj _35reg2694 = primCdr(_35p1362);
+Obj _35reg2695 = primCar(_35reg2694);
+Obj _35reg2696 = primCdr(_35reg2695);
+Obj _35reg2697 = primIsCons(_35reg2696);
+if (True == _35reg2697) {
+Obj _35reg2698 = primCdr(_35p1362);
+Obj _35reg2699 = primCar(_35reg2698);
+Obj _35reg2700 = primCdr(_35reg2699);
+Obj _35reg2701 = primCar(_35reg2700);
+Obj params = _35reg2701;
+Obj _35reg2702 = primCdr(_35p1362);
+Obj _35reg2703 = primCar(_35reg2702);
+Obj _35reg2704 = primCdr(_35reg2703);
+Obj _35reg2705 = primCdr(_35reg2704);
+Obj _35reg2706 = primIsCons(_35reg2705);
+if (True == _35reg2706) {
+Obj _35reg2707 = primCdr(_35p1362);
+Obj _35reg2708 = primCar(_35reg2707);
+Obj _35reg2709 = primCdr(_35reg2708);
+Obj _35reg2710 = primCdr(_35reg2709);
+Obj _35reg2711 = primCar(_35reg2710);
+Obj actives = _35reg2711;
+Obj _35reg2712 = primCdr(_35p1362);
+Obj _35reg2713 = primCar(_35reg2712);
+Obj _35reg2714 = primCdr(_35reg2713);
+Obj _35reg2715 = primCdr(_35reg2714);
+Obj _35reg2716 = primCdr(_35reg2715);
+Obj _35reg2717 = primIsCons(_35reg2716);
+if (True == _35reg2717) {
+Obj _35reg2718 = primCdr(_35p1362);
+Obj _35reg2719 = primCar(_35reg2718);
+Obj _35reg2720 = primCdr(_35reg2719);
+Obj _35reg2721 = primCdr(_35reg2720);
+Obj _35reg2722 = primCdr(_35reg2721);
+Obj _35reg2723 = primCar(_35reg2722);
+Obj body = _35reg2723;
+Obj _35reg2724 = primCdr(_35p1362);
+Obj _35reg2725 = primCar(_35reg2724);
+Obj _35reg2726 = primCdr(_35reg2725);
+Obj _35reg2727 = primCdr(_35reg2726);
+Obj _35reg2728 = primCdr(_35reg2727);
+Obj _35reg2729 = primCdr(_35reg2728);
+Obj _35reg2730 = primEQ(Nil, _35reg2729);
+if (True == _35reg2730) {
+Obj _35reg2731 = primCdr(_35p1362);
+Obj _35reg2732 = primCdr(_35reg2731);
+Obj _35reg2733 = primEQ(Nil, _35reg2732);
+if (True == _35reg2733) {
+pushCont(co, _35clofun3162, 4, actives, params, body, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.code-gen-func-declare"));
 co->args[1] = w;
@@ -1893,7 +1893,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2165;
+co->args[0] = _35cc1363;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1904,7 +1904,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2165;
+co->args[0] = _35cc1363;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1915,7 +1915,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2165;
+co->args[0] = _35cc1363;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1926,7 +1926,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2165;
+co->args[0] = _35cc1363;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1937,7 +1937,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2165;
+co->args[0] = _35cc1363;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1948,7 +1948,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2165;
+co->args[0] = _35cc1363;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1959,7 +1959,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2165;
+co->args[0] = _35cc1363;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1970,7 +1970,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2165;
+co->args[0] = _35cc1363;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1981,7 +1981,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2165;
+co->args[0] = _35cc1363;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1992,13 +1992,13 @@ return;
 }
 }
 
-void _35clofun3964(struct Cora* co) {
-Obj _35val3536 = co->args[1];
+void _35clofun3162(struct Cora* co) {
+Obj _35val2734 = co->args[1];
 Obj actives = co->stack[co->base + 0];
 Obj params = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3965, 4, actives, params, body, w);
+pushCont(co, _35clofun3163, 4, actives, params, body, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -2012,13 +2012,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3965(struct Cora* co) {
-Obj _35val3537 = co->args[1];
+void _35clofun3163(struct Cora* co) {
+Obj _35val2735 = co->args[1];
 Obj actives = co->stack[co->base + 0];
 Obj params = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3966, 4, actives, params, body, w);
+pushCont(co, _35clofun3164, 4, actives, params, body, w);
 co->nargs = 6;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-call-args-reverse"));
 co->args[1] = Nil;
@@ -2035,13 +2035,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3966(struct Cora* co) {
-Obj _35val3538 = co->args[1];
+void _35clofun3164(struct Cora* co) {
+Obj _35val2736 = co->args[1];
 Obj actives = co->stack[co->base + 0];
 Obj params = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3967, 3, params, body, w);
+pushCont(co, _35clofun3165, 3, params, body, w);
 co->nargs = 6;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-call-args-reverse"));
 co->args[1] = Nil;
@@ -2058,12 +2058,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3967(struct Cora* co) {
-Obj _35val3539 = co->args[1];
+void _35clofun3165(struct Cora* co) {
+Obj _35val2737 = co->args[1];
 Obj params = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3968, 1, w);
+pushCont(co, _35clofun3166, 1, w);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = params;
@@ -2078,8 +2078,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3968(struct Cora* co) {
-Obj _35val3540 = co->args[1];
+void _35clofun3166(struct Cora* co) {
+Obj _35val2738 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -2094,7 +2094,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3963(struct Cora* co) {
+void _35clofun3161(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -2107,26 +2107,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3954(struct Cora* co) {
-Obj _35p2156 = co->args[1];
-Obj _35p2157 = co->args[2];
-Obj _35p2158 = co->args[3];
-Obj _35p2159 = co->args[4];
-Obj _35p2160 = co->args[5];
-Obj _35cc2161 = makeNative(_35clofun3955, 0, 5, _35p2156, _35p2157, _35p2158, _35p2159, _35p2160);
-Obj env = _35p2156;
-Obj w = _35p2157;
-Obj dest_45str = _35p2158;
-Obj idx = _35p2159;
-Obj _35reg3483 = primEQ(Nil, _35p2160);
-if (True == _35reg3483) {
+void _35clofun3152(struct Cora* co) {
+Obj _35p1354 = co->args[1];
+Obj _35p1355 = co->args[2];
+Obj _35p1356 = co->args[3];
+Obj _35p1357 = co->args[4];
+Obj _35p1358 = co->args[5];
+Obj _35cc1359 = makeNative(_35clofun3153, 0, 5, _35p1354, _35p1355, _35p1356, _35p1357, _35p1358);
+Obj env = _35p1354;
+Obj w = _35p1355;
+Obj dest_45str = _35p1356;
+Obj idx = _35p1357;
+Obj _35reg2681 = primEQ(Nil, _35p1358);
+if (True == _35reg2681) {
 co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2161;
+co->args[0] = _35cc1359;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2137,19 +2137,19 @@ return;
 }
 }
 
-void _35clofun3955(struct Cora* co) {
-Obj _35cc2162 = makeNative(_35clofun3956, 0, 0);
+void _35clofun3153(struct Cora* co) {
+Obj _35cc1360 = makeNative(_35clofun3154, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj dest_45str = closureRef(co, 2);
 Obj idx = closureRef(co, 3);
-Obj _35reg3474 = primIsCons(closureRef(co, 4));
-if (True == _35reg3474) {
-Obj _35reg3475 = primCar(closureRef(co, 4));
-Obj a = _35reg3475;
-Obj _35reg3476 = primCdr(closureRef(co, 4));
-Obj b = _35reg3476;
-pushCont(co, _35clofun3957, 6, a, idx, env, w, dest_45str, b);
+Obj _35reg2672 = primIsCons(closureRef(co, 4));
+if (True == _35reg2672) {
+Obj _35reg2673 = primCar(closureRef(co, 4));
+Obj a = _35reg2673;
+Obj _35reg2674 = primCdr(closureRef(co, 4));
+Obj b = _35reg2674;
+pushCont(co, _35clofun3155, 6, a, idx, env, w, dest_45str, b);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -2163,7 +2163,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2162;
+co->args[0] = _35cc1360;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2174,15 +2174,15 @@ return;
 }
 }
 
-void _35clofun3957(struct Cora* co) {
-Obj _35val3477 = co->args[1];
+void _35clofun3155(struct Cora* co) {
+Obj _35val2675 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj idx = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj dest_45str = co->stack[co->base + 4];
 Obj b = co->stack[co->base + 5];
-pushCont(co, _35clofun3958, 5, idx, env, w, dest_45str, b);
+pushCont(co, _35clofun3156, 5, idx, env, w, dest_45str, b);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
@@ -2197,14 +2197,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3958(struct Cora* co) {
-Obj _35val3478 = co->args[1];
+void _35clofun3156(struct Cora* co) {
+Obj _35val2676 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj dest_45str = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-pushCont(co, _35clofun3959, 5, idx, env, w, dest_45str, b);
+pushCont(co, _35clofun3157, 5, idx, env, w, dest_45str, b);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -2218,14 +2218,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3959(struct Cora* co) {
-Obj _35val3479 = co->args[1];
+void _35clofun3157(struct Cora* co) {
+Obj _35val2677 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj dest_45str = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-pushCont(co, _35clofun3960, 5, idx, env, w, dest_45str, b);
+pushCont(co, _35clofun3158, 5, idx, env, w, dest_45str, b);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
@@ -2239,14 +2239,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3960(struct Cora* co) {
-Obj _35val3480 = co->args[1];
+void _35clofun3158(struct Cora* co) {
+Obj _35val2678 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj dest_45str = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-pushCont(co, _35clofun3961, 5, idx, env, w, dest_45str, b);
+pushCont(co, _35clofun3159, 5, idx, env, w, dest_45str, b);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -2260,20 +2260,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3961(struct Cora* co) {
-Obj _35val3481 = co->args[1];
+void _35clofun3159(struct Cora* co) {
+Obj _35val2679 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj dest_45str = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-Obj _35reg3482 = primAdd(idx, makeNumber(1));
+Obj _35reg2680 = primAdd(idx, makeNumber(1));
 co->nargs = 6;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-call-args-reverse"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = dest_45str;
-co->args[4] = _35reg3482;
+co->args[4] = _35reg2680;
 co->args[5] = b;
 if (nativeRequired(co->args[0]) == 5) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -2284,7 +2284,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3956(struct Cora* co) {
+void _35clofun3154(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -2297,10 +2297,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3950(struct Cora* co) {
+void _35clofun3148(struct Cora* co) {
 Obj w = co->args[1];
 Obj name = co->args[2];
-pushCont(co, _35clofun3951, 2, name, w);
+pushCont(co, _35clofun3149, 2, name, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -2314,11 +2314,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3951(struct Cora* co) {
-Obj _35val3470 = co->args[1];
+void _35clofun3149(struct Cora* co) {
+Obj _35val2668 = co->args[1];
 Obj name = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3952, 1, w);
+pushCont(co, _35clofun3150, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
@@ -2332,10 +2332,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3952(struct Cora* co) {
-Obj _35val3471 = co->args[1];
+void _35clofun3150(struct Cora* co) {
+Obj _35val2669 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3953, 1, w);
+pushCont(co, _35clofun3151, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -2349,8 +2349,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3953(struct Cora* co) {
-Obj _35val3472 = co->args[1];
+void _35clofun3151(struct Cora* co) {
+Obj _35val2670 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -2365,7 +2365,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3949(struct Cora* co) {
+void _35clofun3147(struct Cora* co) {
 Obj env = co->args[1];
 Obj w = co->args[2];
 Obj l = co->args[3];
@@ -2384,24 +2384,24 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3943(struct Cora* co) {
-Obj _35p2150 = co->args[1];
-Obj _35p2151 = co->args[2];
-Obj _35p2152 = co->args[3];
-Obj _35p2153 = co->args[4];
-Obj _35cc2154 = makeNative(_35clofun3944, 0, 4, _35p2150, _35p2151, _35p2152, _35p2153);
-Obj env = _35p2150;
-Obj fn = _35p2151;
-Obj w = _35p2152;
-Obj _35reg3467 = primEQ(Nil, _35p2153);
-if (True == _35reg3467) {
+void _35clofun3141(struct Cora* co) {
+Obj _35p1348 = co->args[1];
+Obj _35p1349 = co->args[2];
+Obj _35p1350 = co->args[3];
+Obj _35p1351 = co->args[4];
+Obj _35cc1352 = makeNative(_35clofun3142, 0, 4, _35p1348, _35p1349, _35p1350, _35p1351);
+Obj env = _35p1348;
+Obj fn = _35p1349;
+Obj w = _35p1350;
+Obj _35reg2665 = primEQ(Nil, _35p1351);
+if (True == _35reg2665) {
 co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2154;
+co->args[0] = _35cc1352;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2412,18 +2412,18 @@ return;
 }
 }
 
-void _35clofun3944(struct Cora* co) {
-Obj _35cc2155 = makeNative(_35clofun3945, 0, 0);
+void _35clofun3142(struct Cora* co) {
+Obj _35cc1353 = makeNative(_35clofun3143, 0, 0);
 Obj env = closureRef(co, 0);
 Obj fn = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg3460 = primIsCons(closureRef(co, 3));
-if (True == _35reg3460) {
-Obj _35reg3461 = primCar(closureRef(co, 3));
-Obj a = _35reg3461;
-Obj _35reg3462 = primCdr(closureRef(co, 3));
-Obj b = _35reg3462;
-pushCont(co, _35clofun3946, 4, env, fn, w, b);
+Obj _35reg2658 = primIsCons(closureRef(co, 3));
+if (True == _35reg2658) {
+Obj _35reg2659 = primCar(closureRef(co, 3));
+Obj a = _35reg2659;
+Obj _35reg2660 = primCdr(closureRef(co, 3));
+Obj b = _35reg2660;
+pushCont(co, _35clofun3144, 4, env, fn, w, b);
 co->nargs = 4;
 co->args[0] = fn;
 co->args[1] = env;
@@ -2438,7 +2438,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2155;
+co->args[0] = _35cc1353;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2449,13 +2449,13 @@ return;
 }
 }
 
-void _35clofun3946(struct Cora* co) {
-Obj _35val3463 = co->args[1];
+void _35clofun3144(struct Cora* co) {
+Obj _35val2661 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj fn = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj b = co->stack[co->base + 3];
-pushCont(co, _35clofun3947, 4, env, fn, w, b);
+pushCont(co, _35clofun3145, 4, env, fn, w, b);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = b;
@@ -2468,15 +2468,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3947(struct Cora* co) {
-Obj _35val3464 = co->args[1];
+void _35clofun3145(struct Cora* co) {
+Obj _35val2662 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj fn = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj b = co->stack[co->base + 3];
-Obj _35reg3465 = primNot(_35val3464);
-if (True == _35reg3465) {
-pushCont(co, _35clofun3948, 4, env, fn, w, b);
+Obj _35reg2663 = primNot(_35val2662);
+if (True == _35reg2663) {
+pushCont(co, _35clofun3146, 4, env, fn, w, b);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -2506,8 +2506,8 @@ return;
 }
 }
 
-void _35clofun3948(struct Cora* co) {
-Obj _35val3466 = co->args[1];
+void _35clofun3146(struct Cora* co) {
+Obj _35val2664 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj fn = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
@@ -2527,7 +2527,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3945(struct Cora* co) {
+void _35clofun3143(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -2540,26 +2540,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3932(struct Cora* co) {
-Obj _35p2147 = co->args[1];
-Obj _35p2148 = co->args[2];
-Obj _35cc2149 = makeNative(_35clofun3933, 0, 0);
-Obj w = _35p2147;
-Obj _35reg3441 = primIsCons(_35p2148);
-if (True == _35reg3441) {
-Obj _35reg3442 = primCar(_35p2148);
-Obj _35reg3443 = primEQ(intern("%continuation"), _35reg3442);
-if (True == _35reg3443) {
-Obj _35reg3444 = primCdr(_35p2148);
-Obj _35reg3445 = primIsCons(_35reg3444);
-if (True == _35reg3445) {
-Obj _35reg3446 = primCdr(_35p2148);
-Obj _35reg3447 = primCar(_35reg3446);
-Obj label = _35reg3447;
-Obj _35reg3448 = primCdr(_35p2148);
-Obj _35reg3449 = primCdr(_35reg3448);
-Obj stacks = _35reg3449;
-pushCont(co, _35clofun3934, 3, label, stacks, w);
+void _35clofun3130(struct Cora* co) {
+Obj _35p1345 = co->args[1];
+Obj _35p1346 = co->args[2];
+Obj _35cc1347 = makeNative(_35clofun3131, 0, 0);
+Obj w = _35p1345;
+Obj _35reg2639 = primIsCons(_35p1346);
+if (True == _35reg2639) {
+Obj _35reg2640 = primCar(_35p1346);
+Obj _35reg2641 = primEQ(intern("%continuation"), _35reg2640);
+if (True == _35reg2641) {
+Obj _35reg2642 = primCdr(_35p1346);
+Obj _35reg2643 = primIsCons(_35reg2642);
+if (True == _35reg2643) {
+Obj _35reg2644 = primCdr(_35p1346);
+Obj _35reg2645 = primCar(_35reg2644);
+Obj label = _35reg2645;
+Obj _35reg2646 = primCdr(_35p1346);
+Obj _35reg2647 = primCdr(_35reg2646);
+Obj stacks = _35reg2647;
+pushCont(co, _35clofun3132, 3, label, stacks, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -2573,7 +2573,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2149;
+co->args[0] = _35cc1347;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2584,7 +2584,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2149;
+co->args[0] = _35cc1347;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2595,7 +2595,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2149;
+co->args[0] = _35cc1347;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2606,12 +2606,12 @@ return;
 }
 }
 
-void _35clofun3934(struct Cora* co) {
-Obj _35val3450 = co->args[1];
+void _35clofun3132(struct Cora* co) {
+Obj _35val2648 = co->args[1];
 Obj label = co->stack[co->base + 0];
 Obj stacks = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3935, 2, stacks, w);
+pushCont(co, _35clofun3133, 2, stacks, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
@@ -2625,11 +2625,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3935(struct Cora* co) {
-Obj _35val3451 = co->args[1];
+void _35clofun3133(struct Cora* co) {
+Obj _35val2649 = co->args[1];
 Obj stacks = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3936, 2, stacks, w);
+pushCont(co, _35clofun3134, 2, stacks, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -2643,11 +2643,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3936(struct Cora* co) {
-Obj _35val3452 = co->args[1];
+void _35clofun3134(struct Cora* co) {
+Obj _35val2650 = co->args[1];
 Obj stacks = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3937, 2, stacks, w);
+pushCont(co, _35clofun3135, 2, stacks, w);
 co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = stacks;
@@ -2660,15 +2660,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3937(struct Cora* co) {
-Obj _35val3453 = co->args[1];
+void _35clofun3135(struct Cora* co) {
+Obj _35val2651 = co->args[1];
 Obj stacks = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3938, 2, stacks, w);
+pushCont(co, _35clofun3136, 2, stacks, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
-co->args[2] = _35val3453;
+co->args[2] = _35val2651;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2678,11 +2678,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3938(struct Cora* co) {
-Obj _35val3454 = co->args[1];
+void _35clofun3136(struct Cora* co) {
+Obj _35val2652 = co->args[1];
 Obj stacks = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3939, 2, stacks, w);
+pushCont(co, _35clofun3137, 2, stacks, w);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = stacks;
@@ -2695,16 +2695,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3939(struct Cora* co) {
-Obj _35val3455 = co->args[1];
+void _35clofun3137(struct Cora* co) {
+Obj _35val2653 = co->args[1];
 Obj stacks = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-Obj _35reg3456 = primNot(_35val3455);
-if (True == _35reg3456) {
-pushCont(co, _35clofun3942, 1, w);
+Obj _35reg2654 = primNot(_35val2653);
+if (True == _35reg2654) {
+pushCont(co, _35clofun3140, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("for-each"));
-co->args[1] = makeNative(_35clofun3940, 1, 1, w);
+co->args[1] = makeNative(_35clofun3138, 1, 1, w);
 co->args[2] = stacks;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -2729,8 +2729,8 @@ return;
 }
 }
 
-void _35clofun3942(struct Cora* co) {
-Obj _35val3458 = co->args[1];
+void _35clofun3140(struct Cora* co) {
+Obj _35val2656 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -2745,9 +2745,9 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3940(struct Cora* co) {
+void _35clofun3138(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun3941, 1, x);
+pushCont(co, _35clofun3139, 1, x);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = closureRef(co, 0);
@@ -2761,8 +2761,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3941(struct Cora* co) {
-Obj _35val3457 = co->args[1];
+void _35clofun3139(struct Cora* co) {
+Obj _35val2655 = co->args[1];
 Obj x = co->stack[co->base + 0];
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
@@ -2778,7 +2778,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3933(struct Cora* co) {
+void _35clofun3131(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -2791,24 +2791,24 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3924(struct Cora* co) {
-Obj _35p2141 = co->args[1];
-Obj _35p2142 = co->args[2];
-Obj _35p2143 = co->args[3];
-Obj _35p2144 = co->args[4];
-Obj _35cc2145 = makeNative(_35clofun3925, 0, 4, _35p2141, _35p2142, _35p2143, _35p2144);
-Obj env = _35p2141;
-Obj w = _35p2142;
-Obj idx = _35p2143;
-Obj _35reg3439 = primEQ(Nil, _35p2144);
-if (True == _35reg3439) {
+void _35clofun3122(struct Cora* co) {
+Obj _35p1339 = co->args[1];
+Obj _35p1340 = co->args[2];
+Obj _35p1341 = co->args[3];
+Obj _35p1342 = co->args[4];
+Obj _35cc1343 = makeNative(_35clofun3123, 0, 4, _35p1339, _35p1340, _35p1341, _35p1342);
+Obj env = _35p1339;
+Obj w = _35p1340;
+Obj idx = _35p1341;
+Obj _35reg2637 = primEQ(Nil, _35p1342);
+if (True == _35reg2637) {
 co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2145;
+co->args[0] = _35cc1343;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2819,18 +2819,18 @@ return;
 }
 }
 
-void _35clofun3925(struct Cora* co) {
-Obj _35cc2146 = makeNative(_35clofun3926, 0, 0);
+void _35clofun3123(struct Cora* co) {
+Obj _35cc1344 = makeNative(_35clofun3124, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj idx = closureRef(co, 2);
-Obj _35reg3430 = primIsCons(closureRef(co, 3));
-if (True == _35reg3430) {
-Obj _35reg3431 = primCar(closureRef(co, 3));
-Obj a = _35reg3431;
-Obj _35reg3432 = primCdr(closureRef(co, 3));
-Obj b = _35reg3432;
-pushCont(co, _35clofun3927, 5, a, idx, env, w, b);
+Obj _35reg2628 = primIsCons(closureRef(co, 3));
+if (True == _35reg2628) {
+Obj _35reg2629 = primCar(closureRef(co, 3));
+Obj a = _35reg2629;
+Obj _35reg2630 = primCdr(closureRef(co, 3));
+Obj b = _35reg2630;
+pushCont(co, _35clofun3125, 5, a, idx, env, w, b);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -2844,7 +2844,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2146;
+co->args[0] = _35cc1344;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2855,14 +2855,14 @@ return;
 }
 }
 
-void _35clofun3927(struct Cora* co) {
-Obj _35val3433 = co->args[1];
+void _35clofun3125(struct Cora* co) {
+Obj _35val2631 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj idx = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-pushCont(co, _35clofun3928, 5, a, idx, env, w, b);
+pushCont(co, _35clofun3126, 5, a, idx, env, w, b);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
@@ -2876,14 +2876,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3928(struct Cora* co) {
-Obj _35val3434 = co->args[1];
+void _35clofun3126(struct Cora* co) {
+Obj _35val2632 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj idx = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-pushCont(co, _35clofun3929, 5, a, idx, env, w, b);
+pushCont(co, _35clofun3127, 5, a, idx, env, w, b);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -2897,14 +2897,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3929(struct Cora* co) {
-Obj _35val3435 = co->args[1];
+void _35clofun3127(struct Cora* co) {
+Obj _35val2633 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj idx = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-pushCont(co, _35clofun3930, 4, idx, env, w, b);
+pushCont(co, _35clofun3128, 4, idx, env, w, b);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
@@ -2919,13 +2919,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3930(struct Cora* co) {
-Obj _35val3436 = co->args[1];
+void _35clofun3128(struct Cora* co) {
+Obj _35val2634 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj b = co->stack[co->base + 3];
-pushCont(co, _35clofun3931, 4, idx, env, w, b);
+pushCont(co, _35clofun3129, 4, idx, env, w, b);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -2939,18 +2939,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3931(struct Cora* co) {
-Obj _35val3437 = co->args[1];
+void _35clofun3129(struct Cora* co) {
+Obj _35val2635 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj b = co->stack[co->base + 3];
-Obj _35reg3438 = primAdd(idx, makeNumber(1));
+Obj _35reg2636 = primAdd(idx, makeNumber(1));
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-call-args"));
 co->args[1] = env;
 co->args[2] = w;
-co->args[3] = _35reg3438;
+co->args[3] = _35reg2636;
 co->args[4] = b;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -2961,7 +2961,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3926(struct Cora* co) {
+void _35clofun3124(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -2974,16 +2974,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3843(struct Cora* co) {
-Obj _35p2124 = co->args[1];
-Obj _35p2125 = co->args[2];
-Obj _35p2126 = co->args[3];
-Obj _35cc2127 = makeNative(_35clofun3844, 0, 3, _35p2124, _35p2125, _35p2126);
-Obj env = _35p2124;
-Obj w = _35p2125;
-Obj x = _35p2126;
-Obj _35reg3428 = primIsSymbol(x);
-if (True == _35reg3428) {
+void _35clofun3041(struct Cora* co) {
+Obj _35p1322 = co->args[1];
+Obj _35p1323 = co->args[2];
+Obj _35p1324 = co->args[3];
+Obj _35cc1325 = makeNative(_35clofun3042, 0, 3, _35p1322, _35p1323, _35p1324);
+Obj env = _35p1322;
+Obj w = _35p1323;
+Obj x = _35p1324;
+Obj _35reg2626 = primIsSymbol(x);
+if (True == _35reg2626) {
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
@@ -2997,7 +2997,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2127;
+co->args[0] = _35cc1325;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3008,26 +3008,26 @@ return;
 }
 }
 
-void _35clofun3844(struct Cora* co) {
-Obj _35cc2128 = makeNative(_35clofun3845, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3042(struct Cora* co) {
+Obj _35cc1326 = makeNative(_35clofun3043, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3415 = primIsCons(closureRef(co, 2));
-if (True == _35reg3415) {
-Obj _35reg3416 = primCar(closureRef(co, 2));
-Obj _35reg3417 = primEQ(intern("%global"), _35reg3416);
-if (True == _35reg3417) {
-Obj _35reg3418 = primCdr(closureRef(co, 2));
-Obj _35reg3419 = primIsCons(_35reg3418);
-if (True == _35reg3419) {
-Obj _35reg3420 = primCdr(closureRef(co, 2));
-Obj _35reg3421 = primCar(_35reg3420);
-Obj x = _35reg3421;
-Obj _35reg3422 = primCdr(closureRef(co, 2));
-Obj _35reg3423 = primCdr(_35reg3422);
-Obj _35reg3424 = primEQ(Nil, _35reg3423);
-if (True == _35reg3424) {
-pushCont(co, _35clofun3921, 2, x, w);
+Obj _35reg2613 = primIsCons(closureRef(co, 2));
+if (True == _35reg2613) {
+Obj _35reg2614 = primCar(closureRef(co, 2));
+Obj _35reg2615 = primEQ(intern("%global"), _35reg2614);
+if (True == _35reg2615) {
+Obj _35reg2616 = primCdr(closureRef(co, 2));
+Obj _35reg2617 = primIsCons(_35reg2616);
+if (True == _35reg2617) {
+Obj _35reg2618 = primCdr(closureRef(co, 2));
+Obj _35reg2619 = primCar(_35reg2618);
+Obj x = _35reg2619;
+Obj _35reg2620 = primCdr(closureRef(co, 2));
+Obj _35reg2621 = primCdr(_35reg2620);
+Obj _35reg2622 = primEQ(Nil, _35reg2621);
+if (True == _35reg2622) {
+pushCont(co, _35clofun3119, 2, x, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3041,7 +3041,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2128;
+co->args[0] = _35cc1326;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3052,7 +3052,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2128;
+co->args[0] = _35cc1326;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3063,7 +3063,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2128;
+co->args[0] = _35cc1326;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3074,7 +3074,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2128;
+co->args[0] = _35cc1326;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3085,11 +3085,11 @@ return;
 }
 }
 
-void _35clofun3921(struct Cora* co) {
-Obj _35val3425 = co->args[1];
+void _35clofun3119(struct Cora* co) {
+Obj _35val2623 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3922, 1, w);
+pushCont(co, _35clofun3120, 1, w);
 co->nargs = 2;
 co->args[0] = globalRef(intern("symbol->string"));
 co->args[1] = x;
@@ -3102,14 +3102,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3922(struct Cora* co) {
-Obj _35val3426 = co->args[1];
+void _35clofun3120(struct Cora* co) {
+Obj _35val2624 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3923, 1, w);
+pushCont(co, _35clofun3121, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
-co->args[2] = _35val3426;
+co->args[2] = _35val2624;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3119,8 +3119,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3923(struct Cora* co) {
-Obj _35val3427 = co->args[1];
+void _35clofun3121(struct Cora* co) {
+Obj _35val2625 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3135,26 +3135,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3845(struct Cora* co) {
-Obj _35cc2129 = makeNative(_35clofun3846, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3043(struct Cora* co) {
+Obj _35cc1327 = makeNative(_35clofun3044, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3403 = primIsCons(closureRef(co, 2));
-if (True == _35reg3403) {
-Obj _35reg3404 = primCar(closureRef(co, 2));
-Obj _35reg3405 = primEQ(intern("%closure-ref"), _35reg3404);
-if (True == _35reg3405) {
-Obj _35reg3406 = primCdr(closureRef(co, 2));
-Obj _35reg3407 = primIsCons(_35reg3406);
-if (True == _35reg3407) {
-Obj _35reg3408 = primCdr(closureRef(co, 2));
-Obj _35reg3409 = primCar(_35reg3408);
-Obj idx = _35reg3409;
-Obj _35reg3410 = primCdr(closureRef(co, 2));
-Obj _35reg3411 = primCdr(_35reg3410);
-Obj _35reg3412 = primEQ(Nil, _35reg3411);
-if (True == _35reg3412) {
-pushCont(co, _35clofun3919, 2, idx, w);
+Obj _35reg2601 = primIsCons(closureRef(co, 2));
+if (True == _35reg2601) {
+Obj _35reg2602 = primCar(closureRef(co, 2));
+Obj _35reg2603 = primEQ(intern("%closure-ref"), _35reg2602);
+if (True == _35reg2603) {
+Obj _35reg2604 = primCdr(closureRef(co, 2));
+Obj _35reg2605 = primIsCons(_35reg2604);
+if (True == _35reg2605) {
+Obj _35reg2606 = primCdr(closureRef(co, 2));
+Obj _35reg2607 = primCar(_35reg2606);
+Obj idx = _35reg2607;
+Obj _35reg2608 = primCdr(closureRef(co, 2));
+Obj _35reg2609 = primCdr(_35reg2608);
+Obj _35reg2610 = primEQ(Nil, _35reg2609);
+if (True == _35reg2610) {
+pushCont(co, _35clofun3117, 2, idx, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3168,7 +3168,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2129;
+co->args[0] = _35cc1327;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3179,7 +3179,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2129;
+co->args[0] = _35cc1327;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3190,7 +3190,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2129;
+co->args[0] = _35cc1327;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3201,7 +3201,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2129;
+co->args[0] = _35cc1327;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3212,11 +3212,11 @@ return;
 }
 }
 
-void _35clofun3919(struct Cora* co) {
-Obj _35val3413 = co->args[1];
+void _35clofun3117(struct Cora* co) {
+Obj _35val2611 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3920, 1, w);
+pushCont(co, _35clofun3118, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
@@ -3230,8 +3230,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3920(struct Cora* co) {
-Obj _35val3414 = co->args[1];
+void _35clofun3118(struct Cora* co) {
+Obj _35val2612 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3246,26 +3246,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3846(struct Cora* co) {
-Obj _35cc2130 = makeNative(_35clofun3847, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3044(struct Cora* co) {
+Obj _35cc1328 = makeNative(_35clofun3045, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3391 = primIsCons(closureRef(co, 2));
-if (True == _35reg3391) {
-Obj _35reg3392 = primCar(closureRef(co, 2));
-Obj _35reg3393 = primEQ(intern("%stack-ref"), _35reg3392);
-if (True == _35reg3393) {
-Obj _35reg3394 = primCdr(closureRef(co, 2));
-Obj _35reg3395 = primIsCons(_35reg3394);
-if (True == _35reg3395) {
-Obj _35reg3396 = primCdr(closureRef(co, 2));
-Obj _35reg3397 = primCar(_35reg3396);
-Obj idx = _35reg3397;
-Obj _35reg3398 = primCdr(closureRef(co, 2));
-Obj _35reg3399 = primCdr(_35reg3398);
-Obj _35reg3400 = primEQ(Nil, _35reg3399);
-if (True == _35reg3400) {
-pushCont(co, _35clofun3917, 2, idx, w);
+Obj _35reg2589 = primIsCons(closureRef(co, 2));
+if (True == _35reg2589) {
+Obj _35reg2590 = primCar(closureRef(co, 2));
+Obj _35reg2591 = primEQ(intern("%stack-ref"), _35reg2590);
+if (True == _35reg2591) {
+Obj _35reg2592 = primCdr(closureRef(co, 2));
+Obj _35reg2593 = primIsCons(_35reg2592);
+if (True == _35reg2593) {
+Obj _35reg2594 = primCdr(closureRef(co, 2));
+Obj _35reg2595 = primCar(_35reg2594);
+Obj idx = _35reg2595;
+Obj _35reg2596 = primCdr(closureRef(co, 2));
+Obj _35reg2597 = primCdr(_35reg2596);
+Obj _35reg2598 = primEQ(Nil, _35reg2597);
+if (True == _35reg2598) {
+pushCont(co, _35clofun3115, 2, idx, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3279,7 +3279,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2130;
+co->args[0] = _35cc1328;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3290,7 +3290,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2130;
+co->args[0] = _35cc1328;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3301,7 +3301,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2130;
+co->args[0] = _35cc1328;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3312,7 +3312,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2130;
+co->args[0] = _35cc1328;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3323,11 +3323,11 @@ return;
 }
 }
 
-void _35clofun3917(struct Cora* co) {
-Obj _35val3401 = co->args[1];
+void _35clofun3115(struct Cora* co) {
+Obj _35val2599 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3918, 1, w);
+pushCont(co, _35clofun3116, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
@@ -3341,8 +3341,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3918(struct Cora* co) {
-Obj _35val3402 = co->args[1];
+void _35clofun3116(struct Cora* co) {
+Obj _35val2600 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3357,28 +3357,28 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3847(struct Cora* co) {
-Obj _35cc2131 = makeNative(_35clofun3848, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3045(struct Cora* co) {
+Obj _35cc1329 = makeNative(_35clofun3046, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3367 = primIsCons(closureRef(co, 2));
-if (True == _35reg3367) {
-Obj _35reg3368 = primCar(closureRef(co, 2));
-Obj _35reg3369 = primEQ(intern("%const"), _35reg3368);
-if (True == _35reg3369) {
-Obj _35reg3370 = primCdr(closureRef(co, 2));
-Obj _35reg3371 = primIsCons(_35reg3370);
-if (True == _35reg3371) {
-Obj _35reg3372 = primCdr(closureRef(co, 2));
-Obj _35reg3373 = primCar(_35reg3372);
-Obj x = _35reg3373;
-Obj _35reg3374 = primCdr(closureRef(co, 2));
-Obj _35reg3375 = primCdr(_35reg3374);
-Obj _35reg3376 = primEQ(Nil, _35reg3375);
-if (True == _35reg3376) {
-Obj _35reg3377 = primIsSymbol(x);
-if (True == _35reg3377) {
-pushCont(co, _35clofun3908, 2, x, w);
+Obj _35reg2565 = primIsCons(closureRef(co, 2));
+if (True == _35reg2565) {
+Obj _35reg2566 = primCar(closureRef(co, 2));
+Obj _35reg2567 = primEQ(intern("%const"), _35reg2566);
+if (True == _35reg2567) {
+Obj _35reg2568 = primCdr(closureRef(co, 2));
+Obj _35reg2569 = primIsCons(_35reg2568);
+if (True == _35reg2569) {
+Obj _35reg2570 = primCdr(closureRef(co, 2));
+Obj _35reg2571 = primCar(_35reg2570);
+Obj x = _35reg2571;
+Obj _35reg2572 = primCdr(closureRef(co, 2));
+Obj _35reg2573 = primCdr(_35reg2572);
+Obj _35reg2574 = primEQ(Nil, _35reg2573);
+if (True == _35reg2574) {
+Obj _35reg2575 = primIsSymbol(x);
+if (True == _35reg2575) {
+pushCont(co, _35clofun3106, 2, x, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3391,7 +3391,7 @@ co->pc = coraCall;
 }
 return;
 } else {
-pushCont(co, _35clofun3911, 2, x, w);
+pushCont(co, _35clofun3109, 2, x, w);
 co->nargs = 2;
 co->args[0] = globalRef(intern("number?"));
 co->args[1] = x;
@@ -3405,7 +3405,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2131;
+co->args[0] = _35cc1329;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3416,7 +3416,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2131;
+co->args[0] = _35cc1329;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3427,7 +3427,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2131;
+co->args[0] = _35cc1329;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3438,7 +3438,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2131;
+co->args[0] = _35cc1329;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3449,12 +3449,12 @@ return;
 }
 }
 
-void _35clofun3911(struct Cora* co) {
-Obj _35val3381 = co->args[1];
+void _35clofun3109(struct Cora* co) {
+Obj _35val2579 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-if (True == _35val3381) {
-pushCont(co, _35clofun3912, 2, x, w);
+if (True == _35val2579) {
+pushCont(co, _35clofun3110, 2, x, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3467,9 +3467,9 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg3384 = primIsString(x);
-if (True == _35reg3384) {
-pushCont(co, _35clofun3914, 2, x, w);
+Obj _35reg2582 = primIsString(x);
+if (True == _35reg2582) {
+pushCont(co, _35clofun3112, 2, x, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3482,8 +3482,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg3388 = primEQ(x, Nil);
-if (True == _35reg3388) {
+Obj _35reg2586 = primEQ(x, Nil);
+if (True == _35reg2586) {
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3496,8 +3496,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg3389 = primEQ(x, True);
-if (True == _35reg3389) {
+Obj _35reg2587 = primEQ(x, True);
+if (True == _35reg2587) {
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3510,8 +3510,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg3390 = primEQ(x, False);
-if (True == _35reg3390) {
+Obj _35reg2588 = primEQ(x, False);
+if (True == _35reg2588) {
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3541,11 +3541,11 @@ return;
 }
 }
 
-void _35clofun3914(struct Cora* co) {
-Obj _35val3385 = co->args[1];
+void _35clofun3112(struct Cora* co) {
+Obj _35val2583 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3915, 1, w);
+pushCont(co, _35clofun3113, 1, w);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.escape-str"));
 co->args[1] = x;
@@ -3558,14 +3558,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3915(struct Cora* co) {
-Obj _35val3386 = co->args[1];
+void _35clofun3113(struct Cora* co) {
+Obj _35val2584 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3916, 1, w);
+pushCont(co, _35clofun3114, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
-co->args[2] = _35val3386;
+co->args[2] = _35val2584;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3575,8 +3575,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3916(struct Cora* co) {
-Obj _35val3387 = co->args[1];
+void _35clofun3114(struct Cora* co) {
+Obj _35val2585 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3591,11 +3591,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3912(struct Cora* co) {
-Obj _35val3382 = co->args[1];
+void _35clofun3110(struct Cora* co) {
+Obj _35val2580 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3913, 1, w);
+pushCont(co, _35clofun3111, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
@@ -3609,8 +3609,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3913(struct Cora* co) {
-Obj _35val3383 = co->args[1];
+void _35clofun3111(struct Cora* co) {
+Obj _35val2581 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3625,11 +3625,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3908(struct Cora* co) {
-Obj _35val3378 = co->args[1];
+void _35clofun3106(struct Cora* co) {
+Obj _35val2576 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3909, 1, w);
+pushCont(co, _35clofun3107, 1, w);
 co->nargs = 2;
 co->args[0] = globalRef(intern("symbol->string"));
 co->args[1] = x;
@@ -3642,14 +3642,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3909(struct Cora* co) {
-Obj _35val3379 = co->args[1];
+void _35clofun3107(struct Cora* co) {
+Obj _35val2577 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3910, 1, w);
+pushCont(co, _35clofun3108, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
-co->args[2] = _35val3379;
+co->args[2] = _35val2577;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3659,8 +3659,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3910(struct Cora* co) {
-Obj _35val3380 = co->args[1];
+void _35clofun3108(struct Cora* co) {
+Obj _35val2578 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3675,46 +3675,46 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3848(struct Cora* co) {
-Obj _35cc2132 = makeNative(_35clofun3849, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3046(struct Cora* co) {
+Obj _35cc1330 = makeNative(_35clofun3047, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3328 = primIsCons(closureRef(co, 2));
-if (True == _35reg3328) {
-Obj _35reg3329 = primCar(closureRef(co, 2));
-Obj _35reg3330 = primEQ(intern("let"), _35reg3329);
-if (True == _35reg3330) {
-Obj _35reg3331 = primCdr(closureRef(co, 2));
-Obj _35reg3332 = primIsCons(_35reg3331);
-if (True == _35reg3332) {
-Obj _35reg3333 = primCdr(closureRef(co, 2));
-Obj _35reg3334 = primCar(_35reg3333);
-Obj a = _35reg3334;
-Obj _35reg3335 = primCdr(closureRef(co, 2));
-Obj _35reg3336 = primCdr(_35reg3335);
-Obj _35reg3337 = primIsCons(_35reg3336);
-if (True == _35reg3337) {
-Obj _35reg3338 = primCdr(closureRef(co, 2));
-Obj _35reg3339 = primCdr(_35reg3338);
-Obj _35reg3340 = primCar(_35reg3339);
-Obj b = _35reg3340;
-Obj _35reg3341 = primCdr(closureRef(co, 2));
-Obj _35reg3342 = primCdr(_35reg3341);
-Obj _35reg3343 = primCdr(_35reg3342);
-Obj _35reg3344 = primIsCons(_35reg3343);
-if (True == _35reg3344) {
-Obj _35reg3345 = primCdr(closureRef(co, 2));
-Obj _35reg3346 = primCdr(_35reg3345);
-Obj _35reg3347 = primCdr(_35reg3346);
-Obj _35reg3348 = primCar(_35reg3347);
-Obj c = _35reg3348;
-Obj _35reg3349 = primCdr(closureRef(co, 2));
-Obj _35reg3350 = primCdr(_35reg3349);
-Obj _35reg3351 = primCdr(_35reg3350);
-Obj _35reg3352 = primCdr(_35reg3351);
-Obj _35reg3353 = primEQ(Nil, _35reg3352);
-if (True == _35reg3353) {
-pushCont(co, _35clofun3898, 5, b, a, env, w, c);
+Obj _35reg2526 = primIsCons(closureRef(co, 2));
+if (True == _35reg2526) {
+Obj _35reg2527 = primCar(closureRef(co, 2));
+Obj _35reg2528 = primEQ(intern("let"), _35reg2527);
+if (True == _35reg2528) {
+Obj _35reg2529 = primCdr(closureRef(co, 2));
+Obj _35reg2530 = primIsCons(_35reg2529);
+if (True == _35reg2530) {
+Obj _35reg2531 = primCdr(closureRef(co, 2));
+Obj _35reg2532 = primCar(_35reg2531);
+Obj a = _35reg2532;
+Obj _35reg2533 = primCdr(closureRef(co, 2));
+Obj _35reg2534 = primCdr(_35reg2533);
+Obj _35reg2535 = primIsCons(_35reg2534);
+if (True == _35reg2535) {
+Obj _35reg2536 = primCdr(closureRef(co, 2));
+Obj _35reg2537 = primCdr(_35reg2536);
+Obj _35reg2538 = primCar(_35reg2537);
+Obj b = _35reg2538;
+Obj _35reg2539 = primCdr(closureRef(co, 2));
+Obj _35reg2540 = primCdr(_35reg2539);
+Obj _35reg2541 = primCdr(_35reg2540);
+Obj _35reg2542 = primIsCons(_35reg2541);
+if (True == _35reg2542) {
+Obj _35reg2543 = primCdr(closureRef(co, 2));
+Obj _35reg2544 = primCdr(_35reg2543);
+Obj _35reg2545 = primCdr(_35reg2544);
+Obj _35reg2546 = primCar(_35reg2545);
+Obj c = _35reg2546;
+Obj _35reg2547 = primCdr(closureRef(co, 2));
+Obj _35reg2548 = primCdr(_35reg2547);
+Obj _35reg2549 = primCdr(_35reg2548);
+Obj _35reg2550 = primCdr(_35reg2549);
+Obj _35reg2551 = primEQ(Nil, _35reg2550);
+if (True == _35reg2551) {
+pushCont(co, _35clofun3096, 5, b, a, env, w, c);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.index"));
 co->args[1] = a;
@@ -3728,7 +3728,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2132;
+co->args[0] = _35cc1330;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3739,7 +3739,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2132;
+co->args[0] = _35cc1330;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3750,7 +3750,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2132;
+co->args[0] = _35cc1330;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3761,7 +3761,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2132;
+co->args[0] = _35cc1330;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3772,7 +3772,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2132;
+co->args[0] = _35cc1330;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3783,7 +3783,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2132;
+co->args[0] = _35cc1330;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3794,17 +3794,17 @@ return;
 }
 }
 
-void _35clofun3898(struct Cora* co) {
-Obj _35val3354 = co->args[1];
+void _35clofun3096(struct Cora* co) {
+Obj _35val2552 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj c = co->stack[co->base + 4];
-Obj idx = _35val3354;
-Obj _35reg3355 = primLT(idx, makeNumber(0));
-if (True == _35reg3355) {
-pushCont(co, _35clofun3899, 5, b, a, env, w, c);
+Obj idx = _35val2552;
+Obj _35reg2553 = primLT(idx, makeNumber(0));
+if (True == _35reg2553) {
+pushCont(co, _35clofun3097, 5, b, a, env, w, c);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3818,7 +3818,7 @@ co->pc = coraCall;
 return;
 } else {
 Nil;
-pushCont(co, _35clofun3904, 5, b, a, env, w, c);
+pushCont(co, _35clofun3102, 5, b, a, env, w, c);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
@@ -3833,14 +3833,14 @@ return;
 }
 }
 
-void _35clofun3904(struct Cora* co) {
-Obj _35val3362 = co->args[1];
+void _35clofun3102(struct Cora* co) {
+Obj _35val2560 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj c = co->stack[co->base + 4];
-pushCont(co, _35clofun3905, 5, b, a, env, w, c);
+pushCont(co, _35clofun3103, 5, b, a, env, w, c);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3854,14 +3854,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3905(struct Cora* co) {
-Obj _35val3363 = co->args[1];
+void _35clofun3103(struct Cora* co) {
+Obj _35val2561 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj c = co->stack[co->base + 4];
-pushCont(co, _35clofun3906, 4, a, env, w, c);
+pushCont(co, _35clofun3104, 4, a, env, w, c);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
@@ -3876,13 +3876,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3906(struct Cora* co) {
-Obj _35val3364 = co->args[1];
+void _35clofun3104(struct Cora* co) {
+Obj _35val2562 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj c = co->stack[co->base + 3];
-pushCont(co, _35clofun3907, 4, a, env, w, c);
+pushCont(co, _35clofun3105, 4, a, env, w, c);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3896,16 +3896,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3907(struct Cora* co) {
-Obj _35val3365 = co->args[1];
+void _35clofun3105(struct Cora* co) {
+Obj _35val2563 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj c = co->stack[co->base + 3];
-Obj _35reg3366 = primCons(a, env);
+Obj _35reg2564 = primCons(a, env);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
-co->args[1] = _35reg3366;
+co->args[1] = _35reg2564;
 co->args[2] = w;
 co->args[3] = c;
 if (nativeRequired(co->args[0]) == 3) {
@@ -3917,14 +3917,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3899(struct Cora* co) {
-Obj _35val3356 = co->args[1];
+void _35clofun3097(struct Cora* co) {
+Obj _35val2554 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj c = co->stack[co->base + 4];
-pushCont(co, _35clofun3900, 5, b, a, env, w, c);
+pushCont(co, _35clofun3098, 5, b, a, env, w, c);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
@@ -3938,14 +3938,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3900(struct Cora* co) {
-Obj _35val3357 = co->args[1];
+void _35clofun3098(struct Cora* co) {
+Obj _35val2555 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj c = co->stack[co->base + 4];
-pushCont(co, _35clofun3901, 5, b, a, env, w, c);
+pushCont(co, _35clofun3099, 5, b, a, env, w, c);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -3959,14 +3959,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3901(struct Cora* co) {
-Obj _35val3358 = co->args[1];
+void _35clofun3099(struct Cora* co) {
+Obj _35val2556 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj c = co->stack[co->base + 4];
-pushCont(co, _35clofun3902, 4, a, env, w, c);
+pushCont(co, _35clofun3100, 4, a, env, w, c);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
@@ -3981,13 +3981,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3902(struct Cora* co) {
-Obj _35val3359 = co->args[1];
+void _35clofun3100(struct Cora* co) {
+Obj _35val2557 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj c = co->stack[co->base + 3];
-pushCont(co, _35clofun3903, 4, a, env, w, c);
+pushCont(co, _35clofun3101, 4, a, env, w, c);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4001,16 +4001,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3903(struct Cora* co) {
-Obj _35val3360 = co->args[1];
+void _35clofun3101(struct Cora* co) {
+Obj _35val2558 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj c = co->stack[co->base + 3];
-Obj _35reg3361 = primCons(a, env);
+Obj _35reg2559 = primCons(a, env);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
-co->args[1] = _35reg3361;
+co->args[1] = _35reg2559;
 co->args[2] = w;
 co->args[3] = c;
 if (nativeRequired(co->args[0]) == 3) {
@@ -4022,35 +4022,35 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3849(struct Cora* co) {
-Obj _35cc2133 = makeNative(_35clofun3850, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3047(struct Cora* co) {
+Obj _35cc1331 = makeNative(_35clofun3048, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3307 = primIsCons(closureRef(co, 2));
-if (True == _35reg3307) {
-Obj _35reg3308 = primCar(closureRef(co, 2));
-Obj _35reg3309 = primIsCons(_35reg3308);
-if (True == _35reg3309) {
-Obj _35reg3310 = primCar(closureRef(co, 2));
-Obj _35reg3311 = primCar(_35reg3310);
-Obj _35reg3312 = primEQ(intern("%builtin"), _35reg3311);
-if (True == _35reg3312) {
-Obj _35reg3313 = primCar(closureRef(co, 2));
-Obj _35reg3314 = primCdr(_35reg3313);
-Obj _35reg3315 = primIsCons(_35reg3314);
-if (True == _35reg3315) {
-Obj _35reg3316 = primCar(closureRef(co, 2));
-Obj _35reg3317 = primCdr(_35reg3316);
-Obj _35reg3318 = primCar(_35reg3317);
-Obj f = _35reg3318;
-Obj _35reg3319 = primCar(closureRef(co, 2));
-Obj _35reg3320 = primCdr(_35reg3319);
-Obj _35reg3321 = primCdr(_35reg3320);
-Obj _35reg3322 = primEQ(Nil, _35reg3321);
-if (True == _35reg3322) {
-Obj _35reg3323 = primCdr(closureRef(co, 2));
-Obj args = _35reg3323;
-pushCont(co, _35clofun3894, 3, env, args, w);
+Obj _35reg2505 = primIsCons(closureRef(co, 2));
+if (True == _35reg2505) {
+Obj _35reg2506 = primCar(closureRef(co, 2));
+Obj _35reg2507 = primIsCons(_35reg2506);
+if (True == _35reg2507) {
+Obj _35reg2508 = primCar(closureRef(co, 2));
+Obj _35reg2509 = primCar(_35reg2508);
+Obj _35reg2510 = primEQ(intern("%builtin"), _35reg2509);
+if (True == _35reg2510) {
+Obj _35reg2511 = primCar(closureRef(co, 2));
+Obj _35reg2512 = primCdr(_35reg2511);
+Obj _35reg2513 = primIsCons(_35reg2512);
+if (True == _35reg2513) {
+Obj _35reg2514 = primCar(closureRef(co, 2));
+Obj _35reg2515 = primCdr(_35reg2514);
+Obj _35reg2516 = primCar(_35reg2515);
+Obj f = _35reg2516;
+Obj _35reg2517 = primCar(closureRef(co, 2));
+Obj _35reg2518 = primCdr(_35reg2517);
+Obj _35reg2519 = primCdr(_35reg2518);
+Obj _35reg2520 = primEQ(Nil, _35reg2519);
+if (True == _35reg2520) {
+Obj _35reg2521 = primCdr(closureRef(co, 2));
+Obj args = _35reg2521;
+pushCont(co, _35clofun3092, 3, env, args, w);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.builtin->name"));
 co->args[1] = f;
@@ -4063,7 +4063,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2133;
+co->args[0] = _35cc1331;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4074,7 +4074,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2133;
+co->args[0] = _35cc1331;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4085,7 +4085,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2133;
+co->args[0] = _35cc1331;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4096,7 +4096,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2133;
+co->args[0] = _35cc1331;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4107,7 +4107,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2133;
+co->args[0] = _35cc1331;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4118,16 +4118,16 @@ return;
 }
 }
 
-void _35clofun3894(struct Cora* co) {
-Obj _35val3324 = co->args[1];
+void _35clofun3092(struct Cora* co) {
+Obj _35val2522 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3895, 3, env, args, w);
+pushCont(co, _35clofun3093, 3, env, args, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
-co->args[2] = _35val3324;
+co->args[2] = _35val2522;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4137,12 +4137,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3895(struct Cora* co) {
-Obj _35val3325 = co->args[1];
+void _35clofun3093(struct Cora* co) {
+Obj _35val2523 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3896, 3, env, args, w);
+pushCont(co, _35clofun3094, 3, env, args, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4156,12 +4156,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3896(struct Cora* co) {
-Obj _35val3326 = co->args[1];
+void _35clofun3094(struct Cora* co) {
+Obj _35val2524 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3897, 1, w);
+pushCont(co, _35clofun3095, 1, w);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst-list"));
 co->args[1] = env;
@@ -4176,8 +4176,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3897(struct Cora* co) {
-Obj _35val3327 = co->args[1];
+void _35clofun3095(struct Cora* co) {
+Obj _35val2525 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -4192,46 +4192,46 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3850(struct Cora* co) {
-Obj _35cc2134 = makeNative(_35clofun3851, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3048(struct Cora* co) {
+Obj _35cc1332 = makeNative(_35clofun3049, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3275 = primIsCons(closureRef(co, 2));
-if (True == _35reg3275) {
-Obj _35reg3276 = primCar(closureRef(co, 2));
-Obj _35reg3277 = primEQ(intern("if"), _35reg3276);
-if (True == _35reg3277) {
-Obj _35reg3278 = primCdr(closureRef(co, 2));
-Obj _35reg3279 = primIsCons(_35reg3278);
-if (True == _35reg3279) {
-Obj _35reg3280 = primCdr(closureRef(co, 2));
-Obj _35reg3281 = primCar(_35reg3280);
-Obj a = _35reg3281;
-Obj _35reg3282 = primCdr(closureRef(co, 2));
-Obj _35reg3283 = primCdr(_35reg3282);
-Obj _35reg3284 = primIsCons(_35reg3283);
-if (True == _35reg3284) {
-Obj _35reg3285 = primCdr(closureRef(co, 2));
-Obj _35reg3286 = primCdr(_35reg3285);
-Obj _35reg3287 = primCar(_35reg3286);
-Obj b = _35reg3287;
-Obj _35reg3288 = primCdr(closureRef(co, 2));
-Obj _35reg3289 = primCdr(_35reg3288);
-Obj _35reg3290 = primCdr(_35reg3289);
-Obj _35reg3291 = primIsCons(_35reg3290);
-if (True == _35reg3291) {
-Obj _35reg3292 = primCdr(closureRef(co, 2));
-Obj _35reg3293 = primCdr(_35reg3292);
-Obj _35reg3294 = primCdr(_35reg3293);
-Obj _35reg3295 = primCar(_35reg3294);
-Obj c = _35reg3295;
-Obj _35reg3296 = primCdr(closureRef(co, 2));
-Obj _35reg3297 = primCdr(_35reg3296);
-Obj _35reg3298 = primCdr(_35reg3297);
-Obj _35reg3299 = primCdr(_35reg3298);
-Obj _35reg3300 = primEQ(Nil, _35reg3299);
-if (True == _35reg3300) {
-pushCont(co, _35clofun3888, 5, a, b, env, c, w);
+Obj _35reg2473 = primIsCons(closureRef(co, 2));
+if (True == _35reg2473) {
+Obj _35reg2474 = primCar(closureRef(co, 2));
+Obj _35reg2475 = primEQ(intern("if"), _35reg2474);
+if (True == _35reg2475) {
+Obj _35reg2476 = primCdr(closureRef(co, 2));
+Obj _35reg2477 = primIsCons(_35reg2476);
+if (True == _35reg2477) {
+Obj _35reg2478 = primCdr(closureRef(co, 2));
+Obj _35reg2479 = primCar(_35reg2478);
+Obj a = _35reg2479;
+Obj _35reg2480 = primCdr(closureRef(co, 2));
+Obj _35reg2481 = primCdr(_35reg2480);
+Obj _35reg2482 = primIsCons(_35reg2481);
+if (True == _35reg2482) {
+Obj _35reg2483 = primCdr(closureRef(co, 2));
+Obj _35reg2484 = primCdr(_35reg2483);
+Obj _35reg2485 = primCar(_35reg2484);
+Obj b = _35reg2485;
+Obj _35reg2486 = primCdr(closureRef(co, 2));
+Obj _35reg2487 = primCdr(_35reg2486);
+Obj _35reg2488 = primCdr(_35reg2487);
+Obj _35reg2489 = primIsCons(_35reg2488);
+if (True == _35reg2489) {
+Obj _35reg2490 = primCdr(closureRef(co, 2));
+Obj _35reg2491 = primCdr(_35reg2490);
+Obj _35reg2492 = primCdr(_35reg2491);
+Obj _35reg2493 = primCar(_35reg2492);
+Obj c = _35reg2493;
+Obj _35reg2494 = primCdr(closureRef(co, 2));
+Obj _35reg2495 = primCdr(_35reg2494);
+Obj _35reg2496 = primCdr(_35reg2495);
+Obj _35reg2497 = primCdr(_35reg2496);
+Obj _35reg2498 = primEQ(Nil, _35reg2497);
+if (True == _35reg2498) {
+pushCont(co, _35clofun3086, 5, a, b, env, c, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4245,7 +4245,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2134;
+co->args[0] = _35cc1332;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4256,7 +4256,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2134;
+co->args[0] = _35cc1332;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4267,7 +4267,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2134;
+co->args[0] = _35cc1332;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4278,7 +4278,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2134;
+co->args[0] = _35cc1332;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4289,7 +4289,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2134;
+co->args[0] = _35cc1332;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4300,7 +4300,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2134;
+co->args[0] = _35cc1332;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4311,14 +4311,14 @@ return;
 }
 }
 
-void _35clofun3888(struct Cora* co) {
-Obj _35val3301 = co->args[1];
+void _35clofun3086(struct Cora* co) {
+Obj _35val2499 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj b = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj c = co->stack[co->base + 3];
 Obj w = co->stack[co->base + 4];
-pushCont(co, _35clofun3889, 4, b, env, c, w);
+pushCont(co, _35clofun3087, 4, b, env, c, w);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
@@ -4333,13 +4333,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3889(struct Cora* co) {
-Obj _35val3302 = co->args[1];
+void _35clofun3087(struct Cora* co) {
+Obj _35val2500 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj c = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3890, 4, b, env, c, w);
+pushCont(co, _35clofun3088, 4, b, env, c, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4353,13 +4353,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3890(struct Cora* co) {
-Obj _35val3303 = co->args[1];
+void _35clofun3088(struct Cora* co) {
+Obj _35val2501 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj c = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3891, 3, env, c, w);
+pushCont(co, _35clofun3089, 3, env, c, w);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
@@ -4374,12 +4374,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3891(struct Cora* co) {
-Obj _35val3304 = co->args[1];
+void _35clofun3089(struct Cora* co) {
+Obj _35val2502 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj c = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3892, 3, env, c, w);
+pushCont(co, _35clofun3090, 3, env, c, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4393,12 +4393,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3892(struct Cora* co) {
-Obj _35val3305 = co->args[1];
+void _35clofun3090(struct Cora* co) {
+Obj _35val2503 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj c = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3893, 1, w);
+pushCont(co, _35clofun3091, 1, w);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
@@ -4413,8 +4413,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3893(struct Cora* co) {
-Obj _35val3306 = co->args[1];
+void _35clofun3091(struct Cora* co) {
+Obj _35val2504 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -4429,34 +4429,34 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3851(struct Cora* co) {
-Obj _35cc2135 = makeNative(_35clofun3852, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3049(struct Cora* co) {
+Obj _35cc1333 = makeNative(_35clofun3050, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3248 = primIsCons(closureRef(co, 2));
-if (True == _35reg3248) {
-Obj _35reg3249 = primCar(closureRef(co, 2));
-Obj _35reg3250 = primEQ(intern("%closure"), _35reg3249);
-if (True == _35reg3250) {
-Obj _35reg3251 = primCdr(closureRef(co, 2));
-Obj _35reg3252 = primIsCons(_35reg3251);
-if (True == _35reg3252) {
-Obj _35reg3253 = primCdr(closureRef(co, 2));
-Obj _35reg3254 = primCar(_35reg3253);
-Obj label = _35reg3254;
-Obj _35reg3255 = primCdr(closureRef(co, 2));
-Obj _35reg3256 = primCdr(_35reg3255);
-Obj _35reg3257 = primIsCons(_35reg3256);
-if (True == _35reg3257) {
-Obj _35reg3258 = primCdr(closureRef(co, 2));
-Obj _35reg3259 = primCdr(_35reg3258);
-Obj _35reg3260 = primCar(_35reg3259);
-Obj nargs = _35reg3260;
-Obj _35reg3261 = primCdr(closureRef(co, 2));
-Obj _35reg3262 = primCdr(_35reg3261);
-Obj _35reg3263 = primCdr(_35reg3262);
-Obj frees = _35reg3263;
-pushCont(co, _35clofun3878, 5, label, nargs, env, frees, w);
+Obj _35reg2446 = primIsCons(closureRef(co, 2));
+if (True == _35reg2446) {
+Obj _35reg2447 = primCar(closureRef(co, 2));
+Obj _35reg2448 = primEQ(intern("%closure"), _35reg2447);
+if (True == _35reg2448) {
+Obj _35reg2449 = primCdr(closureRef(co, 2));
+Obj _35reg2450 = primIsCons(_35reg2449);
+if (True == _35reg2450) {
+Obj _35reg2451 = primCdr(closureRef(co, 2));
+Obj _35reg2452 = primCar(_35reg2451);
+Obj label = _35reg2452;
+Obj _35reg2453 = primCdr(closureRef(co, 2));
+Obj _35reg2454 = primCdr(_35reg2453);
+Obj _35reg2455 = primIsCons(_35reg2454);
+if (True == _35reg2455) {
+Obj _35reg2456 = primCdr(closureRef(co, 2));
+Obj _35reg2457 = primCdr(_35reg2456);
+Obj _35reg2458 = primCar(_35reg2457);
+Obj nargs = _35reg2458;
+Obj _35reg2459 = primCdr(closureRef(co, 2));
+Obj _35reg2460 = primCdr(_35reg2459);
+Obj _35reg2461 = primCdr(_35reg2460);
+Obj frees = _35reg2461;
+pushCont(co, _35clofun3076, 5, label, nargs, env, frees, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4470,7 +4470,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2135;
+co->args[0] = _35cc1333;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4481,7 +4481,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2135;
+co->args[0] = _35cc1333;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4492,7 +4492,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2135;
+co->args[0] = _35cc1333;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4503,7 +4503,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2135;
+co->args[0] = _35cc1333;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4514,14 +4514,14 @@ return;
 }
 }
 
-void _35clofun3878(struct Cora* co) {
-Obj _35val3264 = co->args[1];
+void _35clofun3076(struct Cora* co) {
+Obj _35val2462 = co->args[1];
 Obj label = co->stack[co->base + 0];
 Obj nargs = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj frees = co->stack[co->base + 3];
 Obj w = co->stack[co->base + 4];
-pushCont(co, _35clofun3879, 4, nargs, env, frees, w);
+pushCont(co, _35clofun3077, 4, nargs, env, frees, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
@@ -4535,13 +4535,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3879(struct Cora* co) {
-Obj _35val3265 = co->args[1];
+void _35clofun3077(struct Cora* co) {
+Obj _35val2463 = co->args[1];
 Obj nargs = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj frees = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3880, 4, nargs, env, frees, w);
+pushCont(co, _35clofun3078, 4, nargs, env, frees, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4555,13 +4555,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3880(struct Cora* co) {
-Obj _35val3266 = co->args[1];
+void _35clofun3078(struct Cora* co) {
+Obj _35val2464 = co->args[1];
 Obj nargs = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj frees = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3881, 3, env, frees, w);
+pushCont(co, _35clofun3079, 3, env, frees, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
@@ -4575,12 +4575,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3881(struct Cora* co) {
-Obj _35val3267 = co->args[1];
+void _35clofun3079(struct Cora* co) {
+Obj _35val2465 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3882, 3, env, frees, w);
+pushCont(co, _35clofun3080, 3, env, frees, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4594,12 +4594,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3882(struct Cora* co) {
-Obj _35val3268 = co->args[1];
+void _35clofun3080(struct Cora* co) {
+Obj _35val2466 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3883, 3, env, frees, w);
+pushCont(co, _35clofun3081, 3, env, frees, w);
 co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = frees;
@@ -4612,16 +4612,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3883(struct Cora* co) {
-Obj _35val3269 = co->args[1];
+void _35clofun3081(struct Cora* co) {
+Obj _35val2467 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3884, 3, env, frees, w);
+pushCont(co, _35clofun3082, 3, env, frees, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
-co->args[2] = _35val3269;
+co->args[2] = _35val2467;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4631,12 +4631,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3884(struct Cora* co) {
-Obj _35val3270 = co->args[1];
+void _35clofun3082(struct Cora* co) {
+Obj _35val2468 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3885, 3, env, frees, w);
+pushCont(co, _35clofun3083, 3, env, frees, w);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = frees;
@@ -4649,14 +4649,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3885(struct Cora* co) {
-Obj _35val3271 = co->args[1];
+void _35clofun3083(struct Cora* co) {
+Obj _35val2469 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-Obj _35reg3272 = primNot(_35val3271);
-if (True == _35reg3272) {
-pushCont(co, _35clofun3886, 3, env, frees, w);
+Obj _35reg2470 = primNot(_35val2469);
+if (True == _35reg2470) {
+pushCont(co, _35clofun3084, 3, env, frees, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4684,12 +4684,12 @@ return;
 }
 }
 
-void _35clofun3886(struct Cora* co) {
-Obj _35val3273 = co->args[1];
+void _35clofun3084(struct Cora* co) {
+Obj _35val2471 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3887, 1, w);
+pushCont(co, _35clofun3085, 1, w);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst-list"));
 co->args[1] = env;
@@ -4704,8 +4704,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3887(struct Cora* co) {
-Obj _35val3274 = co->args[1];
+void _35clofun3085(struct Cora* co) {
+Obj _35val2472 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -4720,35 +4720,35 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3852(struct Cora* co) {
-Obj _35cc2136 = makeNative(_35clofun3853, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3050(struct Cora* co) {
+Obj _35cc1334 = makeNative(_35clofun3051, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3229 = primIsCons(closureRef(co, 2));
-if (True == _35reg3229) {
-Obj _35reg3230 = primCar(closureRef(co, 2));
-Obj _35reg3231 = primEQ(intern("do"), _35reg3230);
-if (True == _35reg3231) {
-Obj _35reg3232 = primCdr(closureRef(co, 2));
-Obj _35reg3233 = primIsCons(_35reg3232);
-if (True == _35reg3233) {
-Obj _35reg3234 = primCdr(closureRef(co, 2));
-Obj _35reg3235 = primCar(_35reg3234);
-Obj a = _35reg3235;
-Obj _35reg3236 = primCdr(closureRef(co, 2));
-Obj _35reg3237 = primCdr(_35reg3236);
-Obj _35reg3238 = primIsCons(_35reg3237);
-if (True == _35reg3238) {
-Obj _35reg3239 = primCdr(closureRef(co, 2));
-Obj _35reg3240 = primCdr(_35reg3239);
-Obj _35reg3241 = primCar(_35reg3240);
-Obj b = _35reg3241;
-Obj _35reg3242 = primCdr(closureRef(co, 2));
-Obj _35reg3243 = primCdr(_35reg3242);
-Obj _35reg3244 = primCdr(_35reg3243);
-Obj _35reg3245 = primEQ(Nil, _35reg3244);
-if (True == _35reg3245) {
-pushCont(co, _35clofun3876, 3, env, w, b);
+Obj _35reg2427 = primIsCons(closureRef(co, 2));
+if (True == _35reg2427) {
+Obj _35reg2428 = primCar(closureRef(co, 2));
+Obj _35reg2429 = primEQ(intern("do"), _35reg2428);
+if (True == _35reg2429) {
+Obj _35reg2430 = primCdr(closureRef(co, 2));
+Obj _35reg2431 = primIsCons(_35reg2430);
+if (True == _35reg2431) {
+Obj _35reg2432 = primCdr(closureRef(co, 2));
+Obj _35reg2433 = primCar(_35reg2432);
+Obj a = _35reg2433;
+Obj _35reg2434 = primCdr(closureRef(co, 2));
+Obj _35reg2435 = primCdr(_35reg2434);
+Obj _35reg2436 = primIsCons(_35reg2435);
+if (True == _35reg2436) {
+Obj _35reg2437 = primCdr(closureRef(co, 2));
+Obj _35reg2438 = primCdr(_35reg2437);
+Obj _35reg2439 = primCar(_35reg2438);
+Obj b = _35reg2439;
+Obj _35reg2440 = primCdr(closureRef(co, 2));
+Obj _35reg2441 = primCdr(_35reg2440);
+Obj _35reg2442 = primCdr(_35reg2441);
+Obj _35reg2443 = primEQ(Nil, _35reg2442);
+if (True == _35reg2443) {
+pushCont(co, _35clofun3074, 3, env, w, b);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
@@ -4763,7 +4763,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2136;
+co->args[0] = _35cc1334;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4774,7 +4774,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2136;
+co->args[0] = _35cc1334;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4785,7 +4785,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2136;
+co->args[0] = _35cc1334;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4796,7 +4796,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2136;
+co->args[0] = _35cc1334;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4807,7 +4807,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2136;
+co->args[0] = _35cc1334;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4818,12 +4818,12 @@ return;
 }
 }
 
-void _35clofun3876(struct Cora* co) {
-Obj _35val3246 = co->args[1];
+void _35clofun3074(struct Cora* co) {
+Obj _35val2444 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
 Obj b = co->stack[co->base + 2];
-pushCont(co, _35clofun3877, 3, env, w, b);
+pushCont(co, _35clofun3075, 3, env, w, b);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4837,8 +4837,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3877(struct Cora* co) {
-Obj _35val3247 = co->args[1];
+void _35clofun3075(struct Cora* co) {
+Obj _35val2445 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
 Obj b = co->stack[co->base + 2];
@@ -4856,26 +4856,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3853(struct Cora* co) {
-Obj _35cc2137 = makeNative(_35clofun3854, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3051(struct Cora* co) {
+Obj _35cc1335 = makeNative(_35clofun3052, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3215 = primIsCons(closureRef(co, 2));
-if (True == _35reg3215) {
-Obj _35reg3216 = primCar(closureRef(co, 2));
-Obj _35reg3217 = primEQ(intern("return"), _35reg3216);
-if (True == _35reg3217) {
-Obj _35reg3218 = primCdr(closureRef(co, 2));
-Obj _35reg3219 = primIsCons(_35reg3218);
-if (True == _35reg3219) {
-Obj _35reg3220 = primCdr(closureRef(co, 2));
-Obj _35reg3221 = primCar(_35reg3220);
-Obj x = _35reg3221;
-Obj _35reg3222 = primCdr(closureRef(co, 2));
-Obj _35reg3223 = primCdr(_35reg3222);
-Obj _35reg3224 = primEQ(Nil, _35reg3223);
-if (True == _35reg3224) {
-pushCont(co, _35clofun3872, 3, env, x, w);
+Obj _35reg2413 = primIsCons(closureRef(co, 2));
+if (True == _35reg2413) {
+Obj _35reg2414 = primCar(closureRef(co, 2));
+Obj _35reg2415 = primEQ(intern("return"), _35reg2414);
+if (True == _35reg2415) {
+Obj _35reg2416 = primCdr(closureRef(co, 2));
+Obj _35reg2417 = primIsCons(_35reg2416);
+if (True == _35reg2417) {
+Obj _35reg2418 = primCdr(closureRef(co, 2));
+Obj _35reg2419 = primCar(_35reg2418);
+Obj x = _35reg2419;
+Obj _35reg2420 = primCdr(closureRef(co, 2));
+Obj _35reg2421 = primCdr(_35reg2420);
+Obj _35reg2422 = primEQ(Nil, _35reg2421);
+if (True == _35reg2422) {
+pushCont(co, _35clofun3070, 3, env, x, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4889,7 +4889,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2137;
+co->args[0] = _35cc1335;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4900,7 +4900,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2137;
+co->args[0] = _35cc1335;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4911,7 +4911,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2137;
+co->args[0] = _35cc1335;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4922,7 +4922,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2137;
+co->args[0] = _35cc1335;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4933,12 +4933,12 @@ return;
 }
 }
 
-void _35clofun3872(struct Cora* co) {
-Obj _35val3225 = co->args[1];
+void _35clofun3070(struct Cora* co) {
+Obj _35val2423 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj x = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3873, 3, env, x, w);
+pushCont(co, _35clofun3071, 3, env, x, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4952,12 +4952,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3873(struct Cora* co) {
-Obj _35val3226 = co->args[1];
+void _35clofun3071(struct Cora* co) {
+Obj _35val2424 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj x = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3874, 1, w);
+pushCont(co, _35clofun3072, 1, w);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
@@ -4972,10 +4972,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3874(struct Cora* co) {
-Obj _35val3227 = co->args[1];
+void _35clofun3072(struct Cora* co) {
+Obj _35val2425 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3875, 1, w);
+pushCont(co, _35clofun3073, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -4989,8 +4989,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3875(struct Cora* co) {
-Obj _35val3228 = co->args[1];
+void _35clofun3073(struct Cora* co) {
+Obj _35val2426 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -5005,25 +5005,25 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3854(struct Cora* co) {
-Obj _35cc2138 = makeNative(_35clofun3855, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3052(struct Cora* co) {
+Obj _35cc1336 = makeNative(_35clofun3053, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3205 = primIsCons(closureRef(co, 2));
-if (True == _35reg3205) {
-Obj _35reg3206 = primCar(closureRef(co, 2));
-Obj _35reg3207 = primEQ(intern("tailcall"), _35reg3206);
-if (True == _35reg3207) {
-Obj _35reg3208 = primCdr(closureRef(co, 2));
-Obj _35reg3209 = primIsCons(_35reg3208);
-if (True == _35reg3209) {
-Obj _35reg3210 = primCdr(closureRef(co, 2));
-Obj _35reg3211 = primCar(_35reg3210);
-Obj exp = _35reg3211;
-Obj _35reg3212 = primCdr(closureRef(co, 2));
-Obj _35reg3213 = primCdr(_35reg3212);
-Obj _35reg3214 = primEQ(Nil, _35reg3213);
-if (True == _35reg3214) {
+Obj _35reg2403 = primIsCons(closureRef(co, 2));
+if (True == _35reg2403) {
+Obj _35reg2404 = primCar(closureRef(co, 2));
+Obj _35reg2405 = primEQ(intern("tailcall"), _35reg2404);
+if (True == _35reg2405) {
+Obj _35reg2406 = primCdr(closureRef(co, 2));
+Obj _35reg2407 = primIsCons(_35reg2406);
+if (True == _35reg2407) {
+Obj _35reg2408 = primCdr(closureRef(co, 2));
+Obj _35reg2409 = primCar(_35reg2408);
+Obj exp = _35reg2409;
+Obj _35reg2410 = primCdr(closureRef(co, 2));
+Obj _35reg2411 = primCdr(_35reg2410);
+Obj _35reg2412 = primEQ(Nil, _35reg2411);
+if (True == _35reg2412) {
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
@@ -5038,7 +5038,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2138;
+co->args[0] = _35cc1336;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5049,7 +5049,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2138;
+co->args[0] = _35cc1336;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5060,7 +5060,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2138;
+co->args[0] = _35cc1336;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5071,7 +5071,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2138;
+co->args[0] = _35cc1336;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5082,35 +5082,35 @@ return;
 }
 }
 
-void _35clofun3855(struct Cora* co) {
-Obj _35cc2139 = makeNative(_35clofun3856, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3053(struct Cora* co) {
+Obj _35cc1337 = makeNative(_35clofun3054, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3187 = primIsCons(closureRef(co, 2));
-if (True == _35reg3187) {
-Obj _35reg3188 = primCar(closureRef(co, 2));
-Obj _35reg3189 = primEQ(intern("call"), _35reg3188);
-if (True == _35reg3189) {
-Obj _35reg3190 = primCdr(closureRef(co, 2));
-Obj _35reg3191 = primIsCons(_35reg3190);
-if (True == _35reg3191) {
-Obj _35reg3192 = primCdr(closureRef(co, 2));
-Obj _35reg3193 = primCar(_35reg3192);
-Obj exp = _35reg3193;
-Obj _35reg3194 = primCdr(closureRef(co, 2));
-Obj _35reg3195 = primCdr(_35reg3194);
-Obj _35reg3196 = primIsCons(_35reg3195);
-if (True == _35reg3196) {
-Obj _35reg3197 = primCdr(closureRef(co, 2));
-Obj _35reg3198 = primCdr(_35reg3197);
-Obj _35reg3199 = primCar(_35reg3198);
-Obj cont = _35reg3199;
-Obj _35reg3200 = primCdr(closureRef(co, 2));
-Obj _35reg3201 = primCdr(_35reg3200);
-Obj _35reg3202 = primCdr(_35reg3201);
-Obj _35reg3203 = primEQ(Nil, _35reg3202);
-if (True == _35reg3203) {
-pushCont(co, _35clofun3871, 3, env, w, exp);
+Obj _35reg2385 = primIsCons(closureRef(co, 2));
+if (True == _35reg2385) {
+Obj _35reg2386 = primCar(closureRef(co, 2));
+Obj _35reg2387 = primEQ(intern("call"), _35reg2386);
+if (True == _35reg2387) {
+Obj _35reg2388 = primCdr(closureRef(co, 2));
+Obj _35reg2389 = primIsCons(_35reg2388);
+if (True == _35reg2389) {
+Obj _35reg2390 = primCdr(closureRef(co, 2));
+Obj _35reg2391 = primCar(_35reg2390);
+Obj exp = _35reg2391;
+Obj _35reg2392 = primCdr(closureRef(co, 2));
+Obj _35reg2393 = primCdr(_35reg2392);
+Obj _35reg2394 = primIsCons(_35reg2393);
+if (True == _35reg2394) {
+Obj _35reg2395 = primCdr(closureRef(co, 2));
+Obj _35reg2396 = primCdr(_35reg2395);
+Obj _35reg2397 = primCar(_35reg2396);
+Obj cont = _35reg2397;
+Obj _35reg2398 = primCdr(closureRef(co, 2));
+Obj _35reg2399 = primCdr(_35reg2398);
+Obj _35reg2400 = primCdr(_35reg2399);
+Obj _35reg2401 = primEQ(Nil, _35reg2400);
+if (True == _35reg2401) {
+pushCont(co, _35clofun3069, 3, env, w, exp);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-cont"));
 co->args[1] = w;
@@ -5124,7 +5124,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2139;
+co->args[0] = _35cc1337;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5135,7 +5135,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2139;
+co->args[0] = _35cc1337;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5146,7 +5146,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2139;
+co->args[0] = _35cc1337;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5157,7 +5157,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2139;
+co->args[0] = _35cc1337;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5168,7 +5168,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2139;
+co->args[0] = _35cc1337;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5179,8 +5179,8 @@ return;
 }
 }
 
-void _35clofun3871(struct Cora* co) {
-Obj _35val3204 = co->args[1];
+void _35clofun3069(struct Cora* co) {
+Obj _35val2402 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
 Obj exp = co->stack[co->base + 2];
@@ -5198,17 +5198,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3856(struct Cora* co) {
-Obj _35cc2140 = makeNative(_35clofun3857, 0, 0);
+void _35clofun3054(struct Cora* co) {
+Obj _35cc1338 = makeNative(_35clofun3055, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg3169 = primIsCons(closureRef(co, 2));
-if (True == _35reg3169) {
-Obj _35reg3170 = primCar(closureRef(co, 2));
-Obj f = _35reg3170;
-Obj _35reg3171 = primCdr(closureRef(co, 2));
-Obj args = _35reg3171;
-pushCont(co, _35clofun3858, 4, f, env, args, w);
+Obj _35reg2367 = primIsCons(closureRef(co, 2));
+if (True == _35reg2367) {
+Obj _35reg2368 = primCar(closureRef(co, 2));
+Obj f = _35reg2368;
+Obj _35reg2369 = primCdr(closureRef(co, 2));
+Obj args = _35reg2369;
+pushCont(co, _35clofun3056, 4, f, env, args, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -5222,7 +5222,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2140;
+co->args[0] = _35cc1338;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5233,17 +5233,17 @@ return;
 }
 }
 
-void _35clofun3858(struct Cora* co) {
-Obj _35val3172 = co->args[1];
+void _35clofun3056(struct Cora* co) {
+Obj _35val2370 = co->args[1];
 Obj f = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj args = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-Obj _35reg3173 = primCons(f, args);
-pushCont(co, _35clofun3859, 4, f, env, args, w);
+Obj _35reg2371 = primCons(f, args);
+pushCont(co, _35clofun3057, 4, f, env, args, w);
 co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
-co->args[1] = _35reg3173;
+co->args[1] = _35reg2371;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5253,17 +5253,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3859(struct Cora* co) {
-Obj _35val3174 = co->args[1];
+void _35clofun3057(struct Cora* co) {
+Obj _35val2372 = co->args[1];
 Obj f = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj args = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3860, 4, f, env, args, w);
+pushCont(co, _35clofun3058, 4, f, env, args, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
-co->args[2] = _35val3174;
+co->args[2] = _35val2372;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5273,13 +5273,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3860(struct Cora* co) {
-Obj _35val3175 = co->args[1];
+void _35clofun3058(struct Cora* co) {
+Obj _35val2373 = co->args[1];
 Obj f = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj args = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3861, 4, f, env, args, w);
+pushCont(co, _35clofun3059, 4, f, env, args, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -5293,20 +5293,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3861(struct Cora* co) {
-Obj _35val3176 = co->args[1];
+void _35clofun3059(struct Cora* co) {
+Obj _35val2374 = co->args[1];
 Obj f = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj args = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-Obj _35reg3177 = primCons(f, args);
-pushCont(co, _35clofun3862, 2, args, w);
+Obj _35reg2375 = primCons(f, args);
+pushCont(co, _35clofun3060, 2, args, w);
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-call-args"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = makeNumber(0);
-co->args[4] = _35reg3177;
+co->args[4] = _35reg2375;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5316,11 +5316,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3862(struct Cora* co) {
-Obj _35val3178 = co->args[1];
+void _35clofun3060(struct Cora* co) {
+Obj _35val2376 = co->args[1];
 Obj args = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3863, 2, args, w);
+pushCont(co, _35clofun3061, 2, args, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -5334,11 +5334,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3863(struct Cora* co) {
-Obj _35val3179 = co->args[1];
+void _35clofun3061(struct Cora* co) {
+Obj _35val2377 = co->args[1];
 Obj args = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3864, 1, w);
+pushCont(co, _35clofun3062, 1, w);
 co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = args;
@@ -5351,14 +5351,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3864(struct Cora* co) {
-Obj _35val3180 = co->args[1];
+void _35clofun3062(struct Cora* co) {
+Obj _35val2378 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3865, 1, w);
+pushCont(co, _35clofun3063, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
-co->args[2] = _35val3180;
+co->args[2] = _35val2378;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5368,10 +5368,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3865(struct Cora* co) {
-Obj _35val3181 = co->args[1];
+void _35clofun3063(struct Cora* co) {
+Obj _35val2379 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3866, 1, w);
+pushCont(co, _35clofun3064, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -5385,10 +5385,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3866(struct Cora* co) {
-Obj _35val3182 = co->args[1];
+void _35clofun3064(struct Cora* co) {
+Obj _35val2380 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3867, 1, w);
+pushCont(co, _35clofun3065, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -5402,10 +5402,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3867(struct Cora* co) {
-Obj _35val3183 = co->args[1];
+void _35clofun3065(struct Cora* co) {
+Obj _35val2381 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3868, 1, w);
+pushCont(co, _35clofun3066, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -5419,10 +5419,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3868(struct Cora* co) {
-Obj _35val3184 = co->args[1];
+void _35clofun3066(struct Cora* co) {
+Obj _35val2382 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3869, 1, w);
+pushCont(co, _35clofun3067, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -5436,10 +5436,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3869(struct Cora* co) {
-Obj _35val3185 = co->args[1];
+void _35clofun3067(struct Cora* co) {
+Obj _35val2383 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3870, 1, w);
+pushCont(co, _35clofun3068, 1, w);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
@@ -5453,8 +5453,8 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3870(struct Cora* co) {
-Obj _35val3186 = co->args[1];
+void _35clofun3068(struct Cora* co) {
+Obj _35val2384 = co->args[1];
 Obj w = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -5469,7 +5469,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3857(struct Cora* co) {
+void _35clofun3055(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -5482,12 +5482,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3841(struct Cora* co) {
+void _35clofun3039(struct Cora* co) {
 Obj x = co->args[1];
 Obj k = co->args[2];
-Obj _35reg3162 = primGenSym(intern("reg"));
-Obj tmp = _35reg3162;
-pushCont(co, _35clofun3842, 2, x, tmp);
+Obj _35reg2360 = primGenSym(intern("reg"));
+Obj tmp = _35reg2360;
+pushCont(co, _35clofun3040, 2, x, tmp);
 co->nargs = 2;
 co->args[0] = k;
 co->args[1] = tmp;
@@ -5500,32 +5500,32 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3842(struct Cora* co) {
-Obj _35val3163 = co->args[1];
+void _35clofun3040(struct Cora* co) {
+Obj _35val2361 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj tmp = co->stack[co->base + 1];
-Obj _35reg3164 = primCons(_35val3163, Nil);
-Obj _35reg3165 = primCons(x, _35reg3164);
-Obj _35reg3166 = primCons(tmp, _35reg3165);
-Obj _35reg3167 = primCons(intern("let"), _35reg3166);
+Obj _35reg2362 = primCons(_35val2361, Nil);
+Obj _35reg2363 = primCons(x, _35reg2362);
+Obj _35reg2364 = primCons(tmp, _35reg2363);
+Obj _35reg2365 = primCons(intern("let"), _35reg2364);
 co->nargs = 2;
-co->args[1] = _35reg3167;
+co->args[1] = _35reg2365;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3836(struct Cora* co) {
-Obj _35p2118 = co->args[1];
-Obj _35p2119 = co->args[2];
-Obj _35p2120 = co->args[3];
-Obj _35p2121 = co->args[4];
-Obj _35cc2122 = makeNative(_35clofun3837, 0, 4, _35p2118, _35p2119, _35p2120, _35p2121);
-Obj res = _35p2118;
-Obj init = _35p2119;
-Obj _35reg3159 = primEQ(Nil, _35p2120);
-if (True == _35reg3159) {
-Obj k = _35p2121;
-pushCont(co, _35clofun3840, 2, k, init);
+void _35clofun3034(struct Cora* co) {
+Obj _35p1316 = co->args[1];
+Obj _35p1317 = co->args[2];
+Obj _35p1318 = co->args[3];
+Obj _35p1319 = co->args[4];
+Obj _35cc1320 = makeNative(_35clofun3035, 0, 4, _35p1316, _35p1317, _35p1318, _35p1319);
+Obj res = _35p1316;
+Obj init = _35p1317;
+Obj _35reg2357 = primEQ(Nil, _35p1318);
+if (True == _35reg2357) {
+Obj k = _35p1319;
+pushCont(co, _35clofun3038, 2, k, init);
 co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = res;
@@ -5538,7 +5538,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2122;
+co->args[0] = _35cc1320;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5549,14 +5549,14 @@ return;
 }
 }
 
-void _35clofun3840(struct Cora* co) {
-Obj _35val3160 = co->args[1];
+void _35clofun3038(struct Cora* co) {
+Obj _35val2358 = co->args[1];
 Obj k = co->stack[co->base + 0];
 Obj init = co->stack[co->base + 1];
 co->nargs = 3;
 co->args[0] = k;
 co->args[1] = init;
-co->args[2] = _35val3160;
+co->args[2] = _35val2358;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5566,22 +5566,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3837(struct Cora* co) {
-Obj _35cc2123 = makeNative(_35clofun3838, 0, 0);
+void _35clofun3035(struct Cora* co) {
+Obj _35cc1321 = makeNative(_35clofun3036, 0, 0);
 Obj res = closureRef(co, 0);
 Obj init = closureRef(co, 1);
-Obj _35reg3155 = primIsCons(closureRef(co, 2));
-if (True == _35reg3155) {
-Obj _35reg3156 = primCar(closureRef(co, 2));
-Obj x = _35reg3156;
-Obj _35reg3157 = primCdr(closureRef(co, 2));
-Obj y = _35reg3157;
+Obj _35reg2353 = primIsCons(closureRef(co, 2));
+if (True == _35reg2353) {
+Obj _35reg2354 = primCar(closureRef(co, 2));
+Obj x = _35reg2354;
+Obj _35reg2355 = primCdr(closureRef(co, 2));
+Obj y = _35reg2355;
 Obj k = closureRef(co, 3);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda"));
 co->args[1] = init;
 co->args[2] = x;
-co->args[3] = makeNative(_35clofun3839, 2, 3, res, y, k);
+co->args[3] = makeNative(_35clofun3037, 2, 3, res, y, k);
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5591,7 +5591,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2123;
+co->args[0] = _35cc1321;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5602,13 +5602,13 @@ return;
 }
 }
 
-void _35clofun3839(struct Cora* co) {
+void _35clofun3037(struct Cora* co) {
 Obj init1 = co->args[1];
 Obj x1 = co->args[2];
-Obj _35reg3158 = primCons(x1, closureRef(co, 0));
+Obj _35reg2356 = primCons(x1, closureRef(co, 0));
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda-list"));
-co->args[1] = _35reg3158;
+co->args[1] = _35reg2356;
 co->args[2] = init1;
 co->args[3] = closureRef(co, 1);
 co->args[4] = closureRef(co, 2);
@@ -5621,7 +5621,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3838(struct Cora* co) {
+void _35clofun3036(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -5634,71 +5634,71 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3826(struct Cora* co) {
-Obj _35p2112 = co->args[1];
-Obj _35p2113 = co->args[2];
-Obj _35p2114 = co->args[3];
-Obj _35cc2115 = makeNative(_35clofun3827, 0, 3, _35p2112, _35p2113, _35p2114);
-Obj res = _35p2112;
-Obj _35reg3049 = primIsCons(_35p2113);
-if (True == _35reg3049) {
-Obj _35reg3050 = primCar(_35p2113);
-Obj clo_45or_45cont = _35reg3050;
-Obj _35reg3051 = primCdr(_35p2113);
-Obj _35reg3052 = primIsCons(_35reg3051);
-if (True == _35reg3052) {
-Obj _35reg3053 = primCdr(_35p2113);
-Obj _35reg3054 = primCar(_35reg3053);
-Obj _35reg3055 = primIsCons(_35reg3054);
-if (True == _35reg3055) {
-Obj _35reg3056 = primCdr(_35p2113);
-Obj _35reg3057 = primCar(_35reg3056);
-Obj _35reg3058 = primCar(_35reg3057);
-Obj _35reg3059 = primEQ(intern("lambda"), _35reg3058);
-if (True == _35reg3059) {
-Obj _35reg3060 = primCdr(_35p2113);
-Obj _35reg3061 = primCar(_35reg3060);
-Obj _35reg3062 = primCdr(_35reg3061);
-Obj _35reg3063 = primIsCons(_35reg3062);
-if (True == _35reg3063) {
-Obj _35reg3064 = primCdr(_35p2113);
-Obj _35reg3065 = primCar(_35reg3064);
-Obj _35reg3066 = primCdr(_35reg3065);
-Obj _35reg3067 = primCar(_35reg3066);
-Obj params = _35reg3067;
-Obj _35reg3068 = primCdr(_35p2113);
-Obj _35reg3069 = primCar(_35reg3068);
-Obj _35reg3070 = primCdr(_35reg3069);
-Obj _35reg3071 = primCdr(_35reg3070);
-Obj _35reg3072 = primIsCons(_35reg3071);
-if (True == _35reg3072) {
-Obj _35reg3073 = primCdr(_35p2113);
-Obj _35reg3074 = primCar(_35reg3073);
-Obj _35reg3075 = primCdr(_35reg3074);
-Obj _35reg3076 = primCdr(_35reg3075);
-Obj _35reg3077 = primCar(_35reg3076);
-Obj body = _35reg3077;
-Obj _35reg3078 = primCdr(_35p2113);
-Obj _35reg3079 = primCar(_35reg3078);
-Obj _35reg3080 = primCdr(_35reg3079);
-Obj _35reg3081 = primCdr(_35reg3080);
-Obj _35reg3082 = primCdr(_35reg3081);
-Obj _35reg3083 = primEQ(Nil, _35reg3082);
-if (True == _35reg3083) {
-Obj _35reg3084 = primCdr(_35p2113);
-Obj _35reg3085 = primCdr(_35reg3084);
-Obj fvs = _35reg3085;
-Obj k = _35p2114;
-Obj _35reg3086 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg3086) {
+void _35clofun3024(struct Cora* co) {
+Obj _35p1310 = co->args[1];
+Obj _35p1311 = co->args[2];
+Obj _35p1312 = co->args[3];
+Obj _35cc1313 = makeNative(_35clofun3025, 0, 3, _35p1310, _35p1311, _35p1312);
+Obj res = _35p1310;
+Obj _35reg2247 = primIsCons(_35p1311);
+if (True == _35reg2247) {
+Obj _35reg2248 = primCar(_35p1311);
+Obj clo_45or_45cont = _35reg2248;
+Obj _35reg2249 = primCdr(_35p1311);
+Obj _35reg2250 = primIsCons(_35reg2249);
+if (True == _35reg2250) {
+Obj _35reg2251 = primCdr(_35p1311);
+Obj _35reg2252 = primCar(_35reg2251);
+Obj _35reg2253 = primIsCons(_35reg2252);
+if (True == _35reg2253) {
+Obj _35reg2254 = primCdr(_35p1311);
+Obj _35reg2255 = primCar(_35reg2254);
+Obj _35reg2256 = primCar(_35reg2255);
+Obj _35reg2257 = primEQ(intern("lambda"), _35reg2256);
+if (True == _35reg2257) {
+Obj _35reg2258 = primCdr(_35p1311);
+Obj _35reg2259 = primCar(_35reg2258);
+Obj _35reg2260 = primCdr(_35reg2259);
+Obj _35reg2261 = primIsCons(_35reg2260);
+if (True == _35reg2261) {
+Obj _35reg2262 = primCdr(_35p1311);
+Obj _35reg2263 = primCar(_35reg2262);
+Obj _35reg2264 = primCdr(_35reg2263);
+Obj _35reg2265 = primCar(_35reg2264);
+Obj params = _35reg2265;
+Obj _35reg2266 = primCdr(_35p1311);
+Obj _35reg2267 = primCar(_35reg2266);
+Obj _35reg2268 = primCdr(_35reg2267);
+Obj _35reg2269 = primCdr(_35reg2268);
+Obj _35reg2270 = primIsCons(_35reg2269);
+if (True == _35reg2270) {
+Obj _35reg2271 = primCdr(_35p1311);
+Obj _35reg2272 = primCar(_35reg2271);
+Obj _35reg2273 = primCdr(_35reg2272);
+Obj _35reg2274 = primCdr(_35reg2273);
+Obj _35reg2275 = primCar(_35reg2274);
+Obj body = _35reg2275;
+Obj _35reg2276 = primCdr(_35p1311);
+Obj _35reg2277 = primCar(_35reg2276);
+Obj _35reg2278 = primCdr(_35reg2277);
+Obj _35reg2279 = primCdr(_35reg2278);
+Obj _35reg2280 = primCdr(_35reg2279);
+Obj _35reg2281 = primEQ(Nil, _35reg2280);
+if (True == _35reg2281) {
+Obj _35reg2282 = primCdr(_35p1311);
+Obj _35reg2283 = primCdr(_35reg2282);
+Obj fvs = _35reg2283;
+Obj k = _35p1312;
+Obj _35reg2284 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2284) {
 if (True == True) {
-Obj _35reg3087 = primGenSym(intern("clofun"));
-Obj name = _35reg3087;
+Obj _35reg2285 = primGenSym(intern("clofun"));
+Obj name = _35reg2285;
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda"));
 co->args[1] = res;
 co->args[2] = body;
-co->args[3] = makeNative(_35clofun3830, 2, 5, k, params, clo_45or_45cont, name, fvs);
+co->args[3] = makeNative(_35clofun3028, 2, 5, k, params, clo_45or_45cont, name, fvs);
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5708,7 +5708,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2115;
+co->args[0] = _35cc1313;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5718,16 +5718,16 @@ co->pc = coraCall;
 return;
 }
 } else {
-Obj _35reg3109 = primEQ(clo_45or_45cont, intern("%continuation"));
-if (True == _35reg3109) {
+Obj _35reg2307 = primEQ(clo_45or_45cont, intern("%continuation"));
+if (True == _35reg2307) {
 if (True == True) {
-Obj _35reg3110 = primGenSym(intern("clofun"));
-Obj name = _35reg3110;
+Obj _35reg2308 = primGenSym(intern("clofun"));
+Obj name = _35reg2308;
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda"));
 co->args[1] = res;
 co->args[2] = body;
-co->args[3] = makeNative(_35clofun3832, 2, 5, k, params, clo_45or_45cont, name, fvs);
+co->args[3] = makeNative(_35clofun3030, 2, 5, k, params, clo_45or_45cont, name, fvs);
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5737,7 +5737,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2115;
+co->args[0] = _35cc1313;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5748,13 +5748,13 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg3132 = primGenSym(intern("clofun"));
-Obj name = _35reg3132;
+Obj _35reg2330 = primGenSym(intern("clofun"));
+Obj name = _35reg2330;
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda"));
 co->args[1] = res;
 co->args[2] = body;
-co->args[3] = makeNative(_35clofun3834, 2, 5, k, params, clo_45or_45cont, name, fvs);
+co->args[3] = makeNative(_35clofun3032, 2, 5, k, params, clo_45or_45cont, name, fvs);
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5764,7 +5764,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2115;
+co->args[0] = _35cc1313;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5777,7 +5777,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2115;
+co->args[0] = _35cc1313;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5788,7 +5788,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2115;
+co->args[0] = _35cc1313;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5799,7 +5799,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2115;
+co->args[0] = _35cc1313;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5810,7 +5810,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2115;
+co->args[0] = _35cc1313;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5821,7 +5821,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2115;
+co->args[0] = _35cc1313;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5832,7 +5832,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2115;
+co->args[0] = _35cc1313;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5843,7 +5843,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2115;
+co->args[0] = _35cc1313;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5854,19 +5854,19 @@ return;
 }
 }
 
-void _35clofun3834(struct Cora* co) {
+void _35clofun3032(struct Cora* co) {
 Obj res1 = co->args[1];
 Obj body1 = co->args[2];
-Obj _35reg3133 = primEQ(closureRef(co, 2), intern("%closure"));
-if (True == _35reg3133) {
-Obj _35reg3134 = primCons(body1, Nil);
-Obj _35reg3135 = primCons(Nil, _35reg3134);
-Obj _35reg3136 = primCons(closureRef(co, 1), _35reg3135);
-Obj _35reg3137 = primCons(intern("lambda"), _35reg3136);
-Obj _35reg3138 = primCons(_35reg3137, Nil);
-Obj _35reg3139 = primCons(closureRef(co, 3), _35reg3138);
-Obj _35reg3140 = primCons(_35reg3139, res1);
-pushCont(co, _35clofun3835, 1, _35reg3140);
+Obj _35reg2331 = primEQ(closureRef(co, 2), intern("%closure"));
+if (True == _35reg2331) {
+Obj _35reg2332 = primCons(body1, Nil);
+Obj _35reg2333 = primCons(Nil, _35reg2332);
+Obj _35reg2334 = primCons(closureRef(co, 1), _35reg2333);
+Obj _35reg2335 = primCons(intern("lambda"), _35reg2334);
+Obj _35reg2336 = primCons(_35reg2335, Nil);
+Obj _35reg2337 = primCons(closureRef(co, 3), _35reg2336);
+Obj _35reg2338 = primCons(_35reg2337, res1);
+pushCont(co, _35clofun3033, 1, _35reg2338);
 co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = closureRef(co, 1);
@@ -5878,19 +5878,19 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg3145 = primCons(body1, Nil);
-Obj _35reg3146 = primCons(closureRef(co, 4), _35reg3145);
-Obj _35reg3147 = primCons(closureRef(co, 1), _35reg3146);
-Obj _35reg3148 = primCons(intern("lambda"), _35reg3147);
-Obj _35reg3149 = primCons(_35reg3148, Nil);
-Obj _35reg3150 = primCons(closureRef(co, 3), _35reg3149);
-Obj _35reg3151 = primCons(_35reg3150, res1);
-Obj _35reg3152 = primCons(closureRef(co, 3), closureRef(co, 4));
-Obj _35reg3153 = primCons(closureRef(co, 2), _35reg3152);
+Obj _35reg2343 = primCons(body1, Nil);
+Obj _35reg2344 = primCons(closureRef(co, 4), _35reg2343);
+Obj _35reg2345 = primCons(closureRef(co, 1), _35reg2344);
+Obj _35reg2346 = primCons(intern("lambda"), _35reg2345);
+Obj _35reg2347 = primCons(_35reg2346, Nil);
+Obj _35reg2348 = primCons(closureRef(co, 3), _35reg2347);
+Obj _35reg2349 = primCons(_35reg2348, res1);
+Obj _35reg2350 = primCons(closureRef(co, 3), closureRef(co, 4));
+Obj _35reg2351 = primCons(closureRef(co, 2), _35reg2350);
 co->nargs = 3;
 co->args[0] = closureRef(co, 0);
-co->args[1] = _35reg3151;
-co->args[2] = _35reg3153;
+co->args[1] = _35reg2349;
+co->args[2] = _35reg2351;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5901,16 +5901,16 @@ return;
 }
 }
 
-void _35clofun3835(struct Cora* co) {
-Obj _35val3141 = co->args[1];
-Obj _35reg3140 = co->stack[co->base + 0];
-Obj _35reg3142 = primCons(_35val3141, closureRef(co, 4));
-Obj _35reg3143 = primCons(closureRef(co, 3), _35reg3142);
-Obj _35reg3144 = primCons(closureRef(co, 2), _35reg3143);
+void _35clofun3033(struct Cora* co) {
+Obj _35val2339 = co->args[1];
+Obj _35reg2338 = co->stack[co->base + 0];
+Obj _35reg2340 = primCons(_35val2339, closureRef(co, 4));
+Obj _35reg2341 = primCons(closureRef(co, 3), _35reg2340);
+Obj _35reg2342 = primCons(closureRef(co, 2), _35reg2341);
 co->nargs = 3;
 co->args[0] = closureRef(co, 0);
-co->args[1] = _35reg3140;
-co->args[2] = _35reg3144;
+co->args[1] = _35reg2338;
+co->args[2] = _35reg2342;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5920,19 +5920,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3832(struct Cora* co) {
+void _35clofun3030(struct Cora* co) {
 Obj res1 = co->args[1];
 Obj body1 = co->args[2];
-Obj _35reg3111 = primEQ(closureRef(co, 2), intern("%closure"));
-if (True == _35reg3111) {
-Obj _35reg3112 = primCons(body1, Nil);
-Obj _35reg3113 = primCons(Nil, _35reg3112);
-Obj _35reg3114 = primCons(closureRef(co, 1), _35reg3113);
-Obj _35reg3115 = primCons(intern("lambda"), _35reg3114);
-Obj _35reg3116 = primCons(_35reg3115, Nil);
-Obj _35reg3117 = primCons(closureRef(co, 3), _35reg3116);
-Obj _35reg3118 = primCons(_35reg3117, res1);
-pushCont(co, _35clofun3833, 1, _35reg3118);
+Obj _35reg2309 = primEQ(closureRef(co, 2), intern("%closure"));
+if (True == _35reg2309) {
+Obj _35reg2310 = primCons(body1, Nil);
+Obj _35reg2311 = primCons(Nil, _35reg2310);
+Obj _35reg2312 = primCons(closureRef(co, 1), _35reg2311);
+Obj _35reg2313 = primCons(intern("lambda"), _35reg2312);
+Obj _35reg2314 = primCons(_35reg2313, Nil);
+Obj _35reg2315 = primCons(closureRef(co, 3), _35reg2314);
+Obj _35reg2316 = primCons(_35reg2315, res1);
+pushCont(co, _35clofun3031, 1, _35reg2316);
 co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = closureRef(co, 1);
@@ -5944,19 +5944,19 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg3123 = primCons(body1, Nil);
-Obj _35reg3124 = primCons(closureRef(co, 4), _35reg3123);
-Obj _35reg3125 = primCons(closureRef(co, 1), _35reg3124);
-Obj _35reg3126 = primCons(intern("lambda"), _35reg3125);
-Obj _35reg3127 = primCons(_35reg3126, Nil);
-Obj _35reg3128 = primCons(closureRef(co, 3), _35reg3127);
-Obj _35reg3129 = primCons(_35reg3128, res1);
-Obj _35reg3130 = primCons(closureRef(co, 3), closureRef(co, 4));
-Obj _35reg3131 = primCons(closureRef(co, 2), _35reg3130);
+Obj _35reg2321 = primCons(body1, Nil);
+Obj _35reg2322 = primCons(closureRef(co, 4), _35reg2321);
+Obj _35reg2323 = primCons(closureRef(co, 1), _35reg2322);
+Obj _35reg2324 = primCons(intern("lambda"), _35reg2323);
+Obj _35reg2325 = primCons(_35reg2324, Nil);
+Obj _35reg2326 = primCons(closureRef(co, 3), _35reg2325);
+Obj _35reg2327 = primCons(_35reg2326, res1);
+Obj _35reg2328 = primCons(closureRef(co, 3), closureRef(co, 4));
+Obj _35reg2329 = primCons(closureRef(co, 2), _35reg2328);
 co->nargs = 3;
 co->args[0] = closureRef(co, 0);
-co->args[1] = _35reg3129;
-co->args[2] = _35reg3131;
+co->args[1] = _35reg2327;
+co->args[2] = _35reg2329;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5967,16 +5967,16 @@ return;
 }
 }
 
-void _35clofun3833(struct Cora* co) {
-Obj _35val3119 = co->args[1];
-Obj _35reg3118 = co->stack[co->base + 0];
-Obj _35reg3120 = primCons(_35val3119, closureRef(co, 4));
-Obj _35reg3121 = primCons(closureRef(co, 3), _35reg3120);
-Obj _35reg3122 = primCons(closureRef(co, 2), _35reg3121);
+void _35clofun3031(struct Cora* co) {
+Obj _35val2317 = co->args[1];
+Obj _35reg2316 = co->stack[co->base + 0];
+Obj _35reg2318 = primCons(_35val2317, closureRef(co, 4));
+Obj _35reg2319 = primCons(closureRef(co, 3), _35reg2318);
+Obj _35reg2320 = primCons(closureRef(co, 2), _35reg2319);
 co->nargs = 3;
 co->args[0] = closureRef(co, 0);
-co->args[1] = _35reg3118;
-co->args[2] = _35reg3122;
+co->args[1] = _35reg2316;
+co->args[2] = _35reg2320;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5986,19 +5986,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3830(struct Cora* co) {
+void _35clofun3028(struct Cora* co) {
 Obj res1 = co->args[1];
 Obj body1 = co->args[2];
-Obj _35reg3088 = primEQ(closureRef(co, 2), intern("%closure"));
-if (True == _35reg3088) {
-Obj _35reg3089 = primCons(body1, Nil);
-Obj _35reg3090 = primCons(Nil, _35reg3089);
-Obj _35reg3091 = primCons(closureRef(co, 1), _35reg3090);
-Obj _35reg3092 = primCons(intern("lambda"), _35reg3091);
-Obj _35reg3093 = primCons(_35reg3092, Nil);
-Obj _35reg3094 = primCons(closureRef(co, 3), _35reg3093);
-Obj _35reg3095 = primCons(_35reg3094, res1);
-pushCont(co, _35clofun3831, 1, _35reg3095);
+Obj _35reg2286 = primEQ(closureRef(co, 2), intern("%closure"));
+if (True == _35reg2286) {
+Obj _35reg2287 = primCons(body1, Nil);
+Obj _35reg2288 = primCons(Nil, _35reg2287);
+Obj _35reg2289 = primCons(closureRef(co, 1), _35reg2288);
+Obj _35reg2290 = primCons(intern("lambda"), _35reg2289);
+Obj _35reg2291 = primCons(_35reg2290, Nil);
+Obj _35reg2292 = primCons(closureRef(co, 3), _35reg2291);
+Obj _35reg2293 = primCons(_35reg2292, res1);
+pushCont(co, _35clofun3029, 1, _35reg2293);
 co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = closureRef(co, 1);
@@ -6010,19 +6010,19 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg3100 = primCons(body1, Nil);
-Obj _35reg3101 = primCons(closureRef(co, 4), _35reg3100);
-Obj _35reg3102 = primCons(closureRef(co, 1), _35reg3101);
-Obj _35reg3103 = primCons(intern("lambda"), _35reg3102);
-Obj _35reg3104 = primCons(_35reg3103, Nil);
-Obj _35reg3105 = primCons(closureRef(co, 3), _35reg3104);
-Obj _35reg3106 = primCons(_35reg3105, res1);
-Obj _35reg3107 = primCons(closureRef(co, 3), closureRef(co, 4));
-Obj _35reg3108 = primCons(closureRef(co, 2), _35reg3107);
+Obj _35reg2298 = primCons(body1, Nil);
+Obj _35reg2299 = primCons(closureRef(co, 4), _35reg2298);
+Obj _35reg2300 = primCons(closureRef(co, 1), _35reg2299);
+Obj _35reg2301 = primCons(intern("lambda"), _35reg2300);
+Obj _35reg2302 = primCons(_35reg2301, Nil);
+Obj _35reg2303 = primCons(closureRef(co, 3), _35reg2302);
+Obj _35reg2304 = primCons(_35reg2303, res1);
+Obj _35reg2305 = primCons(closureRef(co, 3), closureRef(co, 4));
+Obj _35reg2306 = primCons(closureRef(co, 2), _35reg2305);
 co->nargs = 3;
 co->args[0] = closureRef(co, 0);
-co->args[1] = _35reg3106;
-co->args[2] = _35reg3108;
+co->args[1] = _35reg2304;
+co->args[2] = _35reg2306;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6033,16 +6033,16 @@ return;
 }
 }
 
-void _35clofun3831(struct Cora* co) {
-Obj _35val3096 = co->args[1];
-Obj _35reg3095 = co->stack[co->base + 0];
-Obj _35reg3097 = primCons(_35val3096, closureRef(co, 4));
-Obj _35reg3098 = primCons(closureRef(co, 3), _35reg3097);
-Obj _35reg3099 = primCons(closureRef(co, 2), _35reg3098);
+void _35clofun3029(struct Cora* co) {
+Obj _35val2294 = co->args[1];
+Obj _35reg2293 = co->stack[co->base + 0];
+Obj _35reg2295 = primCons(_35val2294, closureRef(co, 4));
+Obj _35reg2296 = primCons(closureRef(co, 3), _35reg2295);
+Obj _35reg2297 = primCons(closureRef(co, 2), _35reg2296);
 co->nargs = 3;
 co->args[0] = closureRef(co, 0);
-co->args[1] = _35reg3095;
-co->args[2] = _35reg3099;
+co->args[1] = _35reg2293;
+co->args[2] = _35reg2297;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6052,13 +6052,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3827(struct Cora* co) {
-Obj _35cc2116 = makeNative(_35clofun3828, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3025(struct Cora* co) {
+Obj _35cc1314 = makeNative(_35clofun3026, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj res = closureRef(co, 0);
 Obj f_45args = closureRef(co, 1);
 Obj k = closureRef(co, 2);
-Obj _35reg3048 = primIsCons(f_45args);
-if (True == _35reg3048) {
+Obj _35reg2246 = primIsCons(f_45args);
+if (True == _35reg2246) {
 co->nargs = 5;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda-list"));
 co->args[1] = Nil;
@@ -6074,7 +6074,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2116;
+co->args[0] = _35cc1314;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6085,8 +6085,8 @@ return;
 }
 }
 
-void _35clofun3828(struct Cora* co) {
-Obj _35cc2117 = makeNative(_35clofun3829, 0, 0);
+void _35clofun3026(struct Cora* co) {
+Obj _35cc1315 = makeNative(_35clofun3027, 0, 0);
 Obj res = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 Obj k = closureRef(co, 2);
@@ -6103,7 +6103,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3829(struct Cora* co) {
+void _35clofun3027(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -6116,13 +6116,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3808(struct Cora* co) {
-Obj _35p2104 = co->args[1];
-Obj _35p2105 = co->args[2];
-Obj _35cc2106 = makeNative(_35clofun3809, 0, 2, _35p2104, _35p2105);
-Obj __ = _35p2104;
-Obj x = _35p2105;
-pushCont(co, _35clofun3825, 2, x, _35cc2106);
+void _35clofun3006(struct Cora* co) {
+Obj _35p1302 = co->args[1];
+Obj _35p1303 = co->args[2];
+Obj _35cc1304 = makeNative(_35clofun3007, 0, 2, _35p1302, _35p1303);
+Obj __ = _35p1302;
+Obj x = _35p1303;
+pushCont(co, _35clofun3023, 2, x, _35cc1304);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.convert-protect?"));
 co->args[1] = x;
@@ -6135,18 +6135,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3825(struct Cora* co) {
-Obj _35val3046 = co->args[1];
+void _35clofun3023(struct Cora* co) {
+Obj _35val2244 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35cc2106 = co->stack[co->base + 1];
-if (True == _35val3046) {
+Obj _35cc1304 = co->stack[co->base + 1];
+if (True == _35val2244) {
 co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2106;
+co->args[0] = _35cc1304;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6157,19 +6157,19 @@ return;
 }
 }
 
-void _35clofun3809(struct Cora* co) {
-Obj _35cc2107 = makeNative(_35clofun3810, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3007(struct Cora* co) {
+Obj _35cc1305 = makeNative(_35clofun3008, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj _35reg3045 = primIsSymbol(var);
-if (True == _35reg3045) {
+Obj _35reg2243 = primIsSymbol(var);
+if (True == _35reg2243) {
 co->nargs = 2;
 co->args[1] = var;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2107;
+co->args[0] = _35cc1305;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6180,34 +6180,34 @@ return;
 }
 }
 
-void _35clofun3810(struct Cora* co) {
-Obj _35cc2108 = makeNative(_35clofun3811, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3008(struct Cora* co) {
+Obj _35cc1306 = makeNative(_35clofun3009, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg3024 = primIsCons(closureRef(co, 1));
-if (True == _35reg3024) {
-Obj _35reg3025 = primCar(closureRef(co, 1));
-Obj _35reg3026 = primEQ(intern("lambda"), _35reg3025);
-if (True == _35reg3026) {
-Obj _35reg3027 = primCdr(closureRef(co, 1));
-Obj _35reg3028 = primIsCons(_35reg3027);
-if (True == _35reg3028) {
-Obj _35reg3029 = primCdr(closureRef(co, 1));
-Obj _35reg3030 = primCar(_35reg3029);
-Obj args = _35reg3030;
-Obj _35reg3031 = primCdr(closureRef(co, 1));
-Obj _35reg3032 = primCdr(_35reg3031);
-Obj _35reg3033 = primIsCons(_35reg3032);
-if (True == _35reg3033) {
-Obj _35reg3034 = primCdr(closureRef(co, 1));
-Obj _35reg3035 = primCdr(_35reg3034);
-Obj _35reg3036 = primCar(_35reg3035);
-Obj body = _35reg3036;
-Obj _35reg3037 = primCdr(closureRef(co, 1));
-Obj _35reg3038 = primCdr(_35reg3037);
-Obj _35reg3039 = primCdr(_35reg3038);
-Obj _35reg3040 = primEQ(Nil, _35reg3039);
-if (True == _35reg3040) {
-pushCont(co, _35clofun3824, 1, args);
+Obj _35reg2222 = primIsCons(closureRef(co, 1));
+if (True == _35reg2222) {
+Obj _35reg2223 = primCar(closureRef(co, 1));
+Obj _35reg2224 = primEQ(intern("lambda"), _35reg2223);
+if (True == _35reg2224) {
+Obj _35reg2225 = primCdr(closureRef(co, 1));
+Obj _35reg2226 = primIsCons(_35reg2225);
+if (True == _35reg2226) {
+Obj _35reg2227 = primCdr(closureRef(co, 1));
+Obj _35reg2228 = primCar(_35reg2227);
+Obj args = _35reg2228;
+Obj _35reg2229 = primCdr(closureRef(co, 1));
+Obj _35reg2230 = primCdr(_35reg2229);
+Obj _35reg2231 = primIsCons(_35reg2230);
+if (True == _35reg2231) {
+Obj _35reg2232 = primCdr(closureRef(co, 1));
+Obj _35reg2233 = primCdr(_35reg2232);
+Obj _35reg2234 = primCar(_35reg2233);
+Obj body = _35reg2234;
+Obj _35reg2235 = primCdr(closureRef(co, 1));
+Obj _35reg2236 = primCdr(_35reg2235);
+Obj _35reg2237 = primCdr(_35reg2236);
+Obj _35reg2238 = primEQ(Nil, _35reg2237);
+if (True == _35reg2238) {
+pushCont(co, _35clofun3022, 1, args);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = fvs;
@@ -6221,7 +6221,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2108;
+co->args[0] = _35cc1306;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6232,7 +6232,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2108;
+co->args[0] = _35cc1306;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6243,7 +6243,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2108;
+co->args[0] = _35cc1306;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6254,7 +6254,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2108;
+co->args[0] = _35cc1306;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6265,7 +6265,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2108;
+co->args[0] = _35cc1306;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6276,46 +6276,46 @@ return;
 }
 }
 
-void _35clofun3824(struct Cora* co) {
-Obj _35val3041 = co->args[1];
+void _35clofun3022(struct Cora* co) {
+Obj _35val2239 = co->args[1];
 Obj args = co->stack[co->base + 0];
-Obj _35reg3042 = primCons(_35val3041, Nil);
-Obj _35reg3043 = primCons(args, _35reg3042);
-Obj _35reg3044 = primCons(intern("lambda"), _35reg3043);
+Obj _35reg2240 = primCons(_35val2239, Nil);
+Obj _35reg2241 = primCons(args, _35reg2240);
+Obj _35reg2242 = primCons(intern("lambda"), _35reg2241);
 co->nargs = 2;
-co->args[1] = _35reg3044;
+co->args[1] = _35reg2242;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3811(struct Cora* co) {
-Obj _35cc2109 = makeNative(_35clofun3812, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3009(struct Cora* co) {
+Obj _35cc1307 = makeNative(_35clofun3010, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2997 = primIsCons(closureRef(co, 1));
-if (True == _35reg2997) {
-Obj _35reg2998 = primCar(closureRef(co, 1));
-Obj _35reg2999 = primEQ(intern("continuation"), _35reg2998);
-if (True == _35reg2999) {
-Obj _35reg3000 = primCdr(closureRef(co, 1));
-Obj _35reg3001 = primIsCons(_35reg3000);
-if (True == _35reg3001) {
-Obj _35reg3002 = primCdr(closureRef(co, 1));
-Obj _35reg3003 = primCar(_35reg3002);
-Obj val = _35reg3003;
-Obj _35reg3004 = primCdr(closureRef(co, 1));
-Obj _35reg3005 = primCdr(_35reg3004);
-Obj _35reg3006 = primIsCons(_35reg3005);
-if (True == _35reg3006) {
-Obj _35reg3007 = primCdr(closureRef(co, 1));
-Obj _35reg3008 = primCdr(_35reg3007);
-Obj _35reg3009 = primCar(_35reg3008);
-Obj body = _35reg3009;
-Obj _35reg3010 = primCdr(closureRef(co, 1));
-Obj _35reg3011 = primCdr(_35reg3010);
-Obj _35reg3012 = primCdr(_35reg3011);
-Obj _35reg3013 = primEQ(Nil, _35reg3012);
-if (True == _35reg3013) {
-pushCont(co, _35clofun3819, 3, fvs, body, val);
+Obj _35reg2195 = primIsCons(closureRef(co, 1));
+if (True == _35reg2195) {
+Obj _35reg2196 = primCar(closureRef(co, 1));
+Obj _35reg2197 = primEQ(intern("continuation"), _35reg2196);
+if (True == _35reg2197) {
+Obj _35reg2198 = primCdr(closureRef(co, 1));
+Obj _35reg2199 = primIsCons(_35reg2198);
+if (True == _35reg2199) {
+Obj _35reg2200 = primCdr(closureRef(co, 1));
+Obj _35reg2201 = primCar(_35reg2200);
+Obj val = _35reg2201;
+Obj _35reg2202 = primCdr(closureRef(co, 1));
+Obj _35reg2203 = primCdr(_35reg2202);
+Obj _35reg2204 = primIsCons(_35reg2203);
+if (True == _35reg2204) {
+Obj _35reg2205 = primCdr(closureRef(co, 1));
+Obj _35reg2206 = primCdr(_35reg2205);
+Obj _35reg2207 = primCar(_35reg2206);
+Obj body = _35reg2207;
+Obj _35reg2208 = primCdr(closureRef(co, 1));
+Obj _35reg2209 = primCdr(_35reg2208);
+Obj _35reg2210 = primCdr(_35reg2209);
+Obj _35reg2211 = primEQ(Nil, _35reg2210);
+if (True == _35reg2211) {
+pushCont(co, _35clofun3017, 3, fvs, body, val);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = body;
@@ -6328,7 +6328,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2109;
+co->args[0] = _35cc1307;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6339,7 +6339,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2109;
+co->args[0] = _35cc1307;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6350,7 +6350,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2109;
+co->args[0] = _35cc1307;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6361,7 +6361,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2109;
+co->args[0] = _35cc1307;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6372,7 +6372,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2109;
+co->args[0] = _35cc1307;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6383,15 +6383,15 @@ return;
 }
 }
 
-void _35clofun3819(struct Cora* co) {
-Obj _35val3014 = co->args[1];
+void _35clofun3017(struct Cora* co) {
+Obj _35val2212 = co->args[1];
 Obj fvs = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj val = co->stack[co->base + 2];
-pushCont(co, _35clofun3820, 3, fvs, body, val);
+pushCont(co, _35clofun3018, 3, fvs, body, val);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
-co->args[1] = _35val3014;
+co->args[1] = _35val2212;
 co->args[2] = val;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -6402,13 +6402,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3820(struct Cora* co) {
-Obj _35val3015 = co->args[1];
+void _35clofun3018(struct Cora* co) {
+Obj _35val2213 = co->args[1];
 Obj fvs = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj val = co->stack[co->base + 2];
-Obj fvs1 = _35val3015;
-pushCont(co, _35clofun3821, 3, fvs1, body, val);
+Obj fvs1 = _35val2213;
+pushCont(co, _35clofun3019, 3, fvs1, body, val);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = fvs;
@@ -6421,15 +6421,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3821(struct Cora* co) {
-Obj _35val3016 = co->args[1];
+void _35clofun3019(struct Cora* co) {
+Obj _35val2214 = co->args[1];
 Obj fvs1 = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj val = co->stack[co->base + 2];
-pushCont(co, _35clofun3822, 3, fvs1, body, val);
+pushCont(co, _35clofun3020, 3, fvs1, body, val);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val3016;
+co->args[1] = _35val2214;
 co->args[2] = fvs1;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -6440,13 +6440,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3822(struct Cora* co) {
-Obj _35val3017 = co->args[1];
+void _35clofun3020(struct Cora* co) {
+Obj _35val2215 = co->args[1];
 Obj fvs1 = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj val = co->stack[co->base + 2];
-Obj fvs2 = _35val3017;
-pushCont(co, _35clofun3823, 2, val, fvs2);
+Obj fvs2 = _35val2215;
+pushCont(co, _35clofun3021, 2, val, fvs2);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = fvs1;
@@ -6460,49 +6460,49 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3823(struct Cora* co) {
-Obj _35val3018 = co->args[1];
+void _35clofun3021(struct Cora* co) {
+Obj _35val2216 = co->args[1];
 Obj val = co->stack[co->base + 0];
 Obj fvs2 = co->stack[co->base + 1];
-Obj _35reg3019 = primCons(_35val3018, Nil);
-Obj _35reg3020 = primCons(val, _35reg3019);
-Obj _35reg3021 = primCons(intern("lambda"), _35reg3020);
-Obj _35reg3022 = primCons(_35reg3021, fvs2);
-Obj _35reg3023 = primCons(intern("%continuation"), _35reg3022);
+Obj _35reg2217 = primCons(_35val2216, Nil);
+Obj _35reg2218 = primCons(val, _35reg2217);
+Obj _35reg2219 = primCons(intern("lambda"), _35reg2218);
+Obj _35reg2220 = primCons(_35reg2219, fvs2);
+Obj _35reg2221 = primCons(intern("%continuation"), _35reg2220);
 co->nargs = 2;
-co->args[1] = _35reg3023;
+co->args[1] = _35reg2221;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3812(struct Cora* co) {
-Obj _35cc2110 = makeNative(_35clofun3813, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3010(struct Cora* co) {
+Obj _35cc1308 = makeNative(_35clofun3011, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2974 = primIsCons(closureRef(co, 1));
-if (True == _35reg2974) {
-Obj _35reg2975 = primCar(closureRef(co, 1));
-Obj _35reg2976 = primEQ(intern("call"), _35reg2975);
-if (True == _35reg2976) {
-Obj _35reg2977 = primCdr(closureRef(co, 1));
-Obj _35reg2978 = primIsCons(_35reg2977);
-if (True == _35reg2978) {
-Obj _35reg2979 = primCdr(closureRef(co, 1));
-Obj _35reg2980 = primCar(_35reg2979);
-Obj exp = _35reg2980;
-Obj _35reg2981 = primCdr(closureRef(co, 1));
-Obj _35reg2982 = primCdr(_35reg2981);
-Obj _35reg2983 = primIsCons(_35reg2982);
-if (True == _35reg2983) {
-Obj _35reg2984 = primCdr(closureRef(co, 1));
-Obj _35reg2985 = primCdr(_35reg2984);
-Obj _35reg2986 = primCar(_35reg2985);
-Obj cont = _35reg2986;
-Obj _35reg2987 = primCdr(closureRef(co, 1));
-Obj _35reg2988 = primCdr(_35reg2987);
-Obj _35reg2989 = primCdr(_35reg2988);
-Obj _35reg2990 = primEQ(Nil, _35reg2989);
-if (True == _35reg2990) {
-pushCont(co, _35clofun3816, 3, exp, fvs, cont);
+Obj _35reg2172 = primIsCons(closureRef(co, 1));
+if (True == _35reg2172) {
+Obj _35reg2173 = primCar(closureRef(co, 1));
+Obj _35reg2174 = primEQ(intern("call"), _35reg2173);
+if (True == _35reg2174) {
+Obj _35reg2175 = primCdr(closureRef(co, 1));
+Obj _35reg2176 = primIsCons(_35reg2175);
+if (True == _35reg2176) {
+Obj _35reg2177 = primCdr(closureRef(co, 1));
+Obj _35reg2178 = primCar(_35reg2177);
+Obj exp = _35reg2178;
+Obj _35reg2179 = primCdr(closureRef(co, 1));
+Obj _35reg2180 = primCdr(_35reg2179);
+Obj _35reg2181 = primIsCons(_35reg2180);
+if (True == _35reg2181) {
+Obj _35reg2182 = primCdr(closureRef(co, 1));
+Obj _35reg2183 = primCdr(_35reg2182);
+Obj _35reg2184 = primCar(_35reg2183);
+Obj cont = _35reg2184;
+Obj _35reg2185 = primCdr(closureRef(co, 1));
+Obj _35reg2186 = primCdr(_35reg2185);
+Obj _35reg2187 = primCdr(_35reg2186);
+Obj _35reg2188 = primEQ(Nil, _35reg2187);
+if (True == _35reg2188) {
+pushCont(co, _35clofun3014, 3, exp, fvs, cont);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = fvs;
@@ -6515,7 +6515,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2110;
+co->args[0] = _35cc1308;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6526,7 +6526,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2110;
+co->args[0] = _35cc1308;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6537,7 +6537,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2110;
+co->args[0] = _35cc1308;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6548,7 +6548,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2110;
+co->args[0] = _35cc1308;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6559,7 +6559,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2110;
+co->args[0] = _35cc1308;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6570,15 +6570,15 @@ return;
 }
 }
 
-void _35clofun3816(struct Cora* co) {
-Obj _35val2991 = co->args[1];
+void _35clofun3014(struct Cora* co) {
+Obj _35val2189 = co->args[1];
 Obj exp = co->stack[co->base + 0];
 Obj fvs = co->stack[co->base + 1];
 Obj cont = co->stack[co->base + 2];
-pushCont(co, _35clofun3817, 2, fvs, cont);
+pushCont(co, _35clofun3015, 2, fvs, cont);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val2991;
+co->args[1] = _35val2189;
 co->args[2] = exp;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -6589,11 +6589,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3817(struct Cora* co) {
-Obj _35val2992 = co->args[1];
+void _35clofun3015(struct Cora* co) {
+Obj _35val2190 = co->args[1];
 Obj fvs = co->stack[co->base + 0];
 Obj cont = co->stack[co->base + 1];
-pushCont(co, _35clofun3818, 1, _35val2992);
+pushCont(co, _35clofun3016, 1, _35val2190);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = fvs;
@@ -6607,28 +6607,28 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3818(struct Cora* co) {
-Obj _35val2993 = co->args[1];
-Obj _35val2992 = co->stack[co->base + 0];
-Obj _35reg2994 = primCons(_35val2993, Nil);
-Obj _35reg2995 = primCons(_35val2992, _35reg2994);
-Obj _35reg2996 = primCons(intern("call"), _35reg2995);
+void _35clofun3016(struct Cora* co) {
+Obj _35val2191 = co->args[1];
+Obj _35val2190 = co->stack[co->base + 0];
+Obj _35reg2192 = primCons(_35val2191, Nil);
+Obj _35reg2193 = primCons(_35val2190, _35reg2192);
+Obj _35reg2194 = primCons(intern("call"), _35reg2193);
 co->nargs = 2;
-co->args[1] = _35reg2996;
+co->args[1] = _35reg2194;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3813(struct Cora* co) {
-Obj _35cc2111 = makeNative(_35clofun3814, 0, 0);
+void _35clofun3011(struct Cora* co) {
+Obj _35cc1309 = makeNative(_35clofun3012, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj _35reg2969 = primIsCons(closureRef(co, 1));
-if (True == _35reg2969) {
-Obj _35reg2970 = primCar(closureRef(co, 1));
-Obj f = _35reg2970;
-Obj _35reg2971 = primCdr(closureRef(co, 1));
-Obj args = _35reg2971;
-pushCont(co, _35clofun3815, 2, f, args);
+Obj _35reg2167 = primIsCons(closureRef(co, 1));
+if (True == _35reg2167) {
+Obj _35reg2168 = primCar(closureRef(co, 1));
+Obj f = _35reg2168;
+Obj _35reg2169 = primCdr(closureRef(co, 1));
+Obj args = _35reg2169;
+pushCont(co, _35clofun3013, 2, f, args);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = fvs;
@@ -6641,7 +6641,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2111;
+co->args[0] = _35cc1309;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6652,15 +6652,15 @@ return;
 }
 }
 
-void _35clofun3815(struct Cora* co) {
-Obj _35val2972 = co->args[1];
+void _35clofun3013(struct Cora* co) {
+Obj _35val2170 = co->args[1];
 Obj f = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
-Obj _35reg2973 = primCons(f, args);
+Obj _35reg2171 = primCons(f, args);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val2972;
-co->args[2] = _35reg2973;
+co->args[1] = _35val2170;
+co->args[2] = _35reg2171;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6670,7 +6670,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3814(struct Cora* co) {
+void _35clofun3012(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -6683,16 +6683,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3798(struct Cora* co) {
-Obj _35p2099 = co->args[1];
-Obj _35p2100 = co->args[2];
-Obj _35p2101 = co->args[3];
-Obj _35cc2102 = makeNative(_35clofun3799, 0, 3, _35p2099, _35p2100, _35p2101);
-Obj _35reg2926 = primEQ(Nil, _35p2099);
-if (True == _35reg2926) {
-Obj ls = _35p2100;
-Obj next = _35p2101;
-pushCont(co, _35clofun3802, 1, next);
+void _35clofun2996(struct Cora* co) {
+Obj _35p1297 = co->args[1];
+Obj _35p1298 = co->args[2];
+Obj _35p1299 = co->args[3];
+Obj _35cc1300 = makeNative(_35clofun2997, 0, 3, _35p1297, _35p1298, _35p1299);
+Obj _35reg2124 = primEQ(Nil, _35p1297);
+if (True == _35reg2124) {
+Obj ls = _35p1298;
+Obj next = _35p1299;
+pushCont(co, _35clofun3000, 1, next);
 co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = ls;
@@ -6705,7 +6705,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2102;
+co->args[0] = _35cc1300;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6716,15 +6716,15 @@ return;
 }
 }
 
-void _35clofun3802(struct Cora* co) {
-Obj _35val2927 = co->args[1];
+void _35clofun3000(struct Cora* co) {
+Obj _35val2125 = co->args[1];
 Obj next = co->stack[co->base + 0];
-Obj exp = _35val2927;
-Obj _35reg2928 = primCar(exp);
-pushCont(co, _35clofun3803, 2, next, exp);
+Obj exp = _35val2125;
+Obj _35reg2126 = primCar(exp);
+pushCont(co, _35clofun3001, 2, next, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("pair?"));
-co->args[1] = _35reg2928;
+co->args[1] = _35reg2126;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6734,12 +6734,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3803(struct Cora* co) {
-Obj _35val2929 = co->args[1];
+void _35clofun3001(struct Cora* co) {
+Obj _35val2127 = co->args[1];
 Obj next = co->stack[co->base + 0];
 Obj exp = co->stack[co->base + 1];
-if (True == _35val2929) {
-pushCont(co, _35clofun3804, 2, next, exp);
+if (True == _35val2127) {
+pushCont(co, _35clofun3002, 2, next, exp);
 co->nargs = 2;
 co->args[0] = globalRef(intern("caar"));
 co->args[1] = exp;
@@ -6764,19 +6764,19 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2956 = primEQ(next, globalRef(intern("cora/lib/toc/include.id")));
-if (True == _35reg2956) {
-Obj _35reg2957 = primCons(exp, Nil);
-Obj _35reg2958 = primCons(intern("tailcall"), _35reg2957);
+Obj _35reg2154 = primEQ(next, globalRef(intern("cora/lib/toc/include.id")));
+if (True == _35reg2154) {
+Obj _35reg2155 = primCons(exp, Nil);
+Obj _35reg2156 = primCons(intern("tailcall"), _35reg2155);
 co->nargs = 2;
-co->args[1] = _35reg2958;
+co->args[1] = _35reg2156;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2959 = primGenSym(intern("val"));
-Obj val = _35reg2959;
-Obj _35reg2960 = primCons(val, Nil);
-pushCont(co, _35clofun3807, 2, _35reg2960, exp);
+Obj _35reg2157 = primGenSym(intern("val"));
+Obj val = _35reg2157;
+Obj _35reg2158 = primCons(val, Nil);
+pushCont(co, _35clofun3005, 2, _35reg2158, exp);
 co->nargs = 2;
 co->args[0] = next;
 co->args[1] = val;
@@ -6792,28 +6792,28 @@ return;
 }
 }
 
-void _35clofun3807(struct Cora* co) {
-Obj _35val2961 = co->args[1];
-Obj _35reg2960 = co->stack[co->base + 0];
+void _35clofun3005(struct Cora* co) {
+Obj _35val2159 = co->args[1];
+Obj _35reg2158 = co->stack[co->base + 0];
 Obj exp = co->stack[co->base + 1];
-Obj _35reg2962 = primCons(_35val2961, Nil);
-Obj _35reg2963 = primCons(_35reg2960, _35reg2962);
-Obj _35reg2964 = primCons(intern("continuation"), _35reg2963);
-Obj _35reg2965 = primCons(_35reg2964, Nil);
-Obj _35reg2966 = primCons(exp, _35reg2965);
-Obj _35reg2967 = primCons(intern("call"), _35reg2966);
+Obj _35reg2160 = primCons(_35val2159, Nil);
+Obj _35reg2161 = primCons(_35reg2158, _35reg2160);
+Obj _35reg2162 = primCons(intern("continuation"), _35reg2161);
+Obj _35reg2163 = primCons(_35reg2162, Nil);
+Obj _35reg2164 = primCons(exp, _35reg2163);
+Obj _35reg2165 = primCons(intern("call"), _35reg2164);
 co->nargs = 2;
-co->args[1] = _35reg2967;
+co->args[1] = _35reg2165;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3804(struct Cora* co) {
-Obj _35val2930 = co->args[1];
+void _35clofun3002(struct Cora* co) {
+Obj _35val2128 = co->args[1];
 Obj next = co->stack[co->base + 0];
 Obj exp = co->stack[co->base + 1];
-Obj _35reg2931 = primEQ(_35val2930, intern("%builtin"));
-if (True == _35reg2931) {
+Obj _35reg2129 = primEQ(_35val2128, intern("%builtin"));
+if (True == _35reg2129) {
 if (True == True) {
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.wrap-var"));
@@ -6827,19 +6827,19 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2932 = primEQ(next, globalRef(intern("cora/lib/toc/include.id")));
-if (True == _35reg2932) {
-Obj _35reg2933 = primCons(exp, Nil);
-Obj _35reg2934 = primCons(intern("tailcall"), _35reg2933);
+Obj _35reg2130 = primEQ(next, globalRef(intern("cora/lib/toc/include.id")));
+if (True == _35reg2130) {
+Obj _35reg2131 = primCons(exp, Nil);
+Obj _35reg2132 = primCons(intern("tailcall"), _35reg2131);
 co->nargs = 2;
-co->args[1] = _35reg2934;
+co->args[1] = _35reg2132;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2935 = primGenSym(intern("val"));
-Obj val = _35reg2935;
-Obj _35reg2936 = primCons(val, Nil);
-pushCont(co, _35clofun3805, 2, _35reg2936, exp);
+Obj _35reg2133 = primGenSym(intern("val"));
+Obj val = _35reg2133;
+Obj _35reg2134 = primCons(val, Nil);
+pushCont(co, _35clofun3003, 2, _35reg2134, exp);
 co->nargs = 2;
 co->args[0] = next;
 co->args[1] = val;
@@ -6866,19 +6866,19 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2944 = primEQ(next, globalRef(intern("cora/lib/toc/include.id")));
-if (True == _35reg2944) {
-Obj _35reg2945 = primCons(exp, Nil);
-Obj _35reg2946 = primCons(intern("tailcall"), _35reg2945);
+Obj _35reg2142 = primEQ(next, globalRef(intern("cora/lib/toc/include.id")));
+if (True == _35reg2142) {
+Obj _35reg2143 = primCons(exp, Nil);
+Obj _35reg2144 = primCons(intern("tailcall"), _35reg2143);
 co->nargs = 2;
-co->args[1] = _35reg2946;
+co->args[1] = _35reg2144;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2947 = primGenSym(intern("val"));
-Obj val = _35reg2947;
-Obj _35reg2948 = primCons(val, Nil);
-pushCont(co, _35clofun3806, 2, _35reg2948, exp);
+Obj _35reg2145 = primGenSym(intern("val"));
+Obj val = _35reg2145;
+Obj _35reg2146 = primCons(val, Nil);
+pushCont(co, _35clofun3004, 2, _35reg2146, exp);
 co->nargs = 2;
 co->args[0] = next;
 co->args[1] = val;
@@ -6894,52 +6894,52 @@ return;
 }
 }
 
-void _35clofun3806(struct Cora* co) {
-Obj _35val2949 = co->args[1];
-Obj _35reg2948 = co->stack[co->base + 0];
+void _35clofun3004(struct Cora* co) {
+Obj _35val2147 = co->args[1];
+Obj _35reg2146 = co->stack[co->base + 0];
 Obj exp = co->stack[co->base + 1];
-Obj _35reg2950 = primCons(_35val2949, Nil);
-Obj _35reg2951 = primCons(_35reg2948, _35reg2950);
-Obj _35reg2952 = primCons(intern("continuation"), _35reg2951);
-Obj _35reg2953 = primCons(_35reg2952, Nil);
-Obj _35reg2954 = primCons(exp, _35reg2953);
-Obj _35reg2955 = primCons(intern("call"), _35reg2954);
+Obj _35reg2148 = primCons(_35val2147, Nil);
+Obj _35reg2149 = primCons(_35reg2146, _35reg2148);
+Obj _35reg2150 = primCons(intern("continuation"), _35reg2149);
+Obj _35reg2151 = primCons(_35reg2150, Nil);
+Obj _35reg2152 = primCons(exp, _35reg2151);
+Obj _35reg2153 = primCons(intern("call"), _35reg2152);
 co->nargs = 2;
-co->args[1] = _35reg2955;
+co->args[1] = _35reg2153;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3805(struct Cora* co) {
-Obj _35val2937 = co->args[1];
-Obj _35reg2936 = co->stack[co->base + 0];
+void _35clofun3003(struct Cora* co) {
+Obj _35val2135 = co->args[1];
+Obj _35reg2134 = co->stack[co->base + 0];
 Obj exp = co->stack[co->base + 1];
-Obj _35reg2938 = primCons(_35val2937, Nil);
-Obj _35reg2939 = primCons(_35reg2936, _35reg2938);
-Obj _35reg2940 = primCons(intern("continuation"), _35reg2939);
-Obj _35reg2941 = primCons(_35reg2940, Nil);
-Obj _35reg2942 = primCons(exp, _35reg2941);
-Obj _35reg2943 = primCons(intern("call"), _35reg2942);
+Obj _35reg2136 = primCons(_35val2135, Nil);
+Obj _35reg2137 = primCons(_35reg2134, _35reg2136);
+Obj _35reg2138 = primCons(intern("continuation"), _35reg2137);
+Obj _35reg2139 = primCons(_35reg2138, Nil);
+Obj _35reg2140 = primCons(exp, _35reg2139);
+Obj _35reg2141 = primCons(intern("call"), _35reg2140);
 co->nargs = 2;
-co->args[1] = _35reg2943;
+co->args[1] = _35reg2141;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3799(struct Cora* co) {
-Obj _35cc2103 = makeNative(_35clofun3800, 0, 0);
-Obj _35reg2922 = primIsCons(closureRef(co, 0));
-if (True == _35reg2922) {
-Obj _35reg2923 = primCar(closureRef(co, 0));
-Obj hd = _35reg2923;
-Obj _35reg2924 = primCdr(closureRef(co, 0));
-Obj tl = _35reg2924;
+void _35clofun2997(struct Cora* co) {
+Obj _35cc1301 = makeNative(_35clofun2998, 0, 0);
+Obj _35reg2120 = primIsCons(closureRef(co, 0));
+if (True == _35reg2120) {
+Obj _35reg2121 = primCar(closureRef(co, 0));
+Obj hd = _35reg2121;
+Obj _35reg2122 = primCdr(closureRef(co, 0));
+Obj tl = _35reg2122;
 Obj ls = closureRef(co, 1);
 Obj next = closureRef(co, 2);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = hd;
-co->args[2] = makeNative(_35clofun3801, 1, 3, tl, ls, next);
+co->args[2] = makeNative(_35clofun2999, 1, 3, tl, ls, next);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6949,7 +6949,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2103;
+co->args[0] = _35cc1301;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6960,13 +6960,13 @@ return;
 }
 }
 
-void _35clofun3801(struct Cora* co) {
+void _35clofun2999(struct Cora* co) {
 Obj hd1 = co->args[1];
-Obj _35reg2925 = primCons(hd1, closureRef(co, 1));
+Obj _35reg2123 = primCons(hd1, closureRef(co, 1));
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify-list"));
 co->args[1] = closureRef(co, 0);
-co->args[2] = _35reg2925;
+co->args[2] = _35reg2123;
 co->args[3] = closureRef(co, 2);
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -6977,7 +6977,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3800(struct Cora* co) {
+void _35clofun2998(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -6990,14 +6990,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3780(struct Cora* co) {
-Obj _35p2090 = co->args[1];
-Obj _35p2091 = co->args[2];
-Obj _35cc2092 = makeNative(_35clofun3781, 0, 2, _35p2090, _35p2091);
-Obj x = _35p2090;
-Obj next = _35p2091;
-Obj _35reg2919 = primIsSymbol(x);
-if (True == _35reg2919) {
+void _35clofun2978(struct Cora* co) {
+Obj _35p1288 = co->args[1];
+Obj _35p1289 = co->args[2];
+Obj _35cc1290 = makeNative(_35clofun2979, 0, 2, _35p1288, _35p1289);
+Obj x = _35p1288;
+Obj next = _35p1289;
+Obj _35reg2117 = primIsSymbol(x);
+if (True == _35reg2117) {
 if (True == True) {
 co->nargs = 2;
 co->args[0] = next;
@@ -7011,7 +7011,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2092;
+co->args[0] = _35cc1290;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7021,7 +7021,7 @@ co->pc = coraCall;
 return;
 }
 } else {
-pushCont(co, _35clofun3797, 3, next, x, _35cc2092);
+pushCont(co, _35clofun2995, 3, next, x, _35cc1290);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.convert-protect?"));
 co->args[1] = x;
@@ -7035,12 +7035,12 @@ return;
 }
 }
 
-void _35clofun3797(struct Cora* co) {
-Obj _35val2920 = co->args[1];
+void _35clofun2995(struct Cora* co) {
+Obj _35val2118 = co->args[1];
 Obj next = co->stack[co->base + 0];
 Obj x = co->stack[co->base + 1];
-Obj _35cc2092 = co->stack[co->base + 2];
-if (True == _35val2920) {
+Obj _35cc1290 = co->stack[co->base + 2];
+if (True == _35val2118) {
 if (True == True) {
 co->nargs = 2;
 co->args[0] = next;
@@ -7054,7 +7054,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2092;
+co->args[0] = _35cc1290;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7077,7 +7077,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2092;
+co->args[0] = _35cc1290;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7089,11 +7089,11 @@ return;
 }
 }
 
-void _35clofun3781(struct Cora* co) {
-Obj _35cc2093 = makeNative(_35clofun3782, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2979(struct Cora* co) {
+Obj _35cc1291 = makeNative(_35clofun2980, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj x = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
-pushCont(co, _35clofun3796, 2, x, _35cc2093);
+pushCont(co, _35clofun2994, 2, x, _35cc1291);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.convert-protect?"));
 co->args[1] = x;
@@ -7106,18 +7106,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3796(struct Cora* co) {
-Obj _35val2918 = co->args[1];
+void _35clofun2994(struct Cora* co) {
+Obj _35val2116 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35cc2093 = co->stack[co->base + 1];
-if (True == _35val2918) {
+Obj _35cc1291 = co->stack[co->base + 1];
+if (True == _35val2116) {
 co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2093;
+co->args[0] = _35cc1291;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7128,48 +7128,48 @@ return;
 }
 }
 
-void _35clofun3782(struct Cora* co) {
-Obj _35cc2094 = makeNative(_35clofun3783, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2886 = primIsCons(closureRef(co, 0));
-if (True == _35reg2886) {
-Obj _35reg2887 = primCar(closureRef(co, 0));
-Obj _35reg2888 = primEQ(intern("if"), _35reg2887);
-if (True == _35reg2888) {
-Obj _35reg2889 = primCdr(closureRef(co, 0));
-Obj _35reg2890 = primIsCons(_35reg2889);
-if (True == _35reg2890) {
-Obj _35reg2891 = primCdr(closureRef(co, 0));
-Obj _35reg2892 = primCar(_35reg2891);
-Obj a = _35reg2892;
-Obj _35reg2893 = primCdr(closureRef(co, 0));
-Obj _35reg2894 = primCdr(_35reg2893);
-Obj _35reg2895 = primIsCons(_35reg2894);
-if (True == _35reg2895) {
-Obj _35reg2896 = primCdr(closureRef(co, 0));
-Obj _35reg2897 = primCdr(_35reg2896);
-Obj _35reg2898 = primCar(_35reg2897);
-Obj b = _35reg2898;
-Obj _35reg2899 = primCdr(closureRef(co, 0));
-Obj _35reg2900 = primCdr(_35reg2899);
-Obj _35reg2901 = primCdr(_35reg2900);
-Obj _35reg2902 = primIsCons(_35reg2901);
-if (True == _35reg2902) {
-Obj _35reg2903 = primCdr(closureRef(co, 0));
-Obj _35reg2904 = primCdr(_35reg2903);
-Obj _35reg2905 = primCdr(_35reg2904);
-Obj _35reg2906 = primCar(_35reg2905);
-Obj c = _35reg2906;
-Obj _35reg2907 = primCdr(closureRef(co, 0));
-Obj _35reg2908 = primCdr(_35reg2907);
-Obj _35reg2909 = primCdr(_35reg2908);
-Obj _35reg2910 = primCdr(_35reg2909);
-Obj _35reg2911 = primEQ(Nil, _35reg2910);
-if (True == _35reg2911) {
+void _35clofun2980(struct Cora* co) {
+Obj _35cc1292 = makeNative(_35clofun2981, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2084 = primIsCons(closureRef(co, 0));
+if (True == _35reg2084) {
+Obj _35reg2085 = primCar(closureRef(co, 0));
+Obj _35reg2086 = primEQ(intern("if"), _35reg2085);
+if (True == _35reg2086) {
+Obj _35reg2087 = primCdr(closureRef(co, 0));
+Obj _35reg2088 = primIsCons(_35reg2087);
+if (True == _35reg2088) {
+Obj _35reg2089 = primCdr(closureRef(co, 0));
+Obj _35reg2090 = primCar(_35reg2089);
+Obj a = _35reg2090;
+Obj _35reg2091 = primCdr(closureRef(co, 0));
+Obj _35reg2092 = primCdr(_35reg2091);
+Obj _35reg2093 = primIsCons(_35reg2092);
+if (True == _35reg2093) {
+Obj _35reg2094 = primCdr(closureRef(co, 0));
+Obj _35reg2095 = primCdr(_35reg2094);
+Obj _35reg2096 = primCar(_35reg2095);
+Obj b = _35reg2096;
+Obj _35reg2097 = primCdr(closureRef(co, 0));
+Obj _35reg2098 = primCdr(_35reg2097);
+Obj _35reg2099 = primCdr(_35reg2098);
+Obj _35reg2100 = primIsCons(_35reg2099);
+if (True == _35reg2100) {
+Obj _35reg2101 = primCdr(closureRef(co, 0));
+Obj _35reg2102 = primCdr(_35reg2101);
+Obj _35reg2103 = primCdr(_35reg2102);
+Obj _35reg2104 = primCar(_35reg2103);
+Obj c = _35reg2104;
+Obj _35reg2105 = primCdr(closureRef(co, 0));
+Obj _35reg2106 = primCdr(_35reg2105);
+Obj _35reg2107 = primCdr(_35reg2106);
+Obj _35reg2108 = primCdr(_35reg2107);
+Obj _35reg2109 = primEQ(Nil, _35reg2108);
+if (True == _35reg2109) {
 Obj next = closureRef(co, 1);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = a;
-co->args[2] = makeNative(_35clofun3793, 1, 3, b, c, next);
+co->args[2] = makeNative(_35clofun2991, 1, 3, b, c, next);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7179,7 +7179,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2094;
+co->args[0] = _35cc1292;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7190,7 +7190,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2094;
+co->args[0] = _35cc1292;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7201,7 +7201,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2094;
+co->args[0] = _35cc1292;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7212,7 +7212,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2094;
+co->args[0] = _35cc1292;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7223,7 +7223,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2094;
+co->args[0] = _35cc1292;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7234,7 +7234,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2094;
+co->args[0] = _35cc1292;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7245,9 +7245,9 @@ return;
 }
 }
 
-void _35clofun3793(struct Cora* co) {
+void _35clofun2991(struct Cora* co) {
 Obj ra = co->args[1];
-pushCont(co, _35clofun3794, 1, ra);
+pushCont(co, _35clofun2992, 1, ra);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = closureRef(co, 0);
@@ -7261,10 +7261,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3794(struct Cora* co) {
-Obj _35val2912 = co->args[1];
+void _35clofun2992(struct Cora* co) {
+Obj _35val2110 = co->args[1];
 Obj ra = co->stack[co->base + 0];
-pushCont(co, _35clofun3795, 2, _35val2912, ra);
+pushCont(co, _35clofun2993, 2, _35val2110, ra);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = closureRef(co, 1);
@@ -7278,51 +7278,51 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3795(struct Cora* co) {
-Obj _35val2913 = co->args[1];
-Obj _35val2912 = co->stack[co->base + 0];
+void _35clofun2993(struct Cora* co) {
+Obj _35val2111 = co->args[1];
+Obj _35val2110 = co->stack[co->base + 0];
 Obj ra = co->stack[co->base + 1];
-Obj _35reg2914 = primCons(_35val2913, Nil);
-Obj _35reg2915 = primCons(_35val2912, _35reg2914);
-Obj _35reg2916 = primCons(ra, _35reg2915);
-Obj _35reg2917 = primCons(intern("if"), _35reg2916);
+Obj _35reg2112 = primCons(_35val2111, Nil);
+Obj _35reg2113 = primCons(_35val2110, _35reg2112);
+Obj _35reg2114 = primCons(ra, _35reg2113);
+Obj _35reg2115 = primCons(intern("if"), _35reg2114);
 co->nargs = 2;
-co->args[1] = _35reg2917;
+co->args[1] = _35reg2115;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3783(struct Cora* co) {
-Obj _35cc2095 = makeNative(_35clofun3784, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2864 = primIsCons(closureRef(co, 0));
-if (True == _35reg2864) {
-Obj _35reg2865 = primCar(closureRef(co, 0));
-Obj _35reg2866 = primEQ(intern("do"), _35reg2865);
-if (True == _35reg2866) {
-Obj _35reg2867 = primCdr(closureRef(co, 0));
-Obj _35reg2868 = primIsCons(_35reg2867);
-if (True == _35reg2868) {
-Obj _35reg2869 = primCdr(closureRef(co, 0));
-Obj _35reg2870 = primCar(_35reg2869);
-Obj a = _35reg2870;
-Obj _35reg2871 = primCdr(closureRef(co, 0));
-Obj _35reg2872 = primCdr(_35reg2871);
-Obj _35reg2873 = primIsCons(_35reg2872);
-if (True == _35reg2873) {
-Obj _35reg2874 = primCdr(closureRef(co, 0));
-Obj _35reg2875 = primCdr(_35reg2874);
-Obj _35reg2876 = primCar(_35reg2875);
-Obj b = _35reg2876;
-Obj _35reg2877 = primCdr(closureRef(co, 0));
-Obj _35reg2878 = primCdr(_35reg2877);
-Obj _35reg2879 = primCdr(_35reg2878);
-Obj _35reg2880 = primEQ(Nil, _35reg2879);
-if (True == _35reg2880) {
+void _35clofun2981(struct Cora* co) {
+Obj _35cc1293 = makeNative(_35clofun2982, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2062 = primIsCons(closureRef(co, 0));
+if (True == _35reg2062) {
+Obj _35reg2063 = primCar(closureRef(co, 0));
+Obj _35reg2064 = primEQ(intern("do"), _35reg2063);
+if (True == _35reg2064) {
+Obj _35reg2065 = primCdr(closureRef(co, 0));
+Obj _35reg2066 = primIsCons(_35reg2065);
+if (True == _35reg2066) {
+Obj _35reg2067 = primCdr(closureRef(co, 0));
+Obj _35reg2068 = primCar(_35reg2067);
+Obj a = _35reg2068;
+Obj _35reg2069 = primCdr(closureRef(co, 0));
+Obj _35reg2070 = primCdr(_35reg2069);
+Obj _35reg2071 = primIsCons(_35reg2070);
+if (True == _35reg2071) {
+Obj _35reg2072 = primCdr(closureRef(co, 0));
+Obj _35reg2073 = primCdr(_35reg2072);
+Obj _35reg2074 = primCar(_35reg2073);
+Obj b = _35reg2074;
+Obj _35reg2075 = primCdr(closureRef(co, 0));
+Obj _35reg2076 = primCdr(_35reg2075);
+Obj _35reg2077 = primCdr(_35reg2076);
+Obj _35reg2078 = primEQ(Nil, _35reg2077);
+if (True == _35reg2078) {
 Obj next = closureRef(co, 1);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = a;
-co->args[2] = makeNative(_35clofun3791, 1, 2, b, next);
+co->args[2] = makeNative(_35clofun2989, 1, 2, b, next);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7332,7 +7332,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2095;
+co->args[0] = _35cc1293;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7343,7 +7343,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2095;
+co->args[0] = _35cc1293;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7354,7 +7354,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2095;
+co->args[0] = _35cc1293;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7365,7 +7365,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2095;
+co->args[0] = _35cc1293;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7376,7 +7376,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2095;
+co->args[0] = _35cc1293;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7387,10 +7387,10 @@ return;
 }
 }
 
-void _35clofun3791(struct Cora* co) {
+void _35clofun2989(struct Cora* co) {
 Obj ra = co->args[1];
-Obj _35reg2881 = primIsSymbol(ra);
-if (True == _35reg2881) {
+Obj _35reg2079 = primIsSymbol(ra);
+if (True == _35reg2079) {
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = closureRef(co, 0);
@@ -7403,7 +7403,7 @@ co->pc = coraCall;
 }
 return;
 } else {
-pushCont(co, _35clofun3792, 1, ra);
+pushCont(co, _35clofun2990, 1, ra);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = closureRef(co, 0);
@@ -7418,60 +7418,60 @@ return;
 }
 }
 
-void _35clofun3792(struct Cora* co) {
-Obj _35val2882 = co->args[1];
+void _35clofun2990(struct Cora* co) {
+Obj _35val2080 = co->args[1];
 Obj ra = co->stack[co->base + 0];
-Obj _35reg2883 = primCons(_35val2882, Nil);
-Obj _35reg2884 = primCons(ra, _35reg2883);
-Obj _35reg2885 = primCons(intern("do"), _35reg2884);
+Obj _35reg2081 = primCons(_35val2080, Nil);
+Obj _35reg2082 = primCons(ra, _35reg2081);
+Obj _35reg2083 = primCons(intern("do"), _35reg2082);
 co->nargs = 2;
-co->args[1] = _35reg2885;
+co->args[1] = _35reg2083;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3784(struct Cora* co) {
-Obj _35cc2096 = makeNative(_35clofun3785, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2833 = primIsCons(closureRef(co, 0));
-if (True == _35reg2833) {
-Obj _35reg2834 = primCar(closureRef(co, 0));
-Obj _35reg2835 = primEQ(intern("let"), _35reg2834);
-if (True == _35reg2835) {
-Obj _35reg2836 = primCdr(closureRef(co, 0));
-Obj _35reg2837 = primIsCons(_35reg2836);
-if (True == _35reg2837) {
-Obj _35reg2838 = primCdr(closureRef(co, 0));
-Obj _35reg2839 = primCar(_35reg2838);
-Obj a = _35reg2839;
-Obj _35reg2840 = primCdr(closureRef(co, 0));
-Obj _35reg2841 = primCdr(_35reg2840);
-Obj _35reg2842 = primIsCons(_35reg2841);
-if (True == _35reg2842) {
-Obj _35reg2843 = primCdr(closureRef(co, 0));
-Obj _35reg2844 = primCdr(_35reg2843);
-Obj _35reg2845 = primCar(_35reg2844);
-Obj b = _35reg2845;
-Obj _35reg2846 = primCdr(closureRef(co, 0));
-Obj _35reg2847 = primCdr(_35reg2846);
-Obj _35reg2848 = primCdr(_35reg2847);
-Obj _35reg2849 = primIsCons(_35reg2848);
-if (True == _35reg2849) {
-Obj _35reg2850 = primCdr(closureRef(co, 0));
-Obj _35reg2851 = primCdr(_35reg2850);
-Obj _35reg2852 = primCdr(_35reg2851);
-Obj _35reg2853 = primCar(_35reg2852);
-Obj c = _35reg2853;
-Obj _35reg2854 = primCdr(closureRef(co, 0));
-Obj _35reg2855 = primCdr(_35reg2854);
-Obj _35reg2856 = primCdr(_35reg2855);
-Obj _35reg2857 = primCdr(_35reg2856);
-Obj _35reg2858 = primEQ(Nil, _35reg2857);
-if (True == _35reg2858) {
+void _35clofun2982(struct Cora* co) {
+Obj _35cc1294 = makeNative(_35clofun2983, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2031 = primIsCons(closureRef(co, 0));
+if (True == _35reg2031) {
+Obj _35reg2032 = primCar(closureRef(co, 0));
+Obj _35reg2033 = primEQ(intern("let"), _35reg2032);
+if (True == _35reg2033) {
+Obj _35reg2034 = primCdr(closureRef(co, 0));
+Obj _35reg2035 = primIsCons(_35reg2034);
+if (True == _35reg2035) {
+Obj _35reg2036 = primCdr(closureRef(co, 0));
+Obj _35reg2037 = primCar(_35reg2036);
+Obj a = _35reg2037;
+Obj _35reg2038 = primCdr(closureRef(co, 0));
+Obj _35reg2039 = primCdr(_35reg2038);
+Obj _35reg2040 = primIsCons(_35reg2039);
+if (True == _35reg2040) {
+Obj _35reg2041 = primCdr(closureRef(co, 0));
+Obj _35reg2042 = primCdr(_35reg2041);
+Obj _35reg2043 = primCar(_35reg2042);
+Obj b = _35reg2043;
+Obj _35reg2044 = primCdr(closureRef(co, 0));
+Obj _35reg2045 = primCdr(_35reg2044);
+Obj _35reg2046 = primCdr(_35reg2045);
+Obj _35reg2047 = primIsCons(_35reg2046);
+if (True == _35reg2047) {
+Obj _35reg2048 = primCdr(closureRef(co, 0));
+Obj _35reg2049 = primCdr(_35reg2048);
+Obj _35reg2050 = primCdr(_35reg2049);
+Obj _35reg2051 = primCar(_35reg2050);
+Obj c = _35reg2051;
+Obj _35reg2052 = primCdr(closureRef(co, 0));
+Obj _35reg2053 = primCdr(_35reg2052);
+Obj _35reg2054 = primCdr(_35reg2053);
+Obj _35reg2055 = primCdr(_35reg2054);
+Obj _35reg2056 = primEQ(Nil, _35reg2055);
+if (True == _35reg2056) {
 Obj next = closureRef(co, 1);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = b;
-co->args[2] = makeNative(_35clofun3789, 1, 3, a, c, next);
+co->args[2] = makeNative(_35clofun2987, 1, 3, a, c, next);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7481,7 +7481,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2096;
+co->args[0] = _35cc1294;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7492,7 +7492,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2096;
+co->args[0] = _35cc1294;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7503,7 +7503,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2096;
+co->args[0] = _35cc1294;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7514,7 +7514,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2096;
+co->args[0] = _35cc1294;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7525,7 +7525,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2096;
+co->args[0] = _35cc1294;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7536,7 +7536,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2096;
+co->args[0] = _35cc1294;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7547,9 +7547,9 @@ return;
 }
 }
 
-void _35clofun3789(struct Cora* co) {
+void _35clofun2987(struct Cora* co) {
 Obj rb = co->args[1];
-pushCont(co, _35clofun3790, 1, rb);
+pushCont(co, _35clofun2988, 1, rb);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = closureRef(co, 1);
@@ -7563,72 +7563,72 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3790(struct Cora* co) {
-Obj _35val2859 = co->args[1];
+void _35clofun2988(struct Cora* co) {
+Obj _35val2057 = co->args[1];
 Obj rb = co->stack[co->base + 0];
-Obj _35reg2860 = primCons(_35val2859, Nil);
-Obj _35reg2861 = primCons(rb, _35reg2860);
-Obj _35reg2862 = primCons(closureRef(co, 0), _35reg2861);
-Obj _35reg2863 = primCons(intern("let"), _35reg2862);
+Obj _35reg2058 = primCons(_35val2057, Nil);
+Obj _35reg2059 = primCons(rb, _35reg2058);
+Obj _35reg2060 = primCons(closureRef(co, 0), _35reg2059);
+Obj _35reg2061 = primCons(intern("let"), _35reg2060);
 co->nargs = 2;
-co->args[1] = _35reg2863;
+co->args[1] = _35reg2061;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3785(struct Cora* co) {
-Obj _35cc2097 = makeNative(_35clofun3786, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2789 = primIsCons(closureRef(co, 0));
-if (True == _35reg2789) {
-Obj _35reg2790 = primCar(closureRef(co, 0));
-Obj _35reg2791 = primEQ(intern("%closure"), _35reg2790);
-if (True == _35reg2791) {
-Obj _35reg2792 = primCdr(closureRef(co, 0));
-Obj _35reg2793 = primIsCons(_35reg2792);
-if (True == _35reg2793) {
-Obj _35reg2794 = primCdr(closureRef(co, 0));
-Obj _35reg2795 = primCar(_35reg2794);
-Obj _35reg2796 = primIsCons(_35reg2795);
-if (True == _35reg2796) {
-Obj _35reg2797 = primCdr(closureRef(co, 0));
-Obj _35reg2798 = primCar(_35reg2797);
-Obj _35reg2799 = primCar(_35reg2798);
-Obj _35reg2800 = primEQ(intern("lambda"), _35reg2799);
-if (True == _35reg2800) {
-Obj _35reg2801 = primCdr(closureRef(co, 0));
-Obj _35reg2802 = primCar(_35reg2801);
-Obj _35reg2803 = primCdr(_35reg2802);
-Obj _35reg2804 = primIsCons(_35reg2803);
-if (True == _35reg2804) {
-Obj _35reg2805 = primCdr(closureRef(co, 0));
-Obj _35reg2806 = primCar(_35reg2805);
-Obj _35reg2807 = primCdr(_35reg2806);
-Obj _35reg2808 = primCar(_35reg2807);
-Obj args = _35reg2808;
-Obj _35reg2809 = primCdr(closureRef(co, 0));
-Obj _35reg2810 = primCar(_35reg2809);
-Obj _35reg2811 = primCdr(_35reg2810);
-Obj _35reg2812 = primCdr(_35reg2811);
-Obj _35reg2813 = primIsCons(_35reg2812);
-if (True == _35reg2813) {
-Obj _35reg2814 = primCdr(closureRef(co, 0));
-Obj _35reg2815 = primCar(_35reg2814);
-Obj _35reg2816 = primCdr(_35reg2815);
-Obj _35reg2817 = primCdr(_35reg2816);
-Obj _35reg2818 = primCar(_35reg2817);
-Obj body = _35reg2818;
-Obj _35reg2819 = primCdr(closureRef(co, 0));
-Obj _35reg2820 = primCar(_35reg2819);
-Obj _35reg2821 = primCdr(_35reg2820);
-Obj _35reg2822 = primCdr(_35reg2821);
-Obj _35reg2823 = primCdr(_35reg2822);
-Obj _35reg2824 = primEQ(Nil, _35reg2823);
-if (True == _35reg2824) {
-Obj _35reg2825 = primCdr(closureRef(co, 0));
-Obj _35reg2826 = primCdr(_35reg2825);
-Obj frees = _35reg2826;
+void _35clofun2983(struct Cora* co) {
+Obj _35cc1295 = makeNative(_35clofun2984, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1987 = primIsCons(closureRef(co, 0));
+if (True == _35reg1987) {
+Obj _35reg1988 = primCar(closureRef(co, 0));
+Obj _35reg1989 = primEQ(intern("%closure"), _35reg1988);
+if (True == _35reg1989) {
+Obj _35reg1990 = primCdr(closureRef(co, 0));
+Obj _35reg1991 = primIsCons(_35reg1990);
+if (True == _35reg1991) {
+Obj _35reg1992 = primCdr(closureRef(co, 0));
+Obj _35reg1993 = primCar(_35reg1992);
+Obj _35reg1994 = primIsCons(_35reg1993);
+if (True == _35reg1994) {
+Obj _35reg1995 = primCdr(closureRef(co, 0));
+Obj _35reg1996 = primCar(_35reg1995);
+Obj _35reg1997 = primCar(_35reg1996);
+Obj _35reg1998 = primEQ(intern("lambda"), _35reg1997);
+if (True == _35reg1998) {
+Obj _35reg1999 = primCdr(closureRef(co, 0));
+Obj _35reg2000 = primCar(_35reg1999);
+Obj _35reg2001 = primCdr(_35reg2000);
+Obj _35reg2002 = primIsCons(_35reg2001);
+if (True == _35reg2002) {
+Obj _35reg2003 = primCdr(closureRef(co, 0));
+Obj _35reg2004 = primCar(_35reg2003);
+Obj _35reg2005 = primCdr(_35reg2004);
+Obj _35reg2006 = primCar(_35reg2005);
+Obj args = _35reg2006;
+Obj _35reg2007 = primCdr(closureRef(co, 0));
+Obj _35reg2008 = primCar(_35reg2007);
+Obj _35reg2009 = primCdr(_35reg2008);
+Obj _35reg2010 = primCdr(_35reg2009);
+Obj _35reg2011 = primIsCons(_35reg2010);
+if (True == _35reg2011) {
+Obj _35reg2012 = primCdr(closureRef(co, 0));
+Obj _35reg2013 = primCar(_35reg2012);
+Obj _35reg2014 = primCdr(_35reg2013);
+Obj _35reg2015 = primCdr(_35reg2014);
+Obj _35reg2016 = primCar(_35reg2015);
+Obj body = _35reg2016;
+Obj _35reg2017 = primCdr(closureRef(co, 0));
+Obj _35reg2018 = primCar(_35reg2017);
+Obj _35reg2019 = primCdr(_35reg2018);
+Obj _35reg2020 = primCdr(_35reg2019);
+Obj _35reg2021 = primCdr(_35reg2020);
+Obj _35reg2022 = primEQ(Nil, _35reg2021);
+if (True == _35reg2022) {
+Obj _35reg2023 = primCdr(closureRef(co, 0));
+Obj _35reg2024 = primCdr(_35reg2023);
+Obj frees = _35reg2024;
 Obj next = closureRef(co, 1);
-pushCont(co, _35clofun3788, 3, args, frees, next);
+pushCont(co, _35clofun2986, 3, args, frees, next);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = body;
@@ -7642,7 +7642,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2097;
+co->args[0] = _35cc1295;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7653,7 +7653,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2097;
+co->args[0] = _35cc1295;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7664,7 +7664,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2097;
+co->args[0] = _35cc1295;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7675,7 +7675,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2097;
+co->args[0] = _35cc1295;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7686,7 +7686,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2097;
+co->args[0] = _35cc1295;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7697,7 +7697,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2097;
+co->args[0] = _35cc1295;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7708,7 +7708,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2097;
+co->args[0] = _35cc1295;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7719,7 +7719,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2097;
+co->args[0] = _35cc1295;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7730,19 +7730,19 @@ return;
 }
 }
 
-void _35clofun3788(struct Cora* co) {
-Obj _35val2827 = co->args[1];
+void _35clofun2986(struct Cora* co) {
+Obj _35val2025 = co->args[1];
 Obj args = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj next = co->stack[co->base + 2];
-Obj _35reg2828 = primCons(_35val2827, Nil);
-Obj _35reg2829 = primCons(args, _35reg2828);
-Obj _35reg2830 = primCons(intern("lambda"), _35reg2829);
-Obj _35reg2831 = primCons(_35reg2830, frees);
-Obj _35reg2832 = primCons(intern("%closure"), _35reg2831);
+Obj _35reg2026 = primCons(_35val2025, Nil);
+Obj _35reg2027 = primCons(args, _35reg2026);
+Obj _35reg2028 = primCons(intern("lambda"), _35reg2027);
+Obj _35reg2029 = primCons(_35reg2028, frees);
+Obj _35reg2030 = primCons(intern("%closure"), _35reg2029);
 co->nargs = 2;
 co->args[0] = next;
-co->args[1] = _35reg2832;
+co->args[1] = _35reg2030;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7752,19 +7752,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3786(struct Cora* co) {
-Obj _35cc2098 = makeNative(_35clofun3787, 0, 0);
-Obj _35reg2785 = primIsCons(closureRef(co, 0));
-if (True == _35reg2785) {
-Obj _35reg2786 = primCar(closureRef(co, 0));
-Obj f = _35reg2786;
-Obj _35reg2787 = primCdr(closureRef(co, 0));
-Obj args = _35reg2787;
+void _35clofun2984(struct Cora* co) {
+Obj _35cc1296 = makeNative(_35clofun2985, 0, 0);
+Obj _35reg1983 = primIsCons(closureRef(co, 0));
+if (True == _35reg1983) {
+Obj _35reg1984 = primCar(closureRef(co, 0));
+Obj f = _35reg1984;
+Obj _35reg1985 = primCdr(closureRef(co, 0));
+Obj args = _35reg1985;
 Obj next = closureRef(co, 1);
-Obj _35reg2788 = primCons(f, args);
+Obj _35reg1986 = primCons(f, args);
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify-list"));
-co->args[1] = _35reg2788;
+co->args[1] = _35reg1986;
 co->args[2] = Nil;
 co->args[3] = next;
 if (nativeRequired(co->args[0]) == 3) {
@@ -7776,7 +7776,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2098;
+co->args[0] = _35cc1296;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7787,7 +7787,7 @@ return;
 }
 }
 
-void _35clofun3787(struct Cora* co) {
+void _35clofun2985(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -7800,23 +7800,23 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3779(struct Cora* co) {
+void _35clofun2977(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg2782 = primCons(x, Nil);
-Obj _35reg2783 = primCons(intern("return"), _35reg2782);
+Obj _35reg1980 = primCons(x, Nil);
+Obj _35reg1981 = primCons(intern("return"), _35reg1980);
 co->nargs = 2;
-co->args[1] = _35reg2783;
+co->args[1] = _35reg1981;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3764(struct Cora* co) {
-Obj _35p2083 = co->args[1];
-Obj _35p2084 = co->args[2];
-Obj _35cc2085 = makeNative(_35clofun3765, 0, 2, _35p2083, _35p2084);
-Obj __ = _35p2083;
-Obj x = _35p2084;
-pushCont(co, _35clofun3778, 2, x, _35cc2085);
+void _35clofun2962(struct Cora* co) {
+Obj _35p1281 = co->args[1];
+Obj _35p1282 = co->args[2];
+Obj _35cc1283 = makeNative(_35clofun2963, 0, 2, _35p1281, _35p1282);
+Obj __ = _35p1281;
+Obj x = _35p1282;
+pushCont(co, _35clofun2976, 2, x, _35cc1283);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.convert-protect?"));
 co->args[1] = x;
@@ -7829,18 +7829,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3778(struct Cora* co) {
-Obj _35val2780 = co->args[1];
+void _35clofun2976(struct Cora* co) {
+Obj _35val1978 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35cc2085 = co->stack[co->base + 1];
-if (True == _35val2780) {
+Obj _35cc1283 = co->stack[co->base + 1];
+if (True == _35val1978) {
 co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2085;
+co->args[0] = _35cc1283;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7851,13 +7851,13 @@ return;
 }
 }
 
-void _35clofun3765(struct Cora* co) {
-Obj _35cc2086 = makeNative(_35clofun3766, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2963(struct Cora* co) {
+Obj _35cc1284 = makeNative(_35clofun2964, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj _35reg2775 = primIsSymbol(var);
-if (True == _35reg2775) {
-pushCont(co, _35clofun3777, 1, var);
+Obj _35reg1973 = primIsSymbol(var);
+if (True == _35reg1973) {
+pushCont(co, _35clofun2975, 1, var);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.index"));
 co->args[1] = var;
@@ -7871,7 +7871,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2086;
+co->args[0] = _35cc1284;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7882,60 +7882,60 @@ return;
 }
 }
 
-void _35clofun3777(struct Cora* co) {
-Obj _35val2776 = co->args[1];
+void _35clofun2975(struct Cora* co) {
+Obj _35val1974 = co->args[1];
 Obj var = co->stack[co->base + 0];
-Obj pos = _35val2776;
-Obj _35reg2777 = primEQ(makeNumber(-1), pos);
-if (True == _35reg2777) {
+Obj pos = _35val1974;
+Obj _35reg1975 = primEQ(makeNumber(-1), pos);
+if (True == _35reg1975) {
 co->nargs = 2;
 co->args[1] = var;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2778 = primCons(pos, Nil);
-Obj _35reg2779 = primCons(intern("%closure-ref"), _35reg2778);
+Obj _35reg1976 = primCons(pos, Nil);
+Obj _35reg1977 = primCons(intern("%closure-ref"), _35reg1976);
 co->nargs = 2;
-co->args[1] = _35reg2779;
+co->args[1] = _35reg1977;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun3766(struct Cora* co) {
-Obj _35cc2087 = makeNative(_35clofun3767, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2964(struct Cora* co) {
+Obj _35cc1285 = makeNative(_35clofun2965, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2746 = primIsCons(closureRef(co, 1));
-if (True == _35reg2746) {
-Obj _35reg2747 = primCar(closureRef(co, 1));
-Obj _35reg2748 = primEQ(intern("lambda"), _35reg2747);
-if (True == _35reg2748) {
-Obj _35reg2749 = primCdr(closureRef(co, 1));
-Obj _35reg2750 = primIsCons(_35reg2749);
-if (True == _35reg2750) {
-Obj _35reg2751 = primCdr(closureRef(co, 1));
-Obj _35reg2752 = primCar(_35reg2751);
-Obj args = _35reg2752;
-Obj _35reg2753 = primCdr(closureRef(co, 1));
-Obj _35reg2754 = primCdr(_35reg2753);
-Obj _35reg2755 = primIsCons(_35reg2754);
-if (True == _35reg2755) {
-Obj _35reg2756 = primCdr(closureRef(co, 1));
-Obj _35reg2757 = primCdr(_35reg2756);
-Obj _35reg2758 = primCar(_35reg2757);
-Obj body = _35reg2758;
-Obj _35reg2759 = primCdr(closureRef(co, 1));
-Obj _35reg2760 = primCdr(_35reg2759);
-Obj _35reg2761 = primCdr(_35reg2760);
-Obj _35reg2762 = primEQ(Nil, _35reg2761);
-if (True == _35reg2762) {
-Obj _35reg2763 = primCons(body, Nil);
-Obj _35reg2764 = primCons(args, _35reg2763);
-Obj _35reg2765 = primCons(intern("lambda"), _35reg2764);
-pushCont(co, _35clofun3773, 3, body, args, fvs);
+Obj _35reg1944 = primIsCons(closureRef(co, 1));
+if (True == _35reg1944) {
+Obj _35reg1945 = primCar(closureRef(co, 1));
+Obj _35reg1946 = primEQ(intern("lambda"), _35reg1945);
+if (True == _35reg1946) {
+Obj _35reg1947 = primCdr(closureRef(co, 1));
+Obj _35reg1948 = primIsCons(_35reg1947);
+if (True == _35reg1948) {
+Obj _35reg1949 = primCdr(closureRef(co, 1));
+Obj _35reg1950 = primCar(_35reg1949);
+Obj args = _35reg1950;
+Obj _35reg1951 = primCdr(closureRef(co, 1));
+Obj _35reg1952 = primCdr(_35reg1951);
+Obj _35reg1953 = primIsCons(_35reg1952);
+if (True == _35reg1953) {
+Obj _35reg1954 = primCdr(closureRef(co, 1));
+Obj _35reg1955 = primCdr(_35reg1954);
+Obj _35reg1956 = primCar(_35reg1955);
+Obj body = _35reg1956;
+Obj _35reg1957 = primCdr(closureRef(co, 1));
+Obj _35reg1958 = primCdr(_35reg1957);
+Obj _35reg1959 = primCdr(_35reg1958);
+Obj _35reg1960 = primEQ(Nil, _35reg1959);
+if (True == _35reg1960) {
+Obj _35reg1961 = primCons(body, Nil);
+Obj _35reg1962 = primCons(args, _35reg1961);
+Obj _35reg1963 = primCons(intern("lambda"), _35reg1962);
+pushCont(co, _35clofun2971, 3, body, args, fvs);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
-co->args[1] = _35reg2765;
+co->args[1] = _35reg1963;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7945,7 +7945,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2087;
+co->args[0] = _35cc1285;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7956,7 +7956,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2087;
+co->args[0] = _35cc1285;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7967,7 +7967,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2087;
+co->args[0] = _35cc1285;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7978,7 +7978,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2087;
+co->args[0] = _35cc1285;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7989,7 +7989,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2087;
+co->args[0] = _35cc1285;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8000,13 +8000,13 @@ return;
 }
 }
 
-void _35clofun3773(struct Cora* co) {
-Obj _35val2766 = co->args[1];
+void _35clofun2971(struct Cora* co) {
+Obj _35val1964 = co->args[1];
 Obj body = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj fvs = co->stack[co->base + 2];
-Obj fvs1 = _35val2766;
-pushCont(co, _35clofun3774, 3, args, fvs, fvs1);
+Obj fvs1 = _35val1964;
+pushCont(co, _35clofun2972, 3, args, fvs, fvs1);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert"));
 co->args[1] = fvs1;
@@ -8020,15 +8020,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3774(struct Cora* co) {
-Obj _35val2767 = co->args[1];
+void _35clofun2972(struct Cora* co) {
+Obj _35val1965 = co->args[1];
 Obj args = co->stack[co->base + 0];
 Obj fvs = co->stack[co->base + 1];
 Obj fvs1 = co->stack[co->base + 2];
-Obj _35reg2768 = primCons(_35val2767, Nil);
-Obj _35reg2769 = primCons(args, _35reg2768);
-Obj _35reg2770 = primCons(intern("lambda"), _35reg2769);
-pushCont(co, _35clofun3775, 2, fvs1, _35reg2770);
+Obj _35reg1966 = primCons(_35val1965, Nil);
+Obj _35reg1967 = primCons(args, _35reg1966);
+Obj _35reg1968 = primCons(intern("lambda"), _35reg1967);
+pushCont(co, _35clofun2973, 2, fvs1, _35reg1968);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert"));
 co->args[1] = fvs;
@@ -8041,14 +8041,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3775(struct Cora* co) {
-Obj _35val2771 = co->args[1];
+void _35clofun2973(struct Cora* co) {
+Obj _35val1969 = co->args[1];
 Obj fvs1 = co->stack[co->base + 0];
-Obj _35reg2770 = co->stack[co->base + 1];
-pushCont(co, _35clofun3776, 1, _35reg2770);
+Obj _35reg1968 = co->stack[co->base + 1];
+pushCont(co, _35clofun2974, 1, _35reg1968);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val2771;
+co->args[1] = _35val1969;
 co->args[2] = fvs1;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -8059,56 +8059,56 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3776(struct Cora* co) {
-Obj _35val2772 = co->args[1];
-Obj _35reg2770 = co->stack[co->base + 0];
-Obj _35reg2773 = primCons(_35reg2770, _35val2772);
-Obj _35reg2774 = primCons(intern("%closure"), _35reg2773);
+void _35clofun2974(struct Cora* co) {
+Obj _35val1970 = co->args[1];
+Obj _35reg1968 = co->stack[co->base + 0];
+Obj _35reg1971 = primCons(_35reg1968, _35val1970);
+Obj _35reg1972 = primCons(intern("%closure"), _35reg1971);
 co->nargs = 2;
-co->args[1] = _35reg2774;
+co->args[1] = _35reg1972;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3767(struct Cora* co) {
-Obj _35cc2088 = makeNative(_35clofun3768, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2965(struct Cora* co) {
+Obj _35cc1286 = makeNative(_35clofun2966, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2714 = primIsCons(closureRef(co, 1));
-if (True == _35reg2714) {
-Obj _35reg2715 = primCar(closureRef(co, 1));
-Obj _35reg2716 = primEQ(intern("let"), _35reg2715);
-if (True == _35reg2716) {
-Obj _35reg2717 = primCdr(closureRef(co, 1));
-Obj _35reg2718 = primIsCons(_35reg2717);
-if (True == _35reg2718) {
-Obj _35reg2719 = primCdr(closureRef(co, 1));
-Obj _35reg2720 = primCar(_35reg2719);
-Obj a = _35reg2720;
-Obj _35reg2721 = primCdr(closureRef(co, 1));
-Obj _35reg2722 = primCdr(_35reg2721);
-Obj _35reg2723 = primIsCons(_35reg2722);
-if (True == _35reg2723) {
-Obj _35reg2724 = primCdr(closureRef(co, 1));
-Obj _35reg2725 = primCdr(_35reg2724);
-Obj _35reg2726 = primCar(_35reg2725);
-Obj b = _35reg2726;
-Obj _35reg2727 = primCdr(closureRef(co, 1));
-Obj _35reg2728 = primCdr(_35reg2727);
-Obj _35reg2729 = primCdr(_35reg2728);
-Obj _35reg2730 = primIsCons(_35reg2729);
-if (True == _35reg2730) {
-Obj _35reg2731 = primCdr(closureRef(co, 1));
-Obj _35reg2732 = primCdr(_35reg2731);
-Obj _35reg2733 = primCdr(_35reg2732);
-Obj _35reg2734 = primCar(_35reg2733);
-Obj c = _35reg2734;
-Obj _35reg2735 = primCdr(closureRef(co, 1));
-Obj _35reg2736 = primCdr(_35reg2735);
-Obj _35reg2737 = primCdr(_35reg2736);
-Obj _35reg2738 = primCdr(_35reg2737);
-Obj _35reg2739 = primEQ(Nil, _35reg2738);
-if (True == _35reg2739) {
-pushCont(co, _35clofun3771, 3, fvs, c, a);
+Obj _35reg1912 = primIsCons(closureRef(co, 1));
+if (True == _35reg1912) {
+Obj _35reg1913 = primCar(closureRef(co, 1));
+Obj _35reg1914 = primEQ(intern("let"), _35reg1913);
+if (True == _35reg1914) {
+Obj _35reg1915 = primCdr(closureRef(co, 1));
+Obj _35reg1916 = primIsCons(_35reg1915);
+if (True == _35reg1916) {
+Obj _35reg1917 = primCdr(closureRef(co, 1));
+Obj _35reg1918 = primCar(_35reg1917);
+Obj a = _35reg1918;
+Obj _35reg1919 = primCdr(closureRef(co, 1));
+Obj _35reg1920 = primCdr(_35reg1919);
+Obj _35reg1921 = primIsCons(_35reg1920);
+if (True == _35reg1921) {
+Obj _35reg1922 = primCdr(closureRef(co, 1));
+Obj _35reg1923 = primCdr(_35reg1922);
+Obj _35reg1924 = primCar(_35reg1923);
+Obj b = _35reg1924;
+Obj _35reg1925 = primCdr(closureRef(co, 1));
+Obj _35reg1926 = primCdr(_35reg1925);
+Obj _35reg1927 = primCdr(_35reg1926);
+Obj _35reg1928 = primIsCons(_35reg1927);
+if (True == _35reg1928) {
+Obj _35reg1929 = primCdr(closureRef(co, 1));
+Obj _35reg1930 = primCdr(_35reg1929);
+Obj _35reg1931 = primCdr(_35reg1930);
+Obj _35reg1932 = primCar(_35reg1931);
+Obj c = _35reg1932;
+Obj _35reg1933 = primCdr(closureRef(co, 1));
+Obj _35reg1934 = primCdr(_35reg1933);
+Obj _35reg1935 = primCdr(_35reg1934);
+Obj _35reg1936 = primCdr(_35reg1935);
+Obj _35reg1937 = primEQ(Nil, _35reg1936);
+if (True == _35reg1937) {
+pushCont(co, _35clofun2969, 3, fvs, c, a);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert"));
 co->args[1] = fvs;
@@ -8122,7 +8122,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2088;
+co->args[0] = _35cc1286;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8133,7 +8133,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2088;
+co->args[0] = _35cc1286;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8144,7 +8144,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2088;
+co->args[0] = _35cc1286;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8155,7 +8155,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2088;
+co->args[0] = _35cc1286;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8166,7 +8166,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2088;
+co->args[0] = _35cc1286;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8177,7 +8177,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2088;
+co->args[0] = _35cc1286;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8188,12 +8188,12 @@ return;
 }
 }
 
-void _35clofun3771(struct Cora* co) {
-Obj _35val2740 = co->args[1];
+void _35clofun2969(struct Cora* co) {
+Obj _35val1938 = co->args[1];
 Obj fvs = co->stack[co->base + 0];
 Obj c = co->stack[co->base + 1];
 Obj a = co->stack[co->base + 2];
-pushCont(co, _35clofun3772, 2, _35val2740, a);
+pushCont(co, _35clofun2970, 2, _35val1938, a);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert"));
 co->args[1] = fvs;
@@ -8207,30 +8207,30 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3772(struct Cora* co) {
-Obj _35val2741 = co->args[1];
-Obj _35val2740 = co->stack[co->base + 0];
+void _35clofun2970(struct Cora* co) {
+Obj _35val1939 = co->args[1];
+Obj _35val1938 = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
-Obj _35reg2742 = primCons(_35val2741, Nil);
-Obj _35reg2743 = primCons(_35val2740, _35reg2742);
-Obj _35reg2744 = primCons(a, _35reg2743);
-Obj _35reg2745 = primCons(intern("let"), _35reg2744);
+Obj _35reg1940 = primCons(_35val1939, Nil);
+Obj _35reg1941 = primCons(_35val1938, _35reg1940);
+Obj _35reg1942 = primCons(a, _35reg1941);
+Obj _35reg1943 = primCons(intern("let"), _35reg1942);
 co->nargs = 2;
-co->args[1] = _35reg2745;
+co->args[1] = _35reg1943;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3768(struct Cora* co) {
-Obj _35cc2089 = makeNative(_35clofun3769, 0, 0);
+void _35clofun2966(struct Cora* co) {
+Obj _35cc1287 = makeNative(_35clofun2967, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj _35reg2709 = primIsCons(closureRef(co, 1));
-if (True == _35reg2709) {
-Obj _35reg2710 = primCar(closureRef(co, 1));
-Obj f = _35reg2710;
-Obj _35reg2711 = primCdr(closureRef(co, 1));
-Obj args = _35reg2711;
-pushCont(co, _35clofun3770, 2, f, args);
+Obj _35reg1907 = primIsCons(closureRef(co, 1));
+if (True == _35reg1907) {
+Obj _35reg1908 = primCar(closureRef(co, 1));
+Obj f = _35reg1908;
+Obj _35reg1909 = primCdr(closureRef(co, 1));
+Obj args = _35reg1909;
+pushCont(co, _35clofun2968, 2, f, args);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert"));
 co->args[1] = fvs;
@@ -8243,7 +8243,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2089;
+co->args[0] = _35cc1287;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8254,15 +8254,15 @@ return;
 }
 }
 
-void _35clofun3770(struct Cora* co) {
-Obj _35val2712 = co->args[1];
+void _35clofun2968(struct Cora* co) {
+Obj _35val1910 = co->args[1];
 Obj f = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
-Obj _35reg2713 = primCons(f, args);
+Obj _35reg1911 = primCons(f, args);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val2712;
-co->args[2] = _35reg2713;
+co->args[1] = _35val1910;
+co->args[2] = _35reg1911;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8272,7 +8272,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3769(struct Cora* co) {
+void _35clofun2967(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -8285,11 +8285,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3741(struct Cora* co) {
-Obj _35p2070 = co->args[1];
-Obj _35cc2071 = makeNative(_35clofun3742, 0, 1, _35p2070);
-Obj x = _35p2070;
-pushCont(co, _35clofun3763, 1, _35cc2071);
+void _35clofun2939(struct Cora* co) {
+Obj _35p1268 = co->args[1];
+Obj _35cc1269 = makeNative(_35clofun2940, 0, 1, _35p1268);
+Obj x = _35p1268;
+pushCont(co, _35clofun2961, 1, _35cc1269);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.convert-protect?"));
 co->args[1] = x;
@@ -8302,17 +8302,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3763(struct Cora* co) {
-Obj _35val2707 = co->args[1];
-Obj _35cc2071 = co->stack[co->base + 0];
-if (True == _35val2707) {
+void _35clofun2961(struct Cora* co) {
+Obj _35val1905 = co->args[1];
+Obj _35cc1269 = co->stack[co->base + 0];
+if (True == _35val1905) {
 co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2071;
+co->args[0] = _35cc1269;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8323,19 +8323,19 @@ return;
 }
 }
 
-void _35clofun3742(struct Cora* co) {
-Obj _35cc2072 = makeNative(_35clofun3743, 0, 1, closureRef(co, 0));
+void _35clofun2940(struct Cora* co) {
+Obj _35cc1270 = makeNative(_35clofun2941, 0, 1, closureRef(co, 0));
 Obj x = closureRef(co, 0);
-Obj _35reg2705 = primIsSymbol(x);
-if (True == _35reg2705) {
-Obj _35reg2706 = primCons(x, Nil);
+Obj _35reg1903 = primIsSymbol(x);
+if (True == _35reg1903) {
+Obj _35reg1904 = primCons(x, Nil);
 co->nargs = 2;
-co->args[1] = _35reg2706;
+co->args[1] = _35reg1904;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2072;
+co->args[0] = _35cc1270;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8346,33 +8346,33 @@ return;
 }
 }
 
-void _35clofun3743(struct Cora* co) {
-Obj _35cc2073 = makeNative(_35clofun3744, 0, 1, closureRef(co, 0));
-Obj _35reg2687 = primIsCons(closureRef(co, 0));
-if (True == _35reg2687) {
-Obj _35reg2688 = primCar(closureRef(co, 0));
-Obj _35reg2689 = primEQ(intern("lambda"), _35reg2688);
-if (True == _35reg2689) {
-Obj _35reg2690 = primCdr(closureRef(co, 0));
-Obj _35reg2691 = primIsCons(_35reg2690);
-if (True == _35reg2691) {
-Obj _35reg2692 = primCdr(closureRef(co, 0));
-Obj _35reg2693 = primCar(_35reg2692);
-Obj args = _35reg2693;
-Obj _35reg2694 = primCdr(closureRef(co, 0));
-Obj _35reg2695 = primCdr(_35reg2694);
-Obj _35reg2696 = primIsCons(_35reg2695);
-if (True == _35reg2696) {
-Obj _35reg2697 = primCdr(closureRef(co, 0));
-Obj _35reg2698 = primCdr(_35reg2697);
-Obj _35reg2699 = primCar(_35reg2698);
-Obj body = _35reg2699;
-Obj _35reg2700 = primCdr(closureRef(co, 0));
-Obj _35reg2701 = primCdr(_35reg2700);
-Obj _35reg2702 = primCdr(_35reg2701);
-Obj _35reg2703 = primEQ(Nil, _35reg2702);
-if (True == _35reg2703) {
-pushCont(co, _35clofun3762, 1, args);
+void _35clofun2941(struct Cora* co) {
+Obj _35cc1271 = makeNative(_35clofun2942, 0, 1, closureRef(co, 0));
+Obj _35reg1885 = primIsCons(closureRef(co, 0));
+if (True == _35reg1885) {
+Obj _35reg1886 = primCar(closureRef(co, 0));
+Obj _35reg1887 = primEQ(intern("lambda"), _35reg1886);
+if (True == _35reg1887) {
+Obj _35reg1888 = primCdr(closureRef(co, 0));
+Obj _35reg1889 = primIsCons(_35reg1888);
+if (True == _35reg1889) {
+Obj _35reg1890 = primCdr(closureRef(co, 0));
+Obj _35reg1891 = primCar(_35reg1890);
+Obj args = _35reg1891;
+Obj _35reg1892 = primCdr(closureRef(co, 0));
+Obj _35reg1893 = primCdr(_35reg1892);
+Obj _35reg1894 = primIsCons(_35reg1893);
+if (True == _35reg1894) {
+Obj _35reg1895 = primCdr(closureRef(co, 0));
+Obj _35reg1896 = primCdr(_35reg1895);
+Obj _35reg1897 = primCar(_35reg1896);
+Obj body = _35reg1897;
+Obj _35reg1898 = primCdr(closureRef(co, 0));
+Obj _35reg1899 = primCdr(_35reg1898);
+Obj _35reg1900 = primCdr(_35reg1899);
+Obj _35reg1901 = primEQ(Nil, _35reg1900);
+if (True == _35reg1901) {
+pushCont(co, _35clofun2960, 1, args);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = body;
@@ -8385,7 +8385,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2073;
+co->args[0] = _35cc1271;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8396,7 +8396,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2073;
+co->args[0] = _35cc1271;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8407,7 +8407,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2073;
+co->args[0] = _35cc1271;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8418,7 +8418,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2073;
+co->args[0] = _35cc1271;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8429,7 +8429,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2073;
+co->args[0] = _35cc1271;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8440,12 +8440,12 @@ return;
 }
 }
 
-void _35clofun3762(struct Cora* co) {
-Obj _35val2704 = co->args[1];
+void _35clofun2960(struct Cora* co) {
+Obj _35val1902 = co->args[1];
 Obj args = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
-co->args[1] = _35val2704;
+co->args[1] = _35val1902;
 co->args[2] = args;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -8456,51 +8456,51 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3744(struct Cora* co) {
-Obj _35cc2074 = makeNative(_35clofun3745, 0, 1, closureRef(co, 0));
-Obj _35reg2657 = primIsCons(closureRef(co, 0));
-if (True == _35reg2657) {
-Obj _35reg2658 = primCar(closureRef(co, 0));
-Obj _35reg2659 = primEQ(intern("if"), _35reg2658);
-if (True == _35reg2659) {
-Obj _35reg2660 = primCdr(closureRef(co, 0));
-Obj _35reg2661 = primIsCons(_35reg2660);
-if (True == _35reg2661) {
-Obj _35reg2662 = primCdr(closureRef(co, 0));
-Obj _35reg2663 = primCar(_35reg2662);
-Obj x = _35reg2663;
-Obj _35reg2664 = primCdr(closureRef(co, 0));
-Obj _35reg2665 = primCdr(_35reg2664);
-Obj _35reg2666 = primIsCons(_35reg2665);
-if (True == _35reg2666) {
-Obj _35reg2667 = primCdr(closureRef(co, 0));
-Obj _35reg2668 = primCdr(_35reg2667);
-Obj _35reg2669 = primCar(_35reg2668);
-Obj y = _35reg2669;
-Obj _35reg2670 = primCdr(closureRef(co, 0));
-Obj _35reg2671 = primCdr(_35reg2670);
-Obj _35reg2672 = primCdr(_35reg2671);
-Obj _35reg2673 = primIsCons(_35reg2672);
-if (True == _35reg2673) {
-Obj _35reg2674 = primCdr(closureRef(co, 0));
-Obj _35reg2675 = primCdr(_35reg2674);
-Obj _35reg2676 = primCdr(_35reg2675);
-Obj _35reg2677 = primCar(_35reg2676);
-Obj z = _35reg2677;
-Obj _35reg2678 = primCdr(closureRef(co, 0));
-Obj _35reg2679 = primCdr(_35reg2678);
-Obj _35reg2680 = primCdr(_35reg2679);
-Obj _35reg2681 = primCdr(_35reg2680);
-Obj _35reg2682 = primEQ(Nil, _35reg2681);
-if (True == _35reg2682) {
-Obj _35reg2683 = primCons(z, Nil);
-Obj _35reg2684 = primCons(y, _35reg2683);
-Obj _35reg2685 = primCons(x, _35reg2684);
-pushCont(co, _35clofun3761, 0);
+void _35clofun2942(struct Cora* co) {
+Obj _35cc1272 = makeNative(_35clofun2943, 0, 1, closureRef(co, 0));
+Obj _35reg1855 = primIsCons(closureRef(co, 0));
+if (True == _35reg1855) {
+Obj _35reg1856 = primCar(closureRef(co, 0));
+Obj _35reg1857 = primEQ(intern("if"), _35reg1856);
+if (True == _35reg1857) {
+Obj _35reg1858 = primCdr(closureRef(co, 0));
+Obj _35reg1859 = primIsCons(_35reg1858);
+if (True == _35reg1859) {
+Obj _35reg1860 = primCdr(closureRef(co, 0));
+Obj _35reg1861 = primCar(_35reg1860);
+Obj x = _35reg1861;
+Obj _35reg1862 = primCdr(closureRef(co, 0));
+Obj _35reg1863 = primCdr(_35reg1862);
+Obj _35reg1864 = primIsCons(_35reg1863);
+if (True == _35reg1864) {
+Obj _35reg1865 = primCdr(closureRef(co, 0));
+Obj _35reg1866 = primCdr(_35reg1865);
+Obj _35reg1867 = primCar(_35reg1866);
+Obj y = _35reg1867;
+Obj _35reg1868 = primCdr(closureRef(co, 0));
+Obj _35reg1869 = primCdr(_35reg1868);
+Obj _35reg1870 = primCdr(_35reg1869);
+Obj _35reg1871 = primIsCons(_35reg1870);
+if (True == _35reg1871) {
+Obj _35reg1872 = primCdr(closureRef(co, 0));
+Obj _35reg1873 = primCdr(_35reg1872);
+Obj _35reg1874 = primCdr(_35reg1873);
+Obj _35reg1875 = primCar(_35reg1874);
+Obj z = _35reg1875;
+Obj _35reg1876 = primCdr(closureRef(co, 0));
+Obj _35reg1877 = primCdr(_35reg1876);
+Obj _35reg1878 = primCdr(_35reg1877);
+Obj _35reg1879 = primCdr(_35reg1878);
+Obj _35reg1880 = primEQ(Nil, _35reg1879);
+if (True == _35reg1880) {
+Obj _35reg1881 = primCons(z, Nil);
+Obj _35reg1882 = primCons(y, _35reg1881);
+Obj _35reg1883 = primCons(x, _35reg1882);
+pushCont(co, _35clofun2959, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.free-vars"));
-co->args[2] = _35reg2685;
+co->args[2] = _35reg1883;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8510,7 +8510,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2074;
+co->args[0] = _35cc1272;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8521,7 +8521,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2074;
+co->args[0] = _35cc1272;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8532,7 +8532,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2074;
+co->args[0] = _35cc1272;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8543,7 +8543,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2074;
+co->args[0] = _35cc1272;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8554,7 +8554,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2074;
+co->args[0] = _35cc1272;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8565,7 +8565,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2074;
+co->args[0] = _35cc1272;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8576,13 +8576,13 @@ return;
 }
 }
 
-void _35clofun3761(struct Cora* co) {
-Obj _35val2686 = co->args[1];
+void _35clofun2959(struct Cora* co) {
+Obj _35val1884 = co->args[1];
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.foldl"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.union"));
 co->args[2] = Nil;
-co->args[3] = _35val2686;
+co->args[3] = _35val1884;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8592,39 +8592,39 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3745(struct Cora* co) {
-Obj _35cc2075 = makeNative(_35clofun3746, 0, 1, closureRef(co, 0));
-Obj _35reg2637 = primIsCons(closureRef(co, 0));
-if (True == _35reg2637) {
-Obj _35reg2638 = primCar(closureRef(co, 0));
-Obj _35reg2639 = primEQ(intern("do"), _35reg2638);
-if (True == _35reg2639) {
-Obj _35reg2640 = primCdr(closureRef(co, 0));
-Obj _35reg2641 = primIsCons(_35reg2640);
-if (True == _35reg2641) {
-Obj _35reg2642 = primCdr(closureRef(co, 0));
-Obj _35reg2643 = primCar(_35reg2642);
-Obj x = _35reg2643;
-Obj _35reg2644 = primCdr(closureRef(co, 0));
-Obj _35reg2645 = primCdr(_35reg2644);
-Obj _35reg2646 = primIsCons(_35reg2645);
-if (True == _35reg2646) {
-Obj _35reg2647 = primCdr(closureRef(co, 0));
-Obj _35reg2648 = primCdr(_35reg2647);
-Obj _35reg2649 = primCar(_35reg2648);
-Obj y = _35reg2649;
-Obj _35reg2650 = primCdr(closureRef(co, 0));
-Obj _35reg2651 = primCdr(_35reg2650);
-Obj _35reg2652 = primCdr(_35reg2651);
-Obj _35reg2653 = primEQ(Nil, _35reg2652);
-if (True == _35reg2653) {
-Obj _35reg2654 = primCons(y, Nil);
-Obj _35reg2655 = primCons(x, _35reg2654);
-pushCont(co, _35clofun3760, 0);
+void _35clofun2943(struct Cora* co) {
+Obj _35cc1273 = makeNative(_35clofun2944, 0, 1, closureRef(co, 0));
+Obj _35reg1835 = primIsCons(closureRef(co, 0));
+if (True == _35reg1835) {
+Obj _35reg1836 = primCar(closureRef(co, 0));
+Obj _35reg1837 = primEQ(intern("do"), _35reg1836);
+if (True == _35reg1837) {
+Obj _35reg1838 = primCdr(closureRef(co, 0));
+Obj _35reg1839 = primIsCons(_35reg1838);
+if (True == _35reg1839) {
+Obj _35reg1840 = primCdr(closureRef(co, 0));
+Obj _35reg1841 = primCar(_35reg1840);
+Obj x = _35reg1841;
+Obj _35reg1842 = primCdr(closureRef(co, 0));
+Obj _35reg1843 = primCdr(_35reg1842);
+Obj _35reg1844 = primIsCons(_35reg1843);
+if (True == _35reg1844) {
+Obj _35reg1845 = primCdr(closureRef(co, 0));
+Obj _35reg1846 = primCdr(_35reg1845);
+Obj _35reg1847 = primCar(_35reg1846);
+Obj y = _35reg1847;
+Obj _35reg1848 = primCdr(closureRef(co, 0));
+Obj _35reg1849 = primCdr(_35reg1848);
+Obj _35reg1850 = primCdr(_35reg1849);
+Obj _35reg1851 = primEQ(Nil, _35reg1850);
+if (True == _35reg1851) {
+Obj _35reg1852 = primCons(y, Nil);
+Obj _35reg1853 = primCons(x, _35reg1852);
+pushCont(co, _35clofun2958, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.free-vars"));
-co->args[2] = _35reg2655;
+co->args[2] = _35reg1853;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8634,7 +8634,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2075;
+co->args[0] = _35cc1273;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8645,7 +8645,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2075;
+co->args[0] = _35cc1273;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8656,7 +8656,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2075;
+co->args[0] = _35cc1273;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8667,7 +8667,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2075;
+co->args[0] = _35cc1273;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8678,7 +8678,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2075;
+co->args[0] = _35cc1273;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8689,13 +8689,13 @@ return;
 }
 }
 
-void _35clofun3760(struct Cora* co) {
-Obj _35val2656 = co->args[1];
+void _35clofun2958(struct Cora* co) {
+Obj _35val1854 = co->args[1];
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.foldl"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.union"));
 co->args[2] = Nil;
-co->args[3] = _35val2656;
+co->args[3] = _35val1854;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8705,44 +8705,44 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3746(struct Cora* co) {
-Obj _35cc2076 = makeNative(_35clofun3747, 0, 1, closureRef(co, 0));
-Obj _35reg2607 = primIsCons(closureRef(co, 0));
-if (True == _35reg2607) {
-Obj _35reg2608 = primCar(closureRef(co, 0));
-Obj _35reg2609 = primEQ(intern("let"), _35reg2608);
-if (True == _35reg2609) {
-Obj _35reg2610 = primCdr(closureRef(co, 0));
-Obj _35reg2611 = primIsCons(_35reg2610);
-if (True == _35reg2611) {
-Obj _35reg2612 = primCdr(closureRef(co, 0));
-Obj _35reg2613 = primCar(_35reg2612);
-Obj a = _35reg2613;
-Obj _35reg2614 = primCdr(closureRef(co, 0));
-Obj _35reg2615 = primCdr(_35reg2614);
-Obj _35reg2616 = primIsCons(_35reg2615);
-if (True == _35reg2616) {
-Obj _35reg2617 = primCdr(closureRef(co, 0));
-Obj _35reg2618 = primCdr(_35reg2617);
-Obj _35reg2619 = primCar(_35reg2618);
-Obj b = _35reg2619;
-Obj _35reg2620 = primCdr(closureRef(co, 0));
-Obj _35reg2621 = primCdr(_35reg2620);
-Obj _35reg2622 = primCdr(_35reg2621);
-Obj _35reg2623 = primIsCons(_35reg2622);
-if (True == _35reg2623) {
-Obj _35reg2624 = primCdr(closureRef(co, 0));
-Obj _35reg2625 = primCdr(_35reg2624);
-Obj _35reg2626 = primCdr(_35reg2625);
-Obj _35reg2627 = primCar(_35reg2626);
-Obj c = _35reg2627;
-Obj _35reg2628 = primCdr(closureRef(co, 0));
-Obj _35reg2629 = primCdr(_35reg2628);
-Obj _35reg2630 = primCdr(_35reg2629);
-Obj _35reg2631 = primCdr(_35reg2630);
-Obj _35reg2632 = primEQ(Nil, _35reg2631);
-if (True == _35reg2632) {
-pushCont(co, _35clofun3757, 2, c, a);
+void _35clofun2944(struct Cora* co) {
+Obj _35cc1274 = makeNative(_35clofun2945, 0, 1, closureRef(co, 0));
+Obj _35reg1805 = primIsCons(closureRef(co, 0));
+if (True == _35reg1805) {
+Obj _35reg1806 = primCar(closureRef(co, 0));
+Obj _35reg1807 = primEQ(intern("let"), _35reg1806);
+if (True == _35reg1807) {
+Obj _35reg1808 = primCdr(closureRef(co, 0));
+Obj _35reg1809 = primIsCons(_35reg1808);
+if (True == _35reg1809) {
+Obj _35reg1810 = primCdr(closureRef(co, 0));
+Obj _35reg1811 = primCar(_35reg1810);
+Obj a = _35reg1811;
+Obj _35reg1812 = primCdr(closureRef(co, 0));
+Obj _35reg1813 = primCdr(_35reg1812);
+Obj _35reg1814 = primIsCons(_35reg1813);
+if (True == _35reg1814) {
+Obj _35reg1815 = primCdr(closureRef(co, 0));
+Obj _35reg1816 = primCdr(_35reg1815);
+Obj _35reg1817 = primCar(_35reg1816);
+Obj b = _35reg1817;
+Obj _35reg1818 = primCdr(closureRef(co, 0));
+Obj _35reg1819 = primCdr(_35reg1818);
+Obj _35reg1820 = primCdr(_35reg1819);
+Obj _35reg1821 = primIsCons(_35reg1820);
+if (True == _35reg1821) {
+Obj _35reg1822 = primCdr(closureRef(co, 0));
+Obj _35reg1823 = primCdr(_35reg1822);
+Obj _35reg1824 = primCdr(_35reg1823);
+Obj _35reg1825 = primCar(_35reg1824);
+Obj c = _35reg1825;
+Obj _35reg1826 = primCdr(closureRef(co, 0));
+Obj _35reg1827 = primCdr(_35reg1826);
+Obj _35reg1828 = primCdr(_35reg1827);
+Obj _35reg1829 = primCdr(_35reg1828);
+Obj _35reg1830 = primEQ(Nil, _35reg1829);
+if (True == _35reg1830) {
+pushCont(co, _35clofun2955, 2, c, a);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = b;
@@ -8755,7 +8755,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2076;
+co->args[0] = _35cc1274;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8766,7 +8766,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2076;
+co->args[0] = _35cc1274;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8777,7 +8777,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2076;
+co->args[0] = _35cc1274;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8788,7 +8788,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2076;
+co->args[0] = _35cc1274;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8799,7 +8799,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2076;
+co->args[0] = _35cc1274;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8810,7 +8810,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2076;
+co->args[0] = _35cc1274;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8821,11 +8821,11 @@ return;
 }
 }
 
-void _35clofun3757(struct Cora* co) {
-Obj _35val2633 = co->args[1];
+void _35clofun2955(struct Cora* co) {
+Obj _35val1831 = co->args[1];
 Obj c = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
-pushCont(co, _35clofun3758, 2, a, _35val2633);
+pushCont(co, _35clofun2956, 2, a, _35val1831);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = c;
@@ -8838,16 +8838,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3758(struct Cora* co) {
-Obj _35val2634 = co->args[1];
+void _35clofun2956(struct Cora* co) {
+Obj _35val1832 = co->args[1];
 Obj a = co->stack[co->base + 0];
-Obj _35val2633 = co->stack[co->base + 1];
-Obj _35reg2635 = primCons(a, Nil);
-pushCont(co, _35clofun3759, 1, _35val2633);
+Obj _35val1831 = co->stack[co->base + 1];
+Obj _35reg1833 = primCons(a, Nil);
+pushCont(co, _35clofun2957, 1, _35val1831);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
-co->args[1] = _35val2634;
-co->args[2] = _35reg2635;
+co->args[1] = _35val1832;
+co->args[2] = _35reg1833;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8857,13 +8857,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3759(struct Cora* co) {
-Obj _35val2636 = co->args[1];
-Obj _35val2633 = co->stack[co->base + 0];
+void _35clofun2957(struct Cora* co) {
+Obj _35val1834 = co->args[1];
+Obj _35val1831 = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.union"));
-co->args[1] = _35val2633;
-co->args[2] = _35val2636;
+co->args[1] = _35val1831;
+co->args[2] = _35val1834;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8873,26 +8873,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3747(struct Cora* co) {
-Obj _35cc2077 = makeNative(_35clofun3748, 0, 1, closureRef(co, 0));
-Obj _35reg2597 = primIsCons(closureRef(co, 0));
-if (True == _35reg2597) {
-Obj _35reg2598 = primCar(closureRef(co, 0));
-Obj _35reg2599 = primEQ(intern("%closure"), _35reg2598);
-if (True == _35reg2599) {
-Obj _35reg2600 = primCdr(closureRef(co, 0));
-Obj _35reg2601 = primIsCons(_35reg2600);
-if (True == _35reg2601) {
-Obj _35reg2602 = primCdr(closureRef(co, 0));
-Obj _35reg2603 = primCar(_35reg2602);
-Obj lam = _35reg2603;
-Obj _35reg2604 = primCdr(closureRef(co, 0));
-Obj _35reg2605 = primCdr(_35reg2604);
-Obj more = _35reg2605;
-Obj _35reg2606 = primCons(lam, more);
+void _35clofun2945(struct Cora* co) {
+Obj _35cc1275 = makeNative(_35clofun2946, 0, 1, closureRef(co, 0));
+Obj _35reg1795 = primIsCons(closureRef(co, 0));
+if (True == _35reg1795) {
+Obj _35reg1796 = primCar(closureRef(co, 0));
+Obj _35reg1797 = primEQ(intern("%closure"), _35reg1796);
+if (True == _35reg1797) {
+Obj _35reg1798 = primCdr(closureRef(co, 0));
+Obj _35reg1799 = primIsCons(_35reg1798);
+if (True == _35reg1799) {
+Obj _35reg1800 = primCdr(closureRef(co, 0));
+Obj _35reg1801 = primCar(_35reg1800);
+Obj lam = _35reg1801;
+Obj _35reg1802 = primCdr(closureRef(co, 0));
+Obj _35reg1803 = primCdr(_35reg1802);
+Obj more = _35reg1803;
+Obj _35reg1804 = primCons(lam, more);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
-co->args[1] = _35reg2606;
+co->args[1] = _35reg1804;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8902,7 +8902,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2077;
+co->args[0] = _35cc1275;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8913,7 +8913,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2077;
+co->args[0] = _35cc1275;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8924,7 +8924,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2077;
+co->args[0] = _35cc1275;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8935,23 +8935,23 @@ return;
 }
 }
 
-void _35clofun3748(struct Cora* co) {
-Obj _35cc2078 = makeNative(_35clofun3749, 0, 1, closureRef(co, 0));
-Obj _35reg2587 = primIsCons(closureRef(co, 0));
-if (True == _35reg2587) {
-Obj _35reg2588 = primCar(closureRef(co, 0));
-Obj _35reg2589 = primEQ(intern("return"), _35reg2588);
-if (True == _35reg2589) {
-Obj _35reg2590 = primCdr(closureRef(co, 0));
-Obj _35reg2591 = primIsCons(_35reg2590);
-if (True == _35reg2591) {
-Obj _35reg2592 = primCdr(closureRef(co, 0));
-Obj _35reg2593 = primCar(_35reg2592);
-Obj x = _35reg2593;
-Obj _35reg2594 = primCdr(closureRef(co, 0));
-Obj _35reg2595 = primCdr(_35reg2594);
-Obj _35reg2596 = primEQ(Nil, _35reg2595);
-if (True == _35reg2596) {
+void _35clofun2946(struct Cora* co) {
+Obj _35cc1276 = makeNative(_35clofun2947, 0, 1, closureRef(co, 0));
+Obj _35reg1785 = primIsCons(closureRef(co, 0));
+if (True == _35reg1785) {
+Obj _35reg1786 = primCar(closureRef(co, 0));
+Obj _35reg1787 = primEQ(intern("return"), _35reg1786);
+if (True == _35reg1787) {
+Obj _35reg1788 = primCdr(closureRef(co, 0));
+Obj _35reg1789 = primIsCons(_35reg1788);
+if (True == _35reg1789) {
+Obj _35reg1790 = primCdr(closureRef(co, 0));
+Obj _35reg1791 = primCar(_35reg1790);
+Obj x = _35reg1791;
+Obj _35reg1792 = primCdr(closureRef(co, 0));
+Obj _35reg1793 = primCdr(_35reg1792);
+Obj _35reg1794 = primEQ(Nil, _35reg1793);
+if (True == _35reg1794) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = x;
@@ -8964,7 +8964,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2078;
+co->args[0] = _35cc1276;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8975,7 +8975,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2078;
+co->args[0] = _35cc1276;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8986,7 +8986,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2078;
+co->args[0] = _35cc1276;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8997,7 +8997,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2078;
+co->args[0] = _35cc1276;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9008,39 +9008,39 @@ return;
 }
 }
 
-void _35clofun3749(struct Cora* co) {
-Obj _35cc2079 = makeNative(_35clofun3750, 0, 1, closureRef(co, 0));
-Obj _35reg2567 = primIsCons(closureRef(co, 0));
-if (True == _35reg2567) {
-Obj _35reg2568 = primCar(closureRef(co, 0));
-Obj _35reg2569 = primEQ(intern("call"), _35reg2568);
-if (True == _35reg2569) {
-Obj _35reg2570 = primCdr(closureRef(co, 0));
-Obj _35reg2571 = primIsCons(_35reg2570);
-if (True == _35reg2571) {
-Obj _35reg2572 = primCdr(closureRef(co, 0));
-Obj _35reg2573 = primCar(_35reg2572);
-Obj exp = _35reg2573;
-Obj _35reg2574 = primCdr(closureRef(co, 0));
-Obj _35reg2575 = primCdr(_35reg2574);
-Obj _35reg2576 = primIsCons(_35reg2575);
-if (True == _35reg2576) {
-Obj _35reg2577 = primCdr(closureRef(co, 0));
-Obj _35reg2578 = primCdr(_35reg2577);
-Obj _35reg2579 = primCar(_35reg2578);
-Obj cont = _35reg2579;
-Obj _35reg2580 = primCdr(closureRef(co, 0));
-Obj _35reg2581 = primCdr(_35reg2580);
-Obj _35reg2582 = primCdr(_35reg2581);
-Obj _35reg2583 = primEQ(Nil, _35reg2582);
-if (True == _35reg2583) {
-Obj _35reg2584 = primCons(cont, Nil);
-Obj _35reg2585 = primCons(exp, _35reg2584);
-pushCont(co, _35clofun3756, 0);
+void _35clofun2947(struct Cora* co) {
+Obj _35cc1277 = makeNative(_35clofun2948, 0, 1, closureRef(co, 0));
+Obj _35reg1765 = primIsCons(closureRef(co, 0));
+if (True == _35reg1765) {
+Obj _35reg1766 = primCar(closureRef(co, 0));
+Obj _35reg1767 = primEQ(intern("call"), _35reg1766);
+if (True == _35reg1767) {
+Obj _35reg1768 = primCdr(closureRef(co, 0));
+Obj _35reg1769 = primIsCons(_35reg1768);
+if (True == _35reg1769) {
+Obj _35reg1770 = primCdr(closureRef(co, 0));
+Obj _35reg1771 = primCar(_35reg1770);
+Obj exp = _35reg1771;
+Obj _35reg1772 = primCdr(closureRef(co, 0));
+Obj _35reg1773 = primCdr(_35reg1772);
+Obj _35reg1774 = primIsCons(_35reg1773);
+if (True == _35reg1774) {
+Obj _35reg1775 = primCdr(closureRef(co, 0));
+Obj _35reg1776 = primCdr(_35reg1775);
+Obj _35reg1777 = primCar(_35reg1776);
+Obj cont = _35reg1777;
+Obj _35reg1778 = primCdr(closureRef(co, 0));
+Obj _35reg1779 = primCdr(_35reg1778);
+Obj _35reg1780 = primCdr(_35reg1779);
+Obj _35reg1781 = primEQ(Nil, _35reg1780);
+if (True == _35reg1781) {
+Obj _35reg1782 = primCons(cont, Nil);
+Obj _35reg1783 = primCons(exp, _35reg1782);
+pushCont(co, _35clofun2954, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.free-vars"));
-co->args[2] = _35reg2585;
+co->args[2] = _35reg1783;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9050,7 +9050,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2079;
+co->args[0] = _35cc1277;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9061,7 +9061,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2079;
+co->args[0] = _35cc1277;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9072,7 +9072,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2079;
+co->args[0] = _35cc1277;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9083,7 +9083,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2079;
+co->args[0] = _35cc1277;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9094,7 +9094,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2079;
+co->args[0] = _35cc1277;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9105,13 +9105,13 @@ return;
 }
 }
 
-void _35clofun3756(struct Cora* co) {
-Obj _35val2586 = co->args[1];
+void _35clofun2954(struct Cora* co) {
+Obj _35val1784 = co->args[1];
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.foldl"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.union"));
 co->args[2] = Nil;
-co->args[3] = _35val2586;
+co->args[3] = _35val1784;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9121,23 +9121,23 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3750(struct Cora* co) {
-Obj _35cc2080 = makeNative(_35clofun3751, 0, 1, closureRef(co, 0));
-Obj _35reg2557 = primIsCons(closureRef(co, 0));
-if (True == _35reg2557) {
-Obj _35reg2558 = primCar(closureRef(co, 0));
-Obj _35reg2559 = primEQ(intern("tailcall"), _35reg2558);
-if (True == _35reg2559) {
-Obj _35reg2560 = primCdr(closureRef(co, 0));
-Obj _35reg2561 = primIsCons(_35reg2560);
-if (True == _35reg2561) {
-Obj _35reg2562 = primCdr(closureRef(co, 0));
-Obj _35reg2563 = primCar(_35reg2562);
-Obj exp = _35reg2563;
-Obj _35reg2564 = primCdr(closureRef(co, 0));
-Obj _35reg2565 = primCdr(_35reg2564);
-Obj _35reg2566 = primEQ(Nil, _35reg2565);
-if (True == _35reg2566) {
+void _35clofun2948(struct Cora* co) {
+Obj _35cc1278 = makeNative(_35clofun2949, 0, 1, closureRef(co, 0));
+Obj _35reg1755 = primIsCons(closureRef(co, 0));
+if (True == _35reg1755) {
+Obj _35reg1756 = primCar(closureRef(co, 0));
+Obj _35reg1757 = primEQ(intern("tailcall"), _35reg1756);
+if (True == _35reg1757) {
+Obj _35reg1758 = primCdr(closureRef(co, 0));
+Obj _35reg1759 = primIsCons(_35reg1758);
+if (True == _35reg1759) {
+Obj _35reg1760 = primCdr(closureRef(co, 0));
+Obj _35reg1761 = primCar(_35reg1760);
+Obj exp = _35reg1761;
+Obj _35reg1762 = primCdr(closureRef(co, 0));
+Obj _35reg1763 = primCdr(_35reg1762);
+Obj _35reg1764 = primEQ(Nil, _35reg1763);
+if (True == _35reg1764) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = exp;
@@ -9150,7 +9150,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2080;
+co->args[0] = _35cc1278;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9161,7 +9161,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2080;
+co->args[0] = _35cc1278;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9172,7 +9172,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2080;
+co->args[0] = _35cc1278;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9183,7 +9183,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2080;
+co->args[0] = _35cc1278;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9194,33 +9194,33 @@ return;
 }
 }
 
-void _35clofun3751(struct Cora* co) {
-Obj _35cc2081 = makeNative(_35clofun3752, 0, 1, closureRef(co, 0));
-Obj _35reg2539 = primIsCons(closureRef(co, 0));
-if (True == _35reg2539) {
-Obj _35reg2540 = primCar(closureRef(co, 0));
-Obj _35reg2541 = primEQ(intern("continuation"), _35reg2540);
-if (True == _35reg2541) {
-Obj _35reg2542 = primCdr(closureRef(co, 0));
-Obj _35reg2543 = primIsCons(_35reg2542);
-if (True == _35reg2543) {
-Obj _35reg2544 = primCdr(closureRef(co, 0));
-Obj _35reg2545 = primCar(_35reg2544);
-Obj arg = _35reg2545;
-Obj _35reg2546 = primCdr(closureRef(co, 0));
-Obj _35reg2547 = primCdr(_35reg2546);
-Obj _35reg2548 = primIsCons(_35reg2547);
-if (True == _35reg2548) {
-Obj _35reg2549 = primCdr(closureRef(co, 0));
-Obj _35reg2550 = primCdr(_35reg2549);
-Obj _35reg2551 = primCar(_35reg2550);
-Obj body = _35reg2551;
-Obj _35reg2552 = primCdr(closureRef(co, 0));
-Obj _35reg2553 = primCdr(_35reg2552);
-Obj _35reg2554 = primCdr(_35reg2553);
-Obj _35reg2555 = primEQ(Nil, _35reg2554);
-if (True == _35reg2555) {
-pushCont(co, _35clofun3755, 1, arg);
+void _35clofun2949(struct Cora* co) {
+Obj _35cc1279 = makeNative(_35clofun2950, 0, 1, closureRef(co, 0));
+Obj _35reg1737 = primIsCons(closureRef(co, 0));
+if (True == _35reg1737) {
+Obj _35reg1738 = primCar(closureRef(co, 0));
+Obj _35reg1739 = primEQ(intern("continuation"), _35reg1738);
+if (True == _35reg1739) {
+Obj _35reg1740 = primCdr(closureRef(co, 0));
+Obj _35reg1741 = primIsCons(_35reg1740);
+if (True == _35reg1741) {
+Obj _35reg1742 = primCdr(closureRef(co, 0));
+Obj _35reg1743 = primCar(_35reg1742);
+Obj arg = _35reg1743;
+Obj _35reg1744 = primCdr(closureRef(co, 0));
+Obj _35reg1745 = primCdr(_35reg1744);
+Obj _35reg1746 = primIsCons(_35reg1745);
+if (True == _35reg1746) {
+Obj _35reg1747 = primCdr(closureRef(co, 0));
+Obj _35reg1748 = primCdr(_35reg1747);
+Obj _35reg1749 = primCar(_35reg1748);
+Obj body = _35reg1749;
+Obj _35reg1750 = primCdr(closureRef(co, 0));
+Obj _35reg1751 = primCdr(_35reg1750);
+Obj _35reg1752 = primCdr(_35reg1751);
+Obj _35reg1753 = primEQ(Nil, _35reg1752);
+if (True == _35reg1753) {
+pushCont(co, _35clofun2953, 1, arg);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = body;
@@ -9233,7 +9233,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2081;
+co->args[0] = _35cc1279;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9244,7 +9244,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2081;
+co->args[0] = _35cc1279;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9255,7 +9255,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2081;
+co->args[0] = _35cc1279;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9266,7 +9266,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2081;
+co->args[0] = _35cc1279;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9277,7 +9277,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2081;
+co->args[0] = _35cc1279;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9288,12 +9288,12 @@ return;
 }
 }
 
-void _35clofun3755(struct Cora* co) {
-Obj _35val2556 = co->args[1];
+void _35clofun2953(struct Cora* co) {
+Obj _35val1754 = co->args[1];
 Obj arg = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
-co->args[1] = _35val2556;
+co->args[1] = _35val1754;
 co->args[2] = arg;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -9304,20 +9304,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3752(struct Cora* co) {
-Obj _35cc2082 = makeNative(_35clofun3753, 0, 0);
-Obj _35reg2534 = primIsCons(closureRef(co, 0));
-if (True == _35reg2534) {
-Obj _35reg2535 = primCar(closureRef(co, 0));
-Obj f = _35reg2535;
-Obj _35reg2536 = primCdr(closureRef(co, 0));
-Obj args = _35reg2536;
-Obj _35reg2537 = primCons(f, args);
-pushCont(co, _35clofun3754, 0);
+void _35clofun2950(struct Cora* co) {
+Obj _35cc1280 = makeNative(_35clofun2951, 0, 0);
+Obj _35reg1732 = primIsCons(closureRef(co, 0));
+if (True == _35reg1732) {
+Obj _35reg1733 = primCar(closureRef(co, 0));
+Obj f = _35reg1733;
+Obj _35reg1734 = primCdr(closureRef(co, 0));
+Obj args = _35reg1734;
+Obj _35reg1735 = primCons(f, args);
+pushCont(co, _35clofun2952, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.free-vars"));
-co->args[2] = _35reg2537;
+co->args[2] = _35reg1735;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9327,7 +9327,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2082;
+co->args[0] = _35cc1280;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9338,13 +9338,13 @@ return;
 }
 }
 
-void _35clofun3754(struct Cora* co) {
-Obj _35val2538 = co->args[1];
+void _35clofun2952(struct Cora* co) {
+Obj _35val1736 = co->args[1];
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.foldl"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.union"));
 co->args[2] = Nil;
-co->args[3] = _35val2538;
+co->args[3] = _35val1736;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9354,7 +9354,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3753(struct Cora* co) {
+void _35clofun2951(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -9367,31 +9367,31 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3734(struct Cora* co) {
-Obj _35p2063 = co->args[1];
-Obj _35cc2064 = makeNative(_35clofun3735, 0, 1, _35p2063);
-Obj _35reg2523 = primIsCons(_35p2063);
-if (True == _35reg2523) {
-Obj _35reg2524 = primCar(_35p2063);
-Obj _35reg2525 = primEQ(intern("%const"), _35reg2524);
-if (True == _35reg2525) {
-Obj _35reg2526 = primCdr(_35p2063);
-Obj _35reg2527 = primIsCons(_35reg2526);
-if (True == _35reg2527) {
-Obj _35reg2528 = primCdr(_35p2063);
-Obj _35reg2529 = primCar(_35reg2528);
-Obj x = _35reg2529;
-Obj _35reg2530 = primCdr(_35p2063);
-Obj _35reg2531 = primCdr(_35reg2530);
-Obj _35reg2532 = primEQ(Nil, _35reg2531);
-if (True == _35reg2532) {
+void _35clofun2932(struct Cora* co) {
+Obj _35p1261 = co->args[1];
+Obj _35cc1262 = makeNative(_35clofun2933, 0, 1, _35p1261);
+Obj _35reg1721 = primIsCons(_35p1261);
+if (True == _35reg1721) {
+Obj _35reg1722 = primCar(_35p1261);
+Obj _35reg1723 = primEQ(intern("%const"), _35reg1722);
+if (True == _35reg1723) {
+Obj _35reg1724 = primCdr(_35p1261);
+Obj _35reg1725 = primIsCons(_35reg1724);
+if (True == _35reg1725) {
+Obj _35reg1726 = primCdr(_35p1261);
+Obj _35reg1727 = primCar(_35reg1726);
+Obj x = _35reg1727;
+Obj _35reg1728 = primCdr(_35p1261);
+Obj _35reg1729 = primCdr(_35reg1728);
+Obj _35reg1730 = primEQ(Nil, _35reg1729);
+if (True == _35reg1730) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2064;
+co->args[0] = _35cc1262;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9402,7 +9402,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2064;
+co->args[0] = _35cc1262;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9413,7 +9413,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2064;
+co->args[0] = _35cc1262;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9424,7 +9424,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2064;
+co->args[0] = _35cc1262;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9435,30 +9435,30 @@ return;
 }
 }
 
-void _35clofun3735(struct Cora* co) {
-Obj _35cc2065 = makeNative(_35clofun3736, 0, 1, closureRef(co, 0));
-Obj _35reg2513 = primIsCons(closureRef(co, 0));
-if (True == _35reg2513) {
-Obj _35reg2514 = primCar(closureRef(co, 0));
-Obj _35reg2515 = primEQ(intern("%global"), _35reg2514);
-if (True == _35reg2515) {
-Obj _35reg2516 = primCdr(closureRef(co, 0));
-Obj _35reg2517 = primIsCons(_35reg2516);
-if (True == _35reg2517) {
-Obj _35reg2518 = primCdr(closureRef(co, 0));
-Obj _35reg2519 = primCar(_35reg2518);
-Obj x = _35reg2519;
-Obj _35reg2520 = primCdr(closureRef(co, 0));
-Obj _35reg2521 = primCdr(_35reg2520);
-Obj _35reg2522 = primEQ(Nil, _35reg2521);
-if (True == _35reg2522) {
+void _35clofun2933(struct Cora* co) {
+Obj _35cc1263 = makeNative(_35clofun2934, 0, 1, closureRef(co, 0));
+Obj _35reg1711 = primIsCons(closureRef(co, 0));
+if (True == _35reg1711) {
+Obj _35reg1712 = primCar(closureRef(co, 0));
+Obj _35reg1713 = primEQ(intern("%global"), _35reg1712);
+if (True == _35reg1713) {
+Obj _35reg1714 = primCdr(closureRef(co, 0));
+Obj _35reg1715 = primIsCons(_35reg1714);
+if (True == _35reg1715) {
+Obj _35reg1716 = primCdr(closureRef(co, 0));
+Obj _35reg1717 = primCar(_35reg1716);
+Obj x = _35reg1717;
+Obj _35reg1718 = primCdr(closureRef(co, 0));
+Obj _35reg1719 = primCdr(_35reg1718);
+Obj _35reg1720 = primEQ(Nil, _35reg1719);
+if (True == _35reg1720) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2065;
+co->args[0] = _35cc1263;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9469,7 +9469,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2065;
+co->args[0] = _35cc1263;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9480,7 +9480,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2065;
+co->args[0] = _35cc1263;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9491,7 +9491,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2065;
+co->args[0] = _35cc1263;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9502,30 +9502,30 @@ return;
 }
 }
 
-void _35clofun3736(struct Cora* co) {
-Obj _35cc2066 = makeNative(_35clofun3737, 0, 1, closureRef(co, 0));
-Obj _35reg2503 = primIsCons(closureRef(co, 0));
-if (True == _35reg2503) {
-Obj _35reg2504 = primCar(closureRef(co, 0));
-Obj _35reg2505 = primEQ(intern("%builtin"), _35reg2504);
-if (True == _35reg2505) {
-Obj _35reg2506 = primCdr(closureRef(co, 0));
-Obj _35reg2507 = primIsCons(_35reg2506);
-if (True == _35reg2507) {
-Obj _35reg2508 = primCdr(closureRef(co, 0));
-Obj _35reg2509 = primCar(_35reg2508);
-Obj op = _35reg2509;
-Obj _35reg2510 = primCdr(closureRef(co, 0));
-Obj _35reg2511 = primCdr(_35reg2510);
-Obj _35reg2512 = primEQ(Nil, _35reg2511);
-if (True == _35reg2512) {
+void _35clofun2934(struct Cora* co) {
+Obj _35cc1264 = makeNative(_35clofun2935, 0, 1, closureRef(co, 0));
+Obj _35reg1701 = primIsCons(closureRef(co, 0));
+if (True == _35reg1701) {
+Obj _35reg1702 = primCar(closureRef(co, 0));
+Obj _35reg1703 = primEQ(intern("%builtin"), _35reg1702);
+if (True == _35reg1703) {
+Obj _35reg1704 = primCdr(closureRef(co, 0));
+Obj _35reg1705 = primIsCons(_35reg1704);
+if (True == _35reg1705) {
+Obj _35reg1706 = primCdr(closureRef(co, 0));
+Obj _35reg1707 = primCar(_35reg1706);
+Obj op = _35reg1707;
+Obj _35reg1708 = primCdr(closureRef(co, 0));
+Obj _35reg1709 = primCdr(_35reg1708);
+Obj _35reg1710 = primEQ(Nil, _35reg1709);
+if (True == _35reg1710) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2066;
+co->args[0] = _35cc1264;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9536,7 +9536,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2066;
+co->args[0] = _35cc1264;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9547,7 +9547,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2066;
+co->args[0] = _35cc1264;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9558,7 +9558,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2066;
+co->args[0] = _35cc1264;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9569,30 +9569,30 @@ return;
 }
 }
 
-void _35clofun3737(struct Cora* co) {
-Obj _35cc2067 = makeNative(_35clofun3738, 0, 1, closureRef(co, 0));
-Obj _35reg2493 = primIsCons(closureRef(co, 0));
-if (True == _35reg2493) {
-Obj _35reg2494 = primCar(closureRef(co, 0));
-Obj _35reg2495 = primEQ(intern("quote"), _35reg2494);
-if (True == _35reg2495) {
-Obj _35reg2496 = primCdr(closureRef(co, 0));
-Obj _35reg2497 = primIsCons(_35reg2496);
-if (True == _35reg2497) {
-Obj _35reg2498 = primCdr(closureRef(co, 0));
-Obj _35reg2499 = primCar(_35reg2498);
-Obj x = _35reg2499;
-Obj _35reg2500 = primCdr(closureRef(co, 0));
-Obj _35reg2501 = primCdr(_35reg2500);
-Obj _35reg2502 = primEQ(Nil, _35reg2501);
-if (True == _35reg2502) {
+void _35clofun2935(struct Cora* co) {
+Obj _35cc1265 = makeNative(_35clofun2936, 0, 1, closureRef(co, 0));
+Obj _35reg1691 = primIsCons(closureRef(co, 0));
+if (True == _35reg1691) {
+Obj _35reg1692 = primCar(closureRef(co, 0));
+Obj _35reg1693 = primEQ(intern("quote"), _35reg1692);
+if (True == _35reg1693) {
+Obj _35reg1694 = primCdr(closureRef(co, 0));
+Obj _35reg1695 = primIsCons(_35reg1694);
+if (True == _35reg1695) {
+Obj _35reg1696 = primCdr(closureRef(co, 0));
+Obj _35reg1697 = primCar(_35reg1696);
+Obj x = _35reg1697;
+Obj _35reg1698 = primCdr(closureRef(co, 0));
+Obj _35reg1699 = primCdr(_35reg1698);
+Obj _35reg1700 = primEQ(Nil, _35reg1699);
+if (True == _35reg1700) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2067;
+co->args[0] = _35cc1265;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9603,7 +9603,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2067;
+co->args[0] = _35cc1265;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9614,7 +9614,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2067;
+co->args[0] = _35cc1265;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9625,7 +9625,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2067;
+co->args[0] = _35cc1265;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9636,30 +9636,30 @@ return;
 }
 }
 
-void _35clofun3738(struct Cora* co) {
-Obj _35cc2068 = makeNative(_35clofun3739, 0, 1, closureRef(co, 0));
-Obj _35reg2483 = primIsCons(closureRef(co, 0));
-if (True == _35reg2483) {
-Obj _35reg2484 = primCar(closureRef(co, 0));
-Obj _35reg2485 = primEQ(intern("%closure-ref"), _35reg2484);
-if (True == _35reg2485) {
-Obj _35reg2486 = primCdr(closureRef(co, 0));
-Obj _35reg2487 = primIsCons(_35reg2486);
-if (True == _35reg2487) {
-Obj _35reg2488 = primCdr(closureRef(co, 0));
-Obj _35reg2489 = primCar(_35reg2488);
-Obj __ = _35reg2489;
-Obj _35reg2490 = primCdr(closureRef(co, 0));
-Obj _35reg2491 = primCdr(_35reg2490);
-Obj _35reg2492 = primEQ(Nil, _35reg2491);
-if (True == _35reg2492) {
+void _35clofun2936(struct Cora* co) {
+Obj _35cc1266 = makeNative(_35clofun2937, 0, 1, closureRef(co, 0));
+Obj _35reg1681 = primIsCons(closureRef(co, 0));
+if (True == _35reg1681) {
+Obj _35reg1682 = primCar(closureRef(co, 0));
+Obj _35reg1683 = primEQ(intern("%closure-ref"), _35reg1682);
+if (True == _35reg1683) {
+Obj _35reg1684 = primCdr(closureRef(co, 0));
+Obj _35reg1685 = primIsCons(_35reg1684);
+if (True == _35reg1685) {
+Obj _35reg1686 = primCdr(closureRef(co, 0));
+Obj _35reg1687 = primCar(_35reg1686);
+Obj __ = _35reg1687;
+Obj _35reg1688 = primCdr(closureRef(co, 0));
+Obj _35reg1689 = primCdr(_35reg1688);
+Obj _35reg1690 = primEQ(Nil, _35reg1689);
+if (True == _35reg1690) {
 co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2068;
+co->args[0] = _35cc1266;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9670,7 +9670,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2068;
+co->args[0] = _35cc1266;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9681,7 +9681,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2068;
+co->args[0] = _35cc1266;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9692,7 +9692,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2068;
+co->args[0] = _35cc1266;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9703,8 +9703,8 @@ return;
 }
 }
 
-void _35clofun3739(struct Cora* co) {
-Obj _35cc2069 = makeNative(_35clofun3740, 0, 0);
+void _35clofun2937(struct Cora* co) {
+Obj _35cc1267 = makeNative(_35clofun2938, 0, 0);
 Obj x = closureRef(co, 0);
 co->nargs = 2;
 co->args[1] = False;
@@ -9712,7 +9712,7 @@ popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3740(struct Cora* co) {
+void _35clofun2938(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -9725,20 +9725,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3728(struct Cora* co) {
-Obj _35p2058 = co->args[1];
-Obj _35p2059 = co->args[2];
-Obj _35cc2060 = makeNative(_35clofun3729, 0, 2, _35p2058, _35p2059);
-Obj _35reg2481 = primEQ(Nil, _35p2058);
-if (True == _35reg2481) {
-Obj __ = _35p2059;
+void _35clofun2926(struct Cora* co) {
+Obj _35p1256 = co->args[1];
+Obj _35p1257 = co->args[2];
+Obj _35cc1258 = makeNative(_35clofun2927, 0, 2, _35p1256, _35p1257);
+Obj _35reg1679 = primEQ(Nil, _35p1256);
+if (True == _35reg1679) {
+Obj __ = _35p1257;
 co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2060;
+co->args[0] = _35cc1258;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9749,16 +9749,16 @@ return;
 }
 }
 
-void _35clofun3729(struct Cora* co) {
-Obj _35cc2061 = makeNative(_35clofun3730, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2477 = primIsCons(closureRef(co, 0));
-if (True == _35reg2477) {
-Obj _35reg2478 = primCar(closureRef(co, 0));
-Obj x = _35reg2478;
-Obj _35reg2479 = primCdr(closureRef(co, 0));
-Obj y = _35reg2479;
+void _35clofun2927(struct Cora* co) {
+Obj _35cc1259 = makeNative(_35clofun2928, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1675 = primIsCons(closureRef(co, 0));
+if (True == _35reg1675) {
+Obj _35reg1676 = primCar(closureRef(co, 0));
+Obj x = _35reg1676;
+Obj _35reg1677 = primCdr(closureRef(co, 0));
+Obj y = _35reg1677;
 Obj s2 = closureRef(co, 1);
-pushCont(co, _35clofun3733, 3, y, s2, _35cc2061);
+pushCont(co, _35clofun2931, 3, y, s2, _35cc1259);
 co->nargs = 3;
 co->args[0] = globalRef(intern("elem?"));
 co->args[1] = x;
@@ -9772,7 +9772,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2061;
+co->args[0] = _35cc1259;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9783,12 +9783,12 @@ return;
 }
 }
 
-void _35clofun3733(struct Cora* co) {
-Obj _35val2480 = co->args[1];
+void _35clofun2931(struct Cora* co) {
+Obj _35val1678 = co->args[1];
 Obj y = co->stack[co->base + 0];
 Obj s2 = co->stack[co->base + 1];
-Obj _35cc2061 = co->stack[co->base + 2];
-if (True == _35val2480) {
+Obj _35cc1259 = co->stack[co->base + 2];
+if (True == _35val1678) {
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
 co->args[1] = y;
@@ -9802,7 +9802,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2061;
+co->args[0] = _35cc1259;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9813,16 +9813,16 @@ return;
 }
 }
 
-void _35clofun3730(struct Cora* co) {
-Obj _35cc2062 = makeNative(_35clofun3731, 0, 0);
-Obj _35reg2472 = primIsCons(closureRef(co, 0));
-if (True == _35reg2472) {
-Obj _35reg2473 = primCar(closureRef(co, 0));
-Obj x = _35reg2473;
-Obj _35reg2474 = primCdr(closureRef(co, 0));
-Obj y = _35reg2474;
+void _35clofun2928(struct Cora* co) {
+Obj _35cc1260 = makeNative(_35clofun2929, 0, 0);
+Obj _35reg1670 = primIsCons(closureRef(co, 0));
+if (True == _35reg1670) {
+Obj _35reg1671 = primCar(closureRef(co, 0));
+Obj x = _35reg1671;
+Obj _35reg1672 = primCdr(closureRef(co, 0));
+Obj y = _35reg1672;
 Obj s2 = closureRef(co, 1);
-pushCont(co, _35clofun3732, 1, x);
+pushCont(co, _35clofun2930, 1, x);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
 co->args[1] = y;
@@ -9836,7 +9836,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2062;
+co->args[0] = _35cc1260;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9847,17 +9847,17 @@ return;
 }
 }
 
-void _35clofun3732(struct Cora* co) {
-Obj _35val2475 = co->args[1];
+void _35clofun2930(struct Cora* co) {
+Obj _35val1673 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35reg2476 = primCons(x, _35val2475);
+Obj _35reg1674 = primCons(x, _35val1673);
 co->nargs = 2;
-co->args[1] = _35reg2476;
+co->args[1] = _35reg1674;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3731(struct Cora* co) {
+void _35clofun2929(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -9870,20 +9870,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3722(struct Cora* co) {
-Obj _35p2053 = co->args[1];
-Obj _35p2054 = co->args[2];
-Obj _35cc2055 = makeNative(_35clofun3723, 0, 2, _35p2053, _35p2054);
-Obj _35reg2470 = primEQ(Nil, _35p2053);
-if (True == _35reg2470) {
-Obj s2 = _35p2054;
+void _35clofun2920(struct Cora* co) {
+Obj _35p1251 = co->args[1];
+Obj _35p1252 = co->args[2];
+Obj _35cc1253 = makeNative(_35clofun2921, 0, 2, _35p1251, _35p1252);
+Obj _35reg1668 = primEQ(Nil, _35p1251);
+if (True == _35reg1668) {
+Obj s2 = _35p1252;
 co->nargs = 2;
 co->args[1] = s2;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2055;
+co->args[0] = _35cc1253;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9894,16 +9894,16 @@ return;
 }
 }
 
-void _35clofun3723(struct Cora* co) {
-Obj _35cc2056 = makeNative(_35clofun3724, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2466 = primIsCons(closureRef(co, 0));
-if (True == _35reg2466) {
-Obj _35reg2467 = primCar(closureRef(co, 0));
-Obj x = _35reg2467;
-Obj _35reg2468 = primCdr(closureRef(co, 0));
-Obj y = _35reg2468;
+void _35clofun2921(struct Cora* co) {
+Obj _35cc1254 = makeNative(_35clofun2922, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1664 = primIsCons(closureRef(co, 0));
+if (True == _35reg1664) {
+Obj _35reg1665 = primCar(closureRef(co, 0));
+Obj x = _35reg1665;
+Obj _35reg1666 = primCdr(closureRef(co, 0));
+Obj y = _35reg1666;
 Obj s2 = closureRef(co, 1);
-pushCont(co, _35clofun3727, 3, y, s2, _35cc2056);
+pushCont(co, _35clofun2925, 3, y, s2, _35cc1254);
 co->nargs = 3;
 co->args[0] = globalRef(intern("elem?"));
 co->args[1] = x;
@@ -9917,7 +9917,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2056;
+co->args[0] = _35cc1254;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9928,12 +9928,12 @@ return;
 }
 }
 
-void _35clofun3727(struct Cora* co) {
-Obj _35val2469 = co->args[1];
+void _35clofun2925(struct Cora* co) {
+Obj _35val1667 = co->args[1];
 Obj y = co->stack[co->base + 0];
 Obj s2 = co->stack[co->base + 1];
-Obj _35cc2056 = co->stack[co->base + 2];
-if (True == _35val2469) {
+Obj _35cc1254 = co->stack[co->base + 2];
+if (True == _35val1667) {
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.union"));
 co->args[1] = y;
@@ -9947,7 +9947,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2056;
+co->args[0] = _35cc1254;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9958,16 +9958,16 @@ return;
 }
 }
 
-void _35clofun3724(struct Cora* co) {
-Obj _35cc2057 = makeNative(_35clofun3725, 0, 0);
-Obj _35reg2461 = primIsCons(closureRef(co, 0));
-if (True == _35reg2461) {
-Obj _35reg2462 = primCar(closureRef(co, 0));
-Obj x = _35reg2462;
-Obj _35reg2463 = primCdr(closureRef(co, 0));
-Obj y = _35reg2463;
+void _35clofun2922(struct Cora* co) {
+Obj _35cc1255 = makeNative(_35clofun2923, 0, 0);
+Obj _35reg1659 = primIsCons(closureRef(co, 0));
+if (True == _35reg1659) {
+Obj _35reg1660 = primCar(closureRef(co, 0));
+Obj x = _35reg1660;
+Obj _35reg1661 = primCdr(closureRef(co, 0));
+Obj y = _35reg1661;
 Obj s2 = closureRef(co, 1);
-pushCont(co, _35clofun3726, 1, x);
+pushCont(co, _35clofun2924, 1, x);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.union"));
 co->args[1] = y;
@@ -9981,7 +9981,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2057;
+co->args[0] = _35cc1255;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9992,17 +9992,17 @@ return;
 }
 }
 
-void _35clofun3726(struct Cora* co) {
-Obj _35val2464 = co->args[1];
+void _35clofun2924(struct Cora* co) {
+Obj _35val1662 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35reg2465 = primCons(x, _35val2464);
+Obj _35reg1663 = primCons(x, _35val1662);
 co->nargs = 2;
-co->args[1] = _35reg2465;
+co->args[1] = _35reg1663;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3725(struct Cora* co) {
+void _35clofun2923(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -10015,13 +10015,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3692(struct Cora* co) {
-Obj _35p2042 = co->args[1];
-Obj _35p2043 = co->args[2];
-Obj _35cc2044 = makeNative(_35clofun3693, 0, 2, _35p2042, _35p2043);
-Obj __ = _35p2042;
-Obj x = _35p2043;
-pushCont(co, _35clofun3719, 2, x, _35cc2044);
+void _35clofun2890(struct Cora* co) {
+Obj _35p1240 = co->args[1];
+Obj _35p1241 = co->args[2];
+Obj _35cc1242 = makeNative(_35clofun2891, 0, 2, _35p1240, _35p1241);
+Obj __ = _35p1240;
+Obj x = _35p1241;
+pushCont(co, _35clofun2917, 2, x, _35cc1242);
 co->nargs = 2;
 co->args[0] = globalRef(intern("number?"));
 co->args[1] = x;
@@ -10034,21 +10034,21 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3719(struct Cora* co) {
-Obj _35val2446 = co->args[1];
+void _35clofun2917(struct Cora* co) {
+Obj _35val1644 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35cc2044 = co->stack[co->base + 1];
-if (True == _35val2446) {
+Obj _35cc1242 = co->stack[co->base + 1];
+if (True == _35val1644) {
 if (True == True) {
-Obj _35reg2447 = primCons(x, Nil);
-Obj _35reg2448 = primCons(intern("%const"), _35reg2447);
+Obj _35reg1645 = primCons(x, Nil);
+Obj _35reg1646 = primCons(intern("%const"), _35reg1645);
 co->nargs = 2;
-co->args[1] = _35reg2448;
+co->args[1] = _35reg1646;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2044;
+co->args[0] = _35cc1242;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10058,18 +10058,18 @@ co->pc = coraCall;
 return;
 }
 } else {
-Obj _35reg2449 = primIsString(x);
-if (True == _35reg2449) {
+Obj _35reg1647 = primIsString(x);
+if (True == _35reg1647) {
 if (True == True) {
-Obj _35reg2450 = primCons(x, Nil);
-Obj _35reg2451 = primCons(intern("%const"), _35reg2450);
+Obj _35reg1648 = primCons(x, Nil);
+Obj _35reg1649 = primCons(intern("%const"), _35reg1648);
 co->nargs = 2;
-co->args[1] = _35reg2451;
+co->args[1] = _35reg1649;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2044;
+co->args[0] = _35cc1242;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10079,7 +10079,7 @@ co->pc = coraCall;
 return;
 }
 } else {
-pushCont(co, _35clofun3720, 2, x, _35cc2044);
+pushCont(co, _35clofun2918, 2, x, _35cc1242);
 co->nargs = 2;
 co->args[0] = globalRef(intern("boolean?"));
 co->args[1] = x;
@@ -10094,21 +10094,21 @@ return;
 }
 }
 
-void _35clofun3720(struct Cora* co) {
-Obj _35val2452 = co->args[1];
+void _35clofun2918(struct Cora* co) {
+Obj _35val1650 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35cc2044 = co->stack[co->base + 1];
-if (True == _35val2452) {
+Obj _35cc1242 = co->stack[co->base + 1];
+if (True == _35val1650) {
 if (True == True) {
-Obj _35reg2453 = primCons(x, Nil);
-Obj _35reg2454 = primCons(intern("%const"), _35reg2453);
+Obj _35reg1651 = primCons(x, Nil);
+Obj _35reg1652 = primCons(intern("%const"), _35reg1651);
 co->nargs = 2;
-co->args[1] = _35reg2454;
+co->args[1] = _35reg1652;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2044;
+co->args[0] = _35cc1242;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10118,7 +10118,7 @@ co->pc = coraCall;
 return;
 }
 } else {
-pushCont(co, _35clofun3721, 2, x, _35cc2044);
+pushCont(co, _35clofun2919, 2, x, _35cc1242);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = x;
@@ -10132,21 +10132,21 @@ return;
 }
 }
 
-void _35clofun3721(struct Cora* co) {
-Obj _35val2455 = co->args[1];
+void _35clofun2919(struct Cora* co) {
+Obj _35val1653 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35cc2044 = co->stack[co->base + 1];
-if (True == _35val2455) {
+Obj _35cc1242 = co->stack[co->base + 1];
+if (True == _35val1653) {
 if (True == True) {
-Obj _35reg2456 = primCons(x, Nil);
-Obj _35reg2457 = primCons(intern("%const"), _35reg2456);
+Obj _35reg1654 = primCons(x, Nil);
+Obj _35reg1655 = primCons(intern("%const"), _35reg1654);
 co->nargs = 2;
-co->args[1] = _35reg2457;
+co->args[1] = _35reg1655;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2044;
+co->args[0] = _35cc1242;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10157,15 +10157,15 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg2458 = primCons(x, Nil);
-Obj _35reg2459 = primCons(intern("%const"), _35reg2458);
+Obj _35reg1656 = primCons(x, Nil);
+Obj _35reg1657 = primCons(intern("%const"), _35reg1656);
 co->nargs = 2;
-co->args[1] = _35reg2459;
+co->args[1] = _35reg1657;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2044;
+co->args[0] = _35cc1242;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10177,33 +10177,33 @@ return;
 }
 }
 
-void _35clofun3693(struct Cora* co) {
-Obj _35cc2045 = makeNative(_35clofun3694, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2891(struct Cora* co) {
+Obj _35cc1243 = makeNative(_35clofun2892, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj __ = closureRef(co, 0);
-Obj _35reg2434 = primIsCons(closureRef(co, 1));
-if (True == _35reg2434) {
-Obj _35reg2435 = primCar(closureRef(co, 1));
-Obj _35reg2436 = primEQ(intern("quote"), _35reg2435);
-if (True == _35reg2436) {
-Obj _35reg2437 = primCdr(closureRef(co, 1));
-Obj _35reg2438 = primIsCons(_35reg2437);
-if (True == _35reg2438) {
-Obj _35reg2439 = primCdr(closureRef(co, 1));
-Obj _35reg2440 = primCar(_35reg2439);
-Obj x = _35reg2440;
-Obj _35reg2441 = primCdr(closureRef(co, 1));
-Obj _35reg2442 = primCdr(_35reg2441);
-Obj _35reg2443 = primEQ(Nil, _35reg2442);
-if (True == _35reg2443) {
-Obj _35reg2444 = primCons(x, Nil);
-Obj _35reg2445 = primCons(intern("%const"), _35reg2444);
+Obj _35reg1632 = primIsCons(closureRef(co, 1));
+if (True == _35reg1632) {
+Obj _35reg1633 = primCar(closureRef(co, 1));
+Obj _35reg1634 = primEQ(intern("quote"), _35reg1633);
+if (True == _35reg1634) {
+Obj _35reg1635 = primCdr(closureRef(co, 1));
+Obj _35reg1636 = primIsCons(_35reg1635);
+if (True == _35reg1636) {
+Obj _35reg1637 = primCdr(closureRef(co, 1));
+Obj _35reg1638 = primCar(_35reg1637);
+Obj x = _35reg1638;
+Obj _35reg1639 = primCdr(closureRef(co, 1));
+Obj _35reg1640 = primCdr(_35reg1639);
+Obj _35reg1641 = primEQ(Nil, _35reg1640);
+if (True == _35reg1641) {
+Obj _35reg1642 = primCons(x, Nil);
+Obj _35reg1643 = primCons(intern("%const"), _35reg1642);
 co->nargs = 2;
-co->args[1] = _35reg2445;
+co->args[1] = _35reg1643;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2045;
+co->args[0] = _35cc1243;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10214,7 +10214,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2045;
+co->args[0] = _35cc1243;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10225,7 +10225,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2045;
+co->args[0] = _35cc1243;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10236,7 +10236,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2045;
+co->args[0] = _35cc1243;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10247,13 +10247,13 @@ return;
 }
 }
 
-void _35clofun3694(struct Cora* co) {
-Obj _35cc2046 = makeNative(_35clofun3695, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2892(struct Cora* co) {
+Obj _35cc1244 = makeNative(_35clofun2893, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg2430 = primIsSymbol(x);
-if (True == _35reg2430) {
-pushCont(co, _35clofun3718, 1, x);
+Obj _35reg1628 = primIsSymbol(x);
+if (True == _35reg1628) {
+pushCont(co, _35clofun2916, 1, x);
 co->nargs = 3;
 co->args[0] = globalRef(intern("elem?"));
 co->args[1] = x;
@@ -10267,7 +10267,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2046;
+co->args[0] = _35cc1244;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10278,52 +10278,52 @@ return;
 }
 }
 
-void _35clofun3718(struct Cora* co) {
-Obj _35val2431 = co->args[1];
+void _35clofun2916(struct Cora* co) {
+Obj _35val1629 = co->args[1];
 Obj x = co->stack[co->base + 0];
-if (True == _35val2431) {
+if (True == _35val1629) {
 co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2432 = primCons(x, Nil);
-Obj _35reg2433 = primCons(intern("%global"), _35reg2432);
+Obj _35reg1630 = primCons(x, Nil);
+Obj _35reg1631 = primCons(intern("%global"), _35reg1630);
 co->nargs = 2;
-co->args[1] = _35reg2433;
+co->args[1] = _35reg1631;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun3695(struct Cora* co) {
-Obj _35cc2047 = makeNative(_35clofun3696, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2893(struct Cora* co) {
+Obj _35cc1245 = makeNative(_35clofun2894, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg2408 = primIsCons(closureRef(co, 1));
-if (True == _35reg2408) {
-Obj _35reg2409 = primCar(closureRef(co, 1));
-Obj _35reg2410 = primEQ(intern("lambda"), _35reg2409);
-if (True == _35reg2410) {
-Obj _35reg2411 = primCdr(closureRef(co, 1));
-Obj _35reg2412 = primIsCons(_35reg2411);
-if (True == _35reg2412) {
-Obj _35reg2413 = primCdr(closureRef(co, 1));
-Obj _35reg2414 = primCar(_35reg2413);
-Obj args = _35reg2414;
-Obj _35reg2415 = primCdr(closureRef(co, 1));
-Obj _35reg2416 = primCdr(_35reg2415);
-Obj _35reg2417 = primIsCons(_35reg2416);
-if (True == _35reg2417) {
-Obj _35reg2418 = primCdr(closureRef(co, 1));
-Obj _35reg2419 = primCdr(_35reg2418);
-Obj _35reg2420 = primCar(_35reg2419);
-Obj body = _35reg2420;
-Obj _35reg2421 = primCdr(closureRef(co, 1));
-Obj _35reg2422 = primCdr(_35reg2421);
-Obj _35reg2423 = primCdr(_35reg2422);
-Obj _35reg2424 = primEQ(Nil, _35reg2423);
-if (True == _35reg2424) {
-pushCont(co, _35clofun3716, 2, body, args);
+Obj _35reg1606 = primIsCons(closureRef(co, 1));
+if (True == _35reg1606) {
+Obj _35reg1607 = primCar(closureRef(co, 1));
+Obj _35reg1608 = primEQ(intern("lambda"), _35reg1607);
+if (True == _35reg1608) {
+Obj _35reg1609 = primCdr(closureRef(co, 1));
+Obj _35reg1610 = primIsCons(_35reg1609);
+if (True == _35reg1610) {
+Obj _35reg1611 = primCdr(closureRef(co, 1));
+Obj _35reg1612 = primCar(_35reg1611);
+Obj args = _35reg1612;
+Obj _35reg1613 = primCdr(closureRef(co, 1));
+Obj _35reg1614 = primCdr(_35reg1613);
+Obj _35reg1615 = primIsCons(_35reg1614);
+if (True == _35reg1615) {
+Obj _35reg1616 = primCdr(closureRef(co, 1));
+Obj _35reg1617 = primCdr(_35reg1616);
+Obj _35reg1618 = primCar(_35reg1617);
+Obj body = _35reg1618;
+Obj _35reg1619 = primCdr(closureRef(co, 1));
+Obj _35reg1620 = primCdr(_35reg1619);
+Obj _35reg1621 = primCdr(_35reg1620);
+Obj _35reg1622 = primEQ(Nil, _35reg1621);
+if (True == _35reg1622) {
+pushCont(co, _35clofun2914, 2, body, args);
 co->nargs = 3;
 co->args[0] = globalRef(intern("append"));
 co->args[1] = args;
@@ -10337,7 +10337,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2047;
+co->args[0] = _35cc1245;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10348,7 +10348,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2047;
+co->args[0] = _35cc1245;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10359,7 +10359,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2047;
+co->args[0] = _35cc1245;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10370,7 +10370,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2047;
+co->args[0] = _35cc1245;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10381,7 +10381,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2047;
+co->args[0] = _35cc1245;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10392,14 +10392,14 @@ return;
 }
 }
 
-void _35clofun3716(struct Cora* co) {
-Obj _35val2425 = co->args[1];
+void _35clofun2914(struct Cora* co) {
+Obj _35val1623 = co->args[1];
 Obj body = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
-pushCont(co, _35clofun3717, 1, args);
+pushCont(co, _35clofun2915, 1, args);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
-co->args[1] = _35val2425;
+co->args[1] = _35val1623;
 co->args[2] = body;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -10410,29 +10410,29 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3717(struct Cora* co) {
-Obj _35val2426 = co->args[1];
+void _35clofun2915(struct Cora* co) {
+Obj _35val1624 = co->args[1];
 Obj args = co->stack[co->base + 0];
-Obj _35reg2427 = primCons(_35val2426, Nil);
-Obj _35reg2428 = primCons(args, _35reg2427);
-Obj _35reg2429 = primCons(intern("lambda"), _35reg2428);
+Obj _35reg1625 = primCons(_35val1624, Nil);
+Obj _35reg1626 = primCons(args, _35reg1625);
+Obj _35reg1627 = primCons(intern("lambda"), _35reg1626);
 co->nargs = 2;
-co->args[1] = _35reg2429;
+co->args[1] = _35reg1627;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3696(struct Cora* co) {
-Obj _35cc2048 = makeNative(_35clofun3697, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2894(struct Cora* co) {
+Obj _35cc1246 = makeNative(_35clofun2895, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg2401 = primIsCons(closureRef(co, 1));
-if (True == _35reg2401) {
-Obj _35reg2402 = primCar(closureRef(co, 1));
-Obj _35reg2403 = primEQ(intern("if"), _35reg2402);
-if (True == _35reg2403) {
-Obj _35reg2404 = primCdr(closureRef(co, 1));
-Obj args = _35reg2404;
-pushCont(co, _35clofun3714, 1, args);
+Obj _35reg1599 = primIsCons(closureRef(co, 1));
+if (True == _35reg1599) {
+Obj _35reg1600 = primCar(closureRef(co, 1));
+Obj _35reg1601 = primEQ(intern("if"), _35reg1600);
+if (True == _35reg1601) {
+Obj _35reg1602 = primCdr(closureRef(co, 1));
+Obj args = _35reg1602;
+pushCont(co, _35clofun2912, 1, args);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
@@ -10445,7 +10445,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2048;
+co->args[0] = _35cc1246;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10456,7 +10456,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2048;
+co->args[0] = _35cc1246;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10467,13 +10467,13 @@ return;
 }
 }
 
-void _35clofun3714(struct Cora* co) {
-Obj _35val2405 = co->args[1];
+void _35clofun2912(struct Cora* co) {
+Obj _35val1603 = co->args[1];
 Obj args = co->stack[co->base + 0];
-pushCont(co, _35clofun3715, 0);
+pushCont(co, _35clofun2913, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val2405;
+co->args[1] = _35val1603;
 co->args[2] = args;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -10484,43 +10484,43 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3715(struct Cora* co) {
-Obj _35val2406 = co->args[1];
-Obj _35reg2407 = primCons(intern("if"), _35val2406);
+void _35clofun2913(struct Cora* co) {
+Obj _35val1604 = co->args[1];
+Obj _35reg1605 = primCons(intern("if"), _35val1604);
 co->nargs = 2;
-co->args[1] = _35reg2407;
+co->args[1] = _35reg1605;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3697(struct Cora* co) {
-Obj _35cc2049 = makeNative(_35clofun3698, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2895(struct Cora* co) {
+Obj _35cc1247 = makeNative(_35clofun2896, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg2379 = primIsCons(closureRef(co, 1));
-if (True == _35reg2379) {
-Obj _35reg2380 = primCar(closureRef(co, 1));
-Obj _35reg2381 = primEQ(intern("do"), _35reg2380);
-if (True == _35reg2381) {
-Obj _35reg2382 = primCdr(closureRef(co, 1));
-Obj _35reg2383 = primIsCons(_35reg2382);
-if (True == _35reg2383) {
-Obj _35reg2384 = primCdr(closureRef(co, 1));
-Obj _35reg2385 = primCar(_35reg2384);
-Obj x = _35reg2385;
-Obj _35reg2386 = primCdr(closureRef(co, 1));
-Obj _35reg2387 = primCdr(_35reg2386);
-Obj _35reg2388 = primIsCons(_35reg2387);
-if (True == _35reg2388) {
-Obj _35reg2389 = primCdr(closureRef(co, 1));
-Obj _35reg2390 = primCdr(_35reg2389);
-Obj _35reg2391 = primCar(_35reg2390);
-Obj y = _35reg2391;
-Obj _35reg2392 = primCdr(closureRef(co, 1));
-Obj _35reg2393 = primCdr(_35reg2392);
-Obj _35reg2394 = primCdr(_35reg2393);
-Obj _35reg2395 = primEQ(Nil, _35reg2394);
-if (True == _35reg2395) {
-pushCont(co, _35clofun3712, 2, env, y);
+Obj _35reg1577 = primIsCons(closureRef(co, 1));
+if (True == _35reg1577) {
+Obj _35reg1578 = primCar(closureRef(co, 1));
+Obj _35reg1579 = primEQ(intern("do"), _35reg1578);
+if (True == _35reg1579) {
+Obj _35reg1580 = primCdr(closureRef(co, 1));
+Obj _35reg1581 = primIsCons(_35reg1580);
+if (True == _35reg1581) {
+Obj _35reg1582 = primCdr(closureRef(co, 1));
+Obj _35reg1583 = primCar(_35reg1582);
+Obj x = _35reg1583;
+Obj _35reg1584 = primCdr(closureRef(co, 1));
+Obj _35reg1585 = primCdr(_35reg1584);
+Obj _35reg1586 = primIsCons(_35reg1585);
+if (True == _35reg1586) {
+Obj _35reg1587 = primCdr(closureRef(co, 1));
+Obj _35reg1588 = primCdr(_35reg1587);
+Obj _35reg1589 = primCar(_35reg1588);
+Obj y = _35reg1589;
+Obj _35reg1590 = primCdr(closureRef(co, 1));
+Obj _35reg1591 = primCdr(_35reg1590);
+Obj _35reg1592 = primCdr(_35reg1591);
+Obj _35reg1593 = primEQ(Nil, _35reg1592);
+if (True == _35reg1593) {
+pushCont(co, _35clofun2910, 2, env, y);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
@@ -10534,7 +10534,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2049;
+co->args[0] = _35cc1247;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10545,7 +10545,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2049;
+co->args[0] = _35cc1247;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10556,7 +10556,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2049;
+co->args[0] = _35cc1247;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10567,7 +10567,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2049;
+co->args[0] = _35cc1247;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10578,7 +10578,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2049;
+co->args[0] = _35cc1247;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10589,11 +10589,11 @@ return;
 }
 }
 
-void _35clofun3712(struct Cora* co) {
-Obj _35val2396 = co->args[1];
+void _35clofun2910(struct Cora* co) {
+Obj _35val1594 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj y = co->stack[co->base + 1];
-pushCont(co, _35clofun3713, 1, _35val2396);
+pushCont(co, _35clofun2911, 1, _35val1594);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
@@ -10607,57 +10607,57 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3713(struct Cora* co) {
-Obj _35val2397 = co->args[1];
-Obj _35val2396 = co->stack[co->base + 0];
-Obj _35reg2398 = primCons(_35val2397, Nil);
-Obj _35reg2399 = primCons(_35val2396, _35reg2398);
-Obj _35reg2400 = primCons(intern("do"), _35reg2399);
+void _35clofun2911(struct Cora* co) {
+Obj _35val1595 = co->args[1];
+Obj _35val1594 = co->stack[co->base + 0];
+Obj _35reg1596 = primCons(_35val1595, Nil);
+Obj _35reg1597 = primCons(_35val1594, _35reg1596);
+Obj _35reg1598 = primCons(intern("do"), _35reg1597);
 co->nargs = 2;
-co->args[1] = _35reg2400;
+co->args[1] = _35reg1598;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3698(struct Cora* co) {
-Obj _35cc2050 = makeNative(_35clofun3699, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2896(struct Cora* co) {
+Obj _35cc1248 = makeNative(_35clofun2897, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg2346 = primIsCons(closureRef(co, 1));
-if (True == _35reg2346) {
-Obj _35reg2347 = primCar(closureRef(co, 1));
-Obj _35reg2348 = primEQ(intern("let"), _35reg2347);
-if (True == _35reg2348) {
-Obj _35reg2349 = primCdr(closureRef(co, 1));
-Obj _35reg2350 = primIsCons(_35reg2349);
-if (True == _35reg2350) {
-Obj _35reg2351 = primCdr(closureRef(co, 1));
-Obj _35reg2352 = primCar(_35reg2351);
-Obj a = _35reg2352;
-Obj _35reg2353 = primCdr(closureRef(co, 1));
-Obj _35reg2354 = primCdr(_35reg2353);
-Obj _35reg2355 = primIsCons(_35reg2354);
-if (True == _35reg2355) {
-Obj _35reg2356 = primCdr(closureRef(co, 1));
-Obj _35reg2357 = primCdr(_35reg2356);
-Obj _35reg2358 = primCar(_35reg2357);
-Obj b = _35reg2358;
-Obj _35reg2359 = primCdr(closureRef(co, 1));
-Obj _35reg2360 = primCdr(_35reg2359);
-Obj _35reg2361 = primCdr(_35reg2360);
-Obj _35reg2362 = primIsCons(_35reg2361);
-if (True == _35reg2362) {
-Obj _35reg2363 = primCdr(closureRef(co, 1));
-Obj _35reg2364 = primCdr(_35reg2363);
-Obj _35reg2365 = primCdr(_35reg2364);
-Obj _35reg2366 = primCar(_35reg2365);
-Obj c = _35reg2366;
-Obj _35reg2367 = primCdr(closureRef(co, 1));
-Obj _35reg2368 = primCdr(_35reg2367);
-Obj _35reg2369 = primCdr(_35reg2368);
-Obj _35reg2370 = primCdr(_35reg2369);
-Obj _35reg2371 = primEQ(Nil, _35reg2370);
-if (True == _35reg2371) {
-pushCont(co, _35clofun3710, 3, env, c, a);
+Obj _35reg1544 = primIsCons(closureRef(co, 1));
+if (True == _35reg1544) {
+Obj _35reg1545 = primCar(closureRef(co, 1));
+Obj _35reg1546 = primEQ(intern("let"), _35reg1545);
+if (True == _35reg1546) {
+Obj _35reg1547 = primCdr(closureRef(co, 1));
+Obj _35reg1548 = primIsCons(_35reg1547);
+if (True == _35reg1548) {
+Obj _35reg1549 = primCdr(closureRef(co, 1));
+Obj _35reg1550 = primCar(_35reg1549);
+Obj a = _35reg1550;
+Obj _35reg1551 = primCdr(closureRef(co, 1));
+Obj _35reg1552 = primCdr(_35reg1551);
+Obj _35reg1553 = primIsCons(_35reg1552);
+if (True == _35reg1553) {
+Obj _35reg1554 = primCdr(closureRef(co, 1));
+Obj _35reg1555 = primCdr(_35reg1554);
+Obj _35reg1556 = primCar(_35reg1555);
+Obj b = _35reg1556;
+Obj _35reg1557 = primCdr(closureRef(co, 1));
+Obj _35reg1558 = primCdr(_35reg1557);
+Obj _35reg1559 = primCdr(_35reg1558);
+Obj _35reg1560 = primIsCons(_35reg1559);
+if (True == _35reg1560) {
+Obj _35reg1561 = primCdr(closureRef(co, 1));
+Obj _35reg1562 = primCdr(_35reg1561);
+Obj _35reg1563 = primCdr(_35reg1562);
+Obj _35reg1564 = primCar(_35reg1563);
+Obj c = _35reg1564;
+Obj _35reg1565 = primCdr(closureRef(co, 1));
+Obj _35reg1566 = primCdr(_35reg1565);
+Obj _35reg1567 = primCdr(_35reg1566);
+Obj _35reg1568 = primCdr(_35reg1567);
+Obj _35reg1569 = primEQ(Nil, _35reg1568);
+if (True == _35reg1569) {
+pushCont(co, _35clofun2908, 3, env, c, a);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
@@ -10671,7 +10671,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2050;
+co->args[0] = _35cc1248;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10682,7 +10682,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2050;
+co->args[0] = _35cc1248;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10693,7 +10693,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2050;
+co->args[0] = _35cc1248;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10704,7 +10704,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2050;
+co->args[0] = _35cc1248;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10715,7 +10715,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2050;
+co->args[0] = _35cc1248;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10726,7 +10726,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2050;
+co->args[0] = _35cc1248;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10737,16 +10737,16 @@ return;
 }
 }
 
-void _35clofun3710(struct Cora* co) {
-Obj _35val2372 = co->args[1];
+void _35clofun2908(struct Cora* co) {
+Obj _35val1570 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj c = co->stack[co->base + 1];
 Obj a = co->stack[co->base + 2];
-Obj _35reg2373 = primCons(a, env);
-pushCont(co, _35clofun3711, 2, _35val2372, a);
+Obj _35reg1571 = primCons(a, env);
+pushCont(co, _35clofun2909, 2, _35val1570, a);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
-co->args[1] = _35reg2373;
+co->args[1] = _35reg1571;
 co->args[2] = c;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -10757,30 +10757,30 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3711(struct Cora* co) {
-Obj _35val2374 = co->args[1];
-Obj _35val2372 = co->stack[co->base + 0];
+void _35clofun2909(struct Cora* co) {
+Obj _35val1572 = co->args[1];
+Obj _35val1570 = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
-Obj _35reg2375 = primCons(_35val2374, Nil);
-Obj _35reg2376 = primCons(_35val2372, _35reg2375);
-Obj _35reg2377 = primCons(a, _35reg2376);
-Obj _35reg2378 = primCons(intern("let"), _35reg2377);
+Obj _35reg1573 = primCons(_35val1572, Nil);
+Obj _35reg1574 = primCons(_35val1570, _35reg1573);
+Obj _35reg1575 = primCons(a, _35reg1574);
+Obj _35reg1576 = primCons(intern("let"), _35reg1575);
 co->nargs = 2;
-co->args[1] = _35reg2378;
+co->args[1] = _35reg1576;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3699(struct Cora* co) {
-Obj _35cc2051 = makeNative(_35clofun3700, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2897(struct Cora* co) {
+Obj _35cc1249 = makeNative(_35clofun2898, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg2326 = primIsCons(closureRef(co, 1));
-if (True == _35reg2326) {
-Obj _35reg2327 = primCar(closureRef(co, 1));
-Obj op = _35reg2327;
-Obj _35reg2328 = primCdr(closureRef(co, 1));
-Obj args = _35reg2328;
-pushCont(co, _35clofun3703, 4, op, args, env, _35cc2051);
+Obj _35reg1524 = primIsCons(closureRef(co, 1));
+if (True == _35reg1524) {
+Obj _35reg1525 = primCar(closureRef(co, 1));
+Obj op = _35reg1525;
+Obj _35reg1526 = primCdr(closureRef(co, 1));
+Obj args = _35reg1526;
+pushCont(co, _35clofun2901, 4, op, args, env, _35cc1249);
 co->nargs = 2;
 co->args[0] = globalRef(intern("builtin?"));
 co->args[1] = op;
@@ -10793,7 +10793,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2051;
+co->args[0] = _35cc1249;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10804,14 +10804,14 @@ return;
 }
 }
 
-void _35clofun3703(struct Cora* co) {
-Obj _35val2329 = co->args[1];
+void _35clofun2901(struct Cora* co) {
+Obj _35val1527 = co->args[1];
 Obj op = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
-Obj _35cc2051 = co->stack[co->base + 3];
-if (True == _35val2329) {
-pushCont(co, _35clofun3704, 3, op, args, env);
+Obj _35cc1249 = co->stack[co->base + 3];
+if (True == _35val1527) {
+pushCont(co, _35clofun2902, 3, op, args, env);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.builtin->args"));
 co->args[1] = op;
@@ -10824,7 +10824,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2051;
+co->args[0] = _35cc1249;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10835,13 +10835,13 @@ return;
 }
 }
 
-void _35clofun3704(struct Cora* co) {
-Obj _35val2330 = co->args[1];
+void _35clofun2902(struct Cora* co) {
+Obj _35val1528 = co->args[1];
 Obj op = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
-Obj required = _35val2330;
-pushCont(co, _35clofun3705, 4, required, op, args, env);
+Obj required = _35val1528;
+pushCont(co, _35clofun2903, 4, required, op, args, env);
 co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = args;
@@ -10854,18 +10854,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3705(struct Cora* co) {
-Obj _35val2331 = co->args[1];
+void _35clofun2903(struct Cora* co) {
+Obj _35val1529 = co->args[1];
 Obj required = co->stack[co->base + 0];
 Obj op = co->stack[co->base + 1];
 Obj args = co->stack[co->base + 2];
 Obj env = co->stack[co->base + 3];
-Obj provided = _35val2331;
-Obj _35reg2332 = primEQ(required, provided);
-if (True == _35reg2332) {
-Obj _35reg2333 = primCons(op, Nil);
-Obj _35reg2334 = primCons(intern("%builtin"), _35reg2333);
-pushCont(co, _35clofun3706, 2, args, _35reg2334);
+Obj provided = _35val1529;
+Obj _35reg1530 = primEQ(required, provided);
+if (True == _35reg1530) {
+Obj _35reg1531 = primCons(op, Nil);
+Obj _35reg1532 = primCons(intern("%builtin"), _35reg1531);
+pushCont(co, _35clofun2904, 2, args, _35reg1532);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
@@ -10877,13 +10877,13 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2338 = primGT(required, provided);
-if (True == _35reg2338) {
-Obj _35reg2339 = primSub(required, provided);
-pushCont(co, _35clofun3708, 3, op, args, env);
+Obj _35reg1536 = primGT(required, provided);
+if (True == _35reg1536) {
+Obj _35reg1537 = primSub(required, provided);
+pushCont(co, _35clofun2906, 3, op, args, env);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.temp-list"));
-co->args[1] = _35reg2339;
+co->args[1] = _35reg1537;
 co->args[2] = Nil;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -10907,17 +10907,17 @@ return;
 }
 }
 
-void _35clofun3708(struct Cora* co) {
-Obj _35val2340 = co->args[1];
+void _35clofun2906(struct Cora* co) {
+Obj _35val1538 = co->args[1];
 Obj op = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
-Obj tmp = _35val2340;
-Obj _35reg2341 = primCons(op, args);
-pushCont(co, _35clofun3709, 2, tmp, env);
+Obj tmp = _35val1538;
+Obj _35reg1539 = primCons(op, args);
+pushCont(co, _35clofun2907, 2, tmp, env);
 co->nargs = 3;
 co->args[0] = globalRef(intern("append"));
-co->args[1] = _35reg2341;
+co->args[1] = _35reg1539;
 co->args[2] = tmp;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -10928,17 +10928,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3709(struct Cora* co) {
-Obj _35val2342 = co->args[1];
+void _35clofun2907(struct Cora* co) {
+Obj _35val1540 = co->args[1];
 Obj tmp = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
-Obj _35reg2343 = primCons(_35val2342, Nil);
-Obj _35reg2344 = primCons(tmp, _35reg2343);
-Obj _35reg2345 = primCons(intern("lambda"), _35reg2344);
+Obj _35reg1541 = primCons(_35val1540, Nil);
+Obj _35reg1542 = primCons(tmp, _35reg1541);
+Obj _35reg1543 = primCons(intern("lambda"), _35reg1542);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
-co->args[2] = _35reg2345;
+co->args[2] = _35reg1543;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10948,14 +10948,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3706(struct Cora* co) {
-Obj _35val2335 = co->args[1];
+void _35clofun2904(struct Cora* co) {
+Obj _35val1533 = co->args[1];
 Obj args = co->stack[co->base + 0];
-Obj _35reg2334 = co->stack[co->base + 1];
-pushCont(co, _35clofun3707, 1, _35reg2334);
+Obj _35reg1532 = co->stack[co->base + 1];
+pushCont(co, _35clofun2905, 1, _35reg1532);
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val2335;
+co->args[1] = _35val1533;
 co->args[2] = args;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -10966,21 +10966,21 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3707(struct Cora* co) {
-Obj _35val2336 = co->args[1];
-Obj _35reg2334 = co->stack[co->base + 0];
-Obj _35reg2337 = primCons(_35reg2334, _35val2336);
+void _35clofun2905(struct Cora* co) {
+Obj _35val1534 = co->args[1];
+Obj _35reg1532 = co->stack[co->base + 0];
+Obj _35reg1535 = primCons(_35reg1532, _35val1534);
 co->nargs = 2;
-co->args[1] = _35reg2337;
+co->args[1] = _35reg1535;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3700(struct Cora* co) {
-Obj _35cc2052 = makeNative(_35clofun3701, 0, 0);
+void _35clofun2898(struct Cora* co) {
+Obj _35cc1250 = makeNative(_35clofun2899, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ls = closureRef(co, 1);
-pushCont(co, _35clofun3702, 1, ls);
+pushCont(co, _35clofun2900, 1, ls);
 co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
@@ -10993,12 +10993,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3702(struct Cora* co) {
-Obj _35val2325 = co->args[1];
+void _35clofun2900(struct Cora* co) {
+Obj _35val1523 = co->args[1];
 Obj ls = co->stack[co->base + 0];
 co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val2325;
+co->args[1] = _35val1523;
 co->args[2] = ls;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -11009,7 +11009,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3701(struct Cora* co) {
+void _35clofun2899(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -11022,20 +11022,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3689(struct Cora* co) {
-Obj _35p2038 = co->args[1];
-Obj _35p2039 = co->args[2];
-Obj _35cc2040 = makeNative(_35clofun3690, 0, 2, _35p2038, _35p2039);
-Obj _35reg2323 = primEQ(makeNumber(0), _35p2038);
-if (True == _35reg2323) {
-Obj res = _35p2039;
+void _35clofun2887(struct Cora* co) {
+Obj _35p1236 = co->args[1];
+Obj _35p1237 = co->args[2];
+Obj _35cc1238 = makeNative(_35clofun2888, 0, 2, _35p1236, _35p1237);
+Obj _35reg1521 = primEQ(makeNumber(0), _35p1236);
+if (True == _35reg1521) {
+Obj res = _35p1237;
 co->nargs = 2;
 co->args[1] = res;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2040;
+co->args[0] = _35cc1238;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11046,17 +11046,17 @@ return;
 }
 }
 
-void _35clofun3690(struct Cora* co) {
-Obj _35cc2041 = makeNative(_35clofun3691, 0, 0);
+void _35clofun2888(struct Cora* co) {
+Obj _35cc1239 = makeNative(_35clofun2889, 0, 0);
 Obj n = closureRef(co, 0);
 Obj res = closureRef(co, 1);
-Obj _35reg2320 = primSub(n, makeNumber(1));
-Obj _35reg2321 = primGenSym(intern("tmp"));
-Obj _35reg2322 = primCons(_35reg2321, res);
+Obj _35reg1518 = primSub(n, makeNumber(1));
+Obj _35reg1519 = primGenSym(intern("tmp"));
+Obj _35reg1520 = primCons(_35reg1519, res);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.temp-list"));
-co->args[1] = _35reg2320;
-co->args[2] = _35reg2322;
+co->args[1] = _35reg1518;
+co->args[2] = _35reg1520;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11066,7 +11066,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3691(struct Cora* co) {
+void _35clofun2889(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -11079,9 +11079,9 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3686(struct Cora* co) {
+void _35clofun2884(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun3687, 0);
+pushCont(co, _35clofun2885, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.assq"));
 co->args[1] = x;
@@ -11095,10 +11095,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3687(struct Cora* co) {
-Obj _35val2317 = co->args[1];
-Obj find = _35val2317;
-pushCont(co, _35clofun3688, 1, find);
+void _35clofun2885(struct Cora* co) {
+Obj _35val1515 = co->args[1];
+Obj find = _35val1515;
+pushCont(co, _35clofun2886, 1, find);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = find;
@@ -11111,10 +11111,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3688(struct Cora* co) {
-Obj _35val2318 = co->args[1];
+void _35clofun2886(struct Cora* co) {
+Obj _35val1516 = co->args[1];
 Obj find = co->stack[co->base + 0];
-if (True == _35val2318) {
+if (True == _35val1516) {
 co->nargs = 2;
 co->args[1] = makeString1("ERROR");
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
@@ -11133,9 +11133,9 @@ return;
 }
 }
 
-void _35clofun3683(struct Cora* co) {
+void _35clofun2881(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun3684, 0);
+pushCont(co, _35clofun2882, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.assq"));
 co->args[1] = x;
@@ -11149,10 +11149,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3684(struct Cora* co) {
-Obj _35val2314 = co->args[1];
-Obj find = _35val2314;
-pushCont(co, _35clofun3685, 1, find);
+void _35clofun2882(struct Cora* co) {
+Obj _35val1512 = co->args[1];
+Obj find = _35val1512;
+pushCont(co, _35clofun2883, 1, find);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = find;
@@ -11165,10 +11165,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3685(struct Cora* co) {
-Obj _35val2315 = co->args[1];
+void _35clofun2883(struct Cora* co) {
+Obj _35val1513 = co->args[1];
 Obj find = co->stack[co->base + 0];
-if (True == _35val2315) {
+if (True == _35val1513) {
 co->nargs = 2;
 co->args[1] = makeString1("ERROR");
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
@@ -11187,9 +11187,9 @@ return;
 }
 }
 
-void _35clofun3680(struct Cora* co) {
+void _35clofun2878(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun3681, 0);
+pushCont(co, _35clofun2879, 0);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.assq"));
 co->args[1] = x;
@@ -11203,12 +11203,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3681(struct Cora* co) {
-Obj _35val2310 = co->args[1];
-pushCont(co, _35clofun3682, 0);
+void _35clofun2879(struct Cora* co) {
+Obj _35val1508 = co->args[1];
+pushCont(co, _35clofun2880, 0);
 co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
-co->args[1] = _35val2310;
+co->args[1] = _35val1508;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11218,29 +11218,29 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3682(struct Cora* co) {
-Obj _35val2311 = co->args[1];
-Obj _35reg2312 = primNot(_35val2311);
+void _35clofun2880(struct Cora* co) {
+Obj _35val1509 = co->args[1];
+Obj _35reg1510 = primNot(_35val1509);
 co->nargs = 2;
-co->args[1] = _35reg2312;
+co->args[1] = _35reg1510;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3676(struct Cora* co) {
-Obj _35p2034 = co->args[1];
-Obj _35p2035 = co->args[2];
-Obj _35cc2036 = makeNative(_35clofun3677, 0, 2, _35p2034, _35p2035);
-Obj x = _35p2034;
-Obj _35reg2239 = primEQ(Nil, _35p2035);
-if (True == _35reg2239) {
+void _35clofun2874(struct Cora* co) {
+Obj _35p1232 = co->args[1];
+Obj _35p1233 = co->args[2];
+Obj _35cc1234 = makeNative(_35clofun2875, 0, 2, _35p1232, _35p1233);
+Obj x = _35p1232;
+Obj _35reg1437 = primEQ(Nil, _35p1233);
+if (True == _35reg1437) {
 co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2036;
+co->args[0] = _35cc1234;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11251,16 +11251,16 @@ return;
 }
 }
 
-void _35clofun3677(struct Cora* co) {
-Obj _35cc2037 = makeNative(_35clofun3678, 0, 0);
+void _35clofun2875(struct Cora* co) {
+Obj _35cc1235 = makeNative(_35clofun2876, 0, 0);
 Obj x = closureRef(co, 0);
-Obj _35reg2234 = primIsCons(closureRef(co, 1));
-if (True == _35reg2234) {
-Obj _35reg2235 = primCar(closureRef(co, 1));
-Obj hd = _35reg2235;
-Obj _35reg2236 = primCdr(closureRef(co, 1));
-Obj tl = _35reg2236;
-pushCont(co, _35clofun3679, 2, x, tl);
+Obj _35reg1432 = primIsCons(closureRef(co, 1));
+if (True == _35reg1432) {
+Obj _35reg1433 = primCar(closureRef(co, 1));
+Obj hd = _35reg1433;
+Obj _35reg1434 = primCdr(closureRef(co, 1));
+Obj tl = _35reg1434;
+pushCont(co, _35clofun2877, 2, x, tl);
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.index"));
 co->args[1] = x;
@@ -11274,7 +11274,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2037;
+co->args[0] = _35cc1235;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11285,12 +11285,12 @@ return;
 }
 }
 
-void _35clofun3679(struct Cora* co) {
-Obj _35val2237 = co->args[1];
+void _35clofun2877(struct Cora* co) {
+Obj _35val1435 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj tl = co->stack[co->base + 1];
-Obj _35reg2238 = primLT(_35val2237, makeNumber(0));
-if (True == _35reg2238) {
+Obj _35reg1436 = primLT(_35val1435, makeNumber(0));
+if (True == _35reg1436) {
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.exist-in-env"));
 co->args[1] = x;
@@ -11310,7 +11310,7 @@ return;
 }
 }
 
-void _35clofun3678(struct Cora* co) {
+void _35clofun2876(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -11323,7 +11323,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3675(struct Cora* co) {
+void _35clofun2873(struct Cora* co) {
 Obj x = co->args[1];
 Obj l = co->args[2];
 co->nargs = 4;
@@ -11340,22 +11340,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3671(struct Cora* co) {
-Obj _35p2028 = co->args[1];
-Obj _35p2029 = co->args[2];
-Obj _35p2030 = co->args[3];
-Obj _35cc2031 = makeNative(_35clofun3672, 0, 3, _35p2028, _35p2029, _35p2030);
-Obj __ = _35p2028;
-Obj x = _35p2029;
-Obj _35reg2231 = primEQ(Nil, _35p2030);
-if (True == _35reg2231) {
+void _35clofun2869(struct Cora* co) {
+Obj _35p1226 = co->args[1];
+Obj _35p1227 = co->args[2];
+Obj _35p1228 = co->args[3];
+Obj _35cc1229 = makeNative(_35clofun2870, 0, 3, _35p1226, _35p1227, _35p1228);
+Obj __ = _35p1226;
+Obj x = _35p1227;
+Obj _35reg1429 = primEQ(Nil, _35p1228);
+if (True == _35reg1429) {
 co->nargs = 2;
 co->args[1] = makeNumber(-1);
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2031;
+co->args[0] = _35cc1229;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11366,25 +11366,25 @@ return;
 }
 }
 
-void _35clofun3672(struct Cora* co) {
-Obj _35cc2032 = makeNative(_35clofun3673, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun2870(struct Cora* co) {
+Obj _35cc1230 = makeNative(_35clofun2871, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg2227 = primIsCons(closureRef(co, 2));
-if (True == _35reg2227) {
-Obj _35reg2228 = primCar(closureRef(co, 2));
-Obj a = _35reg2228;
-Obj _35reg2229 = primCdr(closureRef(co, 2));
-Obj b = _35reg2229;
-Obj _35reg2230 = primEQ(x, a);
-if (True == _35reg2230) {
+Obj _35reg1425 = primIsCons(closureRef(co, 2));
+if (True == _35reg1425) {
+Obj _35reg1426 = primCar(closureRef(co, 2));
+Obj a = _35reg1426;
+Obj _35reg1427 = primCdr(closureRef(co, 2));
+Obj b = _35reg1427;
+Obj _35reg1428 = primEQ(x, a);
+if (True == _35reg1428) {
 co->nargs = 2;
 co->args[1] = pos;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2032;
+co->args[0] = _35cc1230;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11395,7 +11395,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2032;
+co->args[0] = _35cc1230;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11406,20 +11406,20 @@ return;
 }
 }
 
-void _35clofun3673(struct Cora* co) {
-Obj _35cc2033 = makeNative(_35clofun3674, 0, 0);
+void _35clofun2871(struct Cora* co) {
+Obj _35cc1231 = makeNative(_35clofun2872, 0, 0);
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg2223 = primIsCons(closureRef(co, 2));
-if (True == _35reg2223) {
-Obj _35reg2224 = primCar(closureRef(co, 2));
-Obj a = _35reg2224;
-Obj _35reg2225 = primCdr(closureRef(co, 2));
-Obj b = _35reg2225;
-Obj _35reg2226 = primAdd(pos, makeNumber(1));
+Obj _35reg1421 = primIsCons(closureRef(co, 2));
+if (True == _35reg1421) {
+Obj _35reg1422 = primCar(closureRef(co, 2));
+Obj a = _35reg1422;
+Obj _35reg1423 = primCdr(closureRef(co, 2));
+Obj b = _35reg1423;
+Obj _35reg1424 = primAdd(pos, makeNumber(1));
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.pos-in-list0"));
-co->args[1] = _35reg2226;
+co->args[1] = _35reg1424;
 co->args[2] = x;
 co->args[3] = b;
 if (nativeRequired(co->args[0]) == 3) {
@@ -11431,7 +11431,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2033;
+co->args[0] = _35cc1231;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11442,7 +11442,7 @@ return;
 }
 }
 
-void _35clofun3674(struct Cora* co) {
+void _35clofun2872(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -11455,22 +11455,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3667(struct Cora* co) {
-Obj _35p2023 = co->args[1];
-Obj _35p2024 = co->args[2];
-Obj _35p2025 = co->args[3];
-Obj _35cc2026 = makeNative(_35clofun3668, 0, 3, _35p2023, _35p2024, _35p2025);
-Obj f = _35p2023;
-Obj acc = _35p2024;
-Obj _35reg2221 = primEQ(Nil, _35p2025);
-if (True == _35reg2221) {
+void _35clofun2865(struct Cora* co) {
+Obj _35p1221 = co->args[1];
+Obj _35p1222 = co->args[2];
+Obj _35p1223 = co->args[3];
+Obj _35cc1224 = makeNative(_35clofun2866, 0, 3, _35p1221, _35p1222, _35p1223);
+Obj f = _35p1221;
+Obj acc = _35p1222;
+Obj _35reg1419 = primEQ(Nil, _35p1223);
+if (True == _35reg1419) {
 co->nargs = 2;
 co->args[1] = acc;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2026;
+co->args[0] = _35cc1224;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11481,17 +11481,17 @@ return;
 }
 }
 
-void _35clofun3668(struct Cora* co) {
-Obj _35cc2027 = makeNative(_35clofun3669, 0, 0);
+void _35clofun2866(struct Cora* co) {
+Obj _35cc1225 = makeNative(_35clofun2867, 0, 0);
 Obj f = closureRef(co, 0);
 Obj acc = closureRef(co, 1);
-Obj _35reg2217 = primIsCons(closureRef(co, 2));
-if (True == _35reg2217) {
-Obj _35reg2218 = primCar(closureRef(co, 2));
-Obj x = _35reg2218;
-Obj _35reg2219 = primCdr(closureRef(co, 2));
-Obj y = _35reg2219;
-pushCont(co, _35clofun3670, 2, f, y);
+Obj _35reg1415 = primIsCons(closureRef(co, 2));
+if (True == _35reg1415) {
+Obj _35reg1416 = primCar(closureRef(co, 2));
+Obj x = _35reg1416;
+Obj _35reg1417 = primCdr(closureRef(co, 2));
+Obj y = _35reg1417;
+pushCont(co, _35clofun2868, 2, f, y);
 co->nargs = 3;
 co->args[0] = f;
 co->args[1] = acc;
@@ -11505,7 +11505,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2027;
+co->args[0] = _35cc1225;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11516,14 +11516,14 @@ return;
 }
 }
 
-void _35clofun3670(struct Cora* co) {
-Obj _35val2220 = co->args[1];
+void _35clofun2868(struct Cora* co) {
+Obj _35val1418 = co->args[1];
 Obj f = co->stack[co->base + 0];
 Obj y = co->stack[co->base + 1];
 co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.foldl"));
 co->args[1] = f;
-co->args[2] = _35val2220;
+co->args[2] = _35val1418;
 co->args[3] = y;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
@@ -11534,7 +11534,7 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3669(struct Cora* co) {
+void _35clofun2867(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
@@ -11547,20 +11547,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3663(struct Cora* co) {
-Obj _35p2018 = co->args[1];
-Obj _35p2019 = co->args[2];
-Obj _35cc2020 = makeNative(_35clofun3664, 0, 2, _35p2018, _35p2019);
-Obj var = _35p2018;
-Obj _35reg2215 = primEQ(Nil, _35p2019);
-if (True == _35reg2215) {
+void _35clofun2861(struct Cora* co) {
+Obj _35p1216 = co->args[1];
+Obj _35p1217 = co->args[2];
+Obj _35cc1218 = makeNative(_35clofun2862, 0, 2, _35p1216, _35p1217);
+Obj var = _35p1216;
+Obj _35reg1413 = primEQ(Nil, _35p1217);
+if (True == _35reg1413) {
 co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2020;
+co->args[0] = _35cc1218;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11571,32 +11571,32 @@ return;
 }
 }
 
-void _35clofun3664(struct Cora* co) {
-Obj _35cc2021 = makeNative(_35clofun3665, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2862(struct Cora* co) {
+Obj _35cc1219 = makeNative(_35clofun2863, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
-Obj _35reg2205 = primIsCons(closureRef(co, 1));
-if (True == _35reg2205) {
-Obj _35reg2206 = primCar(closureRef(co, 1));
-Obj _35reg2207 = primIsCons(_35reg2206);
-if (True == _35reg2207) {
-Obj _35reg2208 = primCar(closureRef(co, 1));
-Obj _35reg2209 = primCar(_35reg2208);
-Obj x = _35reg2209;
-Obj _35reg2210 = primCar(closureRef(co, 1));
-Obj _35reg2211 = primCdr(_35reg2210);
-Obj y = _35reg2211;
-Obj _35reg2212 = primCdr(closureRef(co, 1));
-Obj __ = _35reg2212;
-Obj _35reg2213 = primEQ(var, x);
-if (True == _35reg2213) {
-Obj _35reg2214 = primCons(x, y);
+Obj _35reg1403 = primIsCons(closureRef(co, 1));
+if (True == _35reg1403) {
+Obj _35reg1404 = primCar(closureRef(co, 1));
+Obj _35reg1405 = primIsCons(_35reg1404);
+if (True == _35reg1405) {
+Obj _35reg1406 = primCar(closureRef(co, 1));
+Obj _35reg1407 = primCar(_35reg1406);
+Obj x = _35reg1407;
+Obj _35reg1408 = primCar(closureRef(co, 1));
+Obj _35reg1409 = primCdr(_35reg1408);
+Obj y = _35reg1409;
+Obj _35reg1410 = primCdr(closureRef(co, 1));
+Obj __ = _35reg1410;
+Obj _35reg1411 = primEQ(var, x);
+if (True == _35reg1411) {
+Obj _35reg1412 = primCons(x, y);
 co->nargs = 2;
-co->args[1] = _35reg2214;
+co->args[1] = _35reg1412;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2021;
+co->args[0] = _35cc1219;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11607,7 +11607,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2021;
+co->args[0] = _35cc1219;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11618,7 +11618,7 @@ return;
 }
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2021;
+co->args[0] = _35cc1219;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11629,15 +11629,15 @@ return;
 }
 }
 
-void _35clofun3665(struct Cora* co) {
-Obj _35cc2022 = makeNative(_35clofun3666, 0, 0);
+void _35clofun2863(struct Cora* co) {
+Obj _35cc1220 = makeNative(_35clofun2864, 0, 0);
 Obj var = closureRef(co, 0);
-Obj _35reg2202 = primIsCons(closureRef(co, 1));
-if (True == _35reg2202) {
-Obj _35reg2203 = primCar(closureRef(co, 1));
-Obj __ = _35reg2203;
-Obj _35reg2204 = primCdr(closureRef(co, 1));
-Obj y = _35reg2204;
+Obj _35reg1400 = primIsCons(closureRef(co, 1));
+if (True == _35reg1400) {
+Obj _35reg1401 = primCar(closureRef(co, 1));
+Obj __ = _35reg1401;
+Obj _35reg1402 = primCdr(closureRef(co, 1));
+Obj y = _35reg1402;
 co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.assq"));
 co->args[1] = var;
@@ -11651,7 +11651,7 @@ co->pc = coraCall;
 return;
 } else {
 co->nargs = 1;
-co->args[0] = _35cc2022;
+co->args[0] = _35cc1220;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11662,7 +11662,7 @@ return;
 }
 }
 
-void _35clofun3666(struct Cora* co) {
+void _35clofun2864(struct Cora* co) {
 co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");

--- a/toc.c
+++ b/toc.c
@@ -2,385 +2,386 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun2858(struct Cora* co);
-void _35clofun2859(struct Cora* co);
-void _35clofun3177(struct Cora* co);
-void _35clofun3217(struct Cora* co);
-void _35clofun3218(struct Cora* co);
-void _35clofun3223(struct Cora* co);
-void _35clofun3226(struct Cora* co);
-void _35clofun3229(struct Cora* co);
-void _35clofun3230(struct Cora* co);
-void _35clofun3227(struct Cora* co);
-void _35clofun3228(struct Cora* co);
-void _35clofun3224(struct Cora* co);
-void _35clofun3225(struct Cora* co);
-void _35clofun3221(struct Cora* co);
-void _35clofun3222(struct Cora* co);
-void _35clofun3219(struct Cora* co);
-void _35clofun3220(struct Cora* co);
-void _35clofun3216(struct Cora* co);
-void _35clofun3215(struct Cora* co);
-void _35clofun3214(struct Cora* co);
-void _35clofun3213(struct Cora* co);
-void _35clofun3212(struct Cora* co);
-void _35clofun3211(struct Cora* co);
-void _35clofun3210(struct Cora* co);
-void _35clofun3209(struct Cora* co);
-void _35clofun3208(struct Cora* co);
-void _35clofun3207(struct Cora* co);
-void _35clofun3206(struct Cora* co);
-void _35clofun3205(struct Cora* co);
-void _35clofun3204(struct Cora* co);
-void _35clofun3203(struct Cora* co);
-void _35clofun3202(struct Cora* co);
-void _35clofun3201(struct Cora* co);
-void _35clofun3195(struct Cora* co);
-void _35clofun3196(struct Cora* co);
-void _35clofun3197(struct Cora* co);
-void _35clofun3198(struct Cora* co);
-void _35clofun3199(struct Cora* co);
-void _35clofun3200(struct Cora* co);
-void _35clofun3187(struct Cora* co);
-void _35clofun3188(struct Cora* co);
-void _35clofun3189(struct Cora* co);
-void _35clofun3192(struct Cora* co);
-void _35clofun3193(struct Cora* co);
-void _35clofun3194(struct Cora* co);
-void _35clofun3190(struct Cora* co);
-void _35clofun3191(struct Cora* co);
-void _35clofun3183(struct Cora* co);
-void _35clofun3184(struct Cora* co);
-void _35clofun3186(struct Cora* co);
-void _35clofun3185(struct Cora* co);
-void _35clofun3178(struct Cora* co);
-void _35clofun3179(struct Cora* co);
-void _35clofun3180(struct Cora* co);
-void _35clofun3181(struct Cora* co);
-void _35clofun3182(struct Cora* co);
-void _35clofun3174(struct Cora* co);
-void _35clofun3175(struct Cora* co);
-void _35clofun3176(struct Cora* co);
-void _35clofun3171(struct Cora* co);
-void _35clofun3172(struct Cora* co);
-void _35clofun3173(struct Cora* co);
-void _35clofun3169(struct Cora* co);
-void _35clofun3170(struct Cora* co);
-void _35clofun3168(struct Cora* co);
-void _35clofun3167(struct Cora* co);
-void _35clofun3166(struct Cora* co);
-void _35clofun3165(struct Cora* co);
-void _35clofun3158(struct Cora* co);
-void _35clofun3160(struct Cora* co);
-void _35clofun3161(struct Cora* co);
-void _35clofun3162(struct Cora* co);
-void _35clofun3163(struct Cora* co);
-void _35clofun3164(struct Cora* co);
-void _35clofun3159(struct Cora* co);
-void _35clofun3150(struct Cora* co);
-void _35clofun3151(struct Cora* co);
-void _35clofun3153(struct Cora* co);
-void _35clofun3154(struct Cora* co);
-void _35clofun3155(struct Cora* co);
-void _35clofun3156(struct Cora* co);
-void _35clofun3157(struct Cora* co);
-void _35clofun3152(struct Cora* co);
-void _35clofun3146(struct Cora* co);
-void _35clofun3147(struct Cora* co);
-void _35clofun3148(struct Cora* co);
-void _35clofun3149(struct Cora* co);
-void _35clofun3145(struct Cora* co);
-void _35clofun3139(struct Cora* co);
-void _35clofun3140(struct Cora* co);
-void _35clofun3142(struct Cora* co);
-void _35clofun3143(struct Cora* co);
-void _35clofun3144(struct Cora* co);
-void _35clofun3141(struct Cora* co);
-void _35clofun3128(struct Cora* co);
-void _35clofun3130(struct Cora* co);
-void _35clofun3131(struct Cora* co);
-void _35clofun3132(struct Cora* co);
-void _35clofun3133(struct Cora* co);
-void _35clofun3134(struct Cora* co);
-void _35clofun3135(struct Cora* co);
-void _35clofun3138(struct Cora* co);
-void _35clofun3136(struct Cora* co);
-void _35clofun3137(struct Cora* co);
-void _35clofun3129(struct Cora* co);
-void _35clofun3120(struct Cora* co);
-void _35clofun3121(struct Cora* co);
-void _35clofun3123(struct Cora* co);
-void _35clofun3124(struct Cora* co);
-void _35clofun3125(struct Cora* co);
-void _35clofun3126(struct Cora* co);
-void _35clofun3127(struct Cora* co);
-void _35clofun3122(struct Cora* co);
-void _35clofun3040(struct Cora* co);
-void _35clofun3041(struct Cora* co);
-void _35clofun3117(struct Cora* co);
-void _35clofun3118(struct Cora* co);
-void _35clofun3119(struct Cora* co);
-void _35clofun3042(struct Cora* co);
-void _35clofun3115(struct Cora* co);
-void _35clofun3116(struct Cora* co);
-void _35clofun3043(struct Cora* co);
-void _35clofun3113(struct Cora* co);
-void _35clofun3114(struct Cora* co);
-void _35clofun3044(struct Cora* co);
-void _35clofun3107(struct Cora* co);
-void _35clofun3110(struct Cora* co);
-void _35clofun3111(struct Cora* co);
-void _35clofun3112(struct Cora* co);
-void _35clofun3108(struct Cora* co);
-void _35clofun3109(struct Cora* co);
-void _35clofun3104(struct Cora* co);
-void _35clofun3105(struct Cora* co);
-void _35clofun3106(struct Cora* co);
-void _35clofun3045(struct Cora* co);
-void _35clofun3094(struct Cora* co);
-void _35clofun3100(struct Cora* co);
-void _35clofun3101(struct Cora* co);
-void _35clofun3102(struct Cora* co);
-void _35clofun3103(struct Cora* co);
-void _35clofun3095(struct Cora* co);
-void _35clofun3096(struct Cora* co);
-void _35clofun3097(struct Cora* co);
-void _35clofun3098(struct Cora* co);
-void _35clofun3099(struct Cora* co);
-void _35clofun3046(struct Cora* co);
-void _35clofun3090(struct Cora* co);
-void _35clofun3091(struct Cora* co);
-void _35clofun3092(struct Cora* co);
-void _35clofun3093(struct Cora* co);
-void _35clofun3047(struct Cora* co);
-void _35clofun3084(struct Cora* co);
-void _35clofun3085(struct Cora* co);
-void _35clofun3086(struct Cora* co);
-void _35clofun3087(struct Cora* co);
-void _35clofun3088(struct Cora* co);
-void _35clofun3089(struct Cora* co);
-void _35clofun3048(struct Cora* co);
-void _35clofun3074(struct Cora* co);
-void _35clofun3075(struct Cora* co);
-void _35clofun3076(struct Cora* co);
-void _35clofun3077(struct Cora* co);
-void _35clofun3078(struct Cora* co);
-void _35clofun3079(struct Cora* co);
-void _35clofun3080(struct Cora* co);
-void _35clofun3081(struct Cora* co);
-void _35clofun3082(struct Cora* co);
-void _35clofun3083(struct Cora* co);
-void _35clofun3049(struct Cora* co);
-void _35clofun3072(struct Cora* co);
-void _35clofun3073(struct Cora* co);
-void _35clofun3050(struct Cora* co);
-void _35clofun3069(struct Cora* co);
-void _35clofun3070(struct Cora* co);
-void _35clofun3071(struct Cora* co);
-void _35clofun3051(struct Cora* co);
-void _35clofun3052(struct Cora* co);
-void _35clofun3068(struct Cora* co);
-void _35clofun3053(struct Cora* co);
-void _35clofun3055(struct Cora* co);
-void _35clofun3056(struct Cora* co);
-void _35clofun3057(struct Cora* co);
-void _35clofun3058(struct Cora* co);
-void _35clofun3059(struct Cora* co);
-void _35clofun3060(struct Cora* co);
-void _35clofun3061(struct Cora* co);
-void _35clofun3062(struct Cora* co);
-void _35clofun3063(struct Cora* co);
-void _35clofun3064(struct Cora* co);
-void _35clofun3065(struct Cora* co);
-void _35clofun3066(struct Cora* co);
-void _35clofun3067(struct Cora* co);
-void _35clofun3054(struct Cora* co);
-void _35clofun3038(struct Cora* co);
-void _35clofun3039(struct Cora* co);
-void _35clofun3033(struct Cora* co);
-void _35clofun3037(struct Cora* co);
-void _35clofun3034(struct Cora* co);
-void _35clofun3036(struct Cora* co);
-void _35clofun3035(struct Cora* co);
-void _35clofun3023(struct Cora* co);
-void _35clofun3031(struct Cora* co);
-void _35clofun3032(struct Cora* co);
-void _35clofun3029(struct Cora* co);
-void _35clofun3030(struct Cora* co);
-void _35clofun3027(struct Cora* co);
-void _35clofun3028(struct Cora* co);
-void _35clofun3024(struct Cora* co);
-void _35clofun3025(struct Cora* co);
-void _35clofun3026(struct Cora* co);
-void _35clofun3005(struct Cora* co);
-void _35clofun3022(struct Cora* co);
-void _35clofun3006(struct Cora* co);
-void _35clofun3007(struct Cora* co);
-void _35clofun3021(struct Cora* co);
-void _35clofun3008(struct Cora* co);
-void _35clofun3016(struct Cora* co);
-void _35clofun3017(struct Cora* co);
-void _35clofun3018(struct Cora* co);
-void _35clofun3019(struct Cora* co);
-void _35clofun3020(struct Cora* co);
-void _35clofun3009(struct Cora* co);
-void _35clofun3013(struct Cora* co);
-void _35clofun3014(struct Cora* co);
-void _35clofun3015(struct Cora* co);
-void _35clofun3010(struct Cora* co);
-void _35clofun3012(struct Cora* co);
-void _35clofun3011(struct Cora* co);
-void _35clofun2995(struct Cora* co);
-void _35clofun2999(struct Cora* co);
-void _35clofun3000(struct Cora* co);
-void _35clofun3004(struct Cora* co);
-void _35clofun3001(struct Cora* co);
-void _35clofun3003(struct Cora* co);
-void _35clofun3002(struct Cora* co);
-void _35clofun2996(struct Cora* co);
-void _35clofun2998(struct Cora* co);
-void _35clofun2997(struct Cora* co);
-void _35clofun2977(struct Cora* co);
-void _35clofun2994(struct Cora* co);
-void _35clofun2978(struct Cora* co);
-void _35clofun2993(struct Cora* co);
-void _35clofun2979(struct Cora* co);
-void _35clofun2990(struct Cora* co);
-void _35clofun2991(struct Cora* co);
-void _35clofun2992(struct Cora* co);
-void _35clofun2980(struct Cora* co);
-void _35clofun2988(struct Cora* co);
-void _35clofun2989(struct Cora* co);
-void _35clofun2981(struct Cora* co);
-void _35clofun2986(struct Cora* co);
-void _35clofun2987(struct Cora* co);
-void _35clofun2982(struct Cora* co);
-void _35clofun2985(struct Cora* co);
-void _35clofun2983(struct Cora* co);
-void _35clofun2984(struct Cora* co);
-void _35clofun2976(struct Cora* co);
-void _35clofun2961(struct Cora* co);
-void _35clofun2975(struct Cora* co);
-void _35clofun2962(struct Cora* co);
-void _35clofun2974(struct Cora* co);
-void _35clofun2963(struct Cora* co);
-void _35clofun2970(struct Cora* co);
-void _35clofun2971(struct Cora* co);
-void _35clofun2972(struct Cora* co);
-void _35clofun2973(struct Cora* co);
-void _35clofun2964(struct Cora* co);
-void _35clofun2968(struct Cora* co);
-void _35clofun2969(struct Cora* co);
-void _35clofun2965(struct Cora* co);
-void _35clofun2967(struct Cora* co);
-void _35clofun2966(struct Cora* co);
-void _35clofun2938(struct Cora* co);
-void _35clofun2960(struct Cora* co);
-void _35clofun2939(struct Cora* co);
-void _35clofun2940(struct Cora* co);
-void _35clofun2959(struct Cora* co);
-void _35clofun2941(struct Cora* co);
-void _35clofun2958(struct Cora* co);
-void _35clofun2942(struct Cora* co);
-void _35clofun2957(struct Cora* co);
-void _35clofun2943(struct Cora* co);
-void _35clofun2954(struct Cora* co);
-void _35clofun2955(struct Cora* co);
-void _35clofun2956(struct Cora* co);
-void _35clofun2944(struct Cora* co);
-void _35clofun2945(struct Cora* co);
-void _35clofun2946(struct Cora* co);
-void _35clofun2953(struct Cora* co);
-void _35clofun2947(struct Cora* co);
-void _35clofun2948(struct Cora* co);
-void _35clofun2952(struct Cora* co);
-void _35clofun2949(struct Cora* co);
-void _35clofun2951(struct Cora* co);
-void _35clofun2950(struct Cora* co);
-void _35clofun2931(struct Cora* co);
-void _35clofun2932(struct Cora* co);
-void _35clofun2933(struct Cora* co);
-void _35clofun2934(struct Cora* co);
-void _35clofun2935(struct Cora* co);
-void _35clofun2936(struct Cora* co);
-void _35clofun2937(struct Cora* co);
-void _35clofun2925(struct Cora* co);
-void _35clofun2926(struct Cora* co);
-void _35clofun2930(struct Cora* co);
-void _35clofun2927(struct Cora* co);
-void _35clofun2929(struct Cora* co);
-void _35clofun2928(struct Cora* co);
-void _35clofun2919(struct Cora* co);
-void _35clofun2920(struct Cora* co);
-void _35clofun2924(struct Cora* co);
-void _35clofun2921(struct Cora* co);
-void _35clofun2923(struct Cora* co);
-void _35clofun2922(struct Cora* co);
-void _35clofun2889(struct Cora* co);
-void _35clofun2916(struct Cora* co);
-void _35clofun2917(struct Cora* co);
-void _35clofun2918(struct Cora* co);
-void _35clofun2890(struct Cora* co);
-void _35clofun2891(struct Cora* co);
-void _35clofun2915(struct Cora* co);
-void _35clofun2892(struct Cora* co);
-void _35clofun2913(struct Cora* co);
-void _35clofun2914(struct Cora* co);
-void _35clofun2893(struct Cora* co);
-void _35clofun2911(struct Cora* co);
-void _35clofun2912(struct Cora* co);
-void _35clofun2894(struct Cora* co);
-void _35clofun2909(struct Cora* co);
-void _35clofun2910(struct Cora* co);
-void _35clofun2895(struct Cora* co);
-void _35clofun2907(struct Cora* co);
-void _35clofun2908(struct Cora* co);
-void _35clofun2896(struct Cora* co);
-void _35clofun2900(struct Cora* co);
-void _35clofun2901(struct Cora* co);
-void _35clofun2902(struct Cora* co);
-void _35clofun2905(struct Cora* co);
-void _35clofun2906(struct Cora* co);
-void _35clofun2903(struct Cora* co);
-void _35clofun2904(struct Cora* co);
-void _35clofun2897(struct Cora* co);
-void _35clofun2899(struct Cora* co);
-void _35clofun2898(struct Cora* co);
-void _35clofun2886(struct Cora* co);
-void _35clofun2887(struct Cora* co);
-void _35clofun2888(struct Cora* co);
-void _35clofun2883(struct Cora* co);
-void _35clofun2884(struct Cora* co);
-void _35clofun2885(struct Cora* co);
-void _35clofun2880(struct Cora* co);
-void _35clofun2881(struct Cora* co);
-void _35clofun2882(struct Cora* co);
-void _35clofun2877(struct Cora* co);
-void _35clofun2878(struct Cora* co);
-void _35clofun2879(struct Cora* co);
-void _35clofun2873(struct Cora* co);
-void _35clofun2874(struct Cora* co);
-void _35clofun2876(struct Cora* co);
-void _35clofun2875(struct Cora* co);
-void _35clofun2872(struct Cora* co);
-void _35clofun2868(struct Cora* co);
-void _35clofun2869(struct Cora* co);
-void _35clofun2870(struct Cora* co);
-void _35clofun2871(struct Cora* co);
-void _35clofun2864(struct Cora* co);
-void _35clofun2865(struct Cora* co);
-void _35clofun2867(struct Cora* co);
-void _35clofun2866(struct Cora* co);
-void _35clofun2860(struct Cora* co);
-void _35clofun2861(struct Cora* co);
-void _35clofun2862(struct Cora* co);
-void _35clofun2863(struct Cora* co);
+void _35clofun3661(struct Cora* co);
+void _35clofun3662(struct Cora* co);
+void _35clofun3981(struct Cora* co);
+void _35clofun4021(struct Cora* co);
+void _35clofun4022(struct Cora* co);
+void _35clofun4027(struct Cora* co);
+void _35clofun4030(struct Cora* co);
+void _35clofun4033(struct Cora* co);
+void _35clofun4034(struct Cora* co);
+void _35clofun4031(struct Cora* co);
+void _35clofun4032(struct Cora* co);
+void _35clofun4028(struct Cora* co);
+void _35clofun4029(struct Cora* co);
+void _35clofun4025(struct Cora* co);
+void _35clofun4026(struct Cora* co);
+void _35clofun4023(struct Cora* co);
+void _35clofun4024(struct Cora* co);
+void _35clofun4020(struct Cora* co);
+void _35clofun4019(struct Cora* co);
+void _35clofun4018(struct Cora* co);
+void _35clofun4017(struct Cora* co);
+void _35clofun4016(struct Cora* co);
+void _35clofun4015(struct Cora* co);
+void _35clofun4014(struct Cora* co);
+void _35clofun4013(struct Cora* co);
+void _35clofun4012(struct Cora* co);
+void _35clofun4011(struct Cora* co);
+void _35clofun4010(struct Cora* co);
+void _35clofun4009(struct Cora* co);
+void _35clofun4008(struct Cora* co);
+void _35clofun4007(struct Cora* co);
+void _35clofun4006(struct Cora* co);
+void _35clofun4005(struct Cora* co);
+void _35clofun3999(struct Cora* co);
+void _35clofun4000(struct Cora* co);
+void _35clofun4001(struct Cora* co);
+void _35clofun4002(struct Cora* co);
+void _35clofun4003(struct Cora* co);
+void _35clofun4004(struct Cora* co);
+void _35clofun3991(struct Cora* co);
+void _35clofun3992(struct Cora* co);
+void _35clofun3993(struct Cora* co);
+void _35clofun3996(struct Cora* co);
+void _35clofun3997(struct Cora* co);
+void _35clofun3998(struct Cora* co);
+void _35clofun3994(struct Cora* co);
+void _35clofun3995(struct Cora* co);
+void _35clofun3987(struct Cora* co);
+void _35clofun3988(struct Cora* co);
+void _35clofun3990(struct Cora* co);
+void _35clofun3989(struct Cora* co);
+void _35clofun3982(struct Cora* co);
+void _35clofun3983(struct Cora* co);
+void _35clofun3984(struct Cora* co);
+void _35clofun3985(struct Cora* co);
+void _35clofun3986(struct Cora* co);
+void _35clofun3978(struct Cora* co);
+void _35clofun3979(struct Cora* co);
+void _35clofun3980(struct Cora* co);
+void _35clofun3975(struct Cora* co);
+void _35clofun3976(struct Cora* co);
+void _35clofun3977(struct Cora* co);
+void _35clofun3973(struct Cora* co);
+void _35clofun3974(struct Cora* co);
+void _35clofun3972(struct Cora* co);
+void _35clofun3971(struct Cora* co);
+void _35clofun3970(struct Cora* co);
+void _35clofun3969(struct Cora* co);
+void _35clofun3962(struct Cora* co);
+void _35clofun3964(struct Cora* co);
+void _35clofun3965(struct Cora* co);
+void _35clofun3966(struct Cora* co);
+void _35clofun3967(struct Cora* co);
+void _35clofun3968(struct Cora* co);
+void _35clofun3963(struct Cora* co);
+void _35clofun3954(struct Cora* co);
+void _35clofun3955(struct Cora* co);
+void _35clofun3957(struct Cora* co);
+void _35clofun3958(struct Cora* co);
+void _35clofun3959(struct Cora* co);
+void _35clofun3960(struct Cora* co);
+void _35clofun3961(struct Cora* co);
+void _35clofun3956(struct Cora* co);
+void _35clofun3950(struct Cora* co);
+void _35clofun3951(struct Cora* co);
+void _35clofun3952(struct Cora* co);
+void _35clofun3953(struct Cora* co);
+void _35clofun3949(struct Cora* co);
+void _35clofun3943(struct Cora* co);
+void _35clofun3944(struct Cora* co);
+void _35clofun3946(struct Cora* co);
+void _35clofun3947(struct Cora* co);
+void _35clofun3948(struct Cora* co);
+void _35clofun3945(struct Cora* co);
+void _35clofun3932(struct Cora* co);
+void _35clofun3934(struct Cora* co);
+void _35clofun3935(struct Cora* co);
+void _35clofun3936(struct Cora* co);
+void _35clofun3937(struct Cora* co);
+void _35clofun3938(struct Cora* co);
+void _35clofun3939(struct Cora* co);
+void _35clofun3942(struct Cora* co);
+void _35clofun3940(struct Cora* co);
+void _35clofun3941(struct Cora* co);
+void _35clofun3933(struct Cora* co);
+void _35clofun3924(struct Cora* co);
+void _35clofun3925(struct Cora* co);
+void _35clofun3927(struct Cora* co);
+void _35clofun3928(struct Cora* co);
+void _35clofun3929(struct Cora* co);
+void _35clofun3930(struct Cora* co);
+void _35clofun3931(struct Cora* co);
+void _35clofun3926(struct Cora* co);
+void _35clofun3843(struct Cora* co);
+void _35clofun3844(struct Cora* co);
+void _35clofun3921(struct Cora* co);
+void _35clofun3922(struct Cora* co);
+void _35clofun3923(struct Cora* co);
+void _35clofun3845(struct Cora* co);
+void _35clofun3919(struct Cora* co);
+void _35clofun3920(struct Cora* co);
+void _35clofun3846(struct Cora* co);
+void _35clofun3917(struct Cora* co);
+void _35clofun3918(struct Cora* co);
+void _35clofun3847(struct Cora* co);
+void _35clofun3911(struct Cora* co);
+void _35clofun3914(struct Cora* co);
+void _35clofun3915(struct Cora* co);
+void _35clofun3916(struct Cora* co);
+void _35clofun3912(struct Cora* co);
+void _35clofun3913(struct Cora* co);
+void _35clofun3908(struct Cora* co);
+void _35clofun3909(struct Cora* co);
+void _35clofun3910(struct Cora* co);
+void _35clofun3848(struct Cora* co);
+void _35clofun3898(struct Cora* co);
+void _35clofun3904(struct Cora* co);
+void _35clofun3905(struct Cora* co);
+void _35clofun3906(struct Cora* co);
+void _35clofun3907(struct Cora* co);
+void _35clofun3899(struct Cora* co);
+void _35clofun3900(struct Cora* co);
+void _35clofun3901(struct Cora* co);
+void _35clofun3902(struct Cora* co);
+void _35clofun3903(struct Cora* co);
+void _35clofun3849(struct Cora* co);
+void _35clofun3894(struct Cora* co);
+void _35clofun3895(struct Cora* co);
+void _35clofun3896(struct Cora* co);
+void _35clofun3897(struct Cora* co);
+void _35clofun3850(struct Cora* co);
+void _35clofun3888(struct Cora* co);
+void _35clofun3889(struct Cora* co);
+void _35clofun3890(struct Cora* co);
+void _35clofun3891(struct Cora* co);
+void _35clofun3892(struct Cora* co);
+void _35clofun3893(struct Cora* co);
+void _35clofun3851(struct Cora* co);
+void _35clofun3878(struct Cora* co);
+void _35clofun3879(struct Cora* co);
+void _35clofun3880(struct Cora* co);
+void _35clofun3881(struct Cora* co);
+void _35clofun3882(struct Cora* co);
+void _35clofun3883(struct Cora* co);
+void _35clofun3884(struct Cora* co);
+void _35clofun3885(struct Cora* co);
+void _35clofun3886(struct Cora* co);
+void _35clofun3887(struct Cora* co);
+void _35clofun3852(struct Cora* co);
+void _35clofun3876(struct Cora* co);
+void _35clofun3877(struct Cora* co);
+void _35clofun3853(struct Cora* co);
+void _35clofun3872(struct Cora* co);
+void _35clofun3873(struct Cora* co);
+void _35clofun3874(struct Cora* co);
+void _35clofun3875(struct Cora* co);
+void _35clofun3854(struct Cora* co);
+void _35clofun3855(struct Cora* co);
+void _35clofun3871(struct Cora* co);
+void _35clofun3856(struct Cora* co);
+void _35clofun3858(struct Cora* co);
+void _35clofun3859(struct Cora* co);
+void _35clofun3860(struct Cora* co);
+void _35clofun3861(struct Cora* co);
+void _35clofun3862(struct Cora* co);
+void _35clofun3863(struct Cora* co);
+void _35clofun3864(struct Cora* co);
+void _35clofun3865(struct Cora* co);
+void _35clofun3866(struct Cora* co);
+void _35clofun3867(struct Cora* co);
+void _35clofun3868(struct Cora* co);
+void _35clofun3869(struct Cora* co);
+void _35clofun3870(struct Cora* co);
+void _35clofun3857(struct Cora* co);
+void _35clofun3841(struct Cora* co);
+void _35clofun3842(struct Cora* co);
+void _35clofun3836(struct Cora* co);
+void _35clofun3840(struct Cora* co);
+void _35clofun3837(struct Cora* co);
+void _35clofun3839(struct Cora* co);
+void _35clofun3838(struct Cora* co);
+void _35clofun3826(struct Cora* co);
+void _35clofun3834(struct Cora* co);
+void _35clofun3835(struct Cora* co);
+void _35clofun3832(struct Cora* co);
+void _35clofun3833(struct Cora* co);
+void _35clofun3830(struct Cora* co);
+void _35clofun3831(struct Cora* co);
+void _35clofun3827(struct Cora* co);
+void _35clofun3828(struct Cora* co);
+void _35clofun3829(struct Cora* co);
+void _35clofun3808(struct Cora* co);
+void _35clofun3825(struct Cora* co);
+void _35clofun3809(struct Cora* co);
+void _35clofun3810(struct Cora* co);
+void _35clofun3824(struct Cora* co);
+void _35clofun3811(struct Cora* co);
+void _35clofun3819(struct Cora* co);
+void _35clofun3820(struct Cora* co);
+void _35clofun3821(struct Cora* co);
+void _35clofun3822(struct Cora* co);
+void _35clofun3823(struct Cora* co);
+void _35clofun3812(struct Cora* co);
+void _35clofun3816(struct Cora* co);
+void _35clofun3817(struct Cora* co);
+void _35clofun3818(struct Cora* co);
+void _35clofun3813(struct Cora* co);
+void _35clofun3815(struct Cora* co);
+void _35clofun3814(struct Cora* co);
+void _35clofun3798(struct Cora* co);
+void _35clofun3802(struct Cora* co);
+void _35clofun3803(struct Cora* co);
+void _35clofun3807(struct Cora* co);
+void _35clofun3804(struct Cora* co);
+void _35clofun3806(struct Cora* co);
+void _35clofun3805(struct Cora* co);
+void _35clofun3799(struct Cora* co);
+void _35clofun3801(struct Cora* co);
+void _35clofun3800(struct Cora* co);
+void _35clofun3780(struct Cora* co);
+void _35clofun3797(struct Cora* co);
+void _35clofun3781(struct Cora* co);
+void _35clofun3796(struct Cora* co);
+void _35clofun3782(struct Cora* co);
+void _35clofun3793(struct Cora* co);
+void _35clofun3794(struct Cora* co);
+void _35clofun3795(struct Cora* co);
+void _35clofun3783(struct Cora* co);
+void _35clofun3791(struct Cora* co);
+void _35clofun3792(struct Cora* co);
+void _35clofun3784(struct Cora* co);
+void _35clofun3789(struct Cora* co);
+void _35clofun3790(struct Cora* co);
+void _35clofun3785(struct Cora* co);
+void _35clofun3788(struct Cora* co);
+void _35clofun3786(struct Cora* co);
+void _35clofun3787(struct Cora* co);
+void _35clofun3779(struct Cora* co);
+void _35clofun3764(struct Cora* co);
+void _35clofun3778(struct Cora* co);
+void _35clofun3765(struct Cora* co);
+void _35clofun3777(struct Cora* co);
+void _35clofun3766(struct Cora* co);
+void _35clofun3773(struct Cora* co);
+void _35clofun3774(struct Cora* co);
+void _35clofun3775(struct Cora* co);
+void _35clofun3776(struct Cora* co);
+void _35clofun3767(struct Cora* co);
+void _35clofun3771(struct Cora* co);
+void _35clofun3772(struct Cora* co);
+void _35clofun3768(struct Cora* co);
+void _35clofun3770(struct Cora* co);
+void _35clofun3769(struct Cora* co);
+void _35clofun3741(struct Cora* co);
+void _35clofun3763(struct Cora* co);
+void _35clofun3742(struct Cora* co);
+void _35clofun3743(struct Cora* co);
+void _35clofun3762(struct Cora* co);
+void _35clofun3744(struct Cora* co);
+void _35clofun3761(struct Cora* co);
+void _35clofun3745(struct Cora* co);
+void _35clofun3760(struct Cora* co);
+void _35clofun3746(struct Cora* co);
+void _35clofun3757(struct Cora* co);
+void _35clofun3758(struct Cora* co);
+void _35clofun3759(struct Cora* co);
+void _35clofun3747(struct Cora* co);
+void _35clofun3748(struct Cora* co);
+void _35clofun3749(struct Cora* co);
+void _35clofun3756(struct Cora* co);
+void _35clofun3750(struct Cora* co);
+void _35clofun3751(struct Cora* co);
+void _35clofun3755(struct Cora* co);
+void _35clofun3752(struct Cora* co);
+void _35clofun3754(struct Cora* co);
+void _35clofun3753(struct Cora* co);
+void _35clofun3734(struct Cora* co);
+void _35clofun3735(struct Cora* co);
+void _35clofun3736(struct Cora* co);
+void _35clofun3737(struct Cora* co);
+void _35clofun3738(struct Cora* co);
+void _35clofun3739(struct Cora* co);
+void _35clofun3740(struct Cora* co);
+void _35clofun3728(struct Cora* co);
+void _35clofun3729(struct Cora* co);
+void _35clofun3733(struct Cora* co);
+void _35clofun3730(struct Cora* co);
+void _35clofun3732(struct Cora* co);
+void _35clofun3731(struct Cora* co);
+void _35clofun3722(struct Cora* co);
+void _35clofun3723(struct Cora* co);
+void _35clofun3727(struct Cora* co);
+void _35clofun3724(struct Cora* co);
+void _35clofun3726(struct Cora* co);
+void _35clofun3725(struct Cora* co);
+void _35clofun3692(struct Cora* co);
+void _35clofun3719(struct Cora* co);
+void _35clofun3720(struct Cora* co);
+void _35clofun3721(struct Cora* co);
+void _35clofun3693(struct Cora* co);
+void _35clofun3694(struct Cora* co);
+void _35clofun3718(struct Cora* co);
+void _35clofun3695(struct Cora* co);
+void _35clofun3716(struct Cora* co);
+void _35clofun3717(struct Cora* co);
+void _35clofun3696(struct Cora* co);
+void _35clofun3714(struct Cora* co);
+void _35clofun3715(struct Cora* co);
+void _35clofun3697(struct Cora* co);
+void _35clofun3712(struct Cora* co);
+void _35clofun3713(struct Cora* co);
+void _35clofun3698(struct Cora* co);
+void _35clofun3710(struct Cora* co);
+void _35clofun3711(struct Cora* co);
+void _35clofun3699(struct Cora* co);
+void _35clofun3703(struct Cora* co);
+void _35clofun3704(struct Cora* co);
+void _35clofun3705(struct Cora* co);
+void _35clofun3708(struct Cora* co);
+void _35clofun3709(struct Cora* co);
+void _35clofun3706(struct Cora* co);
+void _35clofun3707(struct Cora* co);
+void _35clofun3700(struct Cora* co);
+void _35clofun3702(struct Cora* co);
+void _35clofun3701(struct Cora* co);
+void _35clofun3689(struct Cora* co);
+void _35clofun3690(struct Cora* co);
+void _35clofun3691(struct Cora* co);
+void _35clofun3686(struct Cora* co);
+void _35clofun3687(struct Cora* co);
+void _35clofun3688(struct Cora* co);
+void _35clofun3683(struct Cora* co);
+void _35clofun3684(struct Cora* co);
+void _35clofun3685(struct Cora* co);
+void _35clofun3680(struct Cora* co);
+void _35clofun3681(struct Cora* co);
+void _35clofun3682(struct Cora* co);
+void _35clofun3676(struct Cora* co);
+void _35clofun3677(struct Cora* co);
+void _35clofun3679(struct Cora* co);
+void _35clofun3678(struct Cora* co);
+void _35clofun3675(struct Cora* co);
+void _35clofun3671(struct Cora* co);
+void _35clofun3672(struct Cora* co);
+void _35clofun3673(struct Cora* co);
+void _35clofun3674(struct Cora* co);
+void _35clofun3667(struct Cora* co);
+void _35clofun3668(struct Cora* co);
+void _35clofun3670(struct Cora* co);
+void _35clofun3669(struct Cora* co);
+void _35clofun3663(struct Cora* co);
+void _35clofun3664(struct Cora* co);
+void _35clofun3665(struct Cora* co);
+void _35clofun3666(struct Cora* co);
 
 void entry(struct Cora* co) {
-pushCont(co, _35clofun2858, 0);
+pushCont(co, _35clofun3661, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("import"));
 co->args[1] = makeString1("cora/lib/toc/internal");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -390,12 +391,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2858(struct Cora* co) {
-Obj _35val1398 = co->args[1];
-pushCont(co, _35clofun2859, 0);
+void _35clofun3661(struct Cora* co) {
+Obj _35val2200 = co->args[1];
+pushCont(co, _35clofun3662, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("import"));
 co->args[1] = makeString1("cora/lib/io");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -405,118 +406,118 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2859(struct Cora* co) {
-Obj _35val1399 = co->args[1];
-Obj _35reg1414 = primSet(intern("cora/lib/toc/include.assq"), makeNative(_35clofun2860, 2, 0));
-Obj _35reg1420 = primSet(intern("cora/lib/toc/include.foldl"), makeNative(_35clofun2864, 3, 0));
-Obj _35reg1430 = primSet(intern("cora/lib/toc/include.pos-in-list0"), makeNative(_35clofun2868, 3, 0));
-Obj _35reg1431 = primSet(intern("cora/lib/toc/include.index"), makeNative(_35clofun2872, 2, 0));
-Obj _35reg1438 = primSet(intern("cora/lib/toc/include.exist-in-env"), makeNative(_35clofun2873, 2, 0));
-Obj _35reg1439 = primCons(intern("primSet"), Nil);
-Obj _35reg1440 = primCons(makeNumber(2), _35reg1439);
-Obj _35reg1441 = primCons(intern("set"), _35reg1440);
-Obj _35reg1442 = primCons(intern("primCar"), Nil);
-Obj _35reg1443 = primCons(makeNumber(1), _35reg1442);
-Obj _35reg1444 = primCons(intern("car"), _35reg1443);
-Obj _35reg1445 = primCons(intern("primCdr"), Nil);
-Obj _35reg1446 = primCons(makeNumber(1), _35reg1445);
-Obj _35reg1447 = primCons(intern("cdr"), _35reg1446);
-Obj _35reg1448 = primCons(intern("primCons"), Nil);
-Obj _35reg1449 = primCons(makeNumber(2), _35reg1448);
-Obj _35reg1450 = primCons(intern("cons"), _35reg1449);
-Obj _35reg1451 = primCons(intern("primIsCons"), Nil);
-Obj _35reg1452 = primCons(makeNumber(1), _35reg1451);
-Obj _35reg1453 = primCons(intern("cons?"), _35reg1452);
-Obj _35reg1454 = primCons(intern("primAdd"), Nil);
-Obj _35reg1455 = primCons(makeNumber(2), _35reg1454);
-Obj _35reg1456 = primCons(intern("+"), _35reg1455);
-Obj _35reg1457 = primCons(intern("primSub"), Nil);
-Obj _35reg1458 = primCons(makeNumber(2), _35reg1457);
-Obj _35reg1459 = primCons(intern("-"), _35reg1458);
-Obj _35reg1460 = primCons(intern("primMul"), Nil);
-Obj _35reg1461 = primCons(makeNumber(2), _35reg1460);
-Obj _35reg1462 = primCons(intern("*"), _35reg1461);
-Obj _35reg1463 = primCons(intern("primDiv"), Nil);
-Obj _35reg1464 = primCons(makeNumber(2), _35reg1463);
-Obj _35reg1465 = primCons(intern("/"), _35reg1464);
-Obj _35reg1466 = primCons(intern("primEQ"), Nil);
-Obj _35reg1467 = primCons(makeNumber(2), _35reg1466);
-Obj _35reg1468 = primCons(intern("="), _35reg1467);
-Obj _35reg1469 = primCons(intern("primGT"), Nil);
-Obj _35reg1470 = primCons(makeNumber(2), _35reg1469);
-Obj _35reg1471 = primCons(intern(">"), _35reg1470);
-Obj _35reg1472 = primCons(intern("primLT"), Nil);
-Obj _35reg1473 = primCons(makeNumber(2), _35reg1472);
-Obj _35reg1474 = primCons(intern("<"), _35reg1473);
-Obj _35reg1475 = primCons(intern("primGenSym"), Nil);
-Obj _35reg1476 = primCons(makeNumber(1), _35reg1475);
-Obj _35reg1477 = primCons(intern("gensym"), _35reg1476);
-Obj _35reg1478 = primCons(intern("primIsSymbol"), Nil);
-Obj _35reg1479 = primCons(makeNumber(1), _35reg1478);
-Obj _35reg1480 = primCons(intern("symbol?"), _35reg1479);
-Obj _35reg1481 = primCons(intern("primNot"), Nil);
-Obj _35reg1482 = primCons(makeNumber(1), _35reg1481);
-Obj _35reg1483 = primCons(intern("not"), _35reg1482);
-Obj _35reg1484 = primCons(intern("primIsNumber"), Nil);
-Obj _35reg1485 = primCons(makeNumber(1), _35reg1484);
-Obj _35reg1486 = primCons(intern("integer?"), _35reg1485);
-Obj _35reg1487 = primCons(intern("primIsString"), Nil);
-Obj _35reg1488 = primCons(makeNumber(1), _35reg1487);
-Obj _35reg1489 = primCons(intern("string?"), _35reg1488);
-Obj _35reg1490 = primCons(_35reg1489, Nil);
-Obj _35reg1491 = primCons(_35reg1486, _35reg1490);
-Obj _35reg1492 = primCons(_35reg1483, _35reg1491);
-Obj _35reg1493 = primCons(_35reg1480, _35reg1492);
-Obj _35reg1494 = primCons(_35reg1477, _35reg1493);
-Obj _35reg1495 = primCons(_35reg1474, _35reg1494);
-Obj _35reg1496 = primCons(_35reg1471, _35reg1495);
-Obj _35reg1497 = primCons(_35reg1468, _35reg1496);
-Obj _35reg1498 = primCons(_35reg1465, _35reg1497);
-Obj _35reg1499 = primCons(_35reg1462, _35reg1498);
-Obj _35reg1500 = primCons(_35reg1459, _35reg1499);
-Obj _35reg1501 = primCons(_35reg1456, _35reg1500);
-Obj _35reg1502 = primCons(_35reg1453, _35reg1501);
-Obj _35reg1503 = primCons(_35reg1450, _35reg1502);
-Obj _35reg1504 = primCons(_35reg1447, _35reg1503);
-Obj _35reg1505 = primCons(_35reg1444, _35reg1504);
-Obj _35reg1506 = primCons(_35reg1441, _35reg1505);
-Obj _35reg1507 = primSet(intern("cora/lib/toc/include.*builtin-prims*"), _35reg1506);
-Obj _35reg1511 = primSet(intern("builtin?"), makeNative(_35clofun2877, 1, 0));
-Obj _35reg1514 = primSet(intern("cora/lib/toc/include.builtin->name"), makeNative(_35clofun2880, 1, 0));
-Obj _35reg1517 = primSet(intern("cora/lib/toc/include.builtin->args"), makeNative(_35clofun2883, 1, 0));
-Obj _35reg1522 = primSet(intern("cora/lib/toc/include.temp-list"), makeNative(_35clofun2886, 2, 0));
-Obj _35reg1658 = primSet(intern("cora/lib/toc/include.parse"), makeNative(_35clofun2889, 2, 0));
-Obj _35reg1669 = primSet(intern("cora/lib/toc/include.union"), makeNative(_35clofun2919, 2, 0));
-Obj _35reg1680 = primSet(intern("cora/lib/toc/include.diff"), makeNative(_35clofun2925, 2, 0));
-Obj _35reg1731 = primSet(intern("cora/lib/toc/include.convert-protect?"), makeNative(_35clofun2931, 1, 0));
-Obj _35reg1906 = primSet(intern("cora/lib/toc/include.free-vars"), makeNative(_35clofun2938, 1, 0));
-Obj _35reg1979 = primSet(intern("cora/lib/toc/include.closure-convert"), makeNative(_35clofun2961, 2, 0));
-Obj _35reg1982 = primSet(intern("cora/lib/toc/include.id"), makeNative(_35clofun2976, 1, 0));
-Obj _35reg2119 = primSet(intern("cora/lib/toc/include.tailify"), makeNative(_35clofun2977, 2, 0));
-Obj _35reg2166 = primSet(intern("cora/lib/toc/include.tailify-list"), makeNative(_35clofun2995, 3, 0));
-Obj _35reg2245 = primSet(intern("cora/lib/toc/include.explicit-stack"), makeNative(_35clofun3005, 2, 0));
-Obj _35reg2352 = primSet(intern("cora/lib/toc/include.collect-lambda"), makeNative(_35clofun3023, 3, 0));
-Obj _35reg2359 = primSet(intern("cora/lib/toc/include.collect-lambda-list"), makeNative(_35clofun3033, 4, 0));
-Obj _35reg2366 = primSet(intern("cora/lib/toc/include.wrap-var"), makeNative(_35clofun3038, 2, 0));
-Obj _35reg2626 = primSet(intern("cora/lib/toc/include.generate-inst"), makeNative(_35clofun3040, 3, 0));
-Obj _35reg2637 = primSet(intern("cora/lib/toc/include.generate-call-args"), makeNative(_35clofun3120, 4, 0));
-Obj _35reg2656 = primSet(intern("cora/lib/toc/include.generate-cont"), makeNative(_35clofun3128, 2, 0));
-Obj _35reg2665 = primSet(intern("cora/lib/toc/include.generate-inst-list-h"), makeNative(_35clofun3139, 4, 0));
-Obj _35reg2666 = primSet(intern("cora/lib/toc/include.generate-inst-list"), makeNative(_35clofun3145, 3, 0));
-Obj _35reg2670 = primSet(intern("cora/lib/toc/include.code-gen-func-declare"), makeNative(_35clofun3146, 2, 0));
-Obj _35reg2681 = primSet(intern("cora/lib/toc/include.generate-call-args-reverse"), makeNative(_35clofun3150, 5, 0));
-Obj _35reg2738 = primSet(intern("cora/lib/toc/include.code-gen-toplevel"), makeNative(_35clofun3158, 2, 0));
-Obj _35reg2739 = primSet(intern("cora/lib/toc/include.parse-pass"), makeNative(_35clofun3165, 1, 0));
-Obj _35reg2740 = primSet(intern("cora/lib/toc/include.closure-convert-pass"), makeNative(_35clofun3166, 1, 0));
-Obj _35reg2741 = primSet(intern("cora/lib/toc/include.tailify-pass"), makeNative(_35clofun3167, 1, 0));
-Obj _35reg2742 = primSet(intern("cora/lib/toc/include.explicit-stack-pass"), makeNative(_35clofun3168, 1, 0));
-Obj _35reg2750 = primSet(intern("cora/lib/toc/include.collect-lambda-pass"), makeNative(_35clofun3169, 1, 0));
-Obj _35reg2757 = primSet(intern("cora/lib/toc/include.rewrite-->macro"), makeNative(_35clofun3171, 2, 0));
-pushCont(co, _35clofun3177, 0);
+void _35clofun3662(struct Cora* co) {
+Obj _35val2201 = co->args[1];
+Obj _35reg2216 = primSet(intern("cora/lib/toc/include.assq"), makeNative(_35clofun3663, 2, 0));
+Obj _35reg2222 = primSet(intern("cora/lib/toc/include.foldl"), makeNative(_35clofun3667, 3, 0));
+Obj _35reg2232 = primSet(intern("cora/lib/toc/include.pos-in-list0"), makeNative(_35clofun3671, 3, 0));
+Obj _35reg2233 = primSet(intern("cora/lib/toc/include.index"), makeNative(_35clofun3675, 2, 0));
+Obj _35reg2240 = primSet(intern("cora/lib/toc/include.exist-in-env"), makeNative(_35clofun3676, 2, 0));
+Obj _35reg2241 = primCons(intern("primSet"), Nil);
+Obj _35reg2242 = primCons(makeNumber(2), _35reg2241);
+Obj _35reg2243 = primCons(intern("set"), _35reg2242);
+Obj _35reg2244 = primCons(intern("primCar"), Nil);
+Obj _35reg2245 = primCons(makeNumber(1), _35reg2244);
+Obj _35reg2246 = primCons(intern("car"), _35reg2245);
+Obj _35reg2247 = primCons(intern("primCdr"), Nil);
+Obj _35reg2248 = primCons(makeNumber(1), _35reg2247);
+Obj _35reg2249 = primCons(intern("cdr"), _35reg2248);
+Obj _35reg2250 = primCons(intern("primCons"), Nil);
+Obj _35reg2251 = primCons(makeNumber(2), _35reg2250);
+Obj _35reg2252 = primCons(intern("cons"), _35reg2251);
+Obj _35reg2253 = primCons(intern("primIsCons"), Nil);
+Obj _35reg2254 = primCons(makeNumber(1), _35reg2253);
+Obj _35reg2255 = primCons(intern("cons?"), _35reg2254);
+Obj _35reg2256 = primCons(intern("primAdd"), Nil);
+Obj _35reg2257 = primCons(makeNumber(2), _35reg2256);
+Obj _35reg2258 = primCons(intern("+"), _35reg2257);
+Obj _35reg2259 = primCons(intern("primSub"), Nil);
+Obj _35reg2260 = primCons(makeNumber(2), _35reg2259);
+Obj _35reg2261 = primCons(intern("-"), _35reg2260);
+Obj _35reg2262 = primCons(intern("primMul"), Nil);
+Obj _35reg2263 = primCons(makeNumber(2), _35reg2262);
+Obj _35reg2264 = primCons(intern("*"), _35reg2263);
+Obj _35reg2265 = primCons(intern("primDiv"), Nil);
+Obj _35reg2266 = primCons(makeNumber(2), _35reg2265);
+Obj _35reg2267 = primCons(intern("/"), _35reg2266);
+Obj _35reg2268 = primCons(intern("primEQ"), Nil);
+Obj _35reg2269 = primCons(makeNumber(2), _35reg2268);
+Obj _35reg2270 = primCons(intern("="), _35reg2269);
+Obj _35reg2271 = primCons(intern("primGT"), Nil);
+Obj _35reg2272 = primCons(makeNumber(2), _35reg2271);
+Obj _35reg2273 = primCons(intern(">"), _35reg2272);
+Obj _35reg2274 = primCons(intern("primLT"), Nil);
+Obj _35reg2275 = primCons(makeNumber(2), _35reg2274);
+Obj _35reg2276 = primCons(intern("<"), _35reg2275);
+Obj _35reg2277 = primCons(intern("primGenSym"), Nil);
+Obj _35reg2278 = primCons(makeNumber(1), _35reg2277);
+Obj _35reg2279 = primCons(intern("gensym"), _35reg2278);
+Obj _35reg2280 = primCons(intern("primIsSymbol"), Nil);
+Obj _35reg2281 = primCons(makeNumber(1), _35reg2280);
+Obj _35reg2282 = primCons(intern("symbol?"), _35reg2281);
+Obj _35reg2283 = primCons(intern("primNot"), Nil);
+Obj _35reg2284 = primCons(makeNumber(1), _35reg2283);
+Obj _35reg2285 = primCons(intern("not"), _35reg2284);
+Obj _35reg2286 = primCons(intern("primIsNumber"), Nil);
+Obj _35reg2287 = primCons(makeNumber(1), _35reg2286);
+Obj _35reg2288 = primCons(intern("integer?"), _35reg2287);
+Obj _35reg2289 = primCons(intern("primIsString"), Nil);
+Obj _35reg2290 = primCons(makeNumber(1), _35reg2289);
+Obj _35reg2291 = primCons(intern("string?"), _35reg2290);
+Obj _35reg2292 = primCons(_35reg2291, Nil);
+Obj _35reg2293 = primCons(_35reg2288, _35reg2292);
+Obj _35reg2294 = primCons(_35reg2285, _35reg2293);
+Obj _35reg2295 = primCons(_35reg2282, _35reg2294);
+Obj _35reg2296 = primCons(_35reg2279, _35reg2295);
+Obj _35reg2297 = primCons(_35reg2276, _35reg2296);
+Obj _35reg2298 = primCons(_35reg2273, _35reg2297);
+Obj _35reg2299 = primCons(_35reg2270, _35reg2298);
+Obj _35reg2300 = primCons(_35reg2267, _35reg2299);
+Obj _35reg2301 = primCons(_35reg2264, _35reg2300);
+Obj _35reg2302 = primCons(_35reg2261, _35reg2301);
+Obj _35reg2303 = primCons(_35reg2258, _35reg2302);
+Obj _35reg2304 = primCons(_35reg2255, _35reg2303);
+Obj _35reg2305 = primCons(_35reg2252, _35reg2304);
+Obj _35reg2306 = primCons(_35reg2249, _35reg2305);
+Obj _35reg2307 = primCons(_35reg2246, _35reg2306);
+Obj _35reg2308 = primCons(_35reg2243, _35reg2307);
+Obj _35reg2309 = primSet(intern("cora/lib/toc/include.*builtin-prims*"), _35reg2308);
+Obj _35reg2313 = primSet(intern("builtin?"), makeNative(_35clofun3680, 1, 0));
+Obj _35reg2316 = primSet(intern("cora/lib/toc/include.builtin->name"), makeNative(_35clofun3683, 1, 0));
+Obj _35reg2319 = primSet(intern("cora/lib/toc/include.builtin->args"), makeNative(_35clofun3686, 1, 0));
+Obj _35reg2324 = primSet(intern("cora/lib/toc/include.temp-list"), makeNative(_35clofun3689, 2, 0));
+Obj _35reg2460 = primSet(intern("cora/lib/toc/include.parse"), makeNative(_35clofun3692, 2, 0));
+Obj _35reg2471 = primSet(intern("cora/lib/toc/include.union"), makeNative(_35clofun3722, 2, 0));
+Obj _35reg2482 = primSet(intern("cora/lib/toc/include.diff"), makeNative(_35clofun3728, 2, 0));
+Obj _35reg2533 = primSet(intern("cora/lib/toc/include.convert-protect?"), makeNative(_35clofun3734, 1, 0));
+Obj _35reg2708 = primSet(intern("cora/lib/toc/include.free-vars"), makeNative(_35clofun3741, 1, 0));
+Obj _35reg2781 = primSet(intern("cora/lib/toc/include.closure-convert"), makeNative(_35clofun3764, 2, 0));
+Obj _35reg2784 = primSet(intern("cora/lib/toc/include.id"), makeNative(_35clofun3779, 1, 0));
+Obj _35reg2921 = primSet(intern("cora/lib/toc/include.tailify"), makeNative(_35clofun3780, 2, 0));
+Obj _35reg2968 = primSet(intern("cora/lib/toc/include.tailify-list"), makeNative(_35clofun3798, 3, 0));
+Obj _35reg3047 = primSet(intern("cora/lib/toc/include.explicit-stack"), makeNative(_35clofun3808, 2, 0));
+Obj _35reg3154 = primSet(intern("cora/lib/toc/include.collect-lambda"), makeNative(_35clofun3826, 3, 0));
+Obj _35reg3161 = primSet(intern("cora/lib/toc/include.collect-lambda-list"), makeNative(_35clofun3836, 4, 0));
+Obj _35reg3168 = primSet(intern("cora/lib/toc/include.wrap-var"), makeNative(_35clofun3841, 2, 0));
+Obj _35reg3429 = primSet(intern("cora/lib/toc/include.generate-inst"), makeNative(_35clofun3843, 3, 0));
+Obj _35reg3440 = primSet(intern("cora/lib/toc/include.generate-call-args"), makeNative(_35clofun3924, 4, 0));
+Obj _35reg3459 = primSet(intern("cora/lib/toc/include.generate-cont"), makeNative(_35clofun3932, 2, 0));
+Obj _35reg3468 = primSet(intern("cora/lib/toc/include.generate-inst-list-h"), makeNative(_35clofun3943, 4, 0));
+Obj _35reg3469 = primSet(intern("cora/lib/toc/include.generate-inst-list"), makeNative(_35clofun3949, 3, 0));
+Obj _35reg3473 = primSet(intern("cora/lib/toc/include.code-gen-func-declare"), makeNative(_35clofun3950, 2, 0));
+Obj _35reg3484 = primSet(intern("cora/lib/toc/include.generate-call-args-reverse"), makeNative(_35clofun3954, 5, 0));
+Obj _35reg3541 = primSet(intern("cora/lib/toc/include.code-gen-toplevel"), makeNative(_35clofun3962, 2, 0));
+Obj _35reg3542 = primSet(intern("cora/lib/toc/include.parse-pass"), makeNative(_35clofun3969, 1, 0));
+Obj _35reg3543 = primSet(intern("cora/lib/toc/include.closure-convert-pass"), makeNative(_35clofun3970, 1, 0));
+Obj _35reg3544 = primSet(intern("cora/lib/toc/include.tailify-pass"), makeNative(_35clofun3971, 1, 0));
+Obj _35reg3545 = primSet(intern("cora/lib/toc/include.explicit-stack-pass"), makeNative(_35clofun3972, 1, 0));
+Obj _35reg3553 = primSet(intern("cora/lib/toc/include.collect-lambda-pass"), makeNative(_35clofun3973, 1, 0));
+Obj _35reg3560 = primSet(intern("cora/lib/toc/include.rewrite-->macro"), makeNative(_35clofun3975, 2, 0));
+pushCont(co, _35clofun3981, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/init.add-to-*macros*"));
 co->args[1] = intern("->");
-co->args[2] = makeNative(_35clofun3174, 1, 0);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun3978, 1, 0);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -526,41 +527,42 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3177(struct Cora* co) {
-Obj _35val2760 = co->args[1];
-Obj _35reg2765 = primSet(intern("cora/lib/toc/include.compile"), makeNative(_35clofun3178, 1, 0));
-Obj _35reg2771 = primSet(intern("for-each"), makeNative(_35clofun3183, 2, 0));
-Obj _35reg2778 = primSet(intern("cora/lib/toc/include.generate-c"), makeNative(_35clofun3187, 2, 0));
-Obj _35reg2784 = primSet(intern("cora/lib/toc/include.compile-to-c"), makeNative(_35clofun3195, 3, 0));
-Obj _35reg2786 = primSet(intern("set"), makeNative(_35clofun3201, 2, 0));
-Obj _35reg2788 = primSet(intern("car"), makeNative(_35clofun3202, 1, 0));
-Obj _35reg2790 = primSet(intern("cdr"), makeNative(_35clofun3203, 1, 0));
-Obj _35reg2792 = primSet(intern("cons"), makeNative(_35clofun3204, 2, 0));
-Obj _35reg2794 = primSet(intern("cons"), makeNative(_35clofun3205, 2, 0));
-Obj _35reg2796 = primSet(intern("+"), makeNative(_35clofun3206, 2, 0));
-Obj _35reg2798 = primSet(intern("-"), makeNative(_35clofun3207, 2, 0));
-Obj _35reg2800 = primSet(intern("*"), makeNative(_35clofun3208, 2, 0));
-Obj _35reg2802 = primSet(intern("/"), makeNative(_35clofun3209, 2, 0));
-Obj _35reg2804 = primSet(intern("="), makeNative(_35clofun3210, 2, 0));
-Obj _35reg2806 = primSet(intern(">"), makeNative(_35clofun3211, 2, 0));
-Obj _35reg2808 = primSet(intern("<"), makeNative(_35clofun3212, 2, 0));
-Obj _35reg2810 = primSet(intern("gensym"), makeNative(_35clofun3213, 1, 0));
-Obj _35reg2812 = primSet(intern("symbol?"), makeNative(_35clofun3214, 1, 0));
-Obj _35reg2814 = primSet(intern("not"), makeNative(_35clofun3215, 1, 0));
-Obj _35reg2816 = primSet(intern("string?"), makeNative(_35clofun3216, 1, 0));
-Obj _35reg2857 = primSet(intern("cora/lib/toc/include.eval0"), makeNative(_35clofun3217, 1, 0));
-co->args[1] = _35reg2857;
+void _35clofun3981(struct Cora* co) {
+Obj _35val3563 = co->args[1];
+Obj _35reg3568 = primSet(intern("cora/lib/toc/include.compile"), makeNative(_35clofun3982, 1, 0));
+Obj _35reg3574 = primSet(intern("for-each"), makeNative(_35clofun3987, 2, 0));
+Obj _35reg3581 = primSet(intern("cora/lib/toc/include.generate-c"), makeNative(_35clofun3991, 2, 0));
+Obj _35reg3587 = primSet(intern("cora/lib/toc/include.compile-to-c"), makeNative(_35clofun3999, 3, 0));
+Obj _35reg3589 = primSet(intern("set"), makeNative(_35clofun4005, 2, 0));
+Obj _35reg3591 = primSet(intern("car"), makeNative(_35clofun4006, 1, 0));
+Obj _35reg3593 = primSet(intern("cdr"), makeNative(_35clofun4007, 1, 0));
+Obj _35reg3595 = primSet(intern("cons"), makeNative(_35clofun4008, 2, 0));
+Obj _35reg3597 = primSet(intern("cons"), makeNative(_35clofun4009, 2, 0));
+Obj _35reg3599 = primSet(intern("+"), makeNative(_35clofun4010, 2, 0));
+Obj _35reg3601 = primSet(intern("-"), makeNative(_35clofun4011, 2, 0));
+Obj _35reg3603 = primSet(intern("*"), makeNative(_35clofun4012, 2, 0));
+Obj _35reg3605 = primSet(intern("/"), makeNative(_35clofun4013, 2, 0));
+Obj _35reg3607 = primSet(intern("="), makeNative(_35clofun4014, 2, 0));
+Obj _35reg3609 = primSet(intern(">"), makeNative(_35clofun4015, 2, 0));
+Obj _35reg3611 = primSet(intern("<"), makeNative(_35clofun4016, 2, 0));
+Obj _35reg3613 = primSet(intern("gensym"), makeNative(_35clofun4017, 1, 0));
+Obj _35reg3615 = primSet(intern("symbol?"), makeNative(_35clofun4018, 1, 0));
+Obj _35reg3617 = primSet(intern("not"), makeNative(_35clofun4019, 1, 0));
+Obj _35reg3619 = primSet(intern("string?"), makeNative(_35clofun4020, 1, 0));
+Obj _35reg3660 = primSet(intern("cora/lib/toc/include.eval0"), makeNative(_35clofun4021, 1, 0));
+co->nargs = 2;
+co->args[1] = _35reg3660;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3217(struct Cora* co) {
+void _35clofun4021(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg2817 = primIsSymbol(exp);
-if (True == _35reg2817) {
+Obj _35reg3620 = primIsSymbol(exp);
+if (True == _35reg3620) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("value"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -569,10 +571,10 @@ co->pc = coraCall;
 }
 return;
 } else {
-pushCont(co, _35clofun3218, 1, exp);
+pushCont(co, _35clofun4022, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("number?"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -583,23 +585,24 @@ return;
 }
 }
 
-void _35clofun3218(struct Cora* co) {
-Obj _35val2818 = co->args[1];
+void _35clofun4022(struct Cora* co) {
+Obj _35val3621 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-if (True == _35val2818) {
+if (True == _35val3621) {
 if (True == True) {
+co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2819 = primIsCons(exp);
-if (True == _35reg2819) {
-Obj _35reg2820 = primCar(exp);
-Obj _35reg2821 = primEQ(_35reg2820, intern("quote"));
-if (True == _35reg2821) {
+Obj _35reg3622 = primIsCons(exp);
+if (True == _35reg3622) {
+Obj _35reg3623 = primCar(exp);
+Obj _35reg3624 = primEQ(_35reg3623, intern("quote"));
+if (True == _35reg3624) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -608,11 +611,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2822 = primCar(exp);
-pushCont(co, _35clofun3219, 1, exp);
+Obj _35reg3625 = primCar(exp);
+pushCont(co, _35clofun4023, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[1] = _35reg2822;
-co->nargs = 2;
+co->args[1] = _35reg3625;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -622,9 +625,9 @@ co->pc = coraCall;
 return;
 }
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no cond match");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -635,21 +638,22 @@ return;
 }
 }
 } else {
-Obj _35reg2826 = primIsString(exp);
-if (True == _35reg2826) {
+Obj _35reg3629 = primIsString(exp);
+if (True == _35reg3629) {
 if (True == True) {
+co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2827 = primIsCons(exp);
-if (True == _35reg2827) {
-Obj _35reg2828 = primCar(exp);
-Obj _35reg2829 = primEQ(_35reg2828, intern("quote"));
-if (True == _35reg2829) {
+Obj _35reg3630 = primIsCons(exp);
+if (True == _35reg3630) {
+Obj _35reg3631 = primCar(exp);
+Obj _35reg3632 = primEQ(_35reg3631, intern("quote"));
+if (True == _35reg3632) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -658,11 +662,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2830 = primCar(exp);
-pushCont(co, _35clofun3221, 1, exp);
+Obj _35reg3633 = primCar(exp);
+pushCont(co, _35clofun4025, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[1] = _35reg2830;
-co->nargs = 2;
+co->args[1] = _35reg3633;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -672,9 +676,9 @@ co->pc = coraCall;
 return;
 }
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no cond match");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -685,10 +689,10 @@ return;
 }
 }
 } else {
-pushCont(co, _35clofun3223, 1, exp);
+pushCont(co, _35clofun4027, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("boolean?"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -700,23 +704,24 @@ return;
 }
 }
 
-void _35clofun3223(struct Cora* co) {
-Obj _35val2834 = co->args[1];
+void _35clofun4027(struct Cora* co) {
+Obj _35val3637 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-if (True == _35val2834) {
+if (True == _35val3637) {
 if (True == True) {
+co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2835 = primIsCons(exp);
-if (True == _35reg2835) {
-Obj _35reg2836 = primCar(exp);
-Obj _35reg2837 = primEQ(_35reg2836, intern("quote"));
-if (True == _35reg2837) {
+Obj _35reg3638 = primIsCons(exp);
+if (True == _35reg3638) {
+Obj _35reg3639 = primCar(exp);
+Obj _35reg3640 = primEQ(_35reg3639, intern("quote"));
+if (True == _35reg3640) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -725,11 +730,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2838 = primCar(exp);
-pushCont(co, _35clofun3224, 1, exp);
+Obj _35reg3641 = primCar(exp);
+pushCont(co, _35clofun4028, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[1] = _35reg2838;
-co->nargs = 2;
+co->args[1] = _35reg3641;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -739,9 +744,9 @@ co->pc = coraCall;
 return;
 }
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no cond match");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -752,10 +757,10 @@ return;
 }
 }
 } else {
-pushCont(co, _35clofun3226, 1, exp);
+pushCont(co, _35clofun4030, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -766,23 +771,24 @@ return;
 }
 }
 
-void _35clofun3226(struct Cora* co) {
-Obj _35val2842 = co->args[1];
+void _35clofun4030(struct Cora* co) {
+Obj _35val3645 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-if (True == _35val2842) {
+if (True == _35val3645) {
 if (True == True) {
+co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2843 = primIsCons(exp);
-if (True == _35reg2843) {
-Obj _35reg2844 = primCar(exp);
-Obj _35reg2845 = primEQ(_35reg2844, intern("quote"));
-if (True == _35reg2845) {
+Obj _35reg3646 = primIsCons(exp);
+if (True == _35reg3646) {
+Obj _35reg3647 = primCar(exp);
+Obj _35reg3648 = primEQ(_35reg3647, intern("quote"));
+if (True == _35reg3648) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -791,11 +797,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2846 = primCar(exp);
-pushCont(co, _35clofun3227, 1, exp);
+Obj _35reg3649 = primCar(exp);
+pushCont(co, _35clofun4031, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[1] = _35reg2846;
-co->nargs = 2;
+co->args[1] = _35reg3649;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -805,9 +811,9 @@ co->pc = coraCall;
 return;
 }
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no cond match");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -819,18 +825,19 @@ return;
 }
 } else {
 if (True == False) {
+co->nargs = 2;
 co->args[1] = exp;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2850 = primIsCons(exp);
-if (True == _35reg2850) {
-Obj _35reg2851 = primCar(exp);
-Obj _35reg2852 = primEQ(_35reg2851, intern("quote"));
-if (True == _35reg2852) {
+Obj _35reg3653 = primIsCons(exp);
+if (True == _35reg3653) {
+Obj _35reg3654 = primCar(exp);
+Obj _35reg3655 = primEQ(_35reg3654, intern("quote"));
+if (True == _35reg3655) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -839,11 +846,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2853 = primCar(exp);
-pushCont(co, _35clofun3229, 1, exp);
+Obj _35reg3656 = primCar(exp);
+pushCont(co, _35clofun4033, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[1] = _35reg2853;
-co->nargs = 2;
+co->args[1] = _35reg3656;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -853,9 +860,9 @@ co->pc = coraCall;
 return;
 }
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no cond match");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -868,15 +875,15 @@ return;
 }
 }
 
-void _35clofun3229(struct Cora* co) {
-Obj _35val2854 = co->args[1];
+void _35clofun4033(struct Cora* co) {
+Obj _35val3657 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg2855 = primCdr(exp);
-pushCont(co, _35clofun3230, 1, _35val2854);
+Obj _35reg3658 = primCdr(exp);
+pushCont(co, _35clofun4034, 1, _35val3657);
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[2] = _35reg2855;
-co->nargs = 3;
+co->args[2] = _35reg3658;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -886,13 +893,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3230(struct Cora* co) {
-Obj _35val2856 = co->args[1];
-Obj _35val2854 = co->stack[co->base + 0];
+void _35clofun4034(struct Cora* co) {
+Obj _35val3659 = co->args[1];
+Obj _35val3657 = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("apply"));
-co->args[1] = _35val2854;
-co->args[2] = _35val2856;
-co->nargs = 3;
+co->args[1] = _35val3657;
+co->args[2] = _35val3659;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -902,15 +909,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3227(struct Cora* co) {
-Obj _35val2847 = co->args[1];
+void _35clofun4031(struct Cora* co) {
+Obj _35val3650 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg2848 = primCdr(exp);
-pushCont(co, _35clofun3228, 1, _35val2847);
+Obj _35reg3651 = primCdr(exp);
+pushCont(co, _35clofun4032, 1, _35val3650);
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[2] = _35reg2848;
-co->nargs = 3;
+co->args[2] = _35reg3651;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -920,13 +927,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3228(struct Cora* co) {
-Obj _35val2849 = co->args[1];
-Obj _35val2847 = co->stack[co->base + 0];
+void _35clofun4032(struct Cora* co) {
+Obj _35val3652 = co->args[1];
+Obj _35val3650 = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("apply"));
-co->args[1] = _35val2847;
-co->args[2] = _35val2849;
-co->nargs = 3;
+co->args[1] = _35val3650;
+co->args[2] = _35val3652;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -936,15 +943,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3224(struct Cora* co) {
-Obj _35val2839 = co->args[1];
+void _35clofun4028(struct Cora* co) {
+Obj _35val3642 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg2840 = primCdr(exp);
-pushCont(co, _35clofun3225, 1, _35val2839);
+Obj _35reg3643 = primCdr(exp);
+pushCont(co, _35clofun4029, 1, _35val3642);
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[2] = _35reg2840;
-co->nargs = 3;
+co->args[2] = _35reg3643;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -954,13 +961,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3225(struct Cora* co) {
-Obj _35val2841 = co->args[1];
-Obj _35val2839 = co->stack[co->base + 0];
+void _35clofun4029(struct Cora* co) {
+Obj _35val3644 = co->args[1];
+Obj _35val3642 = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("apply"));
-co->args[1] = _35val2839;
-co->args[2] = _35val2841;
-co->nargs = 3;
+co->args[1] = _35val3642;
+co->args[2] = _35val3644;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -970,15 +977,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3221(struct Cora* co) {
-Obj _35val2831 = co->args[1];
+void _35clofun4025(struct Cora* co) {
+Obj _35val3634 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg2832 = primCdr(exp);
-pushCont(co, _35clofun3222, 1, _35val2831);
+Obj _35reg3635 = primCdr(exp);
+pushCont(co, _35clofun4026, 1, _35val3634);
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[2] = _35reg2832;
-co->nargs = 3;
+co->args[2] = _35reg3635;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -988,13 +995,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3222(struct Cora* co) {
-Obj _35val2833 = co->args[1];
-Obj _35val2831 = co->stack[co->base + 0];
+void _35clofun4026(struct Cora* co) {
+Obj _35val3636 = co->args[1];
+Obj _35val3634 = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("apply"));
-co->args[1] = _35val2831;
-co->args[2] = _35val2833;
-co->nargs = 3;
+co->args[1] = _35val3634;
+co->args[2] = _35val3636;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1004,15 +1011,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3219(struct Cora* co) {
-Obj _35val2823 = co->args[1];
+void _35clofun4023(struct Cora* co) {
+Obj _35val3626 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj _35reg2824 = primCdr(exp);
-pushCont(co, _35clofun3220, 1, _35val2823);
+Obj _35reg3627 = primCdr(exp);
+pushCont(co, _35clofun4024, 1, _35val3626);
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.eval0"));
-co->args[2] = _35reg2824;
-co->nargs = 3;
+co->args[2] = _35reg3627;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1022,13 +1029,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3220(struct Cora* co) {
-Obj _35val2825 = co->args[1];
-Obj _35val2823 = co->stack[co->base + 0];
+void _35clofun4024(struct Cora* co) {
+Obj _35val3628 = co->args[1];
+Obj _35val3626 = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("apply"));
-co->args[1] = _35val2823;
-co->args[2] = _35val2825;
-co->nargs = 3;
+co->args[1] = _35val3626;
+co->args[2] = _35val3628;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1038,153 +1045,169 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3216(struct Cora* co) {
-Obj _35tmp1397 = co->args[1];
-Obj _35reg2815 = primIsString(_35tmp1397);
-co->args[1] = _35reg2815;
+void _35clofun4020(struct Cora* co) {
+Obj _35tmp2199 = co->args[1];
+Obj _35reg3618 = primIsString(_35tmp2199);
+co->nargs = 2;
+co->args[1] = _35reg3618;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3215(struct Cora* co) {
-Obj _35tmp1396 = co->args[1];
-Obj _35reg2813 = primNot(_35tmp1396);
-co->args[1] = _35reg2813;
+void _35clofun4019(struct Cora* co) {
+Obj _35tmp2198 = co->args[1];
+Obj _35reg3616 = primNot(_35tmp2198);
+co->nargs = 2;
+co->args[1] = _35reg3616;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3214(struct Cora* co) {
-Obj _35tmp1395 = co->args[1];
-Obj _35reg2811 = primIsSymbol(_35tmp1395);
-co->args[1] = _35reg2811;
+void _35clofun4018(struct Cora* co) {
+Obj _35tmp2197 = co->args[1];
+Obj _35reg3614 = primIsSymbol(_35tmp2197);
+co->nargs = 2;
+co->args[1] = _35reg3614;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3213(struct Cora* co) {
-Obj _35tmp1394 = co->args[1];
-Obj _35reg2809 = primGenSym(_35tmp1394);
-co->args[1] = _35reg2809;
+void _35clofun4017(struct Cora* co) {
+Obj _35tmp2196 = co->args[1];
+Obj _35reg3612 = primGenSym(_35tmp2196);
+co->nargs = 2;
+co->args[1] = _35reg3612;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3212(struct Cora* co) {
-Obj _35tmp1393 = co->args[1];
-Obj _35tmp1392 = co->args[2];
-Obj _35reg2807 = primLT(_35tmp1393, _35tmp1392);
-co->args[1] = _35reg2807;
+void _35clofun4016(struct Cora* co) {
+Obj _35tmp2195 = co->args[1];
+Obj _35tmp2194 = co->args[2];
+Obj _35reg3610 = primLT(_35tmp2195, _35tmp2194);
+co->nargs = 2;
+co->args[1] = _35reg3610;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3211(struct Cora* co) {
-Obj _35tmp1391 = co->args[1];
-Obj _35tmp1390 = co->args[2];
-Obj _35reg2805 = primGT(_35tmp1391, _35tmp1390);
-co->args[1] = _35reg2805;
+void _35clofun4015(struct Cora* co) {
+Obj _35tmp2193 = co->args[1];
+Obj _35tmp2192 = co->args[2];
+Obj _35reg3608 = primGT(_35tmp2193, _35tmp2192);
+co->nargs = 2;
+co->args[1] = _35reg3608;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3210(struct Cora* co) {
-Obj _35tmp1389 = co->args[1];
-Obj _35tmp1388 = co->args[2];
-Obj _35reg2803 = primEQ(_35tmp1389, _35tmp1388);
-co->args[1] = _35reg2803;
+void _35clofun4014(struct Cora* co) {
+Obj _35tmp2191 = co->args[1];
+Obj _35tmp2190 = co->args[2];
+Obj _35reg3606 = primEQ(_35tmp2191, _35tmp2190);
+co->nargs = 2;
+co->args[1] = _35reg3606;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3209(struct Cora* co) {
-Obj _35tmp1387 = co->args[1];
-Obj _35tmp1386 = co->args[2];
-Obj _35reg2801 = primDiv(_35tmp1387, _35tmp1386);
-co->args[1] = _35reg2801;
+void _35clofun4013(struct Cora* co) {
+Obj _35tmp2189 = co->args[1];
+Obj _35tmp2188 = co->args[2];
+Obj _35reg3604 = primDiv(_35tmp2189, _35tmp2188);
+co->nargs = 2;
+co->args[1] = _35reg3604;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3208(struct Cora* co) {
-Obj _35tmp1385 = co->args[1];
-Obj _35tmp1384 = co->args[2];
-Obj _35reg2799 = primMul(_35tmp1385, _35tmp1384);
-co->args[1] = _35reg2799;
+void _35clofun4012(struct Cora* co) {
+Obj _35tmp2187 = co->args[1];
+Obj _35tmp2186 = co->args[2];
+Obj _35reg3602 = primMul(_35tmp2187, _35tmp2186);
+co->nargs = 2;
+co->args[1] = _35reg3602;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3207(struct Cora* co) {
-Obj _35tmp1383 = co->args[1];
-Obj _35tmp1382 = co->args[2];
-Obj _35reg2797 = primSub(_35tmp1383, _35tmp1382);
-co->args[1] = _35reg2797;
+void _35clofun4011(struct Cora* co) {
+Obj _35tmp2185 = co->args[1];
+Obj _35tmp2184 = co->args[2];
+Obj _35reg3600 = primSub(_35tmp2185, _35tmp2184);
+co->nargs = 2;
+co->args[1] = _35reg3600;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3206(struct Cora* co) {
-Obj _35tmp1381 = co->args[1];
-Obj _35tmp1380 = co->args[2];
-Obj _35reg2795 = primAdd(_35tmp1381, _35tmp1380);
-co->args[1] = _35reg2795;
+void _35clofun4010(struct Cora* co) {
+Obj _35tmp2183 = co->args[1];
+Obj _35tmp2182 = co->args[2];
+Obj _35reg3598 = primAdd(_35tmp2183, _35tmp2182);
+co->nargs = 2;
+co->args[1] = _35reg3598;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3205(struct Cora* co) {
-Obj _35tmp1379 = co->args[1];
-Obj _35tmp1378 = co->args[2];
-Obj _35reg2793 = primCons(_35tmp1379, _35tmp1378);
-co->args[1] = _35reg2793;
+void _35clofun4009(struct Cora* co) {
+Obj _35tmp2181 = co->args[1];
+Obj _35tmp2180 = co->args[2];
+Obj _35reg3596 = primCons(_35tmp2181, _35tmp2180);
+co->nargs = 2;
+co->args[1] = _35reg3596;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3204(struct Cora* co) {
-Obj _35tmp1377 = co->args[1];
-Obj _35tmp1376 = co->args[2];
-Obj _35reg2791 = primCons(_35tmp1377, _35tmp1376);
-co->args[1] = _35reg2791;
+void _35clofun4008(struct Cora* co) {
+Obj _35tmp2179 = co->args[1];
+Obj _35tmp2178 = co->args[2];
+Obj _35reg3594 = primCons(_35tmp2179, _35tmp2178);
+co->nargs = 2;
+co->args[1] = _35reg3594;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3203(struct Cora* co) {
-Obj _35tmp1375 = co->args[1];
-Obj _35reg2789 = primCdr(_35tmp1375);
-co->args[1] = _35reg2789;
+void _35clofun4007(struct Cora* co) {
+Obj _35tmp2177 = co->args[1];
+Obj _35reg3592 = primCdr(_35tmp2177);
+co->nargs = 2;
+co->args[1] = _35reg3592;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3202(struct Cora* co) {
-Obj _35tmp1374 = co->args[1];
-Obj _35reg2787 = primCar(_35tmp1374);
-co->args[1] = _35reg2787;
+void _35clofun4006(struct Cora* co) {
+Obj _35tmp2176 = co->args[1];
+Obj _35reg3590 = primCar(_35tmp2176);
+co->nargs = 2;
+co->args[1] = _35reg3590;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3201(struct Cora* co) {
-Obj _35tmp1373 = co->args[1];
-Obj _35tmp1372 = co->args[2];
-Obj _35reg2785 = primSet(_35tmp1373, _35tmp1372);
-co->args[1] = _35reg2785;
+void _35clofun4005(struct Cora* co) {
+Obj _35tmp2175 = co->args[1];
+Obj _35tmp2174 = co->args[2];
+Obj _35reg3588 = primSet(_35tmp2175, _35tmp2174);
+co->nargs = 2;
+co->args[1] = _35reg3588;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3195(struct Cora* co) {
+void _35clofun3999(struct Cora* co) {
 Obj from = co->args[1];
 Obj to = co->args[2];
 Obj pkg_45str = co->args[3];
-pushCont(co, _35clofun3196, 1, to);
+pushCont(co, _35clofun4000, 1, to);
+co->nargs = 3;
 co->args[0] = globalRef(intern("read-file-as-sexp"));
 co->args[1] = from;
 co->args[2] = pkg_45str;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1194,14 +1217,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3196(struct Cora* co) {
-Obj _35val2779 = co->args[1];
+void _35clofun4000(struct Cora* co) {
+Obj _35val3582 = co->args[1];
 Obj to = co->stack[co->base + 0];
-Obj sexp = _35val2779;
-pushCont(co, _35clofun3197, 1, to);
+Obj sexp = _35val3582;
+pushCont(co, _35clofun4001, 1, to);
+co->nargs = 2;
 co->args[0] = globalRef(intern("macroexpand"));
 co->args[1] = sexp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1211,14 +1234,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3197(struct Cora* co) {
-Obj _35val2780 = co->args[1];
+void _35clofun4001(struct Cora* co) {
+Obj _35val3583 = co->args[1];
 Obj to = co->stack[co->base + 0];
-Obj input = _35val2780;
-pushCont(co, _35clofun3198, 1, to);
+Obj input = _35val3583;
+pushCont(co, _35clofun4002, 1, to);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.compile"));
 co->args[1] = input;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1228,14 +1251,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3198(struct Cora* co) {
-Obj _35val2781 = co->args[1];
+void _35clofun4002(struct Cora* co) {
+Obj _35val3584 = co->args[1];
 Obj to = co->stack[co->base + 0];
-Obj bc = _35val2781;
-pushCont(co, _35clofun3199, 1, bc);
+Obj bc = _35val3584;
+pushCont(co, _35clofun4003, 1, bc);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/io.open-output-file"));
 co->args[1] = to;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1245,15 +1268,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3199(struct Cora* co) {
-Obj _35val2782 = co->args[1];
+void _35clofun4003(struct Cora* co) {
+Obj _35val3585 = co->args[1];
 Obj bc = co->stack[co->base + 0];
-Obj stream = _35val2782;
-pushCont(co, _35clofun3200, 1, stream);
+Obj stream = _35val3585;
+pushCont(co, _35clofun4004, 1, stream);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-c"));
 co->args[1] = stream;
 co->args[2] = bc;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1263,12 +1286,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3200(struct Cora* co) {
-Obj _35val2783 = co->args[1];
+void _35clofun4004(struct Cora* co) {
+Obj _35val3586 = co->args[1];
 Obj stream = co->stack[co->base + 0];
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/io.close-output-file"));
 co->args[1] = stream;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1278,14 +1301,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3187(struct Cora* co) {
+void _35clofun3991(struct Cora* co) {
 Obj to = co->args[1];
 Obj bc = co->args[2];
-pushCont(co, _35clofun3188, 2, to, bc);
+pushCont(co, _35clofun3992, 2, to, bc);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = to;
 co->args[2] = makeString1("#include \"types.h\"\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1295,15 +1318,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3188(struct Cora* co) {
-Obj _35val2772 = co->args[1];
+void _35clofun3992(struct Cora* co) {
+Obj _35val3575 = co->args[1];
 Obj to = co->stack[co->base + 0];
 Obj bc = co->stack[co->base + 1];
-pushCont(co, _35clofun3189, 2, to, bc);
+pushCont(co, _35clofun3993, 2, to, bc);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = to;
 co->args[2] = makeString1("#include \"runtime.h\"\n\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1313,15 +1336,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3189(struct Cora* co) {
-Obj _35val2773 = co->args[1];
+void _35clofun3993(struct Cora* co) {
+Obj _35val3576 = co->args[1];
 Obj to = co->stack[co->base + 0];
 Obj bc = co->stack[co->base + 1];
-pushCont(co, _35clofun3192, 2, to, bc);
+pushCont(co, _35clofun3996, 2, to, bc);
+co->nargs = 3;
 co->args[0] = globalRef(intern("for-each"));
-co->args[1] = makeNative(_35clofun3190, 1, 1, to);
+co->args[1] = makeNative(_35clofun3994, 1, 1, to);
 co->args[2] = bc;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1331,15 +1354,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3192(struct Cora* co) {
-Obj _35val2776 = co->args[1];
+void _35clofun3996(struct Cora* co) {
+Obj _35val3579 = co->args[1];
 Obj to = co->stack[co->base + 0];
 Obj bc = co->stack[co->base + 1];
-pushCont(co, _35clofun3193, 2, to, bc);
+pushCont(co, _35clofun3997, 2, to, bc);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = to;
 co->args[2] = makeString1("\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1349,14 +1372,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3193(struct Cora* co) {
-Obj _35val2777 = co->args[1];
+void _35clofun3997(struct Cora* co) {
+Obj _35val3580 = co->args[1];
 Obj to = co->stack[co->base + 0];
 Obj bc = co->stack[co->base + 1];
-co->args[0] = globalRef(intern("for-each"));
-co->args[1] = makeNative(_35clofun3194, 1, 1, to);
-co->args[2] = bc;
 co->nargs = 3;
+co->args[0] = globalRef(intern("for-each"));
+co->args[1] = makeNative(_35clofun3998, 1, 1, to);
+co->args[2] = bc;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1366,12 +1389,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3194(struct Cora* co) {
+void _35clofun3998(struct Cora* co) {
 Obj x = co->args[1];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.code-gen-toplevel"));
 co->args[1] = closureRef(co, 0);
 co->args[2] = x;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1381,14 +1404,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3190(struct Cora* co) {
+void _35clofun3994(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg2774 = primCar(x);
-pushCont(co, _35clofun3191, 0);
+Obj _35reg3577 = primCar(x);
+pushCont(co, _35clofun3995, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.code-gen-func-declare"));
 co->args[1] = closureRef(co, 0);
-co->args[2] = _35reg2774;
-co->nargs = 3;
+co->args[2] = _35reg3577;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1398,12 +1421,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3191(struct Cora* co) {
-Obj _35val2775 = co->args[1];
+void _35clofun3995(struct Cora* co) {
+Obj _35val3578 = co->args[1];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = closureRef(co, 0);
 co->args[2] = makeString1(";\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1413,19 +1436,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3183(struct Cora* co) {
-Obj _35p1368 = co->args[1];
-Obj _35p1369 = co->args[2];
-Obj _35cc1370 = makeNative(_35clofun3184, 0, 2, _35p1368, _35p1369);
-Obj fn = _35p1368;
-Obj _35reg2770 = primEQ(Nil, _35p1369);
-if (True == _35reg2770) {
+void _35clofun3987(struct Cora* co) {
+Obj _35p2170 = co->args[1];
+Obj _35p2171 = co->args[2];
+Obj _35cc2172 = makeNative(_35clofun3988, 0, 2, _35p2170, _35p2171);
+Obj fn = _35p2170;
+Obj _35reg3573 = primEQ(Nil, _35p2171);
+if (True == _35reg3573) {
+co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1370;
 co->nargs = 1;
+co->args[0] = _35cc2172;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1436,19 +1460,19 @@ return;
 }
 }
 
-void _35clofun3184(struct Cora* co) {
-Obj _35cc1371 = makeNative(_35clofun3185, 0, 0);
+void _35clofun3988(struct Cora* co) {
+Obj _35cc2173 = makeNative(_35clofun3989, 0, 0);
 Obj fn = closureRef(co, 0);
-Obj _35reg2766 = primIsCons(closureRef(co, 1));
-if (True == _35reg2766) {
-Obj _35reg2767 = primCar(closureRef(co, 1));
-Obj x = _35reg2767;
-Obj _35reg2768 = primCdr(closureRef(co, 1));
-Obj y = _35reg2768;
-pushCont(co, _35clofun3186, 2, fn, y);
+Obj _35reg3569 = primIsCons(closureRef(co, 1));
+if (True == _35reg3569) {
+Obj _35reg3570 = primCar(closureRef(co, 1));
+Obj x = _35reg3570;
+Obj _35reg3571 = primCdr(closureRef(co, 1));
+Obj y = _35reg3571;
+pushCont(co, _35clofun3990, 2, fn, y);
+co->nargs = 2;
 co->args[0] = fn;
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1457,8 +1481,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1371;
 co->nargs = 1;
+co->args[0] = _35cc2173;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1469,14 +1493,14 @@ return;
 }
 }
 
-void _35clofun3186(struct Cora* co) {
-Obj _35val2769 = co->args[1];
+void _35clofun3990(struct Cora* co) {
+Obj _35val3572 = co->args[1];
 Obj fn = co->stack[co->base + 0];
 Obj y = co->stack[co->base + 1];
+co->nargs = 3;
 co->args[0] = globalRef(intern("for-each"));
 co->args[1] = fn;
 co->args[2] = y;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1486,10 +1510,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3185(struct Cora* co) {
+void _35clofun3989(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1499,12 +1523,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3178(struct Cora* co) {
+void _35clofun3982(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun3179, 0);
+pushCont(co, _35clofun3983, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse-pass"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1514,12 +1538,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3179(struct Cora* co) {
-Obj _35val2761 = co->args[1];
-pushCont(co, _35clofun3180, 0);
+void _35clofun3983(struct Cora* co) {
+Obj _35val3564 = co->args[1];
+pushCont(co, _35clofun3984, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert-pass"));
-co->args[1] = _35val2761;
-co->nargs = 2;
+co->args[1] = _35val3564;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1529,12 +1553,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3180(struct Cora* co) {
-Obj _35val2762 = co->args[1];
-pushCont(co, _35clofun3181, 0);
+void _35clofun3984(struct Cora* co) {
+Obj _35val3565 = co->args[1];
+pushCont(co, _35clofun3985, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify-pass"));
-co->args[1] = _35val2762;
-co->nargs = 2;
+co->args[1] = _35val3565;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1544,12 +1568,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3181(struct Cora* co) {
-Obj _35val2763 = co->args[1];
-pushCont(co, _35clofun3182, 0);
+void _35clofun3985(struct Cora* co) {
+Obj _35val3566 = co->args[1];
+pushCont(co, _35clofun3986, 0);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack-pass"));
-co->args[1] = _35val2763;
-co->nargs = 2;
+co->args[1] = _35val3566;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1559,11 +1583,11 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3182(struct Cora* co) {
-Obj _35val2764 = co->args[1];
+void _35clofun3986(struct Cora* co) {
+Obj _35val3567 = co->args[1];
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda-pass"));
-co->args[1] = _35val2764;
-co->nargs = 2;
+co->args[1] = _35val3567;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1573,12 +1597,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3174(struct Cora* co) {
+void _35clofun3978(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun3175, 1, exp);
+pushCont(co, _35clofun3979, 1, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1588,14 +1612,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3175(struct Cora* co) {
-Obj _35val2758 = co->args[1];
+void _35clofun3979(struct Cora* co) {
+Obj _35val3561 = co->args[1];
 Obj exp = co->stack[co->base + 0];
-Obj obj = _35val2758;
-pushCont(co, _35clofun3176, 1, obj);
+Obj obj = _35val3561;
+pushCont(co, _35clofun3980, 1, obj);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cddr"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1605,14 +1629,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3176(struct Cora* co) {
-Obj _35val2759 = co->args[1];
+void _35clofun3980(struct Cora* co) {
+Obj _35val3562 = co->args[1];
 Obj obj = co->stack[co->base + 0];
-Obj fns = _35val2759;
+Obj fns = _35val3562;
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.rewrite-->macro"));
 co->args[1] = obj;
 co->args[2] = fns;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1622,19 +1646,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3171(struct Cora* co) {
-Obj _35p1364 = co->args[1];
-Obj _35p1365 = co->args[2];
-Obj _35cc1366 = makeNative(_35clofun3172, 0, 2, _35p1364, _35p1365);
-Obj obj = _35p1364;
-Obj _35reg2756 = primEQ(Nil, _35p1365);
-if (True == _35reg2756) {
+void _35clofun3975(struct Cora* co) {
+Obj _35p2166 = co->args[1];
+Obj _35p2167 = co->args[2];
+Obj _35cc2168 = makeNative(_35clofun3976, 0, 2, _35p2166, _35p2167);
+Obj obj = _35p2166;
+Obj _35reg3559 = primEQ(Nil, _35p2167);
+if (True == _35reg3559) {
+co->nargs = 2;
 co->args[1] = obj;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1366;
 co->nargs = 1;
+co->args[0] = _35cc2168;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1645,21 +1670,21 @@ return;
 }
 }
 
-void _35clofun3172(struct Cora* co) {
-Obj _35cc1367 = makeNative(_35clofun3173, 0, 0);
+void _35clofun3976(struct Cora* co) {
+Obj _35cc2169 = makeNative(_35clofun3977, 0, 0);
 Obj obj = closureRef(co, 0);
-Obj _35reg2751 = primIsCons(closureRef(co, 1));
-if (True == _35reg2751) {
-Obj _35reg2752 = primCar(closureRef(co, 1));
-Obj hd = _35reg2752;
-Obj _35reg2753 = primCdr(closureRef(co, 1));
-Obj more = _35reg2753;
-Obj _35reg2754 = primCons(obj, Nil);
-Obj _35reg2755 = primCons(hd, _35reg2754);
-co->args[0] = globalRef(intern("cora/lib/toc/include.rewrite-->macro"));
-co->args[1] = _35reg2755;
-co->args[2] = more;
+Obj _35reg3554 = primIsCons(closureRef(co, 1));
+if (True == _35reg3554) {
+Obj _35reg3555 = primCar(closureRef(co, 1));
+Obj hd = _35reg3555;
+Obj _35reg3556 = primCdr(closureRef(co, 1));
+Obj more = _35reg3556;
+Obj _35reg3557 = primCons(obj, Nil);
+Obj _35reg3558 = primCons(hd, _35reg3557);
 co->nargs = 3;
+co->args[0] = globalRef(intern("cora/lib/toc/include.rewrite-->macro"));
+co->args[1] = _35reg3558;
+co->args[2] = more;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1668,8 +1693,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1367;
 co->nargs = 1;
+co->args[0] = _35cc2169;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1680,10 +1705,10 @@ return;
 }
 }
 
-void _35clofun3173(struct Cora* co) {
+void _35clofun3977(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1693,13 +1718,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3169(struct Cora* co) {
+void _35clofun3973(struct Cora* co) {
 Obj exp = co->args[1];
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda"));
 co->args[1] = Nil;
 co->args[2] = exp;
-co->args[3] = makeNative(_35clofun3170, 2, 0);
-co->nargs = 4;
+co->args[3] = makeNative(_35clofun3974, 2, 0);
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1709,27 +1734,28 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3170(struct Cora* co) {
+void _35clofun3974(struct Cora* co) {
 Obj ls = co->args[1];
 Obj e1 = co->args[2];
-Obj _35reg2743 = primCons(e1, Nil);
-Obj _35reg2744 = primCons(Nil, _35reg2743);
-Obj _35reg2745 = primCons(Nil, _35reg2744);
-Obj _35reg2746 = primCons(intern("lambda"), _35reg2745);
-Obj _35reg2747 = primCons(_35reg2746, Nil);
-Obj _35reg2748 = primCons(intern("entry"), _35reg2747);
-Obj _35reg2749 = primCons(_35reg2748, ls);
-co->args[1] = _35reg2749;
+Obj _35reg3546 = primCons(e1, Nil);
+Obj _35reg3547 = primCons(Nil, _35reg3546);
+Obj _35reg3548 = primCons(Nil, _35reg3547);
+Obj _35reg3549 = primCons(intern("lambda"), _35reg3548);
+Obj _35reg3550 = primCons(_35reg3549, Nil);
+Obj _35reg3551 = primCons(intern("entry"), _35reg3550);
+Obj _35reg3552 = primCons(_35reg3551, ls);
+co->nargs = 2;
+co->args[1] = _35reg3552;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3168(struct Cora* co) {
+void _35clofun3972(struct Cora* co) {
 Obj exp = co->args[1];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = Nil;
 co->args[2] = exp;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1739,12 +1765,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3167(struct Cora* co) {
+void _35clofun3971(struct Cora* co) {
 Obj exp = co->args[1];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = exp;
 co->args[2] = globalRef(intern("cora/lib/toc/include.id"));
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1754,12 +1780,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3166(struct Cora* co) {
+void _35clofun3970(struct Cora* co) {
 Obj exp = co->args[1];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert"));
 co->args[1] = Nil;
 co->args[2] = exp;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1769,12 +1795,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3165(struct Cora* co) {
+void _35clofun3969(struct Cora* co) {
 Obj exp = co->args[1];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = Nil;
 co->args[2] = exp;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1784,80 +1810,80 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3158(struct Cora* co) {
-Obj _35p1361 = co->args[1];
-Obj _35p1362 = co->args[2];
-Obj _35cc1363 = makeNative(_35clofun3159, 0, 0);
-Obj w = _35p1361;
-Obj _35reg2682 = primIsCons(_35p1362);
-if (True == _35reg2682) {
-Obj _35reg2683 = primCar(_35p1362);
-Obj name = _35reg2683;
-Obj _35reg2684 = primCdr(_35p1362);
-Obj _35reg2685 = primIsCons(_35reg2684);
-if (True == _35reg2685) {
-Obj _35reg2686 = primCdr(_35p1362);
-Obj _35reg2687 = primCar(_35reg2686);
-Obj _35reg2688 = primIsCons(_35reg2687);
-if (True == _35reg2688) {
-Obj _35reg2689 = primCdr(_35p1362);
-Obj _35reg2690 = primCar(_35reg2689);
-Obj _35reg2691 = primCar(_35reg2690);
-Obj _35reg2692 = primEQ(intern("lambda"), _35reg2691);
-if (True == _35reg2692) {
-Obj _35reg2693 = primCdr(_35p1362);
-Obj _35reg2694 = primCar(_35reg2693);
-Obj _35reg2695 = primCdr(_35reg2694);
-Obj _35reg2696 = primIsCons(_35reg2695);
-if (True == _35reg2696) {
-Obj _35reg2697 = primCdr(_35p1362);
-Obj _35reg2698 = primCar(_35reg2697);
-Obj _35reg2699 = primCdr(_35reg2698);
-Obj _35reg2700 = primCar(_35reg2699);
-Obj params = _35reg2700;
-Obj _35reg2701 = primCdr(_35p1362);
-Obj _35reg2702 = primCar(_35reg2701);
-Obj _35reg2703 = primCdr(_35reg2702);
-Obj _35reg2704 = primCdr(_35reg2703);
-Obj _35reg2705 = primIsCons(_35reg2704);
-if (True == _35reg2705) {
-Obj _35reg2706 = primCdr(_35p1362);
-Obj _35reg2707 = primCar(_35reg2706);
-Obj _35reg2708 = primCdr(_35reg2707);
-Obj _35reg2709 = primCdr(_35reg2708);
-Obj _35reg2710 = primCar(_35reg2709);
-Obj actives = _35reg2710;
-Obj _35reg2711 = primCdr(_35p1362);
-Obj _35reg2712 = primCar(_35reg2711);
-Obj _35reg2713 = primCdr(_35reg2712);
-Obj _35reg2714 = primCdr(_35reg2713);
-Obj _35reg2715 = primCdr(_35reg2714);
-Obj _35reg2716 = primIsCons(_35reg2715);
-if (True == _35reg2716) {
-Obj _35reg2717 = primCdr(_35p1362);
-Obj _35reg2718 = primCar(_35reg2717);
-Obj _35reg2719 = primCdr(_35reg2718);
-Obj _35reg2720 = primCdr(_35reg2719);
-Obj _35reg2721 = primCdr(_35reg2720);
-Obj _35reg2722 = primCar(_35reg2721);
-Obj body = _35reg2722;
-Obj _35reg2723 = primCdr(_35p1362);
-Obj _35reg2724 = primCar(_35reg2723);
-Obj _35reg2725 = primCdr(_35reg2724);
-Obj _35reg2726 = primCdr(_35reg2725);
-Obj _35reg2727 = primCdr(_35reg2726);
-Obj _35reg2728 = primCdr(_35reg2727);
-Obj _35reg2729 = primEQ(Nil, _35reg2728);
-if (True == _35reg2729) {
-Obj _35reg2730 = primCdr(_35p1362);
-Obj _35reg2731 = primCdr(_35reg2730);
-Obj _35reg2732 = primEQ(Nil, _35reg2731);
-if (True == _35reg2732) {
-pushCont(co, _35clofun3160, 4, actives, params, body, w);
+void _35clofun3962(struct Cora* co) {
+Obj _35p2163 = co->args[1];
+Obj _35p2164 = co->args[2];
+Obj _35cc2165 = makeNative(_35clofun3963, 0, 0);
+Obj w = _35p2163;
+Obj _35reg3485 = primIsCons(_35p2164);
+if (True == _35reg3485) {
+Obj _35reg3486 = primCar(_35p2164);
+Obj name = _35reg3486;
+Obj _35reg3487 = primCdr(_35p2164);
+Obj _35reg3488 = primIsCons(_35reg3487);
+if (True == _35reg3488) {
+Obj _35reg3489 = primCdr(_35p2164);
+Obj _35reg3490 = primCar(_35reg3489);
+Obj _35reg3491 = primIsCons(_35reg3490);
+if (True == _35reg3491) {
+Obj _35reg3492 = primCdr(_35p2164);
+Obj _35reg3493 = primCar(_35reg3492);
+Obj _35reg3494 = primCar(_35reg3493);
+Obj _35reg3495 = primEQ(intern("lambda"), _35reg3494);
+if (True == _35reg3495) {
+Obj _35reg3496 = primCdr(_35p2164);
+Obj _35reg3497 = primCar(_35reg3496);
+Obj _35reg3498 = primCdr(_35reg3497);
+Obj _35reg3499 = primIsCons(_35reg3498);
+if (True == _35reg3499) {
+Obj _35reg3500 = primCdr(_35p2164);
+Obj _35reg3501 = primCar(_35reg3500);
+Obj _35reg3502 = primCdr(_35reg3501);
+Obj _35reg3503 = primCar(_35reg3502);
+Obj params = _35reg3503;
+Obj _35reg3504 = primCdr(_35p2164);
+Obj _35reg3505 = primCar(_35reg3504);
+Obj _35reg3506 = primCdr(_35reg3505);
+Obj _35reg3507 = primCdr(_35reg3506);
+Obj _35reg3508 = primIsCons(_35reg3507);
+if (True == _35reg3508) {
+Obj _35reg3509 = primCdr(_35p2164);
+Obj _35reg3510 = primCar(_35reg3509);
+Obj _35reg3511 = primCdr(_35reg3510);
+Obj _35reg3512 = primCdr(_35reg3511);
+Obj _35reg3513 = primCar(_35reg3512);
+Obj actives = _35reg3513;
+Obj _35reg3514 = primCdr(_35p2164);
+Obj _35reg3515 = primCar(_35reg3514);
+Obj _35reg3516 = primCdr(_35reg3515);
+Obj _35reg3517 = primCdr(_35reg3516);
+Obj _35reg3518 = primCdr(_35reg3517);
+Obj _35reg3519 = primIsCons(_35reg3518);
+if (True == _35reg3519) {
+Obj _35reg3520 = primCdr(_35p2164);
+Obj _35reg3521 = primCar(_35reg3520);
+Obj _35reg3522 = primCdr(_35reg3521);
+Obj _35reg3523 = primCdr(_35reg3522);
+Obj _35reg3524 = primCdr(_35reg3523);
+Obj _35reg3525 = primCar(_35reg3524);
+Obj body = _35reg3525;
+Obj _35reg3526 = primCdr(_35p2164);
+Obj _35reg3527 = primCar(_35reg3526);
+Obj _35reg3528 = primCdr(_35reg3527);
+Obj _35reg3529 = primCdr(_35reg3528);
+Obj _35reg3530 = primCdr(_35reg3529);
+Obj _35reg3531 = primCdr(_35reg3530);
+Obj _35reg3532 = primEQ(Nil, _35reg3531);
+if (True == _35reg3532) {
+Obj _35reg3533 = primCdr(_35p2164);
+Obj _35reg3534 = primCdr(_35reg3533);
+Obj _35reg3535 = primEQ(Nil, _35reg3534);
+if (True == _35reg3535) {
+pushCont(co, _35clofun3964, 4, actives, params, body, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.code-gen-func-declare"));
 co->args[1] = w;
 co->args[2] = name;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1866,8 +1892,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1363;
 co->nargs = 1;
+co->args[0] = _35cc2165;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1877,8 +1903,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1363;
 co->nargs = 1;
+co->args[0] = _35cc2165;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1888,8 +1914,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1363;
 co->nargs = 1;
+co->args[0] = _35cc2165;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1899,8 +1925,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1363;
 co->nargs = 1;
+co->args[0] = _35cc2165;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1910,8 +1936,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1363;
 co->nargs = 1;
+co->args[0] = _35cc2165;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1921,8 +1947,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1363;
 co->nargs = 1;
+co->args[0] = _35cc2165;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1932,8 +1958,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1363;
 co->nargs = 1;
+co->args[0] = _35cc2165;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1943,8 +1969,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1363;
 co->nargs = 1;
+co->args[0] = _35cc2165;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1954,8 +1980,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1363;
 co->nargs = 1;
+co->args[0] = _35cc2165;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1966,17 +1992,17 @@ return;
 }
 }
 
-void _35clofun3160(struct Cora* co) {
-Obj _35val2733 = co->args[1];
+void _35clofun3964(struct Cora* co) {
+Obj _35val3536 = co->args[1];
 Obj actives = co->stack[co->base + 0];
 Obj params = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3161, 4, actives, params, body, w);
+pushCont(co, _35clofun3965, 4, actives, params, body, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(" {\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -1986,20 +2012,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3161(struct Cora* co) {
-Obj _35val2734 = co->args[1];
+void _35clofun3965(struct Cora* co) {
+Obj _35val3537 = co->args[1];
 Obj actives = co->stack[co->base + 0];
 Obj params = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3162, 4, actives, params, body, w);
+pushCont(co, _35clofun3966, 4, actives, params, body, w);
+co->nargs = 6;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-call-args-reverse"));
 co->args[1] = Nil;
 co->args[2] = w;
 co->args[3] = makeString1(" = co->args[");
 co->args[4] = makeNumber(1);
 co->args[5] = params;
-co->nargs = 6;
 if (nativeRequired(co->args[0]) == 5) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2009,20 +2035,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3162(struct Cora* co) {
-Obj _35val2735 = co->args[1];
+void _35clofun3966(struct Cora* co) {
+Obj _35val3538 = co->args[1];
 Obj actives = co->stack[co->base + 0];
 Obj params = co->stack[co->base + 1];
 Obj body = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3163, 3, params, body, w);
+pushCont(co, _35clofun3967, 3, params, body, w);
+co->nargs = 6;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-call-args-reverse"));
 co->args[1] = Nil;
 co->args[2] = w;
 co->args[3] = makeString1(" = co->stack[co->base + ");
 co->args[4] = makeNumber(0);
 co->args[5] = actives;
-co->nargs = 6;
 if (nativeRequired(co->args[0]) == 5) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2032,17 +2058,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3163(struct Cora* co) {
-Obj _35val2736 = co->args[1];
+void _35clofun3967(struct Cora* co) {
+Obj _35val3539 = co->args[1];
 Obj params = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3164, 1, w);
+pushCont(co, _35clofun3968, 1, w);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = params;
 co->args[2] = w;
 co->args[3] = body;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2052,13 +2078,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3164(struct Cora* co) {
-Obj _35val2737 = co->args[1];
+void _35clofun3968(struct Cora* co) {
+Obj _35val3540 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("}\n\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2068,10 +2094,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3159(struct Cora* co) {
+void _35clofun3963(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2081,25 +2107,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3150(struct Cora* co) {
-Obj _35p1354 = co->args[1];
-Obj _35p1355 = co->args[2];
-Obj _35p1356 = co->args[3];
-Obj _35p1357 = co->args[4];
-Obj _35p1358 = co->args[5];
-Obj _35cc1359 = makeNative(_35clofun3151, 0, 5, _35p1354, _35p1355, _35p1356, _35p1357, _35p1358);
-Obj env = _35p1354;
-Obj w = _35p1355;
-Obj dest_45str = _35p1356;
-Obj idx = _35p1357;
-Obj _35reg2680 = primEQ(Nil, _35p1358);
-if (True == _35reg2680) {
+void _35clofun3954(struct Cora* co) {
+Obj _35p2156 = co->args[1];
+Obj _35p2157 = co->args[2];
+Obj _35p2158 = co->args[3];
+Obj _35p2159 = co->args[4];
+Obj _35p2160 = co->args[5];
+Obj _35cc2161 = makeNative(_35clofun3955, 0, 5, _35p2156, _35p2157, _35p2158, _35p2159, _35p2160);
+Obj env = _35p2156;
+Obj w = _35p2157;
+Obj dest_45str = _35p2158;
+Obj idx = _35p2159;
+Obj _35reg3483 = primEQ(Nil, _35p2160);
+if (True == _35reg3483) {
+co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1359;
 co->nargs = 1;
+co->args[0] = _35cc2161;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2110,23 +2137,23 @@ return;
 }
 }
 
-void _35clofun3151(struct Cora* co) {
-Obj _35cc1360 = makeNative(_35clofun3152, 0, 0);
+void _35clofun3955(struct Cora* co) {
+Obj _35cc2162 = makeNative(_35clofun3956, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj dest_45str = closureRef(co, 2);
 Obj idx = closureRef(co, 3);
-Obj _35reg2671 = primIsCons(closureRef(co, 4));
-if (True == _35reg2671) {
-Obj _35reg2672 = primCar(closureRef(co, 4));
-Obj a = _35reg2672;
-Obj _35reg2673 = primCdr(closureRef(co, 4));
-Obj b = _35reg2673;
-pushCont(co, _35clofun3153, 6, a, idx, env, w, dest_45str, b);
+Obj _35reg3474 = primIsCons(closureRef(co, 4));
+if (True == _35reg3474) {
+Obj _35reg3475 = primCar(closureRef(co, 4));
+Obj a = _35reg3475;
+Obj _35reg3476 = primCdr(closureRef(co, 4));
+Obj b = _35reg3476;
+pushCont(co, _35clofun3957, 6, a, idx, env, w, dest_45str, b);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("Obj ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2135,8 +2162,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1360;
 co->nargs = 1;
+co->args[0] = _35cc2162;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2147,20 +2174,20 @@ return;
 }
 }
 
-void _35clofun3153(struct Cora* co) {
-Obj _35val2674 = co->args[1];
+void _35clofun3957(struct Cora* co) {
+Obj _35val3477 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj idx = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj dest_45str = co->stack[co->base + 4];
 Obj b = co->stack[co->base + 5];
-pushCont(co, _35clofun3154, 5, idx, env, w, dest_45str, b);
+pushCont(co, _35clofun3958, 5, idx, env, w, dest_45str, b);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = a;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2170,18 +2197,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3154(struct Cora* co) {
-Obj _35val2675 = co->args[1];
+void _35clofun3958(struct Cora* co) {
+Obj _35val3478 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj dest_45str = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-pushCont(co, _35clofun3155, 5, idx, env, w, dest_45str, b);
+pushCont(co, _35clofun3959, 5, idx, env, w, dest_45str, b);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = dest_45str;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2191,18 +2218,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3155(struct Cora* co) {
-Obj _35val2676 = co->args[1];
+void _35clofun3959(struct Cora* co) {
+Obj _35val3479 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj dest_45str = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-pushCont(co, _35clofun3156, 5, idx, env, w, dest_45str, b);
+pushCont(co, _35clofun3960, 5, idx, env, w, dest_45str, b);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
 co->args[2] = idx;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2212,18 +2239,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3156(struct Cora* co) {
-Obj _35val2677 = co->args[1];
+void _35clofun3960(struct Cora* co) {
+Obj _35val3480 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj dest_45str = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-pushCont(co, _35clofun3157, 5, idx, env, w, dest_45str, b);
+pushCont(co, _35clofun3961, 5, idx, env, w, dest_45str, b);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("];\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2233,21 +2260,21 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3157(struct Cora* co) {
-Obj _35val2678 = co->args[1];
+void _35clofun3961(struct Cora* co) {
+Obj _35val3481 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj dest_45str = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-Obj _35reg2679 = primAdd(idx, makeNumber(1));
+Obj _35reg3482 = primAdd(idx, makeNumber(1));
+co->nargs = 6;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-call-args-reverse"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = dest_45str;
-co->args[4] = _35reg2679;
+co->args[4] = _35reg3482;
 co->args[5] = b;
-co->nargs = 6;
 if (nativeRequired(co->args[0]) == 5) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2257,10 +2284,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3152(struct Cora* co) {
+void _35clofun3956(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2270,14 +2297,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3146(struct Cora* co) {
+void _35clofun3950(struct Cora* co) {
 Obj w = co->args[1];
 Obj name = co->args[2];
-pushCont(co, _35clofun3147, 2, name, w);
+pushCont(co, _35clofun3951, 2, name, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("void ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2287,15 +2314,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3147(struct Cora* co) {
-Obj _35val2667 = co->args[1];
+void _35clofun3951(struct Cora* co) {
+Obj _35val3470 = co->args[1];
 Obj name = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3148, 1, w);
+pushCont(co, _35clofun3952, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
 co->args[2] = name;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2305,14 +2332,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3148(struct Cora* co) {
-Obj _35val2668 = co->args[1];
+void _35clofun3952(struct Cora* co) {
+Obj _35val3471 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3149, 1, w);
+pushCont(co, _35clofun3953, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("(struct Cora* co");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2322,13 +2349,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3149(struct Cora* co) {
-Obj _35val2669 = co->args[1];
+void _35clofun3953(struct Cora* co) {
+Obj _35val3472 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(")");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2338,16 +2365,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3145(struct Cora* co) {
+void _35clofun3949(struct Cora* co) {
 Obj env = co->args[1];
 Obj w = co->args[2];
 Obj l = co->args[3];
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst-list-h"));
 co->args[1] = env;
 co->args[2] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[3] = w;
 co->args[4] = l;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2357,23 +2384,24 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3139(struct Cora* co) {
-Obj _35p1348 = co->args[1];
-Obj _35p1349 = co->args[2];
-Obj _35p1350 = co->args[3];
-Obj _35p1351 = co->args[4];
-Obj _35cc1352 = makeNative(_35clofun3140, 0, 4, _35p1348, _35p1349, _35p1350, _35p1351);
-Obj env = _35p1348;
-Obj fn = _35p1349;
-Obj w = _35p1350;
-Obj _35reg2664 = primEQ(Nil, _35p1351);
-if (True == _35reg2664) {
+void _35clofun3943(struct Cora* co) {
+Obj _35p2150 = co->args[1];
+Obj _35p2151 = co->args[2];
+Obj _35p2152 = co->args[3];
+Obj _35p2153 = co->args[4];
+Obj _35cc2154 = makeNative(_35clofun3944, 0, 4, _35p2150, _35p2151, _35p2152, _35p2153);
+Obj env = _35p2150;
+Obj fn = _35p2151;
+Obj w = _35p2152;
+Obj _35reg3467 = primEQ(Nil, _35p2153);
+if (True == _35reg3467) {
+co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1352;
 co->nargs = 1;
+co->args[0] = _35cc2154;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2384,23 +2412,23 @@ return;
 }
 }
 
-void _35clofun3140(struct Cora* co) {
-Obj _35cc1353 = makeNative(_35clofun3141, 0, 0);
+void _35clofun3944(struct Cora* co) {
+Obj _35cc2155 = makeNative(_35clofun3945, 0, 0);
 Obj env = closureRef(co, 0);
 Obj fn = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2657 = primIsCons(closureRef(co, 3));
-if (True == _35reg2657) {
-Obj _35reg2658 = primCar(closureRef(co, 3));
-Obj a = _35reg2658;
-Obj _35reg2659 = primCdr(closureRef(co, 3));
-Obj b = _35reg2659;
-pushCont(co, _35clofun3142, 4, env, fn, w, b);
+Obj _35reg3460 = primIsCons(closureRef(co, 3));
+if (True == _35reg3460) {
+Obj _35reg3461 = primCar(closureRef(co, 3));
+Obj a = _35reg3461;
+Obj _35reg3462 = primCdr(closureRef(co, 3));
+Obj b = _35reg3462;
+pushCont(co, _35clofun3946, 4, env, fn, w, b);
+co->nargs = 4;
 co->args[0] = fn;
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = a;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2409,8 +2437,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1353;
 co->nargs = 1;
+co->args[0] = _35cc2155;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2421,16 +2449,16 @@ return;
 }
 }
 
-void _35clofun3142(struct Cora* co) {
-Obj _35val2660 = co->args[1];
+void _35clofun3946(struct Cora* co) {
+Obj _35val3463 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj fn = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj b = co->stack[co->base + 3];
-pushCont(co, _35clofun3143, 4, env, fn, w, b);
+pushCont(co, _35clofun3947, 4, env, fn, w, b);
+co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = b;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2440,19 +2468,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3143(struct Cora* co) {
-Obj _35val2661 = co->args[1];
+void _35clofun3947(struct Cora* co) {
+Obj _35val3464 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj fn = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj b = co->stack[co->base + 3];
-Obj _35reg2662 = primNot(_35val2661);
-if (True == _35reg2662) {
-pushCont(co, _35clofun3144, 4, env, fn, w, b);
+Obj _35reg3465 = primNot(_35val3464);
+if (True == _35reg3465) {
+pushCont(co, _35clofun3948, 4, env, fn, w, b);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(", ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2462,12 +2490,12 @@ co->pc = coraCall;
 return;
 } else {
 Nil;
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst-list-h"));
 co->args[1] = env;
 co->args[2] = fn;
 co->args[3] = w;
 co->args[4] = b;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2478,18 +2506,18 @@ return;
 }
 }
 
-void _35clofun3144(struct Cora* co) {
-Obj _35val2663 = co->args[1];
+void _35clofun3948(struct Cora* co) {
+Obj _35val3466 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj fn = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj b = co->stack[co->base + 3];
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst-list-h"));
 co->args[1] = env;
 co->args[2] = fn;
 co->args[3] = w;
 co->args[4] = b;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2499,10 +2527,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3141(struct Cora* co) {
+void _35clofun3945(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2512,30 +2540,30 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3128(struct Cora* co) {
-Obj _35p1345 = co->args[1];
-Obj _35p1346 = co->args[2];
-Obj _35cc1347 = makeNative(_35clofun3129, 0, 0);
-Obj w = _35p1345;
-Obj _35reg2638 = primIsCons(_35p1346);
-if (True == _35reg2638) {
-Obj _35reg2639 = primCar(_35p1346);
-Obj _35reg2640 = primEQ(intern("%continuation"), _35reg2639);
-if (True == _35reg2640) {
-Obj _35reg2641 = primCdr(_35p1346);
-Obj _35reg2642 = primIsCons(_35reg2641);
-if (True == _35reg2642) {
-Obj _35reg2643 = primCdr(_35p1346);
-Obj _35reg2644 = primCar(_35reg2643);
-Obj label = _35reg2644;
-Obj _35reg2645 = primCdr(_35p1346);
-Obj _35reg2646 = primCdr(_35reg2645);
-Obj stacks = _35reg2646;
-pushCont(co, _35clofun3130, 3, label, stacks, w);
+void _35clofun3932(struct Cora* co) {
+Obj _35p2147 = co->args[1];
+Obj _35p2148 = co->args[2];
+Obj _35cc2149 = makeNative(_35clofun3933, 0, 0);
+Obj w = _35p2147;
+Obj _35reg3441 = primIsCons(_35p2148);
+if (True == _35reg3441) {
+Obj _35reg3442 = primCar(_35p2148);
+Obj _35reg3443 = primEQ(intern("%continuation"), _35reg3442);
+if (True == _35reg3443) {
+Obj _35reg3444 = primCdr(_35p2148);
+Obj _35reg3445 = primIsCons(_35reg3444);
+if (True == _35reg3445) {
+Obj _35reg3446 = primCdr(_35p2148);
+Obj _35reg3447 = primCar(_35reg3446);
+Obj label = _35reg3447;
+Obj _35reg3448 = primCdr(_35p2148);
+Obj _35reg3449 = primCdr(_35reg3448);
+Obj stacks = _35reg3449;
+pushCont(co, _35clofun3934, 3, label, stacks, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("pushCont(co, ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2544,8 +2572,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1347;
 co->nargs = 1;
+co->args[0] = _35cc2149;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2555,8 +2583,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1347;
 co->nargs = 1;
+co->args[0] = _35cc2149;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2566,8 +2594,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1347;
 co->nargs = 1;
+co->args[0] = _35cc2149;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2578,16 +2606,16 @@ return;
 }
 }
 
-void _35clofun3130(struct Cora* co) {
-Obj _35val2647 = co->args[1];
+void _35clofun3934(struct Cora* co) {
+Obj _35val3450 = co->args[1];
 Obj label = co->stack[co->base + 0];
 Obj stacks = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3131, 2, stacks, w);
+pushCont(co, _35clofun3935, 2, stacks, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
 co->args[2] = label;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2597,15 +2625,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3131(struct Cora* co) {
-Obj _35val2648 = co->args[1];
+void _35clofun3935(struct Cora* co) {
+Obj _35val3451 = co->args[1];
 Obj stacks = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3132, 2, stacks, w);
+pushCont(co, _35clofun3936, 2, stacks, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(", ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2615,14 +2643,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3132(struct Cora* co) {
-Obj _35val2649 = co->args[1];
+void _35clofun3936(struct Cora* co) {
+Obj _35val3452 = co->args[1];
 Obj stacks = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3133, 2, stacks, w);
+pushCont(co, _35clofun3937, 2, stacks, w);
+co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = stacks;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2632,15 +2660,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3133(struct Cora* co) {
-Obj _35val2650 = co->args[1];
+void _35clofun3937(struct Cora* co) {
+Obj _35val3453 = co->args[1];
 Obj stacks = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3134, 2, stacks, w);
+pushCont(co, _35clofun3938, 2, stacks, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
-co->args[2] = _35val2650;
-co->nargs = 3;
+co->args[2] = _35val3453;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2650,14 +2678,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3134(struct Cora* co) {
-Obj _35val2651 = co->args[1];
+void _35clofun3938(struct Cora* co) {
+Obj _35val3454 = co->args[1];
 Obj stacks = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3135, 2, stacks, w);
+pushCont(co, _35clofun3939, 2, stacks, w);
+co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = stacks;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2667,17 +2695,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3135(struct Cora* co) {
-Obj _35val2652 = co->args[1];
+void _35clofun3939(struct Cora* co) {
+Obj _35val3455 = co->args[1];
 Obj stacks = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-Obj _35reg2653 = primNot(_35val2652);
-if (True == _35reg2653) {
-pushCont(co, _35clofun3138, 1, w);
-co->args[0] = globalRef(intern("for-each"));
-co->args[1] = makeNative(_35clofun3136, 1, 1, w);
-co->args[2] = stacks;
+Obj _35reg3456 = primNot(_35val3455);
+if (True == _35reg3456) {
+pushCont(co, _35clofun3942, 1, w);
 co->nargs = 3;
+co->args[0] = globalRef(intern("for-each"));
+co->args[1] = makeNative(_35clofun3940, 1, 1, w);
+co->args[2] = stacks;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2687,10 +2715,10 @@ co->pc = coraCall;
 return;
 } else {
 Nil;
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(");\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2701,13 +2729,13 @@ return;
 }
 }
 
-void _35clofun3138(struct Cora* co) {
-Obj _35val2655 = co->args[1];
+void _35clofun3942(struct Cora* co) {
+Obj _35val3458 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(");\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2717,13 +2745,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3136(struct Cora* co) {
+void _35clofun3940(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun3137, 1, x);
+pushCont(co, _35clofun3941, 1, x);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = closureRef(co, 0);
 co->args[2] = makeString1(", ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2733,14 +2761,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3137(struct Cora* co) {
-Obj _35val2654 = co->args[1];
+void _35clofun3941(struct Cora* co) {
+Obj _35val3457 = co->args[1];
 Obj x = co->stack[co->base + 0];
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = Nil;
 co->args[2] = closureRef(co, 0);
 co->args[3] = x;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2750,10 +2778,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3129(struct Cora* co) {
+void _35clofun3933(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2763,23 +2791,24 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3120(struct Cora* co) {
-Obj _35p1339 = co->args[1];
-Obj _35p1340 = co->args[2];
-Obj _35p1341 = co->args[3];
-Obj _35p1342 = co->args[4];
-Obj _35cc1343 = makeNative(_35clofun3121, 0, 4, _35p1339, _35p1340, _35p1341, _35p1342);
-Obj env = _35p1339;
-Obj w = _35p1340;
-Obj idx = _35p1341;
-Obj _35reg2636 = primEQ(Nil, _35p1342);
-if (True == _35reg2636) {
+void _35clofun3924(struct Cora* co) {
+Obj _35p2141 = co->args[1];
+Obj _35p2142 = co->args[2];
+Obj _35p2143 = co->args[3];
+Obj _35p2144 = co->args[4];
+Obj _35cc2145 = makeNative(_35clofun3925, 0, 4, _35p2141, _35p2142, _35p2143, _35p2144);
+Obj env = _35p2141;
+Obj w = _35p2142;
+Obj idx = _35p2143;
+Obj _35reg3439 = primEQ(Nil, _35p2144);
+if (True == _35reg3439) {
+co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1343;
 co->nargs = 1;
+co->args[0] = _35cc2145;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2790,22 +2819,22 @@ return;
 }
 }
 
-void _35clofun3121(struct Cora* co) {
-Obj _35cc1344 = makeNative(_35clofun3122, 0, 0);
+void _35clofun3925(struct Cora* co) {
+Obj _35cc2146 = makeNative(_35clofun3926, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj idx = closureRef(co, 2);
-Obj _35reg2627 = primIsCons(closureRef(co, 3));
-if (True == _35reg2627) {
-Obj _35reg2628 = primCar(closureRef(co, 3));
-Obj a = _35reg2628;
-Obj _35reg2629 = primCdr(closureRef(co, 3));
-Obj b = _35reg2629;
-pushCont(co, _35clofun3123, 5, a, idx, env, w, b);
+Obj _35reg3430 = primIsCons(closureRef(co, 3));
+if (True == _35reg3430) {
+Obj _35reg3431 = primCar(closureRef(co, 3));
+Obj a = _35reg3431;
+Obj _35reg3432 = primCdr(closureRef(co, 3));
+Obj b = _35reg3432;
+pushCont(co, _35clofun3927, 5, a, idx, env, w, b);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("co->args[");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2814,8 +2843,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1344;
 co->nargs = 1;
+co->args[0] = _35cc2146;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2826,18 +2855,18 @@ return;
 }
 }
 
-void _35clofun3123(struct Cora* co) {
-Obj _35val2630 = co->args[1];
+void _35clofun3927(struct Cora* co) {
+Obj _35val3433 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj idx = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-pushCont(co, _35clofun3124, 5, a, idx, env, w, b);
+pushCont(co, _35clofun3928, 5, a, idx, env, w, b);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
 co->args[2] = idx;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2847,18 +2876,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3124(struct Cora* co) {
-Obj _35val2631 = co->args[1];
+void _35clofun3928(struct Cora* co) {
+Obj _35val3434 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj idx = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-pushCont(co, _35clofun3125, 5, a, idx, env, w, b);
+pushCont(co, _35clofun3929, 5, a, idx, env, w, b);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("] = ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2868,19 +2897,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3125(struct Cora* co) {
-Obj _35val2632 = co->args[1];
+void _35clofun3929(struct Cora* co) {
+Obj _35val3435 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj idx = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj b = co->stack[co->base + 4];
-pushCont(co, _35clofun3126, 4, idx, env, w, b);
+pushCont(co, _35clofun3930, 4, idx, env, w, b);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = a;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2890,17 +2919,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3126(struct Cora* co) {
-Obj _35val2633 = co->args[1];
+void _35clofun3930(struct Cora* co) {
+Obj _35val3436 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj b = co->stack[co->base + 3];
-pushCont(co, _35clofun3127, 4, idx, env, w, b);
+pushCont(co, _35clofun3931, 4, idx, env, w, b);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(";\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2910,19 +2939,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3127(struct Cora* co) {
-Obj _35val2634 = co->args[1];
+void _35clofun3931(struct Cora* co) {
+Obj _35val3437 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj b = co->stack[co->base + 3];
-Obj _35reg2635 = primAdd(idx, makeNumber(1));
+Obj _35reg3438 = primAdd(idx, makeNumber(1));
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-call-args"));
 co->args[1] = env;
 co->args[2] = w;
-co->args[3] = _35reg2635;
+co->args[3] = _35reg3438;
 co->args[4] = b;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2932,10 +2961,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3122(struct Cora* co) {
+void _35clofun3926(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2945,20 +2974,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3040(struct Cora* co) {
-Obj _35p1322 = co->args[1];
-Obj _35p1323 = co->args[2];
-Obj _35p1324 = co->args[3];
-Obj _35cc1325 = makeNative(_35clofun3041, 0, 3, _35p1322, _35p1323, _35p1324);
-Obj env = _35p1322;
-Obj w = _35p1323;
-Obj x = _35p1324;
-Obj _35reg2625 = primIsSymbol(x);
-if (True == _35reg2625) {
+void _35clofun3843(struct Cora* co) {
+Obj _35p2124 = co->args[1];
+Obj _35p2125 = co->args[2];
+Obj _35p2126 = co->args[3];
+Obj _35cc2127 = makeNative(_35clofun3844, 0, 3, _35p2124, _35p2125, _35p2126);
+Obj env = _35p2124;
+Obj w = _35p2125;
+Obj x = _35p2126;
+Obj _35reg3428 = primIsSymbol(x);
+if (True == _35reg3428) {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
 co->args[2] = x;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2967,8 +2996,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1325;
 co->nargs = 1;
+co->args[0] = _35cc2127;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -2979,30 +3008,30 @@ return;
 }
 }
 
-void _35clofun3041(struct Cora* co) {
-Obj _35cc1326 = makeNative(_35clofun3042, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3844(struct Cora* co) {
+Obj _35cc2128 = makeNative(_35clofun3845, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2612 = primIsCons(closureRef(co, 2));
-if (True == _35reg2612) {
-Obj _35reg2613 = primCar(closureRef(co, 2));
-Obj _35reg2614 = primEQ(intern("%global"), _35reg2613);
-if (True == _35reg2614) {
-Obj _35reg2615 = primCdr(closureRef(co, 2));
-Obj _35reg2616 = primIsCons(_35reg2615);
-if (True == _35reg2616) {
-Obj _35reg2617 = primCdr(closureRef(co, 2));
-Obj _35reg2618 = primCar(_35reg2617);
-Obj x = _35reg2618;
-Obj _35reg2619 = primCdr(closureRef(co, 2));
-Obj _35reg2620 = primCdr(_35reg2619);
-Obj _35reg2621 = primEQ(Nil, _35reg2620);
-if (True == _35reg2621) {
-pushCont(co, _35clofun3117, 2, x, w);
+Obj _35reg3415 = primIsCons(closureRef(co, 2));
+if (True == _35reg3415) {
+Obj _35reg3416 = primCar(closureRef(co, 2));
+Obj _35reg3417 = primEQ(intern("%global"), _35reg3416);
+if (True == _35reg3417) {
+Obj _35reg3418 = primCdr(closureRef(co, 2));
+Obj _35reg3419 = primIsCons(_35reg3418);
+if (True == _35reg3419) {
+Obj _35reg3420 = primCdr(closureRef(co, 2));
+Obj _35reg3421 = primCar(_35reg3420);
+Obj x = _35reg3421;
+Obj _35reg3422 = primCdr(closureRef(co, 2));
+Obj _35reg3423 = primCdr(_35reg3422);
+Obj _35reg3424 = primEQ(Nil, _35reg3423);
+if (True == _35reg3424) {
+pushCont(co, _35clofun3921, 2, x, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("globalRef(intern(\"");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3011,8 +3040,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1326;
 co->nargs = 1;
+co->args[0] = _35cc2128;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3022,8 +3051,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1326;
 co->nargs = 1;
+co->args[0] = _35cc2128;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3033,8 +3062,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1326;
 co->nargs = 1;
+co->args[0] = _35cc2128;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3044,8 +3073,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1326;
 co->nargs = 1;
+co->args[0] = _35cc2128;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3056,14 +3085,14 @@ return;
 }
 }
 
-void _35clofun3117(struct Cora* co) {
-Obj _35val2622 = co->args[1];
+void _35clofun3921(struct Cora* co) {
+Obj _35val3425 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3118, 1, w);
+pushCont(co, _35clofun3922, 1, w);
+co->nargs = 2;
 co->args[0] = globalRef(intern("symbol->string"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3073,14 +3102,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3118(struct Cora* co) {
-Obj _35val2623 = co->args[1];
+void _35clofun3922(struct Cora* co) {
+Obj _35val3426 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3119, 1, w);
+pushCont(co, _35clofun3923, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
-co->args[2] = _35val2623;
-co->nargs = 3;
+co->args[2] = _35val3426;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3090,13 +3119,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3119(struct Cora* co) {
-Obj _35val2624 = co->args[1];
+void _35clofun3923(struct Cora* co) {
+Obj _35val3427 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("\"))");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3106,30 +3135,30 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3042(struct Cora* co) {
-Obj _35cc1327 = makeNative(_35clofun3043, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3845(struct Cora* co) {
+Obj _35cc2129 = makeNative(_35clofun3846, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2600 = primIsCons(closureRef(co, 2));
-if (True == _35reg2600) {
-Obj _35reg2601 = primCar(closureRef(co, 2));
-Obj _35reg2602 = primEQ(intern("%closure-ref"), _35reg2601);
-if (True == _35reg2602) {
-Obj _35reg2603 = primCdr(closureRef(co, 2));
-Obj _35reg2604 = primIsCons(_35reg2603);
-if (True == _35reg2604) {
-Obj _35reg2605 = primCdr(closureRef(co, 2));
-Obj _35reg2606 = primCar(_35reg2605);
-Obj idx = _35reg2606;
-Obj _35reg2607 = primCdr(closureRef(co, 2));
-Obj _35reg2608 = primCdr(_35reg2607);
-Obj _35reg2609 = primEQ(Nil, _35reg2608);
-if (True == _35reg2609) {
-pushCont(co, _35clofun3115, 2, idx, w);
+Obj _35reg3403 = primIsCons(closureRef(co, 2));
+if (True == _35reg3403) {
+Obj _35reg3404 = primCar(closureRef(co, 2));
+Obj _35reg3405 = primEQ(intern("%closure-ref"), _35reg3404);
+if (True == _35reg3405) {
+Obj _35reg3406 = primCdr(closureRef(co, 2));
+Obj _35reg3407 = primIsCons(_35reg3406);
+if (True == _35reg3407) {
+Obj _35reg3408 = primCdr(closureRef(co, 2));
+Obj _35reg3409 = primCar(_35reg3408);
+Obj idx = _35reg3409;
+Obj _35reg3410 = primCdr(closureRef(co, 2));
+Obj _35reg3411 = primCdr(_35reg3410);
+Obj _35reg3412 = primEQ(Nil, _35reg3411);
+if (True == _35reg3412) {
+pushCont(co, _35clofun3919, 2, idx, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("closureRef(co, ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3138,8 +3167,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1327;
 co->nargs = 1;
+co->args[0] = _35cc2129;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3149,8 +3178,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1327;
 co->nargs = 1;
+co->args[0] = _35cc2129;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3160,8 +3189,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1327;
 co->nargs = 1;
+co->args[0] = _35cc2129;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3171,8 +3200,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1327;
 co->nargs = 1;
+co->args[0] = _35cc2129;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3183,15 +3212,15 @@ return;
 }
 }
 
-void _35clofun3115(struct Cora* co) {
-Obj _35val2610 = co->args[1];
+void _35clofun3919(struct Cora* co) {
+Obj _35val3413 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3116, 1, w);
+pushCont(co, _35clofun3920, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
 co->args[2] = idx;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3201,13 +3230,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3116(struct Cora* co) {
-Obj _35val2611 = co->args[1];
+void _35clofun3920(struct Cora* co) {
+Obj _35val3414 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(")");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3217,30 +3246,30 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3043(struct Cora* co) {
-Obj _35cc1328 = makeNative(_35clofun3044, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3846(struct Cora* co) {
+Obj _35cc2130 = makeNative(_35clofun3847, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2588 = primIsCons(closureRef(co, 2));
-if (True == _35reg2588) {
-Obj _35reg2589 = primCar(closureRef(co, 2));
-Obj _35reg2590 = primEQ(intern("%stack-ref"), _35reg2589);
-if (True == _35reg2590) {
-Obj _35reg2591 = primCdr(closureRef(co, 2));
-Obj _35reg2592 = primIsCons(_35reg2591);
-if (True == _35reg2592) {
-Obj _35reg2593 = primCdr(closureRef(co, 2));
-Obj _35reg2594 = primCar(_35reg2593);
-Obj idx = _35reg2594;
-Obj _35reg2595 = primCdr(closureRef(co, 2));
-Obj _35reg2596 = primCdr(_35reg2595);
-Obj _35reg2597 = primEQ(Nil, _35reg2596);
-if (True == _35reg2597) {
-pushCont(co, _35clofun3113, 2, idx, w);
+Obj _35reg3391 = primIsCons(closureRef(co, 2));
+if (True == _35reg3391) {
+Obj _35reg3392 = primCar(closureRef(co, 2));
+Obj _35reg3393 = primEQ(intern("%stack-ref"), _35reg3392);
+if (True == _35reg3393) {
+Obj _35reg3394 = primCdr(closureRef(co, 2));
+Obj _35reg3395 = primIsCons(_35reg3394);
+if (True == _35reg3395) {
+Obj _35reg3396 = primCdr(closureRef(co, 2));
+Obj _35reg3397 = primCar(_35reg3396);
+Obj idx = _35reg3397;
+Obj _35reg3398 = primCdr(closureRef(co, 2));
+Obj _35reg3399 = primCdr(_35reg3398);
+Obj _35reg3400 = primEQ(Nil, _35reg3399);
+if (True == _35reg3400) {
+pushCont(co, _35clofun3917, 2, idx, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("stackRef(co, ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3249,8 +3278,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1328;
 co->nargs = 1;
+co->args[0] = _35cc2130;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3260,8 +3289,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1328;
 co->nargs = 1;
+co->args[0] = _35cc2130;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3271,8 +3300,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1328;
 co->nargs = 1;
+co->args[0] = _35cc2130;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3282,8 +3311,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1328;
 co->nargs = 1;
+co->args[0] = _35cc2130;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3294,15 +3323,15 @@ return;
 }
 }
 
-void _35clofun3113(struct Cora* co) {
-Obj _35val2598 = co->args[1];
+void _35clofun3917(struct Cora* co) {
+Obj _35val3401 = co->args[1];
 Obj idx = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3114, 1, w);
+pushCont(co, _35clofun3918, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
 co->args[2] = idx;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3312,13 +3341,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3114(struct Cora* co) {
-Obj _35val2599 = co->args[1];
+void _35clofun3918(struct Cora* co) {
+Obj _35val3402 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(")");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3328,32 +3357,32 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3044(struct Cora* co) {
-Obj _35cc1329 = makeNative(_35clofun3045, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3847(struct Cora* co) {
+Obj _35cc2131 = makeNative(_35clofun3848, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2564 = primIsCons(closureRef(co, 2));
-if (True == _35reg2564) {
-Obj _35reg2565 = primCar(closureRef(co, 2));
-Obj _35reg2566 = primEQ(intern("%const"), _35reg2565);
-if (True == _35reg2566) {
-Obj _35reg2567 = primCdr(closureRef(co, 2));
-Obj _35reg2568 = primIsCons(_35reg2567);
-if (True == _35reg2568) {
-Obj _35reg2569 = primCdr(closureRef(co, 2));
-Obj _35reg2570 = primCar(_35reg2569);
-Obj x = _35reg2570;
-Obj _35reg2571 = primCdr(closureRef(co, 2));
-Obj _35reg2572 = primCdr(_35reg2571);
-Obj _35reg2573 = primEQ(Nil, _35reg2572);
-if (True == _35reg2573) {
-Obj _35reg2574 = primIsSymbol(x);
-if (True == _35reg2574) {
-pushCont(co, _35clofun3104, 2, x, w);
+Obj _35reg3367 = primIsCons(closureRef(co, 2));
+if (True == _35reg3367) {
+Obj _35reg3368 = primCar(closureRef(co, 2));
+Obj _35reg3369 = primEQ(intern("%const"), _35reg3368);
+if (True == _35reg3369) {
+Obj _35reg3370 = primCdr(closureRef(co, 2));
+Obj _35reg3371 = primIsCons(_35reg3370);
+if (True == _35reg3371) {
+Obj _35reg3372 = primCdr(closureRef(co, 2));
+Obj _35reg3373 = primCar(_35reg3372);
+Obj x = _35reg3373;
+Obj _35reg3374 = primCdr(closureRef(co, 2));
+Obj _35reg3375 = primCdr(_35reg3374);
+Obj _35reg3376 = primEQ(Nil, _35reg3375);
+if (True == _35reg3376) {
+Obj _35reg3377 = primIsSymbol(x);
+if (True == _35reg3377) {
+pushCont(co, _35clofun3908, 2, x, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("intern(\"");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3362,10 +3391,10 @@ co->pc = coraCall;
 }
 return;
 } else {
-pushCont(co, _35clofun3107, 2, x, w);
+pushCont(co, _35clofun3911, 2, x, w);
+co->nargs = 2;
 co->args[0] = globalRef(intern("number?"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3375,8 +3404,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1329;
 co->nargs = 1;
+co->args[0] = _35cc2131;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3386,8 +3415,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1329;
 co->nargs = 1;
+co->args[0] = _35cc2131;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3397,8 +3426,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1329;
 co->nargs = 1;
+co->args[0] = _35cc2131;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3408,8 +3437,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1329;
 co->nargs = 1;
+co->args[0] = _35cc2131;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3420,16 +3449,16 @@ return;
 }
 }
 
-void _35clofun3107(struct Cora* co) {
-Obj _35val2578 = co->args[1];
+void _35clofun3911(struct Cora* co) {
+Obj _35val3381 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-if (True == _35val2578) {
-pushCont(co, _35clofun3108, 2, x, w);
+if (True == _35val3381) {
+pushCont(co, _35clofun3912, 2, x, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("makeNumber(");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3438,13 +3467,13 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2581 = primIsString(x);
-if (True == _35reg2581) {
-pushCont(co, _35clofun3110, 2, x, w);
+Obj _35reg3384 = primIsString(x);
+if (True == _35reg3384) {
+pushCont(co, _35clofun3914, 2, x, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("makeString1(\"");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3453,12 +3482,12 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2585 = primEQ(x, Nil);
-if (True == _35reg2585) {
+Obj _35reg3388 = primEQ(x, Nil);
+if (True == _35reg3388) {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("Nil");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3467,12 +3496,12 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2586 = primEQ(x, True);
-if (True == _35reg2586) {
+Obj _35reg3389 = primEQ(x, True);
+if (True == _35reg3389) {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("True");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3481,12 +3510,12 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2587 = primEQ(x, False);
-if (True == _35reg2587) {
+Obj _35reg3390 = primEQ(x, False);
+if (True == _35reg3390) {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("False");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3495,9 +3524,9 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no cond match");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3512,14 +3541,14 @@ return;
 }
 }
 
-void _35clofun3110(struct Cora* co) {
-Obj _35val2582 = co->args[1];
+void _35clofun3914(struct Cora* co) {
+Obj _35val3385 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3111, 1, w);
+pushCont(co, _35clofun3915, 1, w);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.escape-str"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3529,14 +3558,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3111(struct Cora* co) {
-Obj _35val2583 = co->args[1];
+void _35clofun3915(struct Cora* co) {
+Obj _35val3386 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3112, 1, w);
+pushCont(co, _35clofun3916, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
-co->args[2] = _35val2583;
-co->nargs = 3;
+co->args[2] = _35val3386;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3546,13 +3575,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3112(struct Cora* co) {
-Obj _35val2584 = co->args[1];
+void _35clofun3916(struct Cora* co) {
+Obj _35val3387 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("\")");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3562,15 +3591,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3108(struct Cora* co) {
-Obj _35val2579 = co->args[1];
+void _35clofun3912(struct Cora* co) {
+Obj _35val3382 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3109, 1, w);
+pushCont(co, _35clofun3913, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
 co->args[2] = x;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3580,13 +3609,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3109(struct Cora* co) {
-Obj _35val2580 = co->args[1];
+void _35clofun3913(struct Cora* co) {
+Obj _35val3383 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(")");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3596,14 +3625,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3104(struct Cora* co) {
-Obj _35val2575 = co->args[1];
+void _35clofun3908(struct Cora* co) {
+Obj _35val3378 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3105, 1, w);
+pushCont(co, _35clofun3909, 1, w);
+co->nargs = 2;
 co->args[0] = globalRef(intern("symbol->string"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3613,14 +3642,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3105(struct Cora* co) {
-Obj _35val2576 = co->args[1];
+void _35clofun3909(struct Cora* co) {
+Obj _35val3379 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3106, 1, w);
+pushCont(co, _35clofun3910, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
-co->args[2] = _35val2576;
-co->nargs = 3;
+co->args[2] = _35val3379;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3630,13 +3659,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3106(struct Cora* co) {
-Obj _35val2577 = co->args[1];
+void _35clofun3910(struct Cora* co) {
+Obj _35val3380 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("\")");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3646,50 +3675,50 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3045(struct Cora* co) {
-Obj _35cc1330 = makeNative(_35clofun3046, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3848(struct Cora* co) {
+Obj _35cc2132 = makeNative(_35clofun3849, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2525 = primIsCons(closureRef(co, 2));
-if (True == _35reg2525) {
-Obj _35reg2526 = primCar(closureRef(co, 2));
-Obj _35reg2527 = primEQ(intern("let"), _35reg2526);
-if (True == _35reg2527) {
-Obj _35reg2528 = primCdr(closureRef(co, 2));
-Obj _35reg2529 = primIsCons(_35reg2528);
-if (True == _35reg2529) {
-Obj _35reg2530 = primCdr(closureRef(co, 2));
-Obj _35reg2531 = primCar(_35reg2530);
-Obj a = _35reg2531;
-Obj _35reg2532 = primCdr(closureRef(co, 2));
-Obj _35reg2533 = primCdr(_35reg2532);
-Obj _35reg2534 = primIsCons(_35reg2533);
-if (True == _35reg2534) {
-Obj _35reg2535 = primCdr(closureRef(co, 2));
-Obj _35reg2536 = primCdr(_35reg2535);
-Obj _35reg2537 = primCar(_35reg2536);
-Obj b = _35reg2537;
-Obj _35reg2538 = primCdr(closureRef(co, 2));
-Obj _35reg2539 = primCdr(_35reg2538);
-Obj _35reg2540 = primCdr(_35reg2539);
-Obj _35reg2541 = primIsCons(_35reg2540);
-if (True == _35reg2541) {
-Obj _35reg2542 = primCdr(closureRef(co, 2));
-Obj _35reg2543 = primCdr(_35reg2542);
-Obj _35reg2544 = primCdr(_35reg2543);
-Obj _35reg2545 = primCar(_35reg2544);
-Obj c = _35reg2545;
-Obj _35reg2546 = primCdr(closureRef(co, 2));
-Obj _35reg2547 = primCdr(_35reg2546);
-Obj _35reg2548 = primCdr(_35reg2547);
-Obj _35reg2549 = primCdr(_35reg2548);
-Obj _35reg2550 = primEQ(Nil, _35reg2549);
-if (True == _35reg2550) {
-pushCont(co, _35clofun3094, 5, b, a, env, w, c);
+Obj _35reg3328 = primIsCons(closureRef(co, 2));
+if (True == _35reg3328) {
+Obj _35reg3329 = primCar(closureRef(co, 2));
+Obj _35reg3330 = primEQ(intern("let"), _35reg3329);
+if (True == _35reg3330) {
+Obj _35reg3331 = primCdr(closureRef(co, 2));
+Obj _35reg3332 = primIsCons(_35reg3331);
+if (True == _35reg3332) {
+Obj _35reg3333 = primCdr(closureRef(co, 2));
+Obj _35reg3334 = primCar(_35reg3333);
+Obj a = _35reg3334;
+Obj _35reg3335 = primCdr(closureRef(co, 2));
+Obj _35reg3336 = primCdr(_35reg3335);
+Obj _35reg3337 = primIsCons(_35reg3336);
+if (True == _35reg3337) {
+Obj _35reg3338 = primCdr(closureRef(co, 2));
+Obj _35reg3339 = primCdr(_35reg3338);
+Obj _35reg3340 = primCar(_35reg3339);
+Obj b = _35reg3340;
+Obj _35reg3341 = primCdr(closureRef(co, 2));
+Obj _35reg3342 = primCdr(_35reg3341);
+Obj _35reg3343 = primCdr(_35reg3342);
+Obj _35reg3344 = primIsCons(_35reg3343);
+if (True == _35reg3344) {
+Obj _35reg3345 = primCdr(closureRef(co, 2));
+Obj _35reg3346 = primCdr(_35reg3345);
+Obj _35reg3347 = primCdr(_35reg3346);
+Obj _35reg3348 = primCar(_35reg3347);
+Obj c = _35reg3348;
+Obj _35reg3349 = primCdr(closureRef(co, 2));
+Obj _35reg3350 = primCdr(_35reg3349);
+Obj _35reg3351 = primCdr(_35reg3350);
+Obj _35reg3352 = primCdr(_35reg3351);
+Obj _35reg3353 = primEQ(Nil, _35reg3352);
+if (True == _35reg3353) {
+pushCont(co, _35clofun3898, 5, b, a, env, w, c);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.index"));
 co->args[1] = a;
 co->args[2] = env;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3698,8 +3727,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1330;
 co->nargs = 1;
+co->args[0] = _35cc2132;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3709,8 +3738,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1330;
 co->nargs = 1;
+co->args[0] = _35cc2132;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3720,8 +3749,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1330;
 co->nargs = 1;
+co->args[0] = _35cc2132;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3731,8 +3760,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1330;
 co->nargs = 1;
+co->args[0] = _35cc2132;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3742,8 +3771,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1330;
 co->nargs = 1;
+co->args[0] = _35cc2132;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3753,8 +3782,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1330;
 co->nargs = 1;
+co->args[0] = _35cc2132;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3765,21 +3794,21 @@ return;
 }
 }
 
-void _35clofun3094(struct Cora* co) {
-Obj _35val2551 = co->args[1];
+void _35clofun3898(struct Cora* co) {
+Obj _35val3354 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj c = co->stack[co->base + 4];
-Obj idx = _35val2551;
-Obj _35reg2552 = primLT(idx, makeNumber(0));
-if (True == _35reg2552) {
-pushCont(co, _35clofun3095, 5, b, a, env, w, c);
+Obj idx = _35val3354;
+Obj _35reg3355 = primLT(idx, makeNumber(0));
+if (True == _35reg3355) {
+pushCont(co, _35clofun3899, 5, b, a, env, w, c);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("Obj ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3789,11 +3818,11 @@ co->pc = coraCall;
 return;
 } else {
 Nil;
-pushCont(co, _35clofun3100, 5, b, a, env, w, c);
+pushCont(co, _35clofun3904, 5, b, a, env, w, c);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
 co->args[2] = a;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3804,18 +3833,18 @@ return;
 }
 }
 
-void _35clofun3100(struct Cora* co) {
-Obj _35val2559 = co->args[1];
+void _35clofun3904(struct Cora* co) {
+Obj _35val3362 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj c = co->stack[co->base + 4];
-pushCont(co, _35clofun3101, 5, b, a, env, w, c);
+pushCont(co, _35clofun3905, 5, b, a, env, w, c);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(" = ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3825,19 +3854,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3101(struct Cora* co) {
-Obj _35val2560 = co->args[1];
+void _35clofun3905(struct Cora* co) {
+Obj _35val3363 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj c = co->stack[co->base + 4];
-pushCont(co, _35clofun3102, 4, a, env, w, c);
+pushCont(co, _35clofun3906, 4, a, env, w, c);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = b;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3847,17 +3876,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3102(struct Cora* co) {
-Obj _35val2561 = co->args[1];
+void _35clofun3906(struct Cora* co) {
+Obj _35val3364 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj c = co->stack[co->base + 3];
-pushCont(co, _35clofun3103, 4, a, env, w, c);
+pushCont(co, _35clofun3907, 4, a, env, w, c);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(";\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3867,18 +3896,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3103(struct Cora* co) {
-Obj _35val2562 = co->args[1];
+void _35clofun3907(struct Cora* co) {
+Obj _35val3365 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj c = co->stack[co->base + 3];
-Obj _35reg2563 = primCons(a, env);
+Obj _35reg3366 = primCons(a, env);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
-co->args[1] = _35reg2563;
+co->args[1] = _35reg3366;
 co->args[2] = w;
 co->args[3] = c;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3888,18 +3917,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3095(struct Cora* co) {
-Obj _35val2553 = co->args[1];
+void _35clofun3899(struct Cora* co) {
+Obj _35val3356 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj c = co->stack[co->base + 4];
-pushCont(co, _35clofun3096, 5, b, a, env, w, c);
+pushCont(co, _35clofun3900, 5, b, a, env, w, c);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
 co->args[2] = a;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3909,18 +3938,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3096(struct Cora* co) {
-Obj _35val2554 = co->args[1];
+void _35clofun3900(struct Cora* co) {
+Obj _35val3357 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj c = co->stack[co->base + 4];
-pushCont(co, _35clofun3097, 5, b, a, env, w, c);
+pushCont(co, _35clofun3901, 5, b, a, env, w, c);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(" = ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3930,19 +3959,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3097(struct Cora* co) {
-Obj _35val2555 = co->args[1];
+void _35clofun3901(struct Cora* co) {
+Obj _35val3358 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
 Obj c = co->stack[co->base + 4];
-pushCont(co, _35clofun3098, 4, a, env, w, c);
+pushCont(co, _35clofun3902, 4, a, env, w, c);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = b;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3952,17 +3981,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3098(struct Cora* co) {
-Obj _35val2556 = co->args[1];
+void _35clofun3902(struct Cora* co) {
+Obj _35val3359 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj c = co->stack[co->base + 3];
-pushCont(co, _35clofun3099, 4, a, env, w, c);
+pushCont(co, _35clofun3903, 4, a, env, w, c);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(";\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3972,18 +4001,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3099(struct Cora* co) {
-Obj _35val2557 = co->args[1];
+void _35clofun3903(struct Cora* co) {
+Obj _35val3360 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
 Obj c = co->stack[co->base + 3];
-Obj _35reg2558 = primCons(a, env);
+Obj _35reg3361 = primCons(a, env);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
-co->args[1] = _35reg2558;
+co->args[1] = _35reg3361;
 co->args[2] = w;
 co->args[3] = c;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -3993,38 +4022,38 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3046(struct Cora* co) {
-Obj _35cc1331 = makeNative(_35clofun3047, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3849(struct Cora* co) {
+Obj _35cc2133 = makeNative(_35clofun3850, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2504 = primIsCons(closureRef(co, 2));
-if (True == _35reg2504) {
-Obj _35reg2505 = primCar(closureRef(co, 2));
-Obj _35reg2506 = primIsCons(_35reg2505);
-if (True == _35reg2506) {
-Obj _35reg2507 = primCar(closureRef(co, 2));
-Obj _35reg2508 = primCar(_35reg2507);
-Obj _35reg2509 = primEQ(intern("%builtin"), _35reg2508);
-if (True == _35reg2509) {
-Obj _35reg2510 = primCar(closureRef(co, 2));
-Obj _35reg2511 = primCdr(_35reg2510);
-Obj _35reg2512 = primIsCons(_35reg2511);
-if (True == _35reg2512) {
-Obj _35reg2513 = primCar(closureRef(co, 2));
-Obj _35reg2514 = primCdr(_35reg2513);
-Obj _35reg2515 = primCar(_35reg2514);
-Obj f = _35reg2515;
-Obj _35reg2516 = primCar(closureRef(co, 2));
-Obj _35reg2517 = primCdr(_35reg2516);
-Obj _35reg2518 = primCdr(_35reg2517);
-Obj _35reg2519 = primEQ(Nil, _35reg2518);
-if (True == _35reg2519) {
-Obj _35reg2520 = primCdr(closureRef(co, 2));
-Obj args = _35reg2520;
-pushCont(co, _35clofun3090, 3, env, args, w);
+Obj _35reg3307 = primIsCons(closureRef(co, 2));
+if (True == _35reg3307) {
+Obj _35reg3308 = primCar(closureRef(co, 2));
+Obj _35reg3309 = primIsCons(_35reg3308);
+if (True == _35reg3309) {
+Obj _35reg3310 = primCar(closureRef(co, 2));
+Obj _35reg3311 = primCar(_35reg3310);
+Obj _35reg3312 = primEQ(intern("%builtin"), _35reg3311);
+if (True == _35reg3312) {
+Obj _35reg3313 = primCar(closureRef(co, 2));
+Obj _35reg3314 = primCdr(_35reg3313);
+Obj _35reg3315 = primIsCons(_35reg3314);
+if (True == _35reg3315) {
+Obj _35reg3316 = primCar(closureRef(co, 2));
+Obj _35reg3317 = primCdr(_35reg3316);
+Obj _35reg3318 = primCar(_35reg3317);
+Obj f = _35reg3318;
+Obj _35reg3319 = primCar(closureRef(co, 2));
+Obj _35reg3320 = primCdr(_35reg3319);
+Obj _35reg3321 = primCdr(_35reg3320);
+Obj _35reg3322 = primEQ(Nil, _35reg3321);
+if (True == _35reg3322) {
+Obj _35reg3323 = primCdr(closureRef(co, 2));
+Obj args = _35reg3323;
+pushCont(co, _35clofun3894, 3, env, args, w);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.builtin->name"));
 co->args[1] = f;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4033,8 +4062,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1331;
 co->nargs = 1;
+co->args[0] = _35cc2133;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4044,8 +4073,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1331;
 co->nargs = 1;
+co->args[0] = _35cc2133;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4055,8 +4084,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1331;
 co->nargs = 1;
+co->args[0] = _35cc2133;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4066,8 +4095,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1331;
 co->nargs = 1;
+co->args[0] = _35cc2133;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4077,8 +4106,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1331;
 co->nargs = 1;
+co->args[0] = _35cc2133;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4089,16 +4118,16 @@ return;
 }
 }
 
-void _35clofun3090(struct Cora* co) {
-Obj _35val2521 = co->args[1];
+void _35clofun3894(struct Cora* co) {
+Obj _35val3324 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3091, 3, env, args, w);
+pushCont(co, _35clofun3895, 3, env, args, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
-co->args[2] = _35val2521;
-co->nargs = 3;
+co->args[2] = _35val3324;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4108,16 +4137,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3091(struct Cora* co) {
-Obj _35val2522 = co->args[1];
+void _35clofun3895(struct Cora* co) {
+Obj _35val3325 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3092, 3, env, args, w);
+pushCont(co, _35clofun3896, 3, env, args, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("(");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4127,17 +4156,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3092(struct Cora* co) {
-Obj _35val2523 = co->args[1];
+void _35clofun3896(struct Cora* co) {
+Obj _35val3326 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3093, 1, w);
+pushCont(co, _35clofun3897, 1, w);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst-list"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = args;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4147,13 +4176,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3093(struct Cora* co) {
-Obj _35val2524 = co->args[1];
+void _35clofun3897(struct Cora* co) {
+Obj _35val3327 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(")");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4163,50 +4192,50 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3047(struct Cora* co) {
-Obj _35cc1332 = makeNative(_35clofun3048, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3850(struct Cora* co) {
+Obj _35cc2134 = makeNative(_35clofun3851, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2472 = primIsCons(closureRef(co, 2));
-if (True == _35reg2472) {
-Obj _35reg2473 = primCar(closureRef(co, 2));
-Obj _35reg2474 = primEQ(intern("if"), _35reg2473);
-if (True == _35reg2474) {
-Obj _35reg2475 = primCdr(closureRef(co, 2));
-Obj _35reg2476 = primIsCons(_35reg2475);
-if (True == _35reg2476) {
-Obj _35reg2477 = primCdr(closureRef(co, 2));
-Obj _35reg2478 = primCar(_35reg2477);
-Obj a = _35reg2478;
-Obj _35reg2479 = primCdr(closureRef(co, 2));
-Obj _35reg2480 = primCdr(_35reg2479);
-Obj _35reg2481 = primIsCons(_35reg2480);
-if (True == _35reg2481) {
-Obj _35reg2482 = primCdr(closureRef(co, 2));
-Obj _35reg2483 = primCdr(_35reg2482);
-Obj _35reg2484 = primCar(_35reg2483);
-Obj b = _35reg2484;
-Obj _35reg2485 = primCdr(closureRef(co, 2));
-Obj _35reg2486 = primCdr(_35reg2485);
-Obj _35reg2487 = primCdr(_35reg2486);
-Obj _35reg2488 = primIsCons(_35reg2487);
-if (True == _35reg2488) {
-Obj _35reg2489 = primCdr(closureRef(co, 2));
-Obj _35reg2490 = primCdr(_35reg2489);
-Obj _35reg2491 = primCdr(_35reg2490);
-Obj _35reg2492 = primCar(_35reg2491);
-Obj c = _35reg2492;
-Obj _35reg2493 = primCdr(closureRef(co, 2));
-Obj _35reg2494 = primCdr(_35reg2493);
-Obj _35reg2495 = primCdr(_35reg2494);
-Obj _35reg2496 = primCdr(_35reg2495);
-Obj _35reg2497 = primEQ(Nil, _35reg2496);
-if (True == _35reg2497) {
-pushCont(co, _35clofun3084, 5, a, b, env, c, w);
+Obj _35reg3275 = primIsCons(closureRef(co, 2));
+if (True == _35reg3275) {
+Obj _35reg3276 = primCar(closureRef(co, 2));
+Obj _35reg3277 = primEQ(intern("if"), _35reg3276);
+if (True == _35reg3277) {
+Obj _35reg3278 = primCdr(closureRef(co, 2));
+Obj _35reg3279 = primIsCons(_35reg3278);
+if (True == _35reg3279) {
+Obj _35reg3280 = primCdr(closureRef(co, 2));
+Obj _35reg3281 = primCar(_35reg3280);
+Obj a = _35reg3281;
+Obj _35reg3282 = primCdr(closureRef(co, 2));
+Obj _35reg3283 = primCdr(_35reg3282);
+Obj _35reg3284 = primIsCons(_35reg3283);
+if (True == _35reg3284) {
+Obj _35reg3285 = primCdr(closureRef(co, 2));
+Obj _35reg3286 = primCdr(_35reg3285);
+Obj _35reg3287 = primCar(_35reg3286);
+Obj b = _35reg3287;
+Obj _35reg3288 = primCdr(closureRef(co, 2));
+Obj _35reg3289 = primCdr(_35reg3288);
+Obj _35reg3290 = primCdr(_35reg3289);
+Obj _35reg3291 = primIsCons(_35reg3290);
+if (True == _35reg3291) {
+Obj _35reg3292 = primCdr(closureRef(co, 2));
+Obj _35reg3293 = primCdr(_35reg3292);
+Obj _35reg3294 = primCdr(_35reg3293);
+Obj _35reg3295 = primCar(_35reg3294);
+Obj c = _35reg3295;
+Obj _35reg3296 = primCdr(closureRef(co, 2));
+Obj _35reg3297 = primCdr(_35reg3296);
+Obj _35reg3298 = primCdr(_35reg3297);
+Obj _35reg3299 = primCdr(_35reg3298);
+Obj _35reg3300 = primEQ(Nil, _35reg3299);
+if (True == _35reg3300) {
+pushCont(co, _35clofun3888, 5, a, b, env, c, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("if (True == ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4215,8 +4244,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1332;
 co->nargs = 1;
+co->args[0] = _35cc2134;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4226,8 +4255,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1332;
 co->nargs = 1;
+co->args[0] = _35cc2134;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4237,8 +4266,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1332;
 co->nargs = 1;
+co->args[0] = _35cc2134;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4248,8 +4277,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1332;
 co->nargs = 1;
+co->args[0] = _35cc2134;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4259,8 +4288,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1332;
 co->nargs = 1;
+co->args[0] = _35cc2134;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4270,8 +4299,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1332;
 co->nargs = 1;
+co->args[0] = _35cc2134;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4282,19 +4311,19 @@ return;
 }
 }
 
-void _35clofun3084(struct Cora* co) {
-Obj _35val2498 = co->args[1];
+void _35clofun3888(struct Cora* co) {
+Obj _35val3301 = co->args[1];
 Obj a = co->stack[co->base + 0];
 Obj b = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj c = co->stack[co->base + 3];
 Obj w = co->stack[co->base + 4];
-pushCont(co, _35clofun3085, 4, b, env, c, w);
+pushCont(co, _35clofun3889, 4, b, env, c, w);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = a;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4304,17 +4333,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3085(struct Cora* co) {
-Obj _35val2499 = co->args[1];
+void _35clofun3889(struct Cora* co) {
+Obj _35val3302 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj c = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3086, 4, b, env, c, w);
+pushCont(co, _35clofun3890, 4, b, env, c, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(") {\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4324,18 +4353,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3086(struct Cora* co) {
-Obj _35val2500 = co->args[1];
+void _35clofun3890(struct Cora* co) {
+Obj _35val3303 = co->args[1];
 Obj b = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj c = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3087, 3, env, c, w);
+pushCont(co, _35clofun3891, 3, env, c, w);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = b;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4345,16 +4374,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3087(struct Cora* co) {
-Obj _35val2501 = co->args[1];
+void _35clofun3891(struct Cora* co) {
+Obj _35val3304 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj c = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3088, 3, env, c, w);
+pushCont(co, _35clofun3892, 3, env, c, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("} else {\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4364,17 +4393,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3088(struct Cora* co) {
-Obj _35val2502 = co->args[1];
+void _35clofun3892(struct Cora* co) {
+Obj _35val3305 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj c = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3089, 1, w);
+pushCont(co, _35clofun3893, 1, w);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = c;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4384,13 +4413,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3089(struct Cora* co) {
-Obj _35val2503 = co->args[1];
+void _35clofun3893(struct Cora* co) {
+Obj _35val3306 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("}\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4400,38 +4429,38 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3048(struct Cora* co) {
-Obj _35cc1333 = makeNative(_35clofun3049, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3851(struct Cora* co) {
+Obj _35cc2135 = makeNative(_35clofun3852, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2445 = primIsCons(closureRef(co, 2));
-if (True == _35reg2445) {
-Obj _35reg2446 = primCar(closureRef(co, 2));
-Obj _35reg2447 = primEQ(intern("%closure"), _35reg2446);
-if (True == _35reg2447) {
-Obj _35reg2448 = primCdr(closureRef(co, 2));
-Obj _35reg2449 = primIsCons(_35reg2448);
-if (True == _35reg2449) {
-Obj _35reg2450 = primCdr(closureRef(co, 2));
-Obj _35reg2451 = primCar(_35reg2450);
-Obj label = _35reg2451;
-Obj _35reg2452 = primCdr(closureRef(co, 2));
-Obj _35reg2453 = primCdr(_35reg2452);
-Obj _35reg2454 = primIsCons(_35reg2453);
-if (True == _35reg2454) {
-Obj _35reg2455 = primCdr(closureRef(co, 2));
-Obj _35reg2456 = primCdr(_35reg2455);
-Obj _35reg2457 = primCar(_35reg2456);
-Obj nargs = _35reg2457;
-Obj _35reg2458 = primCdr(closureRef(co, 2));
-Obj _35reg2459 = primCdr(_35reg2458);
-Obj _35reg2460 = primCdr(_35reg2459);
-Obj frees = _35reg2460;
-pushCont(co, _35clofun3074, 5, label, nargs, env, frees, w);
+Obj _35reg3248 = primIsCons(closureRef(co, 2));
+if (True == _35reg3248) {
+Obj _35reg3249 = primCar(closureRef(co, 2));
+Obj _35reg3250 = primEQ(intern("%closure"), _35reg3249);
+if (True == _35reg3250) {
+Obj _35reg3251 = primCdr(closureRef(co, 2));
+Obj _35reg3252 = primIsCons(_35reg3251);
+if (True == _35reg3252) {
+Obj _35reg3253 = primCdr(closureRef(co, 2));
+Obj _35reg3254 = primCar(_35reg3253);
+Obj label = _35reg3254;
+Obj _35reg3255 = primCdr(closureRef(co, 2));
+Obj _35reg3256 = primCdr(_35reg3255);
+Obj _35reg3257 = primIsCons(_35reg3256);
+if (True == _35reg3257) {
+Obj _35reg3258 = primCdr(closureRef(co, 2));
+Obj _35reg3259 = primCdr(_35reg3258);
+Obj _35reg3260 = primCar(_35reg3259);
+Obj nargs = _35reg3260;
+Obj _35reg3261 = primCdr(closureRef(co, 2));
+Obj _35reg3262 = primCdr(_35reg3261);
+Obj _35reg3263 = primCdr(_35reg3262);
+Obj frees = _35reg3263;
+pushCont(co, _35clofun3878, 5, label, nargs, env, frees, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("makeNative(");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4440,8 +4469,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1333;
 co->nargs = 1;
+co->args[0] = _35cc2135;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4451,8 +4480,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1333;
 co->nargs = 1;
+co->args[0] = _35cc2135;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4462,8 +4491,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1333;
 co->nargs = 1;
+co->args[0] = _35cc2135;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4473,8 +4502,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1333;
 co->nargs = 1;
+co->args[0] = _35cc2135;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4485,18 +4514,18 @@ return;
 }
 }
 
-void _35clofun3074(struct Cora* co) {
-Obj _35val2461 = co->args[1];
+void _35clofun3878(struct Cora* co) {
+Obj _35val3264 = co->args[1];
 Obj label = co->stack[co->base + 0];
 Obj nargs = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
 Obj frees = co->stack[co->base + 3];
 Obj w = co->stack[co->base + 4];
-pushCont(co, _35clofun3075, 4, nargs, env, frees, w);
+pushCont(co, _35clofun3879, 4, nargs, env, frees, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 co->args[1] = w;
 co->args[2] = label;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4506,17 +4535,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3075(struct Cora* co) {
-Obj _35val2462 = co->args[1];
+void _35clofun3879(struct Cora* co) {
+Obj _35val3265 = co->args[1];
 Obj nargs = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj frees = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3076, 4, nargs, env, frees, w);
+pushCont(co, _35clofun3880, 4, nargs, env, frees, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(", ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4526,17 +4555,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3076(struct Cora* co) {
-Obj _35val2463 = co->args[1];
+void _35clofun3880(struct Cora* co) {
+Obj _35val3266 = co->args[1];
 Obj nargs = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
 Obj frees = co->stack[co->base + 2];
 Obj w = co->stack[co->base + 3];
-pushCont(co, _35clofun3077, 3, env, frees, w);
+pushCont(co, _35clofun3881, 3, env, frees, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
 co->args[2] = nargs;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4546,16 +4575,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3077(struct Cora* co) {
-Obj _35val2464 = co->args[1];
+void _35clofun3881(struct Cora* co) {
+Obj _35val3267 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3078, 3, env, frees, w);
+pushCont(co, _35clofun3882, 3, env, frees, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(", ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4565,15 +4594,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3078(struct Cora* co) {
-Obj _35val2465 = co->args[1];
+void _35clofun3882(struct Cora* co) {
+Obj _35val3268 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3079, 3, env, frees, w);
+pushCont(co, _35clofun3883, 3, env, frees, w);
+co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = frees;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4583,16 +4612,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3079(struct Cora* co) {
-Obj _35val2466 = co->args[1];
+void _35clofun3883(struct Cora* co) {
+Obj _35val3269 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3080, 3, env, frees, w);
+pushCont(co, _35clofun3884, 3, env, frees, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
-co->args[2] = _35val2466;
-co->nargs = 3;
+co->args[2] = _35val3269;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4602,15 +4631,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3080(struct Cora* co) {
-Obj _35val2467 = co->args[1];
+void _35clofun3884(struct Cora* co) {
+Obj _35val3270 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3081, 3, env, frees, w);
+pushCont(co, _35clofun3885, 3, env, frees, w);
+co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = frees;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4620,18 +4649,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3081(struct Cora* co) {
-Obj _35val2468 = co->args[1];
+void _35clofun3885(struct Cora* co) {
+Obj _35val3271 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-Obj _35reg2469 = primNot(_35val2468);
-if (True == _35reg2469) {
-pushCont(co, _35clofun3082, 3, env, frees, w);
+Obj _35reg3272 = primNot(_35val3271);
+if (True == _35reg3272) {
+pushCont(co, _35clofun3886, 3, env, frees, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(", ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4641,10 +4670,10 @@ co->pc = coraCall;
 return;
 } else {
 Nil;
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(")");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4655,17 +4684,17 @@ return;
 }
 }
 
-void _35clofun3082(struct Cora* co) {
-Obj _35val2470 = co->args[1];
+void _35clofun3886(struct Cora* co) {
+Obj _35val3273 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3083, 1, w);
+pushCont(co, _35clofun3887, 1, w);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst-list"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = frees;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4675,13 +4704,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3083(struct Cora* co) {
-Obj _35val2471 = co->args[1];
+void _35clofun3887(struct Cora* co) {
+Obj _35val3274 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(")");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4691,40 +4720,40 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3049(struct Cora* co) {
-Obj _35cc1334 = makeNative(_35clofun3050, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3852(struct Cora* co) {
+Obj _35cc2136 = makeNative(_35clofun3853, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2426 = primIsCons(closureRef(co, 2));
-if (True == _35reg2426) {
-Obj _35reg2427 = primCar(closureRef(co, 2));
-Obj _35reg2428 = primEQ(intern("do"), _35reg2427);
-if (True == _35reg2428) {
-Obj _35reg2429 = primCdr(closureRef(co, 2));
-Obj _35reg2430 = primIsCons(_35reg2429);
-if (True == _35reg2430) {
-Obj _35reg2431 = primCdr(closureRef(co, 2));
-Obj _35reg2432 = primCar(_35reg2431);
-Obj a = _35reg2432;
-Obj _35reg2433 = primCdr(closureRef(co, 2));
-Obj _35reg2434 = primCdr(_35reg2433);
-Obj _35reg2435 = primIsCons(_35reg2434);
-if (True == _35reg2435) {
-Obj _35reg2436 = primCdr(closureRef(co, 2));
-Obj _35reg2437 = primCdr(_35reg2436);
-Obj _35reg2438 = primCar(_35reg2437);
-Obj b = _35reg2438;
-Obj _35reg2439 = primCdr(closureRef(co, 2));
-Obj _35reg2440 = primCdr(_35reg2439);
-Obj _35reg2441 = primCdr(_35reg2440);
-Obj _35reg2442 = primEQ(Nil, _35reg2441);
-if (True == _35reg2442) {
-pushCont(co, _35clofun3072, 3, env, w, b);
+Obj _35reg3229 = primIsCons(closureRef(co, 2));
+if (True == _35reg3229) {
+Obj _35reg3230 = primCar(closureRef(co, 2));
+Obj _35reg3231 = primEQ(intern("do"), _35reg3230);
+if (True == _35reg3231) {
+Obj _35reg3232 = primCdr(closureRef(co, 2));
+Obj _35reg3233 = primIsCons(_35reg3232);
+if (True == _35reg3233) {
+Obj _35reg3234 = primCdr(closureRef(co, 2));
+Obj _35reg3235 = primCar(_35reg3234);
+Obj a = _35reg3235;
+Obj _35reg3236 = primCdr(closureRef(co, 2));
+Obj _35reg3237 = primCdr(_35reg3236);
+Obj _35reg3238 = primIsCons(_35reg3237);
+if (True == _35reg3238) {
+Obj _35reg3239 = primCdr(closureRef(co, 2));
+Obj _35reg3240 = primCdr(_35reg3239);
+Obj _35reg3241 = primCar(_35reg3240);
+Obj b = _35reg3241;
+Obj _35reg3242 = primCdr(closureRef(co, 2));
+Obj _35reg3243 = primCdr(_35reg3242);
+Obj _35reg3244 = primCdr(_35reg3243);
+Obj _35reg3245 = primEQ(Nil, _35reg3244);
+if (True == _35reg3245) {
+pushCont(co, _35clofun3876, 3, env, w, b);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = a;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4733,8 +4762,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1334;
 co->nargs = 1;
+co->args[0] = _35cc2136;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4744,8 +4773,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1334;
 co->nargs = 1;
+co->args[0] = _35cc2136;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4755,8 +4784,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1334;
 co->nargs = 1;
+co->args[0] = _35cc2136;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4766,8 +4795,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1334;
 co->nargs = 1;
+co->args[0] = _35cc2136;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4777,8 +4806,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1334;
 co->nargs = 1;
+co->args[0] = _35cc2136;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4789,16 +4818,16 @@ return;
 }
 }
 
-void _35clofun3072(struct Cora* co) {
-Obj _35val2443 = co->args[1];
+void _35clofun3876(struct Cora* co) {
+Obj _35val3246 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
 Obj b = co->stack[co->base + 2];
-pushCont(co, _35clofun3073, 3, env, w, b);
+pushCont(co, _35clofun3877, 3, env, w, b);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(";\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4808,16 +4837,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3073(struct Cora* co) {
-Obj _35val2444 = co->args[1];
+void _35clofun3877(struct Cora* co) {
+Obj _35val3247 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
 Obj b = co->stack[co->base + 2];
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = b;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4827,30 +4856,30 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3050(struct Cora* co) {
-Obj _35cc1335 = makeNative(_35clofun3051, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3853(struct Cora* co) {
+Obj _35cc2137 = makeNative(_35clofun3854, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2413 = primIsCons(closureRef(co, 2));
-if (True == _35reg2413) {
-Obj _35reg2414 = primCar(closureRef(co, 2));
-Obj _35reg2415 = primEQ(intern("return"), _35reg2414);
-if (True == _35reg2415) {
-Obj _35reg2416 = primCdr(closureRef(co, 2));
-Obj _35reg2417 = primIsCons(_35reg2416);
-if (True == _35reg2417) {
-Obj _35reg2418 = primCdr(closureRef(co, 2));
-Obj _35reg2419 = primCar(_35reg2418);
-Obj x = _35reg2419;
-Obj _35reg2420 = primCdr(closureRef(co, 2));
-Obj _35reg2421 = primCdr(_35reg2420);
-Obj _35reg2422 = primEQ(Nil, _35reg2421);
-if (True == _35reg2422) {
-pushCont(co, _35clofun3069, 3, env, x, w);
+Obj _35reg3215 = primIsCons(closureRef(co, 2));
+if (True == _35reg3215) {
+Obj _35reg3216 = primCar(closureRef(co, 2));
+Obj _35reg3217 = primEQ(intern("return"), _35reg3216);
+if (True == _35reg3217) {
+Obj _35reg3218 = primCdr(closureRef(co, 2));
+Obj _35reg3219 = primIsCons(_35reg3218);
+if (True == _35reg3219) {
+Obj _35reg3220 = primCdr(closureRef(co, 2));
+Obj _35reg3221 = primCar(_35reg3220);
+Obj x = _35reg3221;
+Obj _35reg3222 = primCdr(closureRef(co, 2));
+Obj _35reg3223 = primCdr(_35reg3222);
+Obj _35reg3224 = primEQ(Nil, _35reg3223);
+if (True == _35reg3224) {
+pushCont(co, _35clofun3872, 3, env, x, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
-co->args[2] = makeString1("co->args[1] = ");
-co->nargs = 3;
+co->args[2] = makeString1("co->nargs = 2;\n");
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4859,8 +4888,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1335;
 co->nargs = 1;
+co->args[0] = _35cc2137;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4870,8 +4899,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1335;
 co->nargs = 1;
+co->args[0] = _35cc2137;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4881,8 +4910,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1335;
 co->nargs = 1;
+co->args[0] = _35cc2137;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4892,8 +4921,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1335;
 co->nargs = 1;
+co->args[0] = _35cc2137;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4904,17 +4933,36 @@ return;
 }
 }
 
-void _35clofun3069(struct Cora* co) {
-Obj _35val2423 = co->args[1];
+void _35clofun3872(struct Cora* co) {
+Obj _35val3225 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj x = co->stack[co->base + 1];
 Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3070, 1, w);
+pushCont(co, _35clofun3873, 3, env, x, w);
+co->nargs = 3;
+co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
+co->args[1] = w;
+co->args[2] = makeString1("co->args[1] = ");
+if (nativeRequired(co->args[0]) == 2) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+
+void _35clofun3873(struct Cora* co) {
+Obj _35val3226 = co->args[1];
+Obj env = co->stack[co->base + 0];
+Obj x = co->stack[co->base + 1];
+Obj w = co->stack[co->base + 2];
+pushCont(co, _35clofun3874, 1, w);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = x;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4924,14 +4972,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3070(struct Cora* co) {
-Obj _35val2424 = co->args[1];
+void _35clofun3874(struct Cora* co) {
+Obj _35val3227 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3071, 1, w);
+pushCont(co, _35clofun3875, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(";\npopStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4941,13 +4989,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3071(struct Cora* co) {
-Obj _35val2425 = co->args[1];
+void _35clofun3875(struct Cora* co) {
+Obj _35val3228 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("\nreturn;\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4957,30 +5005,30 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3051(struct Cora* co) {
-Obj _35cc1336 = makeNative(_35clofun3052, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3854(struct Cora* co) {
+Obj _35cc2138 = makeNative(_35clofun3855, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2403 = primIsCons(closureRef(co, 2));
-if (True == _35reg2403) {
-Obj _35reg2404 = primCar(closureRef(co, 2));
-Obj _35reg2405 = primEQ(intern("tailcall"), _35reg2404);
-if (True == _35reg2405) {
-Obj _35reg2406 = primCdr(closureRef(co, 2));
-Obj _35reg2407 = primIsCons(_35reg2406);
-if (True == _35reg2407) {
-Obj _35reg2408 = primCdr(closureRef(co, 2));
-Obj _35reg2409 = primCar(_35reg2408);
-Obj exp = _35reg2409;
-Obj _35reg2410 = primCdr(closureRef(co, 2));
-Obj _35reg2411 = primCdr(_35reg2410);
-Obj _35reg2412 = primEQ(Nil, _35reg2411);
-if (True == _35reg2412) {
+Obj _35reg3205 = primIsCons(closureRef(co, 2));
+if (True == _35reg3205) {
+Obj _35reg3206 = primCar(closureRef(co, 2));
+Obj _35reg3207 = primEQ(intern("tailcall"), _35reg3206);
+if (True == _35reg3207) {
+Obj _35reg3208 = primCdr(closureRef(co, 2));
+Obj _35reg3209 = primIsCons(_35reg3208);
+if (True == _35reg3209) {
+Obj _35reg3210 = primCdr(closureRef(co, 2));
+Obj _35reg3211 = primCar(_35reg3210);
+Obj exp = _35reg3211;
+Obj _35reg3212 = primCdr(closureRef(co, 2));
+Obj _35reg3213 = primCdr(_35reg3212);
+Obj _35reg3214 = primEQ(Nil, _35reg3213);
+if (True == _35reg3214) {
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = exp;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -4989,8 +5037,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1336;
 co->nargs = 1;
+co->args[0] = _35cc2138;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5000,8 +5048,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1336;
 co->nargs = 1;
+co->args[0] = _35cc2138;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5011,8 +5059,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1336;
 co->nargs = 1;
+co->args[0] = _35cc2138;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5022,8 +5070,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1336;
 co->nargs = 1;
+co->args[0] = _35cc2138;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5034,39 +5082,39 @@ return;
 }
 }
 
-void _35clofun3052(struct Cora* co) {
-Obj _35cc1337 = makeNative(_35clofun3053, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3855(struct Cora* co) {
+Obj _35cc2139 = makeNative(_35clofun3856, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2385 = primIsCons(closureRef(co, 2));
-if (True == _35reg2385) {
-Obj _35reg2386 = primCar(closureRef(co, 2));
-Obj _35reg2387 = primEQ(intern("call"), _35reg2386);
-if (True == _35reg2387) {
-Obj _35reg2388 = primCdr(closureRef(co, 2));
-Obj _35reg2389 = primIsCons(_35reg2388);
-if (True == _35reg2389) {
-Obj _35reg2390 = primCdr(closureRef(co, 2));
-Obj _35reg2391 = primCar(_35reg2390);
-Obj exp = _35reg2391;
-Obj _35reg2392 = primCdr(closureRef(co, 2));
-Obj _35reg2393 = primCdr(_35reg2392);
-Obj _35reg2394 = primIsCons(_35reg2393);
-if (True == _35reg2394) {
-Obj _35reg2395 = primCdr(closureRef(co, 2));
-Obj _35reg2396 = primCdr(_35reg2395);
-Obj _35reg2397 = primCar(_35reg2396);
-Obj cont = _35reg2397;
-Obj _35reg2398 = primCdr(closureRef(co, 2));
-Obj _35reg2399 = primCdr(_35reg2398);
-Obj _35reg2400 = primCdr(_35reg2399);
-Obj _35reg2401 = primEQ(Nil, _35reg2400);
-if (True == _35reg2401) {
-pushCont(co, _35clofun3068, 3, env, w, exp);
+Obj _35reg3187 = primIsCons(closureRef(co, 2));
+if (True == _35reg3187) {
+Obj _35reg3188 = primCar(closureRef(co, 2));
+Obj _35reg3189 = primEQ(intern("call"), _35reg3188);
+if (True == _35reg3189) {
+Obj _35reg3190 = primCdr(closureRef(co, 2));
+Obj _35reg3191 = primIsCons(_35reg3190);
+if (True == _35reg3191) {
+Obj _35reg3192 = primCdr(closureRef(co, 2));
+Obj _35reg3193 = primCar(_35reg3192);
+Obj exp = _35reg3193;
+Obj _35reg3194 = primCdr(closureRef(co, 2));
+Obj _35reg3195 = primCdr(_35reg3194);
+Obj _35reg3196 = primIsCons(_35reg3195);
+if (True == _35reg3196) {
+Obj _35reg3197 = primCdr(closureRef(co, 2));
+Obj _35reg3198 = primCdr(_35reg3197);
+Obj _35reg3199 = primCar(_35reg3198);
+Obj cont = _35reg3199;
+Obj _35reg3200 = primCdr(closureRef(co, 2));
+Obj _35reg3201 = primCdr(_35reg3200);
+Obj _35reg3202 = primCdr(_35reg3201);
+Obj _35reg3203 = primEQ(Nil, _35reg3202);
+if (True == _35reg3203) {
+pushCont(co, _35clofun3871, 3, env, w, exp);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-cont"));
 co->args[1] = w;
 co->args[2] = cont;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5075,8 +5123,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1337;
 co->nargs = 1;
+co->args[0] = _35cc2139;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5086,8 +5134,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1337;
 co->nargs = 1;
+co->args[0] = _35cc2139;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5097,8 +5145,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1337;
 co->nargs = 1;
+co->args[0] = _35cc2139;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5108,8 +5156,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1337;
 co->nargs = 1;
+co->args[0] = _35cc2139;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5119,8 +5167,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1337;
 co->nargs = 1;
+co->args[0] = _35cc2139;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5131,16 +5179,16 @@ return;
 }
 }
 
-void _35clofun3068(struct Cora* co) {
-Obj _35val2402 = co->args[1];
+void _35clofun3871(struct Cora* co) {
+Obj _35val3204 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
 Obj exp = co->stack[co->base + 2];
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-inst"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = exp;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5150,24 +5198,115 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3053(struct Cora* co) {
-Obj _35cc1338 = makeNative(_35clofun3054, 0, 0);
+void _35clofun3856(struct Cora* co) {
+Obj _35cc2140 = makeNative(_35clofun3857, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2367 = primIsCons(closureRef(co, 2));
-if (True == _35reg2367) {
-Obj _35reg2368 = primCar(closureRef(co, 2));
-Obj f = _35reg2368;
-Obj _35reg2369 = primCdr(closureRef(co, 2));
-Obj args = _35reg2369;
-Obj _35reg2370 = primCons(f, args);
-pushCont(co, _35clofun3055, 3, f, args, w);
+Obj _35reg3169 = primIsCons(closureRef(co, 2));
+if (True == _35reg3169) {
+Obj _35reg3170 = primCar(closureRef(co, 2));
+Obj f = _35reg3170;
+Obj _35reg3171 = primCdr(closureRef(co, 2));
+Obj args = _35reg3171;
+pushCont(co, _35clofun3858, 4, f, env, args, w);
+co->nargs = 3;
+co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
+co->args[1] = w;
+co->args[2] = makeString1("co->nargs = ");
+if (nativeRequired(co->args[0]) == 2) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+} else {
+co->nargs = 1;
+co->args[0] = _35cc2140;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+}
+
+void _35clofun3858(struct Cora* co) {
+Obj _35val3172 = co->args[1];
+Obj f = co->stack[co->base + 0];
+Obj env = co->stack[co->base + 1];
+Obj args = co->stack[co->base + 2];
+Obj w = co->stack[co->base + 3];
+Obj _35reg3173 = primCons(f, args);
+pushCont(co, _35clofun3859, 4, f, env, args, w);
+co->nargs = 2;
+co->args[0] = globalRef(intern("length"));
+co->args[1] = _35reg3173;
+if (nativeRequired(co->args[0]) == 1) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+
+void _35clofun3859(struct Cora* co) {
+Obj _35val3174 = co->args[1];
+Obj f = co->stack[co->base + 0];
+Obj env = co->stack[co->base + 1];
+Obj args = co->stack[co->base + 2];
+Obj w = co->stack[co->base + 3];
+pushCont(co, _35clofun3860, 4, f, env, args, w);
+co->nargs = 3;
+co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
+co->args[1] = w;
+co->args[2] = _35val3174;
+if (nativeRequired(co->args[0]) == 2) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+
+void _35clofun3860(struct Cora* co) {
+Obj _35val3175 = co->args[1];
+Obj f = co->stack[co->base + 0];
+Obj env = co->stack[co->base + 1];
+Obj args = co->stack[co->base + 2];
+Obj w = co->stack[co->base + 3];
+pushCont(co, _35clofun3861, 4, f, env, args, w);
+co->nargs = 3;
+co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
+co->args[1] = w;
+co->args[2] = makeString1(";\n");
+if (nativeRequired(co->args[0]) == 2) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+
+void _35clofun3861(struct Cora* co) {
+Obj _35val3176 = co->args[1];
+Obj f = co->stack[co->base + 0];
+Obj env = co->stack[co->base + 1];
+Obj args = co->stack[co->base + 2];
+Obj w = co->stack[co->base + 3];
+Obj _35reg3177 = primCons(f, args);
+pushCont(co, _35clofun3862, 2, args, w);
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/lib/toc/include.generate-call-args"));
 co->args[1] = env;
 co->args[2] = w;
 co->args[3] = makeNumber(0);
-co->args[4] = _35reg2370;
-co->nargs = 5;
+co->args[4] = _35reg3177;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5175,102 +5314,17 @@ co->frees = co->args[0];
 co->pc = coraCall;
 }
 return;
-} else {
-co->args[0] = _35cc1338;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = co->args[0];
-} else {
-co->pc = coraCall;
-}
-return;
-}
 }
 
-void _35clofun3055(struct Cora* co) {
-Obj _35val2371 = co->args[1];
-Obj f = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-pushCont(co, _35clofun3056, 3, f, args, w);
-co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
-co->args[1] = w;
-co->args[2] = makeString1("co->nargs = ");
-co->nargs = 3;
-if (nativeRequired(co->args[0]) == 2) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = co->args[0];
-} else {
-co->pc = coraCall;
-}
-return;
-}
-
-void _35clofun3056(struct Cora* co) {
-Obj _35val2372 = co->args[1];
-Obj f = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj _35reg2373 = primCons(f, args);
-pushCont(co, _35clofun3057, 2, args, w);
-co->args[0] = globalRef(intern("length"));
-co->args[1] = _35reg2373;
-co->nargs = 2;
-if (nativeRequired(co->args[0]) == 1) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = co->args[0];
-} else {
-co->pc = coraCall;
-}
-return;
-}
-
-void _35clofun3057(struct Cora* co) {
-Obj _35val2374 = co->args[1];
+void _35clofun3862(struct Cora* co) {
+Obj _35val3178 = co->args[1];
 Obj args = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3058, 2, args, w);
-co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
-co->args[1] = w;
-co->args[2] = _35val2374;
+pushCont(co, _35clofun3863, 2, args, w);
 co->nargs = 3;
-if (nativeRequired(co->args[0]) == 2) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = co->args[0];
-} else {
-co->pc = coraCall;
-}
-return;
-}
-
-void _35clofun3058(struct Cora* co) {
-Obj _35val2375 = co->args[1];
-Obj args = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3059, 2, args, w);
-co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
-co->args[1] = w;
-co->args[2] = makeString1(";\n");
-co->nargs = 3;
-if (nativeRequired(co->args[0]) == 2) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = co->args[0];
-} else {
-co->pc = coraCall;
-}
-return;
-}
-
-void _35clofun3059(struct Cora* co) {
-Obj _35val2376 = co->args[1];
-Obj args = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3060, 2, args, w);
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("if (nativeRequired(co->args[0]) == ");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5280,14 +5334,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3060(struct Cora* co) {
-Obj _35val2377 = co->args[1];
+void _35clofun3863(struct Cora* co) {
+Obj _35val3179 = co->args[1];
 Obj args = co->stack[co->base + 0];
 Obj w = co->stack[co->base + 1];
-pushCont(co, _35clofun3061, 1, w);
+pushCont(co, _35clofun3864, 1, w);
+co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = args;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5297,14 +5351,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3061(struct Cora* co) {
-Obj _35val2378 = co->args[1];
+void _35clofun3864(struct Cora* co) {
+Obj _35val3180 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3062, 1, w);
+pushCont(co, _35clofun3865, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-num"));
 co->args[1] = w;
-co->args[2] = _35val2378;
-co->nargs = 3;
+co->args[2] = _35val3180;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5314,14 +5368,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3062(struct Cora* co) {
-Obj _35val2379 = co->args[1];
+void _35clofun3865(struct Cora* co) {
+Obj _35val3181 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3063, 1, w);
+pushCont(co, _35clofun3866, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1(") {\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5331,14 +5385,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3063(struct Cora* co) {
-Obj _35val2380 = co->args[1];
+void _35clofun3866(struct Cora* co) {
+Obj _35val3182 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3064, 1, w);
+pushCont(co, _35clofun3867, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("co->pc = nativeFuncPtr(co->args[0]);\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5348,14 +5402,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3064(struct Cora* co) {
-Obj _35val2381 = co->args[1];
+void _35clofun3867(struct Cora* co) {
+Obj _35val3183 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3065, 1, w);
+pushCont(co, _35clofun3868, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("co->frees = co->args[0];\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5365,14 +5419,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3065(struct Cora* co) {
-Obj _35val2382 = co->args[1];
+void _35clofun3868(struct Cora* co) {
+Obj _35val3184 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3066, 1, w);
+pushCont(co, _35clofun3869, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("} else {\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5382,14 +5436,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3066(struct Cora* co) {
-Obj _35val2383 = co->args[1];
+void _35clofun3869(struct Cora* co) {
+Obj _35val3185 = co->args[1];
 Obj w = co->stack[co->base + 0];
-pushCont(co, _35clofun3067, 1, w);
+pushCont(co, _35clofun3870, 1, w);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("co->pc = coraCall;\n}\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5399,13 +5453,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3067(struct Cora* co) {
-Obj _35val2384 = co->args[1];
+void _35clofun3870(struct Cora* co) {
+Obj _35val3186 = co->args[1];
 Obj w = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
 co->args[2] = makeString1("return;\n");
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5415,10 +5469,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3054(struct Cora* co) {
+void _35clofun3857(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5428,15 +5482,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3038(struct Cora* co) {
+void _35clofun3841(struct Cora* co) {
 Obj x = co->args[1];
 Obj k = co->args[2];
-Obj _35reg2360 = primGenSym(intern("reg"));
-Obj tmp = _35reg2360;
-pushCont(co, _35clofun3039, 2, x, tmp);
+Obj _35reg3162 = primGenSym(intern("reg"));
+Obj tmp = _35reg3162;
+pushCont(co, _35clofun3842, 2, x, tmp);
+co->nargs = 2;
 co->args[0] = k;
 co->args[1] = tmp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5446,34 +5500,35 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3039(struct Cora* co) {
-Obj _35val2361 = co->args[1];
+void _35clofun3842(struct Cora* co) {
+Obj _35val3163 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj tmp = co->stack[co->base + 1];
-Obj _35reg2362 = primCons(_35val2361, Nil);
-Obj _35reg2363 = primCons(x, _35reg2362);
-Obj _35reg2364 = primCons(tmp, _35reg2363);
-Obj _35reg2365 = primCons(intern("let"), _35reg2364);
-co->args[1] = _35reg2365;
+Obj _35reg3164 = primCons(_35val3163, Nil);
+Obj _35reg3165 = primCons(x, _35reg3164);
+Obj _35reg3166 = primCons(tmp, _35reg3165);
+Obj _35reg3167 = primCons(intern("let"), _35reg3166);
+co->nargs = 2;
+co->args[1] = _35reg3167;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3033(struct Cora* co) {
-Obj _35p1316 = co->args[1];
-Obj _35p1317 = co->args[2];
-Obj _35p1318 = co->args[3];
-Obj _35p1319 = co->args[4];
-Obj _35cc1320 = makeNative(_35clofun3034, 0, 4, _35p1316, _35p1317, _35p1318, _35p1319);
-Obj res = _35p1316;
-Obj init = _35p1317;
-Obj _35reg2357 = primEQ(Nil, _35p1318);
-if (True == _35reg2357) {
-Obj k = _35p1319;
-pushCont(co, _35clofun3037, 2, k, init);
+void _35clofun3836(struct Cora* co) {
+Obj _35p2118 = co->args[1];
+Obj _35p2119 = co->args[2];
+Obj _35p2120 = co->args[3];
+Obj _35p2121 = co->args[4];
+Obj _35cc2122 = makeNative(_35clofun3837, 0, 4, _35p2118, _35p2119, _35p2120, _35p2121);
+Obj res = _35p2118;
+Obj init = _35p2119;
+Obj _35reg3159 = primEQ(Nil, _35p2120);
+if (True == _35reg3159) {
+Obj k = _35p2121;
+pushCont(co, _35clofun3840, 2, k, init);
+co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = res;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5482,8 +5537,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1320;
 co->nargs = 1;
+co->args[0] = _35cc2122;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5494,14 +5549,14 @@ return;
 }
 }
 
-void _35clofun3037(struct Cora* co) {
-Obj _35val2358 = co->args[1];
+void _35clofun3840(struct Cora* co) {
+Obj _35val3160 = co->args[1];
 Obj k = co->stack[co->base + 0];
 Obj init = co->stack[co->base + 1];
+co->nargs = 3;
 co->args[0] = k;
 co->args[1] = init;
-co->args[2] = _35val2358;
-co->nargs = 3;
+co->args[2] = _35val3160;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5511,22 +5566,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3034(struct Cora* co) {
-Obj _35cc1321 = makeNative(_35clofun3035, 0, 0);
+void _35clofun3837(struct Cora* co) {
+Obj _35cc2123 = makeNative(_35clofun3838, 0, 0);
 Obj res = closureRef(co, 0);
 Obj init = closureRef(co, 1);
-Obj _35reg2353 = primIsCons(closureRef(co, 2));
-if (True == _35reg2353) {
-Obj _35reg2354 = primCar(closureRef(co, 2));
-Obj x = _35reg2354;
-Obj _35reg2355 = primCdr(closureRef(co, 2));
-Obj y = _35reg2355;
+Obj _35reg3155 = primIsCons(closureRef(co, 2));
+if (True == _35reg3155) {
+Obj _35reg3156 = primCar(closureRef(co, 2));
+Obj x = _35reg3156;
+Obj _35reg3157 = primCdr(closureRef(co, 2));
+Obj y = _35reg3157;
 Obj k = closureRef(co, 3);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda"));
 co->args[1] = init;
 co->args[2] = x;
-co->args[3] = makeNative(_35clofun3036, 2, 3, res, y, k);
-co->nargs = 4;
+co->args[3] = makeNative(_35clofun3839, 2, 3, res, y, k);
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5535,8 +5590,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1321;
 co->nargs = 1;
+co->args[0] = _35cc2123;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5547,16 +5602,16 @@ return;
 }
 }
 
-void _35clofun3036(struct Cora* co) {
+void _35clofun3839(struct Cora* co) {
 Obj init1 = co->args[1];
 Obj x1 = co->args[2];
-Obj _35reg2356 = primCons(x1, closureRef(co, 0));
+Obj _35reg3158 = primCons(x1, closureRef(co, 0));
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda-list"));
-co->args[1] = _35reg2356;
+co->args[1] = _35reg3158;
 co->args[2] = init1;
 co->args[3] = closureRef(co, 1);
 co->args[4] = closureRef(co, 2);
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5566,10 +5621,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3035(struct Cora* co) {
+void _35clofun3838(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5579,71 +5634,71 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3023(struct Cora* co) {
-Obj _35p1310 = co->args[1];
-Obj _35p1311 = co->args[2];
-Obj _35p1312 = co->args[3];
-Obj _35cc1313 = makeNative(_35clofun3024, 0, 3, _35p1310, _35p1311, _35p1312);
-Obj res = _35p1310;
-Obj _35reg2247 = primIsCons(_35p1311);
-if (True == _35reg2247) {
-Obj _35reg2248 = primCar(_35p1311);
-Obj clo_45or_45cont = _35reg2248;
-Obj _35reg2249 = primCdr(_35p1311);
-Obj _35reg2250 = primIsCons(_35reg2249);
-if (True == _35reg2250) {
-Obj _35reg2251 = primCdr(_35p1311);
-Obj _35reg2252 = primCar(_35reg2251);
-Obj _35reg2253 = primIsCons(_35reg2252);
-if (True == _35reg2253) {
-Obj _35reg2254 = primCdr(_35p1311);
-Obj _35reg2255 = primCar(_35reg2254);
-Obj _35reg2256 = primCar(_35reg2255);
-Obj _35reg2257 = primEQ(intern("lambda"), _35reg2256);
-if (True == _35reg2257) {
-Obj _35reg2258 = primCdr(_35p1311);
-Obj _35reg2259 = primCar(_35reg2258);
-Obj _35reg2260 = primCdr(_35reg2259);
-Obj _35reg2261 = primIsCons(_35reg2260);
-if (True == _35reg2261) {
-Obj _35reg2262 = primCdr(_35p1311);
-Obj _35reg2263 = primCar(_35reg2262);
-Obj _35reg2264 = primCdr(_35reg2263);
-Obj _35reg2265 = primCar(_35reg2264);
-Obj params = _35reg2265;
-Obj _35reg2266 = primCdr(_35p1311);
-Obj _35reg2267 = primCar(_35reg2266);
-Obj _35reg2268 = primCdr(_35reg2267);
-Obj _35reg2269 = primCdr(_35reg2268);
-Obj _35reg2270 = primIsCons(_35reg2269);
-if (True == _35reg2270) {
-Obj _35reg2271 = primCdr(_35p1311);
-Obj _35reg2272 = primCar(_35reg2271);
-Obj _35reg2273 = primCdr(_35reg2272);
-Obj _35reg2274 = primCdr(_35reg2273);
-Obj _35reg2275 = primCar(_35reg2274);
-Obj body = _35reg2275;
-Obj _35reg2276 = primCdr(_35p1311);
-Obj _35reg2277 = primCar(_35reg2276);
-Obj _35reg2278 = primCdr(_35reg2277);
-Obj _35reg2279 = primCdr(_35reg2278);
-Obj _35reg2280 = primCdr(_35reg2279);
-Obj _35reg2281 = primEQ(Nil, _35reg2280);
-if (True == _35reg2281) {
-Obj _35reg2282 = primCdr(_35p1311);
-Obj _35reg2283 = primCdr(_35reg2282);
-Obj fvs = _35reg2283;
-Obj k = _35p1312;
-Obj _35reg2284 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2284) {
+void _35clofun3826(struct Cora* co) {
+Obj _35p2112 = co->args[1];
+Obj _35p2113 = co->args[2];
+Obj _35p2114 = co->args[3];
+Obj _35cc2115 = makeNative(_35clofun3827, 0, 3, _35p2112, _35p2113, _35p2114);
+Obj res = _35p2112;
+Obj _35reg3049 = primIsCons(_35p2113);
+if (True == _35reg3049) {
+Obj _35reg3050 = primCar(_35p2113);
+Obj clo_45or_45cont = _35reg3050;
+Obj _35reg3051 = primCdr(_35p2113);
+Obj _35reg3052 = primIsCons(_35reg3051);
+if (True == _35reg3052) {
+Obj _35reg3053 = primCdr(_35p2113);
+Obj _35reg3054 = primCar(_35reg3053);
+Obj _35reg3055 = primIsCons(_35reg3054);
+if (True == _35reg3055) {
+Obj _35reg3056 = primCdr(_35p2113);
+Obj _35reg3057 = primCar(_35reg3056);
+Obj _35reg3058 = primCar(_35reg3057);
+Obj _35reg3059 = primEQ(intern("lambda"), _35reg3058);
+if (True == _35reg3059) {
+Obj _35reg3060 = primCdr(_35p2113);
+Obj _35reg3061 = primCar(_35reg3060);
+Obj _35reg3062 = primCdr(_35reg3061);
+Obj _35reg3063 = primIsCons(_35reg3062);
+if (True == _35reg3063) {
+Obj _35reg3064 = primCdr(_35p2113);
+Obj _35reg3065 = primCar(_35reg3064);
+Obj _35reg3066 = primCdr(_35reg3065);
+Obj _35reg3067 = primCar(_35reg3066);
+Obj params = _35reg3067;
+Obj _35reg3068 = primCdr(_35p2113);
+Obj _35reg3069 = primCar(_35reg3068);
+Obj _35reg3070 = primCdr(_35reg3069);
+Obj _35reg3071 = primCdr(_35reg3070);
+Obj _35reg3072 = primIsCons(_35reg3071);
+if (True == _35reg3072) {
+Obj _35reg3073 = primCdr(_35p2113);
+Obj _35reg3074 = primCar(_35reg3073);
+Obj _35reg3075 = primCdr(_35reg3074);
+Obj _35reg3076 = primCdr(_35reg3075);
+Obj _35reg3077 = primCar(_35reg3076);
+Obj body = _35reg3077;
+Obj _35reg3078 = primCdr(_35p2113);
+Obj _35reg3079 = primCar(_35reg3078);
+Obj _35reg3080 = primCdr(_35reg3079);
+Obj _35reg3081 = primCdr(_35reg3080);
+Obj _35reg3082 = primCdr(_35reg3081);
+Obj _35reg3083 = primEQ(Nil, _35reg3082);
+if (True == _35reg3083) {
+Obj _35reg3084 = primCdr(_35p2113);
+Obj _35reg3085 = primCdr(_35reg3084);
+Obj fvs = _35reg3085;
+Obj k = _35p2114;
+Obj _35reg3086 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg3086) {
 if (True == True) {
-Obj _35reg2285 = primGenSym(intern("clofun"));
-Obj name = _35reg2285;
+Obj _35reg3087 = primGenSym(intern("clofun"));
+Obj name = _35reg3087;
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda"));
 co->args[1] = res;
 co->args[2] = body;
-co->args[3] = makeNative(_35clofun3027, 2, 5, k, params, clo_45or_45cont, name, fvs);
-co->nargs = 4;
+co->args[3] = makeNative(_35clofun3830, 2, 5, k, params, clo_45or_45cont, name, fvs);
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5652,8 +5707,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1313;
 co->nargs = 1;
+co->args[0] = _35cc2115;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5663,16 +5718,16 @@ co->pc = coraCall;
 return;
 }
 } else {
-Obj _35reg2307 = primEQ(clo_45or_45cont, intern("%continuation"));
-if (True == _35reg2307) {
+Obj _35reg3109 = primEQ(clo_45or_45cont, intern("%continuation"));
+if (True == _35reg3109) {
 if (True == True) {
-Obj _35reg2308 = primGenSym(intern("clofun"));
-Obj name = _35reg2308;
+Obj _35reg3110 = primGenSym(intern("clofun"));
+Obj name = _35reg3110;
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda"));
 co->args[1] = res;
 co->args[2] = body;
-co->args[3] = makeNative(_35clofun3029, 2, 5, k, params, clo_45or_45cont, name, fvs);
-co->nargs = 4;
+co->args[3] = makeNative(_35clofun3832, 2, 5, k, params, clo_45or_45cont, name, fvs);
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5681,8 +5736,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1313;
 co->nargs = 1;
+co->args[0] = _35cc2115;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5693,13 +5748,13 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg2330 = primGenSym(intern("clofun"));
-Obj name = _35reg2330;
+Obj _35reg3132 = primGenSym(intern("clofun"));
+Obj name = _35reg3132;
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda"));
 co->args[1] = res;
 co->args[2] = body;
-co->args[3] = makeNative(_35clofun3031, 2, 5, k, params, clo_45or_45cont, name, fvs);
-co->nargs = 4;
+co->args[3] = makeNative(_35clofun3834, 2, 5, k, params, clo_45or_45cont, name, fvs);
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5708,8 +5763,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1313;
 co->nargs = 1;
+co->args[0] = _35cc2115;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5721,8 +5776,8 @@ return;
 }
 }
 } else {
-co->args[0] = _35cc1313;
 co->nargs = 1;
+co->args[0] = _35cc2115;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5732,8 +5787,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1313;
 co->nargs = 1;
+co->args[0] = _35cc2115;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5743,8 +5798,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1313;
 co->nargs = 1;
+co->args[0] = _35cc2115;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5754,8 +5809,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1313;
 co->nargs = 1;
+co->args[0] = _35cc2115;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5765,8 +5820,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1313;
 co->nargs = 1;
+co->args[0] = _35cc2115;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5776,8 +5831,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1313;
 co->nargs = 1;
+co->args[0] = _35cc2115;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5787,8 +5842,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1313;
 co->nargs = 1;
+co->args[0] = _35cc2115;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5799,22 +5854,22 @@ return;
 }
 }
 
-void _35clofun3031(struct Cora* co) {
+void _35clofun3834(struct Cora* co) {
 Obj res1 = co->args[1];
 Obj body1 = co->args[2];
-Obj _35reg2331 = primEQ(closureRef(co, 2), intern("%closure"));
-if (True == _35reg2331) {
-Obj _35reg2332 = primCons(body1, Nil);
-Obj _35reg2333 = primCons(Nil, _35reg2332);
-Obj _35reg2334 = primCons(closureRef(co, 1), _35reg2333);
-Obj _35reg2335 = primCons(intern("lambda"), _35reg2334);
-Obj _35reg2336 = primCons(_35reg2335, Nil);
-Obj _35reg2337 = primCons(closureRef(co, 3), _35reg2336);
-Obj _35reg2338 = primCons(_35reg2337, res1);
-pushCont(co, _35clofun3032, 1, _35reg2338);
+Obj _35reg3133 = primEQ(closureRef(co, 2), intern("%closure"));
+if (True == _35reg3133) {
+Obj _35reg3134 = primCons(body1, Nil);
+Obj _35reg3135 = primCons(Nil, _35reg3134);
+Obj _35reg3136 = primCons(closureRef(co, 1), _35reg3135);
+Obj _35reg3137 = primCons(intern("lambda"), _35reg3136);
+Obj _35reg3138 = primCons(_35reg3137, Nil);
+Obj _35reg3139 = primCons(closureRef(co, 3), _35reg3138);
+Obj _35reg3140 = primCons(_35reg3139, res1);
+pushCont(co, _35clofun3835, 1, _35reg3140);
+co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = closureRef(co, 1);
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5823,19 +5878,19 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2343 = primCons(body1, Nil);
-Obj _35reg2344 = primCons(closureRef(co, 4), _35reg2343);
-Obj _35reg2345 = primCons(closureRef(co, 1), _35reg2344);
-Obj _35reg2346 = primCons(intern("lambda"), _35reg2345);
-Obj _35reg2347 = primCons(_35reg2346, Nil);
-Obj _35reg2348 = primCons(closureRef(co, 3), _35reg2347);
-Obj _35reg2349 = primCons(_35reg2348, res1);
-Obj _35reg2350 = primCons(closureRef(co, 3), closureRef(co, 4));
-Obj _35reg2351 = primCons(closureRef(co, 2), _35reg2350);
-co->args[0] = closureRef(co, 0);
-co->args[1] = _35reg2349;
-co->args[2] = _35reg2351;
+Obj _35reg3145 = primCons(body1, Nil);
+Obj _35reg3146 = primCons(closureRef(co, 4), _35reg3145);
+Obj _35reg3147 = primCons(closureRef(co, 1), _35reg3146);
+Obj _35reg3148 = primCons(intern("lambda"), _35reg3147);
+Obj _35reg3149 = primCons(_35reg3148, Nil);
+Obj _35reg3150 = primCons(closureRef(co, 3), _35reg3149);
+Obj _35reg3151 = primCons(_35reg3150, res1);
+Obj _35reg3152 = primCons(closureRef(co, 3), closureRef(co, 4));
+Obj _35reg3153 = primCons(closureRef(co, 2), _35reg3152);
 co->nargs = 3;
+co->args[0] = closureRef(co, 0);
+co->args[1] = _35reg3151;
+co->args[2] = _35reg3153;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5846,16 +5901,16 @@ return;
 }
 }
 
-void _35clofun3032(struct Cora* co) {
-Obj _35val2339 = co->args[1];
-Obj _35reg2338 = co->stack[co->base + 0];
-Obj _35reg2340 = primCons(_35val2339, closureRef(co, 4));
-Obj _35reg2341 = primCons(closureRef(co, 3), _35reg2340);
-Obj _35reg2342 = primCons(closureRef(co, 2), _35reg2341);
-co->args[0] = closureRef(co, 0);
-co->args[1] = _35reg2338;
-co->args[2] = _35reg2342;
+void _35clofun3835(struct Cora* co) {
+Obj _35val3141 = co->args[1];
+Obj _35reg3140 = co->stack[co->base + 0];
+Obj _35reg3142 = primCons(_35val3141, closureRef(co, 4));
+Obj _35reg3143 = primCons(closureRef(co, 3), _35reg3142);
+Obj _35reg3144 = primCons(closureRef(co, 2), _35reg3143);
 co->nargs = 3;
+co->args[0] = closureRef(co, 0);
+co->args[1] = _35reg3140;
+co->args[2] = _35reg3144;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5865,22 +5920,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3029(struct Cora* co) {
+void _35clofun3832(struct Cora* co) {
 Obj res1 = co->args[1];
 Obj body1 = co->args[2];
-Obj _35reg2309 = primEQ(closureRef(co, 2), intern("%closure"));
-if (True == _35reg2309) {
-Obj _35reg2310 = primCons(body1, Nil);
-Obj _35reg2311 = primCons(Nil, _35reg2310);
-Obj _35reg2312 = primCons(closureRef(co, 1), _35reg2311);
-Obj _35reg2313 = primCons(intern("lambda"), _35reg2312);
-Obj _35reg2314 = primCons(_35reg2313, Nil);
-Obj _35reg2315 = primCons(closureRef(co, 3), _35reg2314);
-Obj _35reg2316 = primCons(_35reg2315, res1);
-pushCont(co, _35clofun3030, 1, _35reg2316);
+Obj _35reg3111 = primEQ(closureRef(co, 2), intern("%closure"));
+if (True == _35reg3111) {
+Obj _35reg3112 = primCons(body1, Nil);
+Obj _35reg3113 = primCons(Nil, _35reg3112);
+Obj _35reg3114 = primCons(closureRef(co, 1), _35reg3113);
+Obj _35reg3115 = primCons(intern("lambda"), _35reg3114);
+Obj _35reg3116 = primCons(_35reg3115, Nil);
+Obj _35reg3117 = primCons(closureRef(co, 3), _35reg3116);
+Obj _35reg3118 = primCons(_35reg3117, res1);
+pushCont(co, _35clofun3833, 1, _35reg3118);
+co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = closureRef(co, 1);
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5889,19 +5944,19 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2321 = primCons(body1, Nil);
-Obj _35reg2322 = primCons(closureRef(co, 4), _35reg2321);
-Obj _35reg2323 = primCons(closureRef(co, 1), _35reg2322);
-Obj _35reg2324 = primCons(intern("lambda"), _35reg2323);
-Obj _35reg2325 = primCons(_35reg2324, Nil);
-Obj _35reg2326 = primCons(closureRef(co, 3), _35reg2325);
-Obj _35reg2327 = primCons(_35reg2326, res1);
-Obj _35reg2328 = primCons(closureRef(co, 3), closureRef(co, 4));
-Obj _35reg2329 = primCons(closureRef(co, 2), _35reg2328);
-co->args[0] = closureRef(co, 0);
-co->args[1] = _35reg2327;
-co->args[2] = _35reg2329;
+Obj _35reg3123 = primCons(body1, Nil);
+Obj _35reg3124 = primCons(closureRef(co, 4), _35reg3123);
+Obj _35reg3125 = primCons(closureRef(co, 1), _35reg3124);
+Obj _35reg3126 = primCons(intern("lambda"), _35reg3125);
+Obj _35reg3127 = primCons(_35reg3126, Nil);
+Obj _35reg3128 = primCons(closureRef(co, 3), _35reg3127);
+Obj _35reg3129 = primCons(_35reg3128, res1);
+Obj _35reg3130 = primCons(closureRef(co, 3), closureRef(co, 4));
+Obj _35reg3131 = primCons(closureRef(co, 2), _35reg3130);
 co->nargs = 3;
+co->args[0] = closureRef(co, 0);
+co->args[1] = _35reg3129;
+co->args[2] = _35reg3131;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5912,16 +5967,16 @@ return;
 }
 }
 
-void _35clofun3030(struct Cora* co) {
-Obj _35val2317 = co->args[1];
-Obj _35reg2316 = co->stack[co->base + 0];
-Obj _35reg2318 = primCons(_35val2317, closureRef(co, 4));
-Obj _35reg2319 = primCons(closureRef(co, 3), _35reg2318);
-Obj _35reg2320 = primCons(closureRef(co, 2), _35reg2319);
-co->args[0] = closureRef(co, 0);
-co->args[1] = _35reg2316;
-co->args[2] = _35reg2320;
+void _35clofun3833(struct Cora* co) {
+Obj _35val3119 = co->args[1];
+Obj _35reg3118 = co->stack[co->base + 0];
+Obj _35reg3120 = primCons(_35val3119, closureRef(co, 4));
+Obj _35reg3121 = primCons(closureRef(co, 3), _35reg3120);
+Obj _35reg3122 = primCons(closureRef(co, 2), _35reg3121);
 co->nargs = 3;
+co->args[0] = closureRef(co, 0);
+co->args[1] = _35reg3118;
+co->args[2] = _35reg3122;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5931,22 +5986,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3027(struct Cora* co) {
+void _35clofun3830(struct Cora* co) {
 Obj res1 = co->args[1];
 Obj body1 = co->args[2];
-Obj _35reg2286 = primEQ(closureRef(co, 2), intern("%closure"));
-if (True == _35reg2286) {
-Obj _35reg2287 = primCons(body1, Nil);
-Obj _35reg2288 = primCons(Nil, _35reg2287);
-Obj _35reg2289 = primCons(closureRef(co, 1), _35reg2288);
-Obj _35reg2290 = primCons(intern("lambda"), _35reg2289);
-Obj _35reg2291 = primCons(_35reg2290, Nil);
-Obj _35reg2292 = primCons(closureRef(co, 3), _35reg2291);
-Obj _35reg2293 = primCons(_35reg2292, res1);
-pushCont(co, _35clofun3028, 1, _35reg2293);
+Obj _35reg3088 = primEQ(closureRef(co, 2), intern("%closure"));
+if (True == _35reg3088) {
+Obj _35reg3089 = primCons(body1, Nil);
+Obj _35reg3090 = primCons(Nil, _35reg3089);
+Obj _35reg3091 = primCons(closureRef(co, 1), _35reg3090);
+Obj _35reg3092 = primCons(intern("lambda"), _35reg3091);
+Obj _35reg3093 = primCons(_35reg3092, Nil);
+Obj _35reg3094 = primCons(closureRef(co, 3), _35reg3093);
+Obj _35reg3095 = primCons(_35reg3094, res1);
+pushCont(co, _35clofun3831, 1, _35reg3095);
+co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = closureRef(co, 1);
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5955,19 +6010,19 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2298 = primCons(body1, Nil);
-Obj _35reg2299 = primCons(closureRef(co, 4), _35reg2298);
-Obj _35reg2300 = primCons(closureRef(co, 1), _35reg2299);
-Obj _35reg2301 = primCons(intern("lambda"), _35reg2300);
-Obj _35reg2302 = primCons(_35reg2301, Nil);
-Obj _35reg2303 = primCons(closureRef(co, 3), _35reg2302);
-Obj _35reg2304 = primCons(_35reg2303, res1);
-Obj _35reg2305 = primCons(closureRef(co, 3), closureRef(co, 4));
-Obj _35reg2306 = primCons(closureRef(co, 2), _35reg2305);
-co->args[0] = closureRef(co, 0);
-co->args[1] = _35reg2304;
-co->args[2] = _35reg2306;
+Obj _35reg3100 = primCons(body1, Nil);
+Obj _35reg3101 = primCons(closureRef(co, 4), _35reg3100);
+Obj _35reg3102 = primCons(closureRef(co, 1), _35reg3101);
+Obj _35reg3103 = primCons(intern("lambda"), _35reg3102);
+Obj _35reg3104 = primCons(_35reg3103, Nil);
+Obj _35reg3105 = primCons(closureRef(co, 3), _35reg3104);
+Obj _35reg3106 = primCons(_35reg3105, res1);
+Obj _35reg3107 = primCons(closureRef(co, 3), closureRef(co, 4));
+Obj _35reg3108 = primCons(closureRef(co, 2), _35reg3107);
 co->nargs = 3;
+co->args[0] = closureRef(co, 0);
+co->args[1] = _35reg3106;
+co->args[2] = _35reg3108;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5978,16 +6033,16 @@ return;
 }
 }
 
-void _35clofun3028(struct Cora* co) {
-Obj _35val2294 = co->args[1];
-Obj _35reg2293 = co->stack[co->base + 0];
-Obj _35reg2295 = primCons(_35val2294, closureRef(co, 4));
-Obj _35reg2296 = primCons(closureRef(co, 3), _35reg2295);
-Obj _35reg2297 = primCons(closureRef(co, 2), _35reg2296);
-co->args[0] = closureRef(co, 0);
-co->args[1] = _35reg2293;
-co->args[2] = _35reg2297;
+void _35clofun3831(struct Cora* co) {
+Obj _35val3096 = co->args[1];
+Obj _35reg3095 = co->stack[co->base + 0];
+Obj _35reg3097 = primCons(_35val3096, closureRef(co, 4));
+Obj _35reg3098 = primCons(closureRef(co, 3), _35reg3097);
+Obj _35reg3099 = primCons(closureRef(co, 2), _35reg3098);
 co->nargs = 3;
+co->args[0] = closureRef(co, 0);
+co->args[1] = _35reg3095;
+co->args[2] = _35reg3099;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -5997,19 +6052,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3024(struct Cora* co) {
-Obj _35cc1314 = makeNative(_35clofun3025, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3827(struct Cora* co) {
+Obj _35cc2116 = makeNative(_35clofun3828, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj res = closureRef(co, 0);
 Obj f_45args = closureRef(co, 1);
 Obj k = closureRef(co, 2);
-Obj _35reg2246 = primIsCons(f_45args);
-if (True == _35reg2246) {
+Obj _35reg3048 = primIsCons(f_45args);
+if (True == _35reg3048) {
+co->nargs = 5;
 co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda-list"));
 co->args[1] = Nil;
 co->args[2] = res;
 co->args[3] = f_45args;
 co->args[4] = k;
-co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6018,8 +6073,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1314;
 co->nargs = 1;
+co->args[0] = _35cc2116;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6030,15 +6085,15 @@ return;
 }
 }
 
-void _35clofun3025(struct Cora* co) {
-Obj _35cc1315 = makeNative(_35clofun3026, 0, 0);
+void _35clofun3828(struct Cora* co) {
+Obj _35cc2117 = makeNative(_35clofun3829, 0, 0);
 Obj res = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 Obj k = closureRef(co, 2);
+co->nargs = 3;
 co->args[0] = k;
 co->args[1] = res;
 co->args[2] = x;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6048,10 +6103,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3026(struct Cora* co) {
+void _35clofun3829(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6061,16 +6116,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3005(struct Cora* co) {
-Obj _35p1302 = co->args[1];
-Obj _35p1303 = co->args[2];
-Obj _35cc1304 = makeNative(_35clofun3006, 0, 2, _35p1302, _35p1303);
-Obj __ = _35p1302;
-Obj x = _35p1303;
-pushCont(co, _35clofun3022, 2, x, _35cc1304);
+void _35clofun3808(struct Cora* co) {
+Obj _35p2104 = co->args[1];
+Obj _35p2105 = co->args[2];
+Obj _35cc2106 = makeNative(_35clofun3809, 0, 2, _35p2104, _35p2105);
+Obj __ = _35p2104;
+Obj x = _35p2105;
+pushCont(co, _35clofun3825, 2, x, _35cc2106);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.convert-protect?"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6080,17 +6135,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3022(struct Cora* co) {
-Obj _35val2244 = co->args[1];
+void _35clofun3825(struct Cora* co) {
+Obj _35val3046 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35cc1304 = co->stack[co->base + 1];
-if (True == _35val2244) {
+Obj _35cc2106 = co->stack[co->base + 1];
+if (True == _35val3046) {
+co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1304;
 co->nargs = 1;
+co->args[0] = _35cc2106;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6101,18 +6157,19 @@ return;
 }
 }
 
-void _35clofun3006(struct Cora* co) {
-Obj _35cc1305 = makeNative(_35clofun3007, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3809(struct Cora* co) {
+Obj _35cc2107 = makeNative(_35clofun3810, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj _35reg2243 = primIsSymbol(var);
-if (True == _35reg2243) {
+Obj _35reg3045 = primIsSymbol(var);
+if (True == _35reg3045) {
+co->nargs = 2;
 co->args[1] = var;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1305;
 co->nargs = 1;
+co->args[0] = _35cc2107;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6123,38 +6180,38 @@ return;
 }
 }
 
-void _35clofun3007(struct Cora* co) {
-Obj _35cc1306 = makeNative(_35clofun3008, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3810(struct Cora* co) {
+Obj _35cc2108 = makeNative(_35clofun3811, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2222 = primIsCons(closureRef(co, 1));
-if (True == _35reg2222) {
-Obj _35reg2223 = primCar(closureRef(co, 1));
-Obj _35reg2224 = primEQ(intern("lambda"), _35reg2223);
-if (True == _35reg2224) {
-Obj _35reg2225 = primCdr(closureRef(co, 1));
-Obj _35reg2226 = primIsCons(_35reg2225);
-if (True == _35reg2226) {
-Obj _35reg2227 = primCdr(closureRef(co, 1));
-Obj _35reg2228 = primCar(_35reg2227);
-Obj args = _35reg2228;
-Obj _35reg2229 = primCdr(closureRef(co, 1));
-Obj _35reg2230 = primCdr(_35reg2229);
-Obj _35reg2231 = primIsCons(_35reg2230);
-if (True == _35reg2231) {
-Obj _35reg2232 = primCdr(closureRef(co, 1));
-Obj _35reg2233 = primCdr(_35reg2232);
-Obj _35reg2234 = primCar(_35reg2233);
-Obj body = _35reg2234;
-Obj _35reg2235 = primCdr(closureRef(co, 1));
-Obj _35reg2236 = primCdr(_35reg2235);
-Obj _35reg2237 = primCdr(_35reg2236);
-Obj _35reg2238 = primEQ(Nil, _35reg2237);
-if (True == _35reg2238) {
-pushCont(co, _35clofun3021, 1, args);
+Obj _35reg3024 = primIsCons(closureRef(co, 1));
+if (True == _35reg3024) {
+Obj _35reg3025 = primCar(closureRef(co, 1));
+Obj _35reg3026 = primEQ(intern("lambda"), _35reg3025);
+if (True == _35reg3026) {
+Obj _35reg3027 = primCdr(closureRef(co, 1));
+Obj _35reg3028 = primIsCons(_35reg3027);
+if (True == _35reg3028) {
+Obj _35reg3029 = primCdr(closureRef(co, 1));
+Obj _35reg3030 = primCar(_35reg3029);
+Obj args = _35reg3030;
+Obj _35reg3031 = primCdr(closureRef(co, 1));
+Obj _35reg3032 = primCdr(_35reg3031);
+Obj _35reg3033 = primIsCons(_35reg3032);
+if (True == _35reg3033) {
+Obj _35reg3034 = primCdr(closureRef(co, 1));
+Obj _35reg3035 = primCdr(_35reg3034);
+Obj _35reg3036 = primCar(_35reg3035);
+Obj body = _35reg3036;
+Obj _35reg3037 = primCdr(closureRef(co, 1));
+Obj _35reg3038 = primCdr(_35reg3037);
+Obj _35reg3039 = primCdr(_35reg3038);
+Obj _35reg3040 = primEQ(Nil, _35reg3039);
+if (True == _35reg3040) {
+pushCont(co, _35clofun3824, 1, args);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = fvs;
 co->args[2] = body;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6163,8 +6220,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1306;
 co->nargs = 1;
+co->args[0] = _35cc2108;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6174,8 +6231,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1306;
 co->nargs = 1;
+co->args[0] = _35cc2108;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6185,8 +6242,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1306;
 co->nargs = 1;
+co->args[0] = _35cc2108;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6196,8 +6253,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1306;
 co->nargs = 1;
+co->args[0] = _35cc2108;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6207,8 +6264,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1306;
 co->nargs = 1;
+co->args[0] = _35cc2108;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6219,48 +6276,49 @@ return;
 }
 }
 
-void _35clofun3021(struct Cora* co) {
-Obj _35val2239 = co->args[1];
+void _35clofun3824(struct Cora* co) {
+Obj _35val3041 = co->args[1];
 Obj args = co->stack[co->base + 0];
-Obj _35reg2240 = primCons(_35val2239, Nil);
-Obj _35reg2241 = primCons(args, _35reg2240);
-Obj _35reg2242 = primCons(intern("lambda"), _35reg2241);
-co->args[1] = _35reg2242;
+Obj _35reg3042 = primCons(_35val3041, Nil);
+Obj _35reg3043 = primCons(args, _35reg3042);
+Obj _35reg3044 = primCons(intern("lambda"), _35reg3043);
+co->nargs = 2;
+co->args[1] = _35reg3044;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3008(struct Cora* co) {
-Obj _35cc1307 = makeNative(_35clofun3009, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3811(struct Cora* co) {
+Obj _35cc2109 = makeNative(_35clofun3812, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2195 = primIsCons(closureRef(co, 1));
-if (True == _35reg2195) {
-Obj _35reg2196 = primCar(closureRef(co, 1));
-Obj _35reg2197 = primEQ(intern("continuation"), _35reg2196);
-if (True == _35reg2197) {
-Obj _35reg2198 = primCdr(closureRef(co, 1));
-Obj _35reg2199 = primIsCons(_35reg2198);
-if (True == _35reg2199) {
-Obj _35reg2200 = primCdr(closureRef(co, 1));
-Obj _35reg2201 = primCar(_35reg2200);
-Obj val = _35reg2201;
-Obj _35reg2202 = primCdr(closureRef(co, 1));
-Obj _35reg2203 = primCdr(_35reg2202);
-Obj _35reg2204 = primIsCons(_35reg2203);
-if (True == _35reg2204) {
-Obj _35reg2205 = primCdr(closureRef(co, 1));
-Obj _35reg2206 = primCdr(_35reg2205);
-Obj _35reg2207 = primCar(_35reg2206);
-Obj body = _35reg2207;
-Obj _35reg2208 = primCdr(closureRef(co, 1));
-Obj _35reg2209 = primCdr(_35reg2208);
-Obj _35reg2210 = primCdr(_35reg2209);
-Obj _35reg2211 = primEQ(Nil, _35reg2210);
-if (True == _35reg2211) {
-pushCont(co, _35clofun3016, 3, fvs, body, val);
+Obj _35reg2997 = primIsCons(closureRef(co, 1));
+if (True == _35reg2997) {
+Obj _35reg2998 = primCar(closureRef(co, 1));
+Obj _35reg2999 = primEQ(intern("continuation"), _35reg2998);
+if (True == _35reg2999) {
+Obj _35reg3000 = primCdr(closureRef(co, 1));
+Obj _35reg3001 = primIsCons(_35reg3000);
+if (True == _35reg3001) {
+Obj _35reg3002 = primCdr(closureRef(co, 1));
+Obj _35reg3003 = primCar(_35reg3002);
+Obj val = _35reg3003;
+Obj _35reg3004 = primCdr(closureRef(co, 1));
+Obj _35reg3005 = primCdr(_35reg3004);
+Obj _35reg3006 = primIsCons(_35reg3005);
+if (True == _35reg3006) {
+Obj _35reg3007 = primCdr(closureRef(co, 1));
+Obj _35reg3008 = primCdr(_35reg3007);
+Obj _35reg3009 = primCar(_35reg3008);
+Obj body = _35reg3009;
+Obj _35reg3010 = primCdr(closureRef(co, 1));
+Obj _35reg3011 = primCdr(_35reg3010);
+Obj _35reg3012 = primCdr(_35reg3011);
+Obj _35reg3013 = primEQ(Nil, _35reg3012);
+if (True == _35reg3013) {
+pushCont(co, _35clofun3819, 3, fvs, body, val);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = body;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6269,8 +6327,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1307;
 co->nargs = 1;
+co->args[0] = _35cc2109;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6280,8 +6338,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1307;
 co->nargs = 1;
+co->args[0] = _35cc2109;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6291,8 +6349,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1307;
 co->nargs = 1;
+co->args[0] = _35cc2109;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6302,8 +6360,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1307;
 co->nargs = 1;
+co->args[0] = _35cc2109;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6313,8 +6371,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1307;
 co->nargs = 1;
+co->args[0] = _35cc2109;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6325,16 +6383,16 @@ return;
 }
 }
 
-void _35clofun3016(struct Cora* co) {
-Obj _35val2212 = co->args[1];
+void _35clofun3819(struct Cora* co) {
+Obj _35val3014 = co->args[1];
 Obj fvs = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj val = co->stack[co->base + 2];
-pushCont(co, _35clofun3017, 3, fvs, body, val);
-co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
-co->args[1] = _35val2212;
-co->args[2] = val;
+pushCont(co, _35clofun3820, 3, fvs, body, val);
 co->nargs = 3;
+co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
+co->args[1] = _35val3014;
+co->args[2] = val;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6344,16 +6402,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3017(struct Cora* co) {
-Obj _35val2213 = co->args[1];
+void _35clofun3820(struct Cora* co) {
+Obj _35val3015 = co->args[1];
 Obj fvs = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj val = co->stack[co->base + 2];
-Obj fvs1 = _35val2213;
-pushCont(co, _35clofun3018, 3, fvs1, body, val);
+Obj fvs1 = _35val3015;
+pushCont(co, _35clofun3821, 3, fvs1, body, val);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = fvs;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6363,16 +6421,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3018(struct Cora* co) {
-Obj _35val2214 = co->args[1];
+void _35clofun3821(struct Cora* co) {
+Obj _35val3016 = co->args[1];
 Obj fvs1 = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj val = co->stack[co->base + 2];
-pushCont(co, _35clofun3019, 3, fvs1, body, val);
-co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val2214;
-co->args[2] = fvs1;
+pushCont(co, _35clofun3822, 3, fvs1, body, val);
 co->nargs = 3;
+co->args[0] = globalRef(intern("map"));
+co->args[1] = _35val3016;
+co->args[2] = fvs1;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6382,17 +6440,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3019(struct Cora* co) {
-Obj _35val2215 = co->args[1];
+void _35clofun3822(struct Cora* co) {
+Obj _35val3017 = co->args[1];
 Obj fvs1 = co->stack[co->base + 0];
 Obj body = co->stack[co->base + 1];
 Obj val = co->stack[co->base + 2];
-Obj fvs2 = _35val2215;
-pushCont(co, _35clofun3020, 2, val, fvs2);
+Obj fvs2 = _35val3017;
+pushCont(co, _35clofun3823, 2, val, fvs2);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = fvs1;
 co->args[2] = body;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6402,51 +6460,52 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3020(struct Cora* co) {
-Obj _35val2216 = co->args[1];
+void _35clofun3823(struct Cora* co) {
+Obj _35val3018 = co->args[1];
 Obj val = co->stack[co->base + 0];
 Obj fvs2 = co->stack[co->base + 1];
-Obj _35reg2217 = primCons(_35val2216, Nil);
-Obj _35reg2218 = primCons(val, _35reg2217);
-Obj _35reg2219 = primCons(intern("lambda"), _35reg2218);
-Obj _35reg2220 = primCons(_35reg2219, fvs2);
-Obj _35reg2221 = primCons(intern("%continuation"), _35reg2220);
-co->args[1] = _35reg2221;
+Obj _35reg3019 = primCons(_35val3018, Nil);
+Obj _35reg3020 = primCons(val, _35reg3019);
+Obj _35reg3021 = primCons(intern("lambda"), _35reg3020);
+Obj _35reg3022 = primCons(_35reg3021, fvs2);
+Obj _35reg3023 = primCons(intern("%continuation"), _35reg3022);
+co->nargs = 2;
+co->args[1] = _35reg3023;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3009(struct Cora* co) {
-Obj _35cc1308 = makeNative(_35clofun3010, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3812(struct Cora* co) {
+Obj _35cc2110 = makeNative(_35clofun3813, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2172 = primIsCons(closureRef(co, 1));
-if (True == _35reg2172) {
-Obj _35reg2173 = primCar(closureRef(co, 1));
-Obj _35reg2174 = primEQ(intern("call"), _35reg2173);
-if (True == _35reg2174) {
-Obj _35reg2175 = primCdr(closureRef(co, 1));
-Obj _35reg2176 = primIsCons(_35reg2175);
-if (True == _35reg2176) {
-Obj _35reg2177 = primCdr(closureRef(co, 1));
-Obj _35reg2178 = primCar(_35reg2177);
-Obj exp = _35reg2178;
-Obj _35reg2179 = primCdr(closureRef(co, 1));
-Obj _35reg2180 = primCdr(_35reg2179);
-Obj _35reg2181 = primIsCons(_35reg2180);
-if (True == _35reg2181) {
-Obj _35reg2182 = primCdr(closureRef(co, 1));
-Obj _35reg2183 = primCdr(_35reg2182);
-Obj _35reg2184 = primCar(_35reg2183);
-Obj cont = _35reg2184;
-Obj _35reg2185 = primCdr(closureRef(co, 1));
-Obj _35reg2186 = primCdr(_35reg2185);
-Obj _35reg2187 = primCdr(_35reg2186);
-Obj _35reg2188 = primEQ(Nil, _35reg2187);
-if (True == _35reg2188) {
-pushCont(co, _35clofun3013, 3, exp, fvs, cont);
+Obj _35reg2974 = primIsCons(closureRef(co, 1));
+if (True == _35reg2974) {
+Obj _35reg2975 = primCar(closureRef(co, 1));
+Obj _35reg2976 = primEQ(intern("call"), _35reg2975);
+if (True == _35reg2976) {
+Obj _35reg2977 = primCdr(closureRef(co, 1));
+Obj _35reg2978 = primIsCons(_35reg2977);
+if (True == _35reg2978) {
+Obj _35reg2979 = primCdr(closureRef(co, 1));
+Obj _35reg2980 = primCar(_35reg2979);
+Obj exp = _35reg2980;
+Obj _35reg2981 = primCdr(closureRef(co, 1));
+Obj _35reg2982 = primCdr(_35reg2981);
+Obj _35reg2983 = primIsCons(_35reg2982);
+if (True == _35reg2983) {
+Obj _35reg2984 = primCdr(closureRef(co, 1));
+Obj _35reg2985 = primCdr(_35reg2984);
+Obj _35reg2986 = primCar(_35reg2985);
+Obj cont = _35reg2986;
+Obj _35reg2987 = primCdr(closureRef(co, 1));
+Obj _35reg2988 = primCdr(_35reg2987);
+Obj _35reg2989 = primCdr(_35reg2988);
+Obj _35reg2990 = primEQ(Nil, _35reg2989);
+if (True == _35reg2990) {
+pushCont(co, _35clofun3816, 3, exp, fvs, cont);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = fvs;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6455,8 +6514,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1308;
 co->nargs = 1;
+co->args[0] = _35cc2110;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6466,8 +6525,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1308;
 co->nargs = 1;
+co->args[0] = _35cc2110;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6477,8 +6536,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1308;
 co->nargs = 1;
+co->args[0] = _35cc2110;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6488,8 +6547,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1308;
 co->nargs = 1;
+co->args[0] = _35cc2110;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6499,8 +6558,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1308;
 co->nargs = 1;
+co->args[0] = _35cc2110;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6511,16 +6570,16 @@ return;
 }
 }
 
-void _35clofun3013(struct Cora* co) {
-Obj _35val2189 = co->args[1];
+void _35clofun3816(struct Cora* co) {
+Obj _35val2991 = co->args[1];
 Obj exp = co->stack[co->base + 0];
 Obj fvs = co->stack[co->base + 1];
 Obj cont = co->stack[co->base + 2];
-pushCont(co, _35clofun3014, 2, fvs, cont);
-co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val2189;
-co->args[2] = exp;
+pushCont(co, _35clofun3817, 2, fvs, cont);
 co->nargs = 3;
+co->args[0] = globalRef(intern("map"));
+co->args[1] = _35val2991;
+co->args[2] = exp;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6530,15 +6589,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3014(struct Cora* co) {
-Obj _35val2190 = co->args[1];
+void _35clofun3817(struct Cora* co) {
+Obj _35val2992 = co->args[1];
 Obj fvs = co->stack[co->base + 0];
 Obj cont = co->stack[co->base + 1];
-pushCont(co, _35clofun3015, 1, _35val2190);
+pushCont(co, _35clofun3818, 1, _35val2992);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = fvs;
 co->args[2] = cont;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6548,30 +6607,31 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3015(struct Cora* co) {
-Obj _35val2191 = co->args[1];
-Obj _35val2190 = co->stack[co->base + 0];
-Obj _35reg2192 = primCons(_35val2191, Nil);
-Obj _35reg2193 = primCons(_35val2190, _35reg2192);
-Obj _35reg2194 = primCons(intern("call"), _35reg2193);
-co->args[1] = _35reg2194;
+void _35clofun3818(struct Cora* co) {
+Obj _35val2993 = co->args[1];
+Obj _35val2992 = co->stack[co->base + 0];
+Obj _35reg2994 = primCons(_35val2993, Nil);
+Obj _35reg2995 = primCons(_35val2992, _35reg2994);
+Obj _35reg2996 = primCons(intern("call"), _35reg2995);
+co->nargs = 2;
+co->args[1] = _35reg2996;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3010(struct Cora* co) {
-Obj _35cc1309 = makeNative(_35clofun3011, 0, 0);
+void _35clofun3813(struct Cora* co) {
+Obj _35cc2111 = makeNative(_35clofun3814, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj _35reg2167 = primIsCons(closureRef(co, 1));
-if (True == _35reg2167) {
-Obj _35reg2168 = primCar(closureRef(co, 1));
-Obj f = _35reg2168;
-Obj _35reg2169 = primCdr(closureRef(co, 1));
-Obj args = _35reg2169;
-pushCont(co, _35clofun3012, 2, f, args);
+Obj _35reg2969 = primIsCons(closureRef(co, 1));
+if (True == _35reg2969) {
+Obj _35reg2970 = primCar(closureRef(co, 1));
+Obj f = _35reg2970;
+Obj _35reg2971 = primCdr(closureRef(co, 1));
+Obj args = _35reg2971;
+pushCont(co, _35clofun3815, 2, f, args);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.explicit-stack"));
 co->args[1] = fvs;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6580,8 +6640,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1309;
 co->nargs = 1;
+co->args[0] = _35cc2111;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6592,15 +6652,15 @@ return;
 }
 }
 
-void _35clofun3012(struct Cora* co) {
-Obj _35val2170 = co->args[1];
+void _35clofun3815(struct Cora* co) {
+Obj _35val2972 = co->args[1];
 Obj f = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
-Obj _35reg2171 = primCons(f, args);
-co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val2170;
-co->args[2] = _35reg2171;
+Obj _35reg2973 = primCons(f, args);
 co->nargs = 3;
+co->args[0] = globalRef(intern("map"));
+co->args[1] = _35val2972;
+co->args[2] = _35reg2973;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6610,10 +6670,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3011(struct Cora* co) {
+void _35clofun3814(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6623,19 +6683,19 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2995(struct Cora* co) {
-Obj _35p1297 = co->args[1];
-Obj _35p1298 = co->args[2];
-Obj _35p1299 = co->args[3];
-Obj _35cc1300 = makeNative(_35clofun2996, 0, 3, _35p1297, _35p1298, _35p1299);
-Obj _35reg2124 = primEQ(Nil, _35p1297);
-if (True == _35reg2124) {
-Obj ls = _35p1298;
-Obj next = _35p1299;
-pushCont(co, _35clofun2999, 1, next);
+void _35clofun3798(struct Cora* co) {
+Obj _35p2099 = co->args[1];
+Obj _35p2100 = co->args[2];
+Obj _35p2101 = co->args[3];
+Obj _35cc2102 = makeNative(_35clofun3799, 0, 3, _35p2099, _35p2100, _35p2101);
+Obj _35reg2926 = primEQ(Nil, _35p2099);
+if (True == _35reg2926) {
+Obj ls = _35p2100;
+Obj next = _35p2101;
+pushCont(co, _35clofun3802, 1, next);
+co->nargs = 2;
 co->args[0] = globalRef(intern("reverse"));
 co->args[1] = ls;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6644,8 +6704,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1300;
 co->nargs = 1;
+co->args[0] = _35cc2102;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6656,15 +6716,15 @@ return;
 }
 }
 
-void _35clofun2999(struct Cora* co) {
-Obj _35val2125 = co->args[1];
+void _35clofun3802(struct Cora* co) {
+Obj _35val2927 = co->args[1];
 Obj next = co->stack[co->base + 0];
-Obj exp = _35val2125;
-Obj _35reg2126 = primCar(exp);
-pushCont(co, _35clofun3000, 2, next, exp);
-co->args[0] = globalRef(intern("pair?"));
-co->args[1] = _35reg2126;
+Obj exp = _35val2927;
+Obj _35reg2928 = primCar(exp);
+pushCont(co, _35clofun3803, 2, next, exp);
 co->nargs = 2;
+co->args[0] = globalRef(intern("pair?"));
+co->args[1] = _35reg2928;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6674,15 +6734,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun3000(struct Cora* co) {
-Obj _35val2127 = co->args[1];
+void _35clofun3803(struct Cora* co) {
+Obj _35val2929 = co->args[1];
 Obj next = co->stack[co->base + 0];
 Obj exp = co->stack[co->base + 1];
-if (True == _35val2127) {
-pushCont(co, _35clofun3001, 2, next, exp);
+if (True == _35val2929) {
+pushCont(co, _35clofun3804, 2, next, exp);
+co->nargs = 2;
 co->args[0] = globalRef(intern("caar"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6692,10 +6752,10 @@ co->pc = coraCall;
 return;
 } else {
 if (True == False) {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.wrap-var"));
 co->args[1] = exp;
 co->args[2] = next;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6704,21 +6764,22 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2154 = primEQ(next, globalRef(intern("cora/lib/toc/include.id")));
-if (True == _35reg2154) {
-Obj _35reg2155 = primCons(exp, Nil);
-Obj _35reg2156 = primCons(intern("tailcall"), _35reg2155);
-co->args[1] = _35reg2156;
+Obj _35reg2956 = primEQ(next, globalRef(intern("cora/lib/toc/include.id")));
+if (True == _35reg2956) {
+Obj _35reg2957 = primCons(exp, Nil);
+Obj _35reg2958 = primCons(intern("tailcall"), _35reg2957);
+co->nargs = 2;
+co->args[1] = _35reg2958;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2157 = primGenSym(intern("val"));
-Obj val = _35reg2157;
-Obj _35reg2158 = primCons(val, Nil);
-pushCont(co, _35clofun3004, 2, _35reg2158, exp);
+Obj _35reg2959 = primGenSym(intern("val"));
+Obj val = _35reg2959;
+Obj _35reg2960 = primCons(val, Nil);
+pushCont(co, _35clofun3807, 2, _35reg2960, exp);
+co->nargs = 2;
 co->args[0] = next;
 co->args[1] = val;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6731,32 +6792,33 @@ return;
 }
 }
 
-void _35clofun3004(struct Cora* co) {
-Obj _35val2159 = co->args[1];
-Obj _35reg2158 = co->stack[co->base + 0];
+void _35clofun3807(struct Cora* co) {
+Obj _35val2961 = co->args[1];
+Obj _35reg2960 = co->stack[co->base + 0];
 Obj exp = co->stack[co->base + 1];
-Obj _35reg2160 = primCons(_35val2159, Nil);
-Obj _35reg2161 = primCons(_35reg2158, _35reg2160);
-Obj _35reg2162 = primCons(intern("continuation"), _35reg2161);
-Obj _35reg2163 = primCons(_35reg2162, Nil);
-Obj _35reg2164 = primCons(exp, _35reg2163);
-Obj _35reg2165 = primCons(intern("call"), _35reg2164);
-co->args[1] = _35reg2165;
+Obj _35reg2962 = primCons(_35val2961, Nil);
+Obj _35reg2963 = primCons(_35reg2960, _35reg2962);
+Obj _35reg2964 = primCons(intern("continuation"), _35reg2963);
+Obj _35reg2965 = primCons(_35reg2964, Nil);
+Obj _35reg2966 = primCons(exp, _35reg2965);
+Obj _35reg2967 = primCons(intern("call"), _35reg2966);
+co->nargs = 2;
+co->args[1] = _35reg2967;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3001(struct Cora* co) {
-Obj _35val2128 = co->args[1];
+void _35clofun3804(struct Cora* co) {
+Obj _35val2930 = co->args[1];
 Obj next = co->stack[co->base + 0];
 Obj exp = co->stack[co->base + 1];
-Obj _35reg2129 = primEQ(_35val2128, intern("%builtin"));
-if (True == _35reg2129) {
+Obj _35reg2931 = primEQ(_35val2930, intern("%builtin"));
+if (True == _35reg2931) {
 if (True == True) {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.wrap-var"));
 co->args[1] = exp;
 co->args[2] = next;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6765,21 +6827,22 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2130 = primEQ(next, globalRef(intern("cora/lib/toc/include.id")));
-if (True == _35reg2130) {
-Obj _35reg2131 = primCons(exp, Nil);
-Obj _35reg2132 = primCons(intern("tailcall"), _35reg2131);
-co->args[1] = _35reg2132;
+Obj _35reg2932 = primEQ(next, globalRef(intern("cora/lib/toc/include.id")));
+if (True == _35reg2932) {
+Obj _35reg2933 = primCons(exp, Nil);
+Obj _35reg2934 = primCons(intern("tailcall"), _35reg2933);
+co->nargs = 2;
+co->args[1] = _35reg2934;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2133 = primGenSym(intern("val"));
-Obj val = _35reg2133;
-Obj _35reg2134 = primCons(val, Nil);
-pushCont(co, _35clofun3002, 2, _35reg2134, exp);
+Obj _35reg2935 = primGenSym(intern("val"));
+Obj val = _35reg2935;
+Obj _35reg2936 = primCons(val, Nil);
+pushCont(co, _35clofun3805, 2, _35reg2936, exp);
+co->nargs = 2;
 co->args[0] = next;
 co->args[1] = val;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6791,10 +6854,10 @@ return;
 }
 } else {
 if (True == False) {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.wrap-var"));
 co->args[1] = exp;
 co->args[2] = next;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6803,21 +6866,22 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg2142 = primEQ(next, globalRef(intern("cora/lib/toc/include.id")));
-if (True == _35reg2142) {
-Obj _35reg2143 = primCons(exp, Nil);
-Obj _35reg2144 = primCons(intern("tailcall"), _35reg2143);
-co->args[1] = _35reg2144;
+Obj _35reg2944 = primEQ(next, globalRef(intern("cora/lib/toc/include.id")));
+if (True == _35reg2944) {
+Obj _35reg2945 = primCons(exp, Nil);
+Obj _35reg2946 = primCons(intern("tailcall"), _35reg2945);
+co->nargs = 2;
+co->args[1] = _35reg2946;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg2145 = primGenSym(intern("val"));
-Obj val = _35reg2145;
-Obj _35reg2146 = primCons(val, Nil);
-pushCont(co, _35clofun3003, 2, _35reg2146, exp);
+Obj _35reg2947 = primGenSym(intern("val"));
+Obj val = _35reg2947;
+Obj _35reg2948 = primCons(val, Nil);
+pushCont(co, _35clofun3806, 2, _35reg2948, exp);
+co->nargs = 2;
 co->args[0] = next;
 co->args[1] = val;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6830,50 +6894,52 @@ return;
 }
 }
 
-void _35clofun3003(struct Cora* co) {
-Obj _35val2147 = co->args[1];
-Obj _35reg2146 = co->stack[co->base + 0];
+void _35clofun3806(struct Cora* co) {
+Obj _35val2949 = co->args[1];
+Obj _35reg2948 = co->stack[co->base + 0];
 Obj exp = co->stack[co->base + 1];
-Obj _35reg2148 = primCons(_35val2147, Nil);
-Obj _35reg2149 = primCons(_35reg2146, _35reg2148);
-Obj _35reg2150 = primCons(intern("continuation"), _35reg2149);
-Obj _35reg2151 = primCons(_35reg2150, Nil);
-Obj _35reg2152 = primCons(exp, _35reg2151);
-Obj _35reg2153 = primCons(intern("call"), _35reg2152);
-co->args[1] = _35reg2153;
+Obj _35reg2950 = primCons(_35val2949, Nil);
+Obj _35reg2951 = primCons(_35reg2948, _35reg2950);
+Obj _35reg2952 = primCons(intern("continuation"), _35reg2951);
+Obj _35reg2953 = primCons(_35reg2952, Nil);
+Obj _35reg2954 = primCons(exp, _35reg2953);
+Obj _35reg2955 = primCons(intern("call"), _35reg2954);
+co->nargs = 2;
+co->args[1] = _35reg2955;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun3002(struct Cora* co) {
-Obj _35val2135 = co->args[1];
-Obj _35reg2134 = co->stack[co->base + 0];
+void _35clofun3805(struct Cora* co) {
+Obj _35val2937 = co->args[1];
+Obj _35reg2936 = co->stack[co->base + 0];
 Obj exp = co->stack[co->base + 1];
-Obj _35reg2136 = primCons(_35val2135, Nil);
-Obj _35reg2137 = primCons(_35reg2134, _35reg2136);
-Obj _35reg2138 = primCons(intern("continuation"), _35reg2137);
-Obj _35reg2139 = primCons(_35reg2138, Nil);
-Obj _35reg2140 = primCons(exp, _35reg2139);
-Obj _35reg2141 = primCons(intern("call"), _35reg2140);
-co->args[1] = _35reg2141;
+Obj _35reg2938 = primCons(_35val2937, Nil);
+Obj _35reg2939 = primCons(_35reg2936, _35reg2938);
+Obj _35reg2940 = primCons(intern("continuation"), _35reg2939);
+Obj _35reg2941 = primCons(_35reg2940, Nil);
+Obj _35reg2942 = primCons(exp, _35reg2941);
+Obj _35reg2943 = primCons(intern("call"), _35reg2942);
+co->nargs = 2;
+co->args[1] = _35reg2943;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2996(struct Cora* co) {
-Obj _35cc1301 = makeNative(_35clofun2997, 0, 0);
-Obj _35reg2120 = primIsCons(closureRef(co, 0));
-if (True == _35reg2120) {
-Obj _35reg2121 = primCar(closureRef(co, 0));
-Obj hd = _35reg2121;
-Obj _35reg2122 = primCdr(closureRef(co, 0));
-Obj tl = _35reg2122;
+void _35clofun3799(struct Cora* co) {
+Obj _35cc2103 = makeNative(_35clofun3800, 0, 0);
+Obj _35reg2922 = primIsCons(closureRef(co, 0));
+if (True == _35reg2922) {
+Obj _35reg2923 = primCar(closureRef(co, 0));
+Obj hd = _35reg2923;
+Obj _35reg2924 = primCdr(closureRef(co, 0));
+Obj tl = _35reg2924;
 Obj ls = closureRef(co, 1);
 Obj next = closureRef(co, 2);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = hd;
-co->args[2] = makeNative(_35clofun2998, 1, 3, tl, ls, next);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun3801, 1, 3, tl, ls, next);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6882,8 +6948,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1301;
 co->nargs = 1;
+co->args[0] = _35cc2103;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6894,14 +6960,14 @@ return;
 }
 }
 
-void _35clofun2998(struct Cora* co) {
+void _35clofun3801(struct Cora* co) {
 Obj hd1 = co->args[1];
-Obj _35reg2123 = primCons(hd1, closureRef(co, 1));
+Obj _35reg2925 = primCons(hd1, closureRef(co, 1));
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify-list"));
 co->args[1] = closureRef(co, 0);
-co->args[2] = _35reg2123;
+co->args[2] = _35reg2925;
 co->args[3] = closureRef(co, 2);
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6911,10 +6977,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2997(struct Cora* co) {
+void _35clofun3800(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6924,18 +6990,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2977(struct Cora* co) {
-Obj _35p1288 = co->args[1];
-Obj _35p1289 = co->args[2];
-Obj _35cc1290 = makeNative(_35clofun2978, 0, 2, _35p1288, _35p1289);
-Obj x = _35p1288;
-Obj next = _35p1289;
-Obj _35reg2117 = primIsSymbol(x);
-if (True == _35reg2117) {
+void _35clofun3780(struct Cora* co) {
+Obj _35p2090 = co->args[1];
+Obj _35p2091 = co->args[2];
+Obj _35cc2092 = makeNative(_35clofun3781, 0, 2, _35p2090, _35p2091);
+Obj x = _35p2090;
+Obj next = _35p2091;
+Obj _35reg2919 = primIsSymbol(x);
+if (True == _35reg2919) {
 if (True == True) {
+co->nargs = 2;
 co->args[0] = next;
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6944,8 +7010,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1290;
 co->nargs = 1;
+co->args[0] = _35cc2092;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6955,10 +7021,10 @@ co->pc = coraCall;
 return;
 }
 } else {
-pushCont(co, _35clofun2994, 3, next, x, _35cc1290);
+pushCont(co, _35clofun3797, 3, next, x, _35cc2092);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.convert-protect?"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6969,16 +7035,16 @@ return;
 }
 }
 
-void _35clofun2994(struct Cora* co) {
-Obj _35val2118 = co->args[1];
+void _35clofun3797(struct Cora* co) {
+Obj _35val2920 = co->args[1];
 Obj next = co->stack[co->base + 0];
 Obj x = co->stack[co->base + 1];
-Obj _35cc1290 = co->stack[co->base + 2];
-if (True == _35val2118) {
+Obj _35cc2092 = co->stack[co->base + 2];
+if (True == _35val2920) {
 if (True == True) {
+co->nargs = 2;
 co->args[0] = next;
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6987,8 +7053,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1290;
 co->nargs = 1;
+co->args[0] = _35cc2092;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -6999,9 +7065,9 @@ return;
 }
 } else {
 if (True == False) {
+co->nargs = 2;
 co->args[0] = next;
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7010,8 +7076,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1290;
 co->nargs = 1;
+co->args[0] = _35cc2092;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7023,14 +7089,14 @@ return;
 }
 }
 
-void _35clofun2978(struct Cora* co) {
-Obj _35cc1291 = makeNative(_35clofun2979, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3781(struct Cora* co) {
+Obj _35cc2093 = makeNative(_35clofun3782, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj x = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
-pushCont(co, _35clofun2993, 2, x, _35cc1291);
+pushCont(co, _35clofun3796, 2, x, _35cc2093);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.convert-protect?"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7040,17 +7106,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2993(struct Cora* co) {
-Obj _35val2116 = co->args[1];
+void _35clofun3796(struct Cora* co) {
+Obj _35val2918 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35cc1291 = co->stack[co->base + 1];
-if (True == _35val2116) {
+Obj _35cc2093 = co->stack[co->base + 1];
+if (True == _35val2918) {
+co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1291;
 co->nargs = 1;
+co->args[0] = _35cc2093;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7061,48 +7128,48 @@ return;
 }
 }
 
-void _35clofun2979(struct Cora* co) {
-Obj _35cc1292 = makeNative(_35clofun2980, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2084 = primIsCons(closureRef(co, 0));
-if (True == _35reg2084) {
-Obj _35reg2085 = primCar(closureRef(co, 0));
-Obj _35reg2086 = primEQ(intern("if"), _35reg2085);
-if (True == _35reg2086) {
-Obj _35reg2087 = primCdr(closureRef(co, 0));
-Obj _35reg2088 = primIsCons(_35reg2087);
-if (True == _35reg2088) {
-Obj _35reg2089 = primCdr(closureRef(co, 0));
-Obj _35reg2090 = primCar(_35reg2089);
-Obj a = _35reg2090;
-Obj _35reg2091 = primCdr(closureRef(co, 0));
-Obj _35reg2092 = primCdr(_35reg2091);
-Obj _35reg2093 = primIsCons(_35reg2092);
-if (True == _35reg2093) {
-Obj _35reg2094 = primCdr(closureRef(co, 0));
-Obj _35reg2095 = primCdr(_35reg2094);
-Obj _35reg2096 = primCar(_35reg2095);
-Obj b = _35reg2096;
-Obj _35reg2097 = primCdr(closureRef(co, 0));
-Obj _35reg2098 = primCdr(_35reg2097);
-Obj _35reg2099 = primCdr(_35reg2098);
-Obj _35reg2100 = primIsCons(_35reg2099);
-if (True == _35reg2100) {
-Obj _35reg2101 = primCdr(closureRef(co, 0));
-Obj _35reg2102 = primCdr(_35reg2101);
-Obj _35reg2103 = primCdr(_35reg2102);
-Obj _35reg2104 = primCar(_35reg2103);
-Obj c = _35reg2104;
-Obj _35reg2105 = primCdr(closureRef(co, 0));
-Obj _35reg2106 = primCdr(_35reg2105);
-Obj _35reg2107 = primCdr(_35reg2106);
-Obj _35reg2108 = primCdr(_35reg2107);
-Obj _35reg2109 = primEQ(Nil, _35reg2108);
-if (True == _35reg2109) {
+void _35clofun3782(struct Cora* co) {
+Obj _35cc2094 = makeNative(_35clofun3783, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2886 = primIsCons(closureRef(co, 0));
+if (True == _35reg2886) {
+Obj _35reg2887 = primCar(closureRef(co, 0));
+Obj _35reg2888 = primEQ(intern("if"), _35reg2887);
+if (True == _35reg2888) {
+Obj _35reg2889 = primCdr(closureRef(co, 0));
+Obj _35reg2890 = primIsCons(_35reg2889);
+if (True == _35reg2890) {
+Obj _35reg2891 = primCdr(closureRef(co, 0));
+Obj _35reg2892 = primCar(_35reg2891);
+Obj a = _35reg2892;
+Obj _35reg2893 = primCdr(closureRef(co, 0));
+Obj _35reg2894 = primCdr(_35reg2893);
+Obj _35reg2895 = primIsCons(_35reg2894);
+if (True == _35reg2895) {
+Obj _35reg2896 = primCdr(closureRef(co, 0));
+Obj _35reg2897 = primCdr(_35reg2896);
+Obj _35reg2898 = primCar(_35reg2897);
+Obj b = _35reg2898;
+Obj _35reg2899 = primCdr(closureRef(co, 0));
+Obj _35reg2900 = primCdr(_35reg2899);
+Obj _35reg2901 = primCdr(_35reg2900);
+Obj _35reg2902 = primIsCons(_35reg2901);
+if (True == _35reg2902) {
+Obj _35reg2903 = primCdr(closureRef(co, 0));
+Obj _35reg2904 = primCdr(_35reg2903);
+Obj _35reg2905 = primCdr(_35reg2904);
+Obj _35reg2906 = primCar(_35reg2905);
+Obj c = _35reg2906;
+Obj _35reg2907 = primCdr(closureRef(co, 0));
+Obj _35reg2908 = primCdr(_35reg2907);
+Obj _35reg2909 = primCdr(_35reg2908);
+Obj _35reg2910 = primCdr(_35reg2909);
+Obj _35reg2911 = primEQ(Nil, _35reg2910);
+if (True == _35reg2911) {
 Obj next = closureRef(co, 1);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = a;
-co->args[2] = makeNative(_35clofun2990, 1, 3, b, c, next);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun3793, 1, 3, b, c, next);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7111,8 +7178,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1292;
 co->nargs = 1;
+co->args[0] = _35cc2094;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7122,8 +7189,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1292;
 co->nargs = 1;
+co->args[0] = _35cc2094;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7133,8 +7200,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1292;
 co->nargs = 1;
+co->args[0] = _35cc2094;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7144,8 +7211,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1292;
 co->nargs = 1;
+co->args[0] = _35cc2094;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7155,8 +7222,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1292;
 co->nargs = 1;
+co->args[0] = _35cc2094;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7166,8 +7233,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1292;
 co->nargs = 1;
+co->args[0] = _35cc2094;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7178,13 +7245,13 @@ return;
 }
 }
 
-void _35clofun2990(struct Cora* co) {
+void _35clofun3793(struct Cora* co) {
 Obj ra = co->args[1];
-pushCont(co, _35clofun2991, 1, ra);
+pushCont(co, _35clofun3794, 1, ra);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = closureRef(co, 0);
 co->args[2] = closureRef(co, 2);
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7194,14 +7261,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2991(struct Cora* co) {
-Obj _35val2110 = co->args[1];
+void _35clofun3794(struct Cora* co) {
+Obj _35val2912 = co->args[1];
 Obj ra = co->stack[co->base + 0];
-pushCont(co, _35clofun2992, 2, _35val2110, ra);
+pushCont(co, _35clofun3795, 2, _35val2912, ra);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = closureRef(co, 1);
 co->args[2] = closureRef(co, 2);
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7211,50 +7278,51 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2992(struct Cora* co) {
-Obj _35val2111 = co->args[1];
-Obj _35val2110 = co->stack[co->base + 0];
+void _35clofun3795(struct Cora* co) {
+Obj _35val2913 = co->args[1];
+Obj _35val2912 = co->stack[co->base + 0];
 Obj ra = co->stack[co->base + 1];
-Obj _35reg2112 = primCons(_35val2111, Nil);
-Obj _35reg2113 = primCons(_35val2110, _35reg2112);
-Obj _35reg2114 = primCons(ra, _35reg2113);
-Obj _35reg2115 = primCons(intern("if"), _35reg2114);
-co->args[1] = _35reg2115;
+Obj _35reg2914 = primCons(_35val2913, Nil);
+Obj _35reg2915 = primCons(_35val2912, _35reg2914);
+Obj _35reg2916 = primCons(ra, _35reg2915);
+Obj _35reg2917 = primCons(intern("if"), _35reg2916);
+co->nargs = 2;
+co->args[1] = _35reg2917;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2980(struct Cora* co) {
-Obj _35cc1293 = makeNative(_35clofun2981, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2062 = primIsCons(closureRef(co, 0));
-if (True == _35reg2062) {
-Obj _35reg2063 = primCar(closureRef(co, 0));
-Obj _35reg2064 = primEQ(intern("do"), _35reg2063);
-if (True == _35reg2064) {
-Obj _35reg2065 = primCdr(closureRef(co, 0));
-Obj _35reg2066 = primIsCons(_35reg2065);
-if (True == _35reg2066) {
-Obj _35reg2067 = primCdr(closureRef(co, 0));
-Obj _35reg2068 = primCar(_35reg2067);
-Obj a = _35reg2068;
-Obj _35reg2069 = primCdr(closureRef(co, 0));
-Obj _35reg2070 = primCdr(_35reg2069);
-Obj _35reg2071 = primIsCons(_35reg2070);
-if (True == _35reg2071) {
-Obj _35reg2072 = primCdr(closureRef(co, 0));
-Obj _35reg2073 = primCdr(_35reg2072);
-Obj _35reg2074 = primCar(_35reg2073);
-Obj b = _35reg2074;
-Obj _35reg2075 = primCdr(closureRef(co, 0));
-Obj _35reg2076 = primCdr(_35reg2075);
-Obj _35reg2077 = primCdr(_35reg2076);
-Obj _35reg2078 = primEQ(Nil, _35reg2077);
-if (True == _35reg2078) {
+void _35clofun3783(struct Cora* co) {
+Obj _35cc2095 = makeNative(_35clofun3784, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2864 = primIsCons(closureRef(co, 0));
+if (True == _35reg2864) {
+Obj _35reg2865 = primCar(closureRef(co, 0));
+Obj _35reg2866 = primEQ(intern("do"), _35reg2865);
+if (True == _35reg2866) {
+Obj _35reg2867 = primCdr(closureRef(co, 0));
+Obj _35reg2868 = primIsCons(_35reg2867);
+if (True == _35reg2868) {
+Obj _35reg2869 = primCdr(closureRef(co, 0));
+Obj _35reg2870 = primCar(_35reg2869);
+Obj a = _35reg2870;
+Obj _35reg2871 = primCdr(closureRef(co, 0));
+Obj _35reg2872 = primCdr(_35reg2871);
+Obj _35reg2873 = primIsCons(_35reg2872);
+if (True == _35reg2873) {
+Obj _35reg2874 = primCdr(closureRef(co, 0));
+Obj _35reg2875 = primCdr(_35reg2874);
+Obj _35reg2876 = primCar(_35reg2875);
+Obj b = _35reg2876;
+Obj _35reg2877 = primCdr(closureRef(co, 0));
+Obj _35reg2878 = primCdr(_35reg2877);
+Obj _35reg2879 = primCdr(_35reg2878);
+Obj _35reg2880 = primEQ(Nil, _35reg2879);
+if (True == _35reg2880) {
 Obj next = closureRef(co, 1);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = a;
-co->args[2] = makeNative(_35clofun2988, 1, 2, b, next);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun3791, 1, 2, b, next);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7263,8 +7331,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1293;
 co->nargs = 1;
+co->args[0] = _35cc2095;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7274,8 +7342,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1293;
 co->nargs = 1;
+co->args[0] = _35cc2095;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7285,8 +7353,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1293;
 co->nargs = 1;
+co->args[0] = _35cc2095;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7296,8 +7364,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1293;
 co->nargs = 1;
+co->args[0] = _35cc2095;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7307,8 +7375,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1293;
 co->nargs = 1;
+co->args[0] = _35cc2095;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7319,14 +7387,14 @@ return;
 }
 }
 
-void _35clofun2988(struct Cora* co) {
+void _35clofun3791(struct Cora* co) {
 Obj ra = co->args[1];
-Obj _35reg2079 = primIsSymbol(ra);
-if (True == _35reg2079) {
+Obj _35reg2881 = primIsSymbol(ra);
+if (True == _35reg2881) {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = closureRef(co, 0);
 co->args[2] = closureRef(co, 1);
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7335,11 +7403,11 @@ co->pc = coraCall;
 }
 return;
 } else {
-pushCont(co, _35clofun2989, 1, ra);
+pushCont(co, _35clofun3792, 1, ra);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = closureRef(co, 0);
 co->args[2] = closureRef(co, 1);
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7350,59 +7418,60 @@ return;
 }
 }
 
-void _35clofun2989(struct Cora* co) {
-Obj _35val2080 = co->args[1];
+void _35clofun3792(struct Cora* co) {
+Obj _35val2882 = co->args[1];
 Obj ra = co->stack[co->base + 0];
-Obj _35reg2081 = primCons(_35val2080, Nil);
-Obj _35reg2082 = primCons(ra, _35reg2081);
-Obj _35reg2083 = primCons(intern("do"), _35reg2082);
-co->args[1] = _35reg2083;
+Obj _35reg2883 = primCons(_35val2882, Nil);
+Obj _35reg2884 = primCons(ra, _35reg2883);
+Obj _35reg2885 = primCons(intern("do"), _35reg2884);
+co->nargs = 2;
+co->args[1] = _35reg2885;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2981(struct Cora* co) {
-Obj _35cc1294 = makeNative(_35clofun2982, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2031 = primIsCons(closureRef(co, 0));
-if (True == _35reg2031) {
-Obj _35reg2032 = primCar(closureRef(co, 0));
-Obj _35reg2033 = primEQ(intern("let"), _35reg2032);
-if (True == _35reg2033) {
-Obj _35reg2034 = primCdr(closureRef(co, 0));
-Obj _35reg2035 = primIsCons(_35reg2034);
-if (True == _35reg2035) {
-Obj _35reg2036 = primCdr(closureRef(co, 0));
-Obj _35reg2037 = primCar(_35reg2036);
-Obj a = _35reg2037;
-Obj _35reg2038 = primCdr(closureRef(co, 0));
-Obj _35reg2039 = primCdr(_35reg2038);
-Obj _35reg2040 = primIsCons(_35reg2039);
-if (True == _35reg2040) {
-Obj _35reg2041 = primCdr(closureRef(co, 0));
-Obj _35reg2042 = primCdr(_35reg2041);
-Obj _35reg2043 = primCar(_35reg2042);
-Obj b = _35reg2043;
-Obj _35reg2044 = primCdr(closureRef(co, 0));
-Obj _35reg2045 = primCdr(_35reg2044);
-Obj _35reg2046 = primCdr(_35reg2045);
-Obj _35reg2047 = primIsCons(_35reg2046);
-if (True == _35reg2047) {
-Obj _35reg2048 = primCdr(closureRef(co, 0));
-Obj _35reg2049 = primCdr(_35reg2048);
-Obj _35reg2050 = primCdr(_35reg2049);
-Obj _35reg2051 = primCar(_35reg2050);
-Obj c = _35reg2051;
-Obj _35reg2052 = primCdr(closureRef(co, 0));
-Obj _35reg2053 = primCdr(_35reg2052);
-Obj _35reg2054 = primCdr(_35reg2053);
-Obj _35reg2055 = primCdr(_35reg2054);
-Obj _35reg2056 = primEQ(Nil, _35reg2055);
-if (True == _35reg2056) {
+void _35clofun3784(struct Cora* co) {
+Obj _35cc2096 = makeNative(_35clofun3785, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2833 = primIsCons(closureRef(co, 0));
+if (True == _35reg2833) {
+Obj _35reg2834 = primCar(closureRef(co, 0));
+Obj _35reg2835 = primEQ(intern("let"), _35reg2834);
+if (True == _35reg2835) {
+Obj _35reg2836 = primCdr(closureRef(co, 0));
+Obj _35reg2837 = primIsCons(_35reg2836);
+if (True == _35reg2837) {
+Obj _35reg2838 = primCdr(closureRef(co, 0));
+Obj _35reg2839 = primCar(_35reg2838);
+Obj a = _35reg2839;
+Obj _35reg2840 = primCdr(closureRef(co, 0));
+Obj _35reg2841 = primCdr(_35reg2840);
+Obj _35reg2842 = primIsCons(_35reg2841);
+if (True == _35reg2842) {
+Obj _35reg2843 = primCdr(closureRef(co, 0));
+Obj _35reg2844 = primCdr(_35reg2843);
+Obj _35reg2845 = primCar(_35reg2844);
+Obj b = _35reg2845;
+Obj _35reg2846 = primCdr(closureRef(co, 0));
+Obj _35reg2847 = primCdr(_35reg2846);
+Obj _35reg2848 = primCdr(_35reg2847);
+Obj _35reg2849 = primIsCons(_35reg2848);
+if (True == _35reg2849) {
+Obj _35reg2850 = primCdr(closureRef(co, 0));
+Obj _35reg2851 = primCdr(_35reg2850);
+Obj _35reg2852 = primCdr(_35reg2851);
+Obj _35reg2853 = primCar(_35reg2852);
+Obj c = _35reg2853;
+Obj _35reg2854 = primCdr(closureRef(co, 0));
+Obj _35reg2855 = primCdr(_35reg2854);
+Obj _35reg2856 = primCdr(_35reg2855);
+Obj _35reg2857 = primCdr(_35reg2856);
+Obj _35reg2858 = primEQ(Nil, _35reg2857);
+if (True == _35reg2858) {
 Obj next = closureRef(co, 1);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = b;
-co->args[2] = makeNative(_35clofun2986, 1, 3, a, c, next);
-co->nargs = 3;
+co->args[2] = makeNative(_35clofun3789, 1, 3, a, c, next);
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7411,8 +7480,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1294;
 co->nargs = 1;
+co->args[0] = _35cc2096;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7422,8 +7491,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1294;
 co->nargs = 1;
+co->args[0] = _35cc2096;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7433,8 +7502,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1294;
 co->nargs = 1;
+co->args[0] = _35cc2096;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7444,8 +7513,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1294;
 co->nargs = 1;
+co->args[0] = _35cc2096;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7455,8 +7524,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1294;
 co->nargs = 1;
+co->args[0] = _35cc2096;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7466,8 +7535,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1294;
 co->nargs = 1;
+co->args[0] = _35cc2096;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7478,13 +7547,13 @@ return;
 }
 }
 
-void _35clofun2986(struct Cora* co) {
+void _35clofun3789(struct Cora* co) {
 Obj rb = co->args[1];
-pushCont(co, _35clofun2987, 1, rb);
+pushCont(co, _35clofun3790, 1, rb);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = closureRef(co, 1);
 co->args[2] = closureRef(co, 2);
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7494,75 +7563,76 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2987(struct Cora* co) {
-Obj _35val2057 = co->args[1];
+void _35clofun3790(struct Cora* co) {
+Obj _35val2859 = co->args[1];
 Obj rb = co->stack[co->base + 0];
-Obj _35reg2058 = primCons(_35val2057, Nil);
-Obj _35reg2059 = primCons(rb, _35reg2058);
-Obj _35reg2060 = primCons(closureRef(co, 0), _35reg2059);
-Obj _35reg2061 = primCons(intern("let"), _35reg2060);
-co->args[1] = _35reg2061;
+Obj _35reg2860 = primCons(_35val2859, Nil);
+Obj _35reg2861 = primCons(rb, _35reg2860);
+Obj _35reg2862 = primCons(closureRef(co, 0), _35reg2861);
+Obj _35reg2863 = primCons(intern("let"), _35reg2862);
+co->nargs = 2;
+co->args[1] = _35reg2863;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2982(struct Cora* co) {
-Obj _35cc1295 = makeNative(_35clofun2983, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1987 = primIsCons(closureRef(co, 0));
-if (True == _35reg1987) {
-Obj _35reg1988 = primCar(closureRef(co, 0));
-Obj _35reg1989 = primEQ(intern("%closure"), _35reg1988);
-if (True == _35reg1989) {
-Obj _35reg1990 = primCdr(closureRef(co, 0));
-Obj _35reg1991 = primIsCons(_35reg1990);
-if (True == _35reg1991) {
-Obj _35reg1992 = primCdr(closureRef(co, 0));
-Obj _35reg1993 = primCar(_35reg1992);
-Obj _35reg1994 = primIsCons(_35reg1993);
-if (True == _35reg1994) {
-Obj _35reg1995 = primCdr(closureRef(co, 0));
-Obj _35reg1996 = primCar(_35reg1995);
-Obj _35reg1997 = primCar(_35reg1996);
-Obj _35reg1998 = primEQ(intern("lambda"), _35reg1997);
-if (True == _35reg1998) {
-Obj _35reg1999 = primCdr(closureRef(co, 0));
-Obj _35reg2000 = primCar(_35reg1999);
-Obj _35reg2001 = primCdr(_35reg2000);
-Obj _35reg2002 = primIsCons(_35reg2001);
-if (True == _35reg2002) {
-Obj _35reg2003 = primCdr(closureRef(co, 0));
-Obj _35reg2004 = primCar(_35reg2003);
-Obj _35reg2005 = primCdr(_35reg2004);
-Obj _35reg2006 = primCar(_35reg2005);
-Obj args = _35reg2006;
-Obj _35reg2007 = primCdr(closureRef(co, 0));
-Obj _35reg2008 = primCar(_35reg2007);
-Obj _35reg2009 = primCdr(_35reg2008);
-Obj _35reg2010 = primCdr(_35reg2009);
-Obj _35reg2011 = primIsCons(_35reg2010);
-if (True == _35reg2011) {
-Obj _35reg2012 = primCdr(closureRef(co, 0));
-Obj _35reg2013 = primCar(_35reg2012);
-Obj _35reg2014 = primCdr(_35reg2013);
-Obj _35reg2015 = primCdr(_35reg2014);
-Obj _35reg2016 = primCar(_35reg2015);
-Obj body = _35reg2016;
-Obj _35reg2017 = primCdr(closureRef(co, 0));
-Obj _35reg2018 = primCar(_35reg2017);
-Obj _35reg2019 = primCdr(_35reg2018);
-Obj _35reg2020 = primCdr(_35reg2019);
-Obj _35reg2021 = primCdr(_35reg2020);
-Obj _35reg2022 = primEQ(Nil, _35reg2021);
-if (True == _35reg2022) {
-Obj _35reg2023 = primCdr(closureRef(co, 0));
-Obj _35reg2024 = primCdr(_35reg2023);
-Obj frees = _35reg2024;
+void _35clofun3785(struct Cora* co) {
+Obj _35cc2097 = makeNative(_35clofun3786, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2789 = primIsCons(closureRef(co, 0));
+if (True == _35reg2789) {
+Obj _35reg2790 = primCar(closureRef(co, 0));
+Obj _35reg2791 = primEQ(intern("%closure"), _35reg2790);
+if (True == _35reg2791) {
+Obj _35reg2792 = primCdr(closureRef(co, 0));
+Obj _35reg2793 = primIsCons(_35reg2792);
+if (True == _35reg2793) {
+Obj _35reg2794 = primCdr(closureRef(co, 0));
+Obj _35reg2795 = primCar(_35reg2794);
+Obj _35reg2796 = primIsCons(_35reg2795);
+if (True == _35reg2796) {
+Obj _35reg2797 = primCdr(closureRef(co, 0));
+Obj _35reg2798 = primCar(_35reg2797);
+Obj _35reg2799 = primCar(_35reg2798);
+Obj _35reg2800 = primEQ(intern("lambda"), _35reg2799);
+if (True == _35reg2800) {
+Obj _35reg2801 = primCdr(closureRef(co, 0));
+Obj _35reg2802 = primCar(_35reg2801);
+Obj _35reg2803 = primCdr(_35reg2802);
+Obj _35reg2804 = primIsCons(_35reg2803);
+if (True == _35reg2804) {
+Obj _35reg2805 = primCdr(closureRef(co, 0));
+Obj _35reg2806 = primCar(_35reg2805);
+Obj _35reg2807 = primCdr(_35reg2806);
+Obj _35reg2808 = primCar(_35reg2807);
+Obj args = _35reg2808;
+Obj _35reg2809 = primCdr(closureRef(co, 0));
+Obj _35reg2810 = primCar(_35reg2809);
+Obj _35reg2811 = primCdr(_35reg2810);
+Obj _35reg2812 = primCdr(_35reg2811);
+Obj _35reg2813 = primIsCons(_35reg2812);
+if (True == _35reg2813) {
+Obj _35reg2814 = primCdr(closureRef(co, 0));
+Obj _35reg2815 = primCar(_35reg2814);
+Obj _35reg2816 = primCdr(_35reg2815);
+Obj _35reg2817 = primCdr(_35reg2816);
+Obj _35reg2818 = primCar(_35reg2817);
+Obj body = _35reg2818;
+Obj _35reg2819 = primCdr(closureRef(co, 0));
+Obj _35reg2820 = primCar(_35reg2819);
+Obj _35reg2821 = primCdr(_35reg2820);
+Obj _35reg2822 = primCdr(_35reg2821);
+Obj _35reg2823 = primCdr(_35reg2822);
+Obj _35reg2824 = primEQ(Nil, _35reg2823);
+if (True == _35reg2824) {
+Obj _35reg2825 = primCdr(closureRef(co, 0));
+Obj _35reg2826 = primCdr(_35reg2825);
+Obj frees = _35reg2826;
 Obj next = closureRef(co, 1);
-pushCont(co, _35clofun2985, 3, args, frees, next);
+pushCont(co, _35clofun3788, 3, args, frees, next);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify"));
 co->args[1] = body;
 co->args[2] = globalRef(intern("cora/lib/toc/include.id"));
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7571,8 +7641,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1295;
 co->nargs = 1;
+co->args[0] = _35cc2097;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7582,8 +7652,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1295;
 co->nargs = 1;
+co->args[0] = _35cc2097;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7593,8 +7663,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1295;
 co->nargs = 1;
+co->args[0] = _35cc2097;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7604,8 +7674,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1295;
 co->nargs = 1;
+co->args[0] = _35cc2097;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7615,8 +7685,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1295;
 co->nargs = 1;
+co->args[0] = _35cc2097;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7626,8 +7696,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1295;
 co->nargs = 1;
+co->args[0] = _35cc2097;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7637,8 +7707,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1295;
 co->nargs = 1;
+co->args[0] = _35cc2097;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7648,8 +7718,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1295;
 co->nargs = 1;
+co->args[0] = _35cc2097;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7660,19 +7730,19 @@ return;
 }
 }
 
-void _35clofun2985(struct Cora* co) {
-Obj _35val2025 = co->args[1];
+void _35clofun3788(struct Cora* co) {
+Obj _35val2827 = co->args[1];
 Obj args = co->stack[co->base + 0];
 Obj frees = co->stack[co->base + 1];
 Obj next = co->stack[co->base + 2];
-Obj _35reg2026 = primCons(_35val2025, Nil);
-Obj _35reg2027 = primCons(args, _35reg2026);
-Obj _35reg2028 = primCons(intern("lambda"), _35reg2027);
-Obj _35reg2029 = primCons(_35reg2028, frees);
-Obj _35reg2030 = primCons(intern("%closure"), _35reg2029);
-co->args[0] = next;
-co->args[1] = _35reg2030;
+Obj _35reg2828 = primCons(_35val2827, Nil);
+Obj _35reg2829 = primCons(args, _35reg2828);
+Obj _35reg2830 = primCons(intern("lambda"), _35reg2829);
+Obj _35reg2831 = primCons(_35reg2830, frees);
+Obj _35reg2832 = primCons(intern("%closure"), _35reg2831);
 co->nargs = 2;
+co->args[0] = next;
+co->args[1] = _35reg2832;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7682,21 +7752,21 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2983(struct Cora* co) {
-Obj _35cc1296 = makeNative(_35clofun2984, 0, 0);
-Obj _35reg1983 = primIsCons(closureRef(co, 0));
-if (True == _35reg1983) {
-Obj _35reg1984 = primCar(closureRef(co, 0));
-Obj f = _35reg1984;
-Obj _35reg1985 = primCdr(closureRef(co, 0));
-Obj args = _35reg1985;
+void _35clofun3786(struct Cora* co) {
+Obj _35cc2098 = makeNative(_35clofun3787, 0, 0);
+Obj _35reg2785 = primIsCons(closureRef(co, 0));
+if (True == _35reg2785) {
+Obj _35reg2786 = primCar(closureRef(co, 0));
+Obj f = _35reg2786;
+Obj _35reg2787 = primCdr(closureRef(co, 0));
+Obj args = _35reg2787;
 Obj next = closureRef(co, 1);
-Obj _35reg1986 = primCons(f, args);
+Obj _35reg2788 = primCons(f, args);
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.tailify-list"));
-co->args[1] = _35reg1986;
+co->args[1] = _35reg2788;
 co->args[2] = Nil;
 co->args[3] = next;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7705,8 +7775,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1296;
 co->nargs = 1;
+co->args[0] = _35cc2098;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7717,10 +7787,10 @@ return;
 }
 }
 
-void _35clofun2984(struct Cora* co) {
+void _35clofun3787(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7730,25 +7800,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2976(struct Cora* co) {
+void _35clofun3779(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg1980 = primCons(x, Nil);
-Obj _35reg1981 = primCons(intern("return"), _35reg1980);
-co->args[1] = _35reg1981;
+Obj _35reg2782 = primCons(x, Nil);
+Obj _35reg2783 = primCons(intern("return"), _35reg2782);
+co->nargs = 2;
+co->args[1] = _35reg2783;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2961(struct Cora* co) {
-Obj _35p1281 = co->args[1];
-Obj _35p1282 = co->args[2];
-Obj _35cc1283 = makeNative(_35clofun2962, 0, 2, _35p1281, _35p1282);
-Obj __ = _35p1281;
-Obj x = _35p1282;
-pushCont(co, _35clofun2975, 2, x, _35cc1283);
+void _35clofun3764(struct Cora* co) {
+Obj _35p2083 = co->args[1];
+Obj _35p2084 = co->args[2];
+Obj _35cc2085 = makeNative(_35clofun3765, 0, 2, _35p2083, _35p2084);
+Obj __ = _35p2083;
+Obj x = _35p2084;
+pushCont(co, _35clofun3778, 2, x, _35cc2085);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.convert-protect?"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7758,17 +7829,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2975(struct Cora* co) {
-Obj _35val1978 = co->args[1];
+void _35clofun3778(struct Cora* co) {
+Obj _35val2780 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35cc1283 = co->stack[co->base + 1];
-if (True == _35val1978) {
+Obj _35cc2085 = co->stack[co->base + 1];
+if (True == _35val2780) {
+co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1283;
 co->nargs = 1;
+co->args[0] = _35cc2085;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7779,17 +7851,17 @@ return;
 }
 }
 
-void _35clofun2962(struct Cora* co) {
-Obj _35cc1284 = makeNative(_35clofun2963, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3765(struct Cora* co) {
+Obj _35cc2086 = makeNative(_35clofun3766, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj _35reg1973 = primIsSymbol(var);
-if (True == _35reg1973) {
-pushCont(co, _35clofun2974, 1, var);
+Obj _35reg2775 = primIsSymbol(var);
+if (True == _35reg2775) {
+pushCont(co, _35clofun3777, 1, var);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.index"));
 co->args[1] = var;
 co->args[2] = fvs;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7798,8 +7870,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1284;
 co->nargs = 1;
+co->args[0] = _35cc2086;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7810,58 +7882,60 @@ return;
 }
 }
 
-void _35clofun2974(struct Cora* co) {
-Obj _35val1974 = co->args[1];
+void _35clofun3777(struct Cora* co) {
+Obj _35val2776 = co->args[1];
 Obj var = co->stack[co->base + 0];
-Obj pos = _35val1974;
-Obj _35reg1975 = primEQ(makeNumber(-1), pos);
-if (True == _35reg1975) {
+Obj pos = _35val2776;
+Obj _35reg2777 = primEQ(makeNumber(-1), pos);
+if (True == _35reg2777) {
+co->nargs = 2;
 co->args[1] = var;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg1976 = primCons(pos, Nil);
-Obj _35reg1977 = primCons(intern("%closure-ref"), _35reg1976);
-co->args[1] = _35reg1977;
+Obj _35reg2778 = primCons(pos, Nil);
+Obj _35reg2779 = primCons(intern("%closure-ref"), _35reg2778);
+co->nargs = 2;
+co->args[1] = _35reg2779;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun2963(struct Cora* co) {
-Obj _35cc1285 = makeNative(_35clofun2964, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3766(struct Cora* co) {
+Obj _35cc2087 = makeNative(_35clofun3767, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg1944 = primIsCons(closureRef(co, 1));
-if (True == _35reg1944) {
-Obj _35reg1945 = primCar(closureRef(co, 1));
-Obj _35reg1946 = primEQ(intern("lambda"), _35reg1945);
-if (True == _35reg1946) {
-Obj _35reg1947 = primCdr(closureRef(co, 1));
-Obj _35reg1948 = primIsCons(_35reg1947);
-if (True == _35reg1948) {
-Obj _35reg1949 = primCdr(closureRef(co, 1));
-Obj _35reg1950 = primCar(_35reg1949);
-Obj args = _35reg1950;
-Obj _35reg1951 = primCdr(closureRef(co, 1));
-Obj _35reg1952 = primCdr(_35reg1951);
-Obj _35reg1953 = primIsCons(_35reg1952);
-if (True == _35reg1953) {
-Obj _35reg1954 = primCdr(closureRef(co, 1));
-Obj _35reg1955 = primCdr(_35reg1954);
-Obj _35reg1956 = primCar(_35reg1955);
-Obj body = _35reg1956;
-Obj _35reg1957 = primCdr(closureRef(co, 1));
-Obj _35reg1958 = primCdr(_35reg1957);
-Obj _35reg1959 = primCdr(_35reg1958);
-Obj _35reg1960 = primEQ(Nil, _35reg1959);
-if (True == _35reg1960) {
-Obj _35reg1961 = primCons(body, Nil);
-Obj _35reg1962 = primCons(args, _35reg1961);
-Obj _35reg1963 = primCons(intern("lambda"), _35reg1962);
-pushCont(co, _35clofun2970, 3, body, args, fvs);
-co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
-co->args[1] = _35reg1963;
+Obj _35reg2746 = primIsCons(closureRef(co, 1));
+if (True == _35reg2746) {
+Obj _35reg2747 = primCar(closureRef(co, 1));
+Obj _35reg2748 = primEQ(intern("lambda"), _35reg2747);
+if (True == _35reg2748) {
+Obj _35reg2749 = primCdr(closureRef(co, 1));
+Obj _35reg2750 = primIsCons(_35reg2749);
+if (True == _35reg2750) {
+Obj _35reg2751 = primCdr(closureRef(co, 1));
+Obj _35reg2752 = primCar(_35reg2751);
+Obj args = _35reg2752;
+Obj _35reg2753 = primCdr(closureRef(co, 1));
+Obj _35reg2754 = primCdr(_35reg2753);
+Obj _35reg2755 = primIsCons(_35reg2754);
+if (True == _35reg2755) {
+Obj _35reg2756 = primCdr(closureRef(co, 1));
+Obj _35reg2757 = primCdr(_35reg2756);
+Obj _35reg2758 = primCar(_35reg2757);
+Obj body = _35reg2758;
+Obj _35reg2759 = primCdr(closureRef(co, 1));
+Obj _35reg2760 = primCdr(_35reg2759);
+Obj _35reg2761 = primCdr(_35reg2760);
+Obj _35reg2762 = primEQ(Nil, _35reg2761);
+if (True == _35reg2762) {
+Obj _35reg2763 = primCons(body, Nil);
+Obj _35reg2764 = primCons(args, _35reg2763);
+Obj _35reg2765 = primCons(intern("lambda"), _35reg2764);
+pushCont(co, _35clofun3773, 3, body, args, fvs);
 co->nargs = 2;
+co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
+co->args[1] = _35reg2765;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7870,8 +7944,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1285;
 co->nargs = 1;
+co->args[0] = _35cc2087;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7881,8 +7955,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1285;
 co->nargs = 1;
+co->args[0] = _35cc2087;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7892,8 +7966,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1285;
 co->nargs = 1;
+co->args[0] = _35cc2087;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7903,8 +7977,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1285;
 co->nargs = 1;
+co->args[0] = _35cc2087;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7914,8 +7988,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1285;
 co->nargs = 1;
+co->args[0] = _35cc2087;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7926,17 +8000,17 @@ return;
 }
 }
 
-void _35clofun2970(struct Cora* co) {
-Obj _35val1964 = co->args[1];
+void _35clofun3773(struct Cora* co) {
+Obj _35val2766 = co->args[1];
 Obj body = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj fvs = co->stack[co->base + 2];
-Obj fvs1 = _35val1964;
-pushCont(co, _35clofun2971, 3, args, fvs, fvs1);
+Obj fvs1 = _35val2766;
+pushCont(co, _35clofun3774, 3, args, fvs, fvs1);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert"));
 co->args[1] = fvs1;
 co->args[2] = body;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7946,18 +8020,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2971(struct Cora* co) {
-Obj _35val1965 = co->args[1];
+void _35clofun3774(struct Cora* co) {
+Obj _35val2767 = co->args[1];
 Obj args = co->stack[co->base + 0];
 Obj fvs = co->stack[co->base + 1];
 Obj fvs1 = co->stack[co->base + 2];
-Obj _35reg1966 = primCons(_35val1965, Nil);
-Obj _35reg1967 = primCons(args, _35reg1966);
-Obj _35reg1968 = primCons(intern("lambda"), _35reg1967);
-pushCont(co, _35clofun2972, 2, fvs1, _35reg1968);
+Obj _35reg2768 = primCons(_35val2767, Nil);
+Obj _35reg2769 = primCons(args, _35reg2768);
+Obj _35reg2770 = primCons(intern("lambda"), _35reg2769);
+pushCont(co, _35clofun3775, 2, fvs1, _35reg2770);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert"));
 co->args[1] = fvs;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7967,15 +8041,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2972(struct Cora* co) {
-Obj _35val1969 = co->args[1];
+void _35clofun3775(struct Cora* co) {
+Obj _35val2771 = co->args[1];
 Obj fvs1 = co->stack[co->base + 0];
-Obj _35reg1968 = co->stack[co->base + 1];
-pushCont(co, _35clofun2973, 1, _35reg1968);
-co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val1969;
-co->args[2] = fvs1;
+Obj _35reg2770 = co->stack[co->base + 1];
+pushCont(co, _35clofun3776, 1, _35reg2770);
 co->nargs = 3;
+co->args[0] = globalRef(intern("map"));
+co->args[1] = _35val2771;
+co->args[2] = fvs1;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -7985,59 +8059,60 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2973(struct Cora* co) {
-Obj _35val1970 = co->args[1];
-Obj _35reg1968 = co->stack[co->base + 0];
-Obj _35reg1971 = primCons(_35reg1968, _35val1970);
-Obj _35reg1972 = primCons(intern("%closure"), _35reg1971);
-co->args[1] = _35reg1972;
+void _35clofun3776(struct Cora* co) {
+Obj _35val2772 = co->args[1];
+Obj _35reg2770 = co->stack[co->base + 0];
+Obj _35reg2773 = primCons(_35reg2770, _35val2772);
+Obj _35reg2774 = primCons(intern("%closure"), _35reg2773);
+co->nargs = 2;
+co->args[1] = _35reg2774;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2964(struct Cora* co) {
-Obj _35cc1286 = makeNative(_35clofun2965, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3767(struct Cora* co) {
+Obj _35cc2088 = makeNative(_35clofun3768, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg1912 = primIsCons(closureRef(co, 1));
-if (True == _35reg1912) {
-Obj _35reg1913 = primCar(closureRef(co, 1));
-Obj _35reg1914 = primEQ(intern("let"), _35reg1913);
-if (True == _35reg1914) {
-Obj _35reg1915 = primCdr(closureRef(co, 1));
-Obj _35reg1916 = primIsCons(_35reg1915);
-if (True == _35reg1916) {
-Obj _35reg1917 = primCdr(closureRef(co, 1));
-Obj _35reg1918 = primCar(_35reg1917);
-Obj a = _35reg1918;
-Obj _35reg1919 = primCdr(closureRef(co, 1));
-Obj _35reg1920 = primCdr(_35reg1919);
-Obj _35reg1921 = primIsCons(_35reg1920);
-if (True == _35reg1921) {
-Obj _35reg1922 = primCdr(closureRef(co, 1));
-Obj _35reg1923 = primCdr(_35reg1922);
-Obj _35reg1924 = primCar(_35reg1923);
-Obj b = _35reg1924;
-Obj _35reg1925 = primCdr(closureRef(co, 1));
-Obj _35reg1926 = primCdr(_35reg1925);
-Obj _35reg1927 = primCdr(_35reg1926);
-Obj _35reg1928 = primIsCons(_35reg1927);
-if (True == _35reg1928) {
-Obj _35reg1929 = primCdr(closureRef(co, 1));
-Obj _35reg1930 = primCdr(_35reg1929);
-Obj _35reg1931 = primCdr(_35reg1930);
-Obj _35reg1932 = primCar(_35reg1931);
-Obj c = _35reg1932;
-Obj _35reg1933 = primCdr(closureRef(co, 1));
-Obj _35reg1934 = primCdr(_35reg1933);
-Obj _35reg1935 = primCdr(_35reg1934);
-Obj _35reg1936 = primCdr(_35reg1935);
-Obj _35reg1937 = primEQ(Nil, _35reg1936);
-if (True == _35reg1937) {
-pushCont(co, _35clofun2968, 3, fvs, c, a);
+Obj _35reg2714 = primIsCons(closureRef(co, 1));
+if (True == _35reg2714) {
+Obj _35reg2715 = primCar(closureRef(co, 1));
+Obj _35reg2716 = primEQ(intern("let"), _35reg2715);
+if (True == _35reg2716) {
+Obj _35reg2717 = primCdr(closureRef(co, 1));
+Obj _35reg2718 = primIsCons(_35reg2717);
+if (True == _35reg2718) {
+Obj _35reg2719 = primCdr(closureRef(co, 1));
+Obj _35reg2720 = primCar(_35reg2719);
+Obj a = _35reg2720;
+Obj _35reg2721 = primCdr(closureRef(co, 1));
+Obj _35reg2722 = primCdr(_35reg2721);
+Obj _35reg2723 = primIsCons(_35reg2722);
+if (True == _35reg2723) {
+Obj _35reg2724 = primCdr(closureRef(co, 1));
+Obj _35reg2725 = primCdr(_35reg2724);
+Obj _35reg2726 = primCar(_35reg2725);
+Obj b = _35reg2726;
+Obj _35reg2727 = primCdr(closureRef(co, 1));
+Obj _35reg2728 = primCdr(_35reg2727);
+Obj _35reg2729 = primCdr(_35reg2728);
+Obj _35reg2730 = primIsCons(_35reg2729);
+if (True == _35reg2730) {
+Obj _35reg2731 = primCdr(closureRef(co, 1));
+Obj _35reg2732 = primCdr(_35reg2731);
+Obj _35reg2733 = primCdr(_35reg2732);
+Obj _35reg2734 = primCar(_35reg2733);
+Obj c = _35reg2734;
+Obj _35reg2735 = primCdr(closureRef(co, 1));
+Obj _35reg2736 = primCdr(_35reg2735);
+Obj _35reg2737 = primCdr(_35reg2736);
+Obj _35reg2738 = primCdr(_35reg2737);
+Obj _35reg2739 = primEQ(Nil, _35reg2738);
+if (True == _35reg2739) {
+pushCont(co, _35clofun3771, 3, fvs, c, a);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert"));
 co->args[1] = fvs;
 co->args[2] = b;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8046,8 +8121,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1286;
 co->nargs = 1;
+co->args[0] = _35cc2088;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8057,8 +8132,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1286;
 co->nargs = 1;
+co->args[0] = _35cc2088;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8068,8 +8143,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1286;
 co->nargs = 1;
+co->args[0] = _35cc2088;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8079,8 +8154,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1286;
 co->nargs = 1;
+co->args[0] = _35cc2088;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8090,8 +8165,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1286;
 co->nargs = 1;
+co->args[0] = _35cc2088;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8101,8 +8176,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1286;
 co->nargs = 1;
+co->args[0] = _35cc2088;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8113,16 +8188,16 @@ return;
 }
 }
 
-void _35clofun2968(struct Cora* co) {
-Obj _35val1938 = co->args[1];
+void _35clofun3771(struct Cora* co) {
+Obj _35val2740 = co->args[1];
 Obj fvs = co->stack[co->base + 0];
 Obj c = co->stack[co->base + 1];
 Obj a = co->stack[co->base + 2];
-pushCont(co, _35clofun2969, 2, _35val1938, a);
+pushCont(co, _35clofun3772, 2, _35val2740, a);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert"));
 co->args[1] = fvs;
 co->args[2] = c;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8132,32 +8207,33 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2969(struct Cora* co) {
-Obj _35val1939 = co->args[1];
-Obj _35val1938 = co->stack[co->base + 0];
+void _35clofun3772(struct Cora* co) {
+Obj _35val2741 = co->args[1];
+Obj _35val2740 = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
-Obj _35reg1940 = primCons(_35val1939, Nil);
-Obj _35reg1941 = primCons(_35val1938, _35reg1940);
-Obj _35reg1942 = primCons(a, _35reg1941);
-Obj _35reg1943 = primCons(intern("let"), _35reg1942);
-co->args[1] = _35reg1943;
+Obj _35reg2742 = primCons(_35val2741, Nil);
+Obj _35reg2743 = primCons(_35val2740, _35reg2742);
+Obj _35reg2744 = primCons(a, _35reg2743);
+Obj _35reg2745 = primCons(intern("let"), _35reg2744);
+co->nargs = 2;
+co->args[1] = _35reg2745;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2965(struct Cora* co) {
-Obj _35cc1287 = makeNative(_35clofun2966, 0, 0);
+void _35clofun3768(struct Cora* co) {
+Obj _35cc2089 = makeNative(_35clofun3769, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj _35reg1907 = primIsCons(closureRef(co, 1));
-if (True == _35reg1907) {
-Obj _35reg1908 = primCar(closureRef(co, 1));
-Obj f = _35reg1908;
-Obj _35reg1909 = primCdr(closureRef(co, 1));
-Obj args = _35reg1909;
-pushCont(co, _35clofun2967, 2, f, args);
+Obj _35reg2709 = primIsCons(closureRef(co, 1));
+if (True == _35reg2709) {
+Obj _35reg2710 = primCar(closureRef(co, 1));
+Obj f = _35reg2710;
+Obj _35reg2711 = primCdr(closureRef(co, 1));
+Obj args = _35reg2711;
+pushCont(co, _35clofun3770, 2, f, args);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.closure-convert"));
 co->args[1] = fvs;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8166,8 +8242,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1287;
 co->nargs = 1;
+co->args[0] = _35cc2089;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8178,15 +8254,15 @@ return;
 }
 }
 
-void _35clofun2967(struct Cora* co) {
-Obj _35val1910 = co->args[1];
+void _35clofun3770(struct Cora* co) {
+Obj _35val2712 = co->args[1];
 Obj f = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
-Obj _35reg1911 = primCons(f, args);
-co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val1910;
-co->args[2] = _35reg1911;
+Obj _35reg2713 = primCons(f, args);
 co->nargs = 3;
+co->args[0] = globalRef(intern("map"));
+co->args[1] = _35val2712;
+co->args[2] = _35reg2713;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8196,10 +8272,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2966(struct Cora* co) {
+void _35clofun3769(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8209,14 +8285,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2938(struct Cora* co) {
-Obj _35p1268 = co->args[1];
-Obj _35cc1269 = makeNative(_35clofun2939, 0, 1, _35p1268);
-Obj x = _35p1268;
-pushCont(co, _35clofun2960, 1, _35cc1269);
+void _35clofun3741(struct Cora* co) {
+Obj _35p2070 = co->args[1];
+Obj _35cc2071 = makeNative(_35clofun3742, 0, 1, _35p2070);
+Obj x = _35p2070;
+pushCont(co, _35clofun3763, 1, _35cc2071);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.convert-protect?"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8226,16 +8302,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2960(struct Cora* co) {
-Obj _35val1905 = co->args[1];
-Obj _35cc1269 = co->stack[co->base + 0];
-if (True == _35val1905) {
+void _35clofun3763(struct Cora* co) {
+Obj _35val2707 = co->args[1];
+Obj _35cc2071 = co->stack[co->base + 0];
+if (True == _35val2707) {
+co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1269;
 co->nargs = 1;
+co->args[0] = _35cc2071;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8246,18 +8323,19 @@ return;
 }
 }
 
-void _35clofun2939(struct Cora* co) {
-Obj _35cc1270 = makeNative(_35clofun2940, 0, 1, closureRef(co, 0));
+void _35clofun3742(struct Cora* co) {
+Obj _35cc2072 = makeNative(_35clofun3743, 0, 1, closureRef(co, 0));
 Obj x = closureRef(co, 0);
-Obj _35reg1903 = primIsSymbol(x);
-if (True == _35reg1903) {
-Obj _35reg1904 = primCons(x, Nil);
-co->args[1] = _35reg1904;
+Obj _35reg2705 = primIsSymbol(x);
+if (True == _35reg2705) {
+Obj _35reg2706 = primCons(x, Nil);
+co->nargs = 2;
+co->args[1] = _35reg2706;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1270;
 co->nargs = 1;
+co->args[0] = _35cc2072;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8268,36 +8346,36 @@ return;
 }
 }
 
-void _35clofun2940(struct Cora* co) {
-Obj _35cc1271 = makeNative(_35clofun2941, 0, 1, closureRef(co, 0));
-Obj _35reg1885 = primIsCons(closureRef(co, 0));
-if (True == _35reg1885) {
-Obj _35reg1886 = primCar(closureRef(co, 0));
-Obj _35reg1887 = primEQ(intern("lambda"), _35reg1886);
-if (True == _35reg1887) {
-Obj _35reg1888 = primCdr(closureRef(co, 0));
-Obj _35reg1889 = primIsCons(_35reg1888);
-if (True == _35reg1889) {
-Obj _35reg1890 = primCdr(closureRef(co, 0));
-Obj _35reg1891 = primCar(_35reg1890);
-Obj args = _35reg1891;
-Obj _35reg1892 = primCdr(closureRef(co, 0));
-Obj _35reg1893 = primCdr(_35reg1892);
-Obj _35reg1894 = primIsCons(_35reg1893);
-if (True == _35reg1894) {
-Obj _35reg1895 = primCdr(closureRef(co, 0));
-Obj _35reg1896 = primCdr(_35reg1895);
-Obj _35reg1897 = primCar(_35reg1896);
-Obj body = _35reg1897;
-Obj _35reg1898 = primCdr(closureRef(co, 0));
-Obj _35reg1899 = primCdr(_35reg1898);
-Obj _35reg1900 = primCdr(_35reg1899);
-Obj _35reg1901 = primEQ(Nil, _35reg1900);
-if (True == _35reg1901) {
-pushCont(co, _35clofun2959, 1, args);
+void _35clofun3743(struct Cora* co) {
+Obj _35cc2073 = makeNative(_35clofun3744, 0, 1, closureRef(co, 0));
+Obj _35reg2687 = primIsCons(closureRef(co, 0));
+if (True == _35reg2687) {
+Obj _35reg2688 = primCar(closureRef(co, 0));
+Obj _35reg2689 = primEQ(intern("lambda"), _35reg2688);
+if (True == _35reg2689) {
+Obj _35reg2690 = primCdr(closureRef(co, 0));
+Obj _35reg2691 = primIsCons(_35reg2690);
+if (True == _35reg2691) {
+Obj _35reg2692 = primCdr(closureRef(co, 0));
+Obj _35reg2693 = primCar(_35reg2692);
+Obj args = _35reg2693;
+Obj _35reg2694 = primCdr(closureRef(co, 0));
+Obj _35reg2695 = primCdr(_35reg2694);
+Obj _35reg2696 = primIsCons(_35reg2695);
+if (True == _35reg2696) {
+Obj _35reg2697 = primCdr(closureRef(co, 0));
+Obj _35reg2698 = primCdr(_35reg2697);
+Obj _35reg2699 = primCar(_35reg2698);
+Obj body = _35reg2699;
+Obj _35reg2700 = primCdr(closureRef(co, 0));
+Obj _35reg2701 = primCdr(_35reg2700);
+Obj _35reg2702 = primCdr(_35reg2701);
+Obj _35reg2703 = primEQ(Nil, _35reg2702);
+if (True == _35reg2703) {
+pushCont(co, _35clofun3762, 1, args);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = body;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8306,8 +8384,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1271;
 co->nargs = 1;
+co->args[0] = _35cc2073;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8317,8 +8395,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1271;
 co->nargs = 1;
+co->args[0] = _35cc2073;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8328,8 +8406,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1271;
 co->nargs = 1;
+co->args[0] = _35cc2073;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8339,8 +8417,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1271;
 co->nargs = 1;
+co->args[0] = _35cc2073;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8350,8 +8428,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1271;
 co->nargs = 1;
+co->args[0] = _35cc2073;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8362,13 +8440,13 @@ return;
 }
 }
 
-void _35clofun2959(struct Cora* co) {
-Obj _35val1902 = co->args[1];
+void _35clofun3762(struct Cora* co) {
+Obj _35val2704 = co->args[1];
 Obj args = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
-co->args[1] = _35val1902;
+co->args[1] = _35val2704;
 co->args[2] = args;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8378,51 +8456,51 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2941(struct Cora* co) {
-Obj _35cc1272 = makeNative(_35clofun2942, 0, 1, closureRef(co, 0));
-Obj _35reg1855 = primIsCons(closureRef(co, 0));
-if (True == _35reg1855) {
-Obj _35reg1856 = primCar(closureRef(co, 0));
-Obj _35reg1857 = primEQ(intern("if"), _35reg1856);
-if (True == _35reg1857) {
-Obj _35reg1858 = primCdr(closureRef(co, 0));
-Obj _35reg1859 = primIsCons(_35reg1858);
-if (True == _35reg1859) {
-Obj _35reg1860 = primCdr(closureRef(co, 0));
-Obj _35reg1861 = primCar(_35reg1860);
-Obj x = _35reg1861;
-Obj _35reg1862 = primCdr(closureRef(co, 0));
-Obj _35reg1863 = primCdr(_35reg1862);
-Obj _35reg1864 = primIsCons(_35reg1863);
-if (True == _35reg1864) {
-Obj _35reg1865 = primCdr(closureRef(co, 0));
-Obj _35reg1866 = primCdr(_35reg1865);
-Obj _35reg1867 = primCar(_35reg1866);
-Obj y = _35reg1867;
-Obj _35reg1868 = primCdr(closureRef(co, 0));
-Obj _35reg1869 = primCdr(_35reg1868);
-Obj _35reg1870 = primCdr(_35reg1869);
-Obj _35reg1871 = primIsCons(_35reg1870);
-if (True == _35reg1871) {
-Obj _35reg1872 = primCdr(closureRef(co, 0));
-Obj _35reg1873 = primCdr(_35reg1872);
-Obj _35reg1874 = primCdr(_35reg1873);
-Obj _35reg1875 = primCar(_35reg1874);
-Obj z = _35reg1875;
-Obj _35reg1876 = primCdr(closureRef(co, 0));
-Obj _35reg1877 = primCdr(_35reg1876);
-Obj _35reg1878 = primCdr(_35reg1877);
-Obj _35reg1879 = primCdr(_35reg1878);
-Obj _35reg1880 = primEQ(Nil, _35reg1879);
-if (True == _35reg1880) {
-Obj _35reg1881 = primCons(z, Nil);
-Obj _35reg1882 = primCons(y, _35reg1881);
-Obj _35reg1883 = primCons(x, _35reg1882);
-pushCont(co, _35clofun2958, 0);
+void _35clofun3744(struct Cora* co) {
+Obj _35cc2074 = makeNative(_35clofun3745, 0, 1, closureRef(co, 0));
+Obj _35reg2657 = primIsCons(closureRef(co, 0));
+if (True == _35reg2657) {
+Obj _35reg2658 = primCar(closureRef(co, 0));
+Obj _35reg2659 = primEQ(intern("if"), _35reg2658);
+if (True == _35reg2659) {
+Obj _35reg2660 = primCdr(closureRef(co, 0));
+Obj _35reg2661 = primIsCons(_35reg2660);
+if (True == _35reg2661) {
+Obj _35reg2662 = primCdr(closureRef(co, 0));
+Obj _35reg2663 = primCar(_35reg2662);
+Obj x = _35reg2663;
+Obj _35reg2664 = primCdr(closureRef(co, 0));
+Obj _35reg2665 = primCdr(_35reg2664);
+Obj _35reg2666 = primIsCons(_35reg2665);
+if (True == _35reg2666) {
+Obj _35reg2667 = primCdr(closureRef(co, 0));
+Obj _35reg2668 = primCdr(_35reg2667);
+Obj _35reg2669 = primCar(_35reg2668);
+Obj y = _35reg2669;
+Obj _35reg2670 = primCdr(closureRef(co, 0));
+Obj _35reg2671 = primCdr(_35reg2670);
+Obj _35reg2672 = primCdr(_35reg2671);
+Obj _35reg2673 = primIsCons(_35reg2672);
+if (True == _35reg2673) {
+Obj _35reg2674 = primCdr(closureRef(co, 0));
+Obj _35reg2675 = primCdr(_35reg2674);
+Obj _35reg2676 = primCdr(_35reg2675);
+Obj _35reg2677 = primCar(_35reg2676);
+Obj z = _35reg2677;
+Obj _35reg2678 = primCdr(closureRef(co, 0));
+Obj _35reg2679 = primCdr(_35reg2678);
+Obj _35reg2680 = primCdr(_35reg2679);
+Obj _35reg2681 = primCdr(_35reg2680);
+Obj _35reg2682 = primEQ(Nil, _35reg2681);
+if (True == _35reg2682) {
+Obj _35reg2683 = primCons(z, Nil);
+Obj _35reg2684 = primCons(y, _35reg2683);
+Obj _35reg2685 = primCons(x, _35reg2684);
+pushCont(co, _35clofun3761, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.free-vars"));
-co->args[2] = _35reg1883;
-co->nargs = 3;
+co->args[2] = _35reg2685;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8431,8 +8509,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1272;
 co->nargs = 1;
+co->args[0] = _35cc2074;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8442,8 +8520,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1272;
 co->nargs = 1;
+co->args[0] = _35cc2074;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8453,8 +8531,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1272;
 co->nargs = 1;
+co->args[0] = _35cc2074;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8464,8 +8542,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1272;
 co->nargs = 1;
+co->args[0] = _35cc2074;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8475,8 +8553,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1272;
 co->nargs = 1;
+co->args[0] = _35cc2074;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8486,8 +8564,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1272;
 co->nargs = 1;
+co->args[0] = _35cc2074;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8498,13 +8576,13 @@ return;
 }
 }
 
-void _35clofun2958(struct Cora* co) {
-Obj _35val1884 = co->args[1];
+void _35clofun3761(struct Cora* co) {
+Obj _35val2686 = co->args[1];
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.foldl"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.union"));
 co->args[2] = Nil;
-co->args[3] = _35val1884;
-co->nargs = 4;
+co->args[3] = _35val2686;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8514,39 +8592,39 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2942(struct Cora* co) {
-Obj _35cc1273 = makeNative(_35clofun2943, 0, 1, closureRef(co, 0));
-Obj _35reg1835 = primIsCons(closureRef(co, 0));
-if (True == _35reg1835) {
-Obj _35reg1836 = primCar(closureRef(co, 0));
-Obj _35reg1837 = primEQ(intern("do"), _35reg1836);
-if (True == _35reg1837) {
-Obj _35reg1838 = primCdr(closureRef(co, 0));
-Obj _35reg1839 = primIsCons(_35reg1838);
-if (True == _35reg1839) {
-Obj _35reg1840 = primCdr(closureRef(co, 0));
-Obj _35reg1841 = primCar(_35reg1840);
-Obj x = _35reg1841;
-Obj _35reg1842 = primCdr(closureRef(co, 0));
-Obj _35reg1843 = primCdr(_35reg1842);
-Obj _35reg1844 = primIsCons(_35reg1843);
-if (True == _35reg1844) {
-Obj _35reg1845 = primCdr(closureRef(co, 0));
-Obj _35reg1846 = primCdr(_35reg1845);
-Obj _35reg1847 = primCar(_35reg1846);
-Obj y = _35reg1847;
-Obj _35reg1848 = primCdr(closureRef(co, 0));
-Obj _35reg1849 = primCdr(_35reg1848);
-Obj _35reg1850 = primCdr(_35reg1849);
-Obj _35reg1851 = primEQ(Nil, _35reg1850);
-if (True == _35reg1851) {
-Obj _35reg1852 = primCons(y, Nil);
-Obj _35reg1853 = primCons(x, _35reg1852);
-pushCont(co, _35clofun2957, 0);
+void _35clofun3745(struct Cora* co) {
+Obj _35cc2075 = makeNative(_35clofun3746, 0, 1, closureRef(co, 0));
+Obj _35reg2637 = primIsCons(closureRef(co, 0));
+if (True == _35reg2637) {
+Obj _35reg2638 = primCar(closureRef(co, 0));
+Obj _35reg2639 = primEQ(intern("do"), _35reg2638);
+if (True == _35reg2639) {
+Obj _35reg2640 = primCdr(closureRef(co, 0));
+Obj _35reg2641 = primIsCons(_35reg2640);
+if (True == _35reg2641) {
+Obj _35reg2642 = primCdr(closureRef(co, 0));
+Obj _35reg2643 = primCar(_35reg2642);
+Obj x = _35reg2643;
+Obj _35reg2644 = primCdr(closureRef(co, 0));
+Obj _35reg2645 = primCdr(_35reg2644);
+Obj _35reg2646 = primIsCons(_35reg2645);
+if (True == _35reg2646) {
+Obj _35reg2647 = primCdr(closureRef(co, 0));
+Obj _35reg2648 = primCdr(_35reg2647);
+Obj _35reg2649 = primCar(_35reg2648);
+Obj y = _35reg2649;
+Obj _35reg2650 = primCdr(closureRef(co, 0));
+Obj _35reg2651 = primCdr(_35reg2650);
+Obj _35reg2652 = primCdr(_35reg2651);
+Obj _35reg2653 = primEQ(Nil, _35reg2652);
+if (True == _35reg2653) {
+Obj _35reg2654 = primCons(y, Nil);
+Obj _35reg2655 = primCons(x, _35reg2654);
+pushCont(co, _35clofun3760, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.free-vars"));
-co->args[2] = _35reg1853;
-co->nargs = 3;
+co->args[2] = _35reg2655;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8555,8 +8633,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1273;
 co->nargs = 1;
+co->args[0] = _35cc2075;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8566,8 +8644,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1273;
 co->nargs = 1;
+co->args[0] = _35cc2075;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8577,8 +8655,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1273;
 co->nargs = 1;
+co->args[0] = _35cc2075;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8588,8 +8666,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1273;
 co->nargs = 1;
+co->args[0] = _35cc2075;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8599,8 +8677,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1273;
 co->nargs = 1;
+co->args[0] = _35cc2075;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8611,13 +8689,13 @@ return;
 }
 }
 
-void _35clofun2957(struct Cora* co) {
-Obj _35val1854 = co->args[1];
+void _35clofun3760(struct Cora* co) {
+Obj _35val2656 = co->args[1];
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.foldl"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.union"));
 co->args[2] = Nil;
-co->args[3] = _35val1854;
-co->nargs = 4;
+co->args[3] = _35val2656;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8627,47 +8705,47 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2943(struct Cora* co) {
-Obj _35cc1274 = makeNative(_35clofun2944, 0, 1, closureRef(co, 0));
-Obj _35reg1805 = primIsCons(closureRef(co, 0));
-if (True == _35reg1805) {
-Obj _35reg1806 = primCar(closureRef(co, 0));
-Obj _35reg1807 = primEQ(intern("let"), _35reg1806);
-if (True == _35reg1807) {
-Obj _35reg1808 = primCdr(closureRef(co, 0));
-Obj _35reg1809 = primIsCons(_35reg1808);
-if (True == _35reg1809) {
-Obj _35reg1810 = primCdr(closureRef(co, 0));
-Obj _35reg1811 = primCar(_35reg1810);
-Obj a = _35reg1811;
-Obj _35reg1812 = primCdr(closureRef(co, 0));
-Obj _35reg1813 = primCdr(_35reg1812);
-Obj _35reg1814 = primIsCons(_35reg1813);
-if (True == _35reg1814) {
-Obj _35reg1815 = primCdr(closureRef(co, 0));
-Obj _35reg1816 = primCdr(_35reg1815);
-Obj _35reg1817 = primCar(_35reg1816);
-Obj b = _35reg1817;
-Obj _35reg1818 = primCdr(closureRef(co, 0));
-Obj _35reg1819 = primCdr(_35reg1818);
-Obj _35reg1820 = primCdr(_35reg1819);
-Obj _35reg1821 = primIsCons(_35reg1820);
-if (True == _35reg1821) {
-Obj _35reg1822 = primCdr(closureRef(co, 0));
-Obj _35reg1823 = primCdr(_35reg1822);
-Obj _35reg1824 = primCdr(_35reg1823);
-Obj _35reg1825 = primCar(_35reg1824);
-Obj c = _35reg1825;
-Obj _35reg1826 = primCdr(closureRef(co, 0));
-Obj _35reg1827 = primCdr(_35reg1826);
-Obj _35reg1828 = primCdr(_35reg1827);
-Obj _35reg1829 = primCdr(_35reg1828);
-Obj _35reg1830 = primEQ(Nil, _35reg1829);
-if (True == _35reg1830) {
-pushCont(co, _35clofun2954, 2, c, a);
+void _35clofun3746(struct Cora* co) {
+Obj _35cc2076 = makeNative(_35clofun3747, 0, 1, closureRef(co, 0));
+Obj _35reg2607 = primIsCons(closureRef(co, 0));
+if (True == _35reg2607) {
+Obj _35reg2608 = primCar(closureRef(co, 0));
+Obj _35reg2609 = primEQ(intern("let"), _35reg2608);
+if (True == _35reg2609) {
+Obj _35reg2610 = primCdr(closureRef(co, 0));
+Obj _35reg2611 = primIsCons(_35reg2610);
+if (True == _35reg2611) {
+Obj _35reg2612 = primCdr(closureRef(co, 0));
+Obj _35reg2613 = primCar(_35reg2612);
+Obj a = _35reg2613;
+Obj _35reg2614 = primCdr(closureRef(co, 0));
+Obj _35reg2615 = primCdr(_35reg2614);
+Obj _35reg2616 = primIsCons(_35reg2615);
+if (True == _35reg2616) {
+Obj _35reg2617 = primCdr(closureRef(co, 0));
+Obj _35reg2618 = primCdr(_35reg2617);
+Obj _35reg2619 = primCar(_35reg2618);
+Obj b = _35reg2619;
+Obj _35reg2620 = primCdr(closureRef(co, 0));
+Obj _35reg2621 = primCdr(_35reg2620);
+Obj _35reg2622 = primCdr(_35reg2621);
+Obj _35reg2623 = primIsCons(_35reg2622);
+if (True == _35reg2623) {
+Obj _35reg2624 = primCdr(closureRef(co, 0));
+Obj _35reg2625 = primCdr(_35reg2624);
+Obj _35reg2626 = primCdr(_35reg2625);
+Obj _35reg2627 = primCar(_35reg2626);
+Obj c = _35reg2627;
+Obj _35reg2628 = primCdr(closureRef(co, 0));
+Obj _35reg2629 = primCdr(_35reg2628);
+Obj _35reg2630 = primCdr(_35reg2629);
+Obj _35reg2631 = primCdr(_35reg2630);
+Obj _35reg2632 = primEQ(Nil, _35reg2631);
+if (True == _35reg2632) {
+pushCont(co, _35clofun3757, 2, c, a);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = b;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8676,8 +8754,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1274;
 co->nargs = 1;
+co->args[0] = _35cc2076;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8687,8 +8765,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1274;
 co->nargs = 1;
+co->args[0] = _35cc2076;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8698,8 +8776,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1274;
 co->nargs = 1;
+co->args[0] = _35cc2076;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8709,8 +8787,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1274;
 co->nargs = 1;
+co->args[0] = _35cc2076;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8720,8 +8798,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1274;
 co->nargs = 1;
+co->args[0] = _35cc2076;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8731,8 +8809,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1274;
 co->nargs = 1;
+co->args[0] = _35cc2076;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8743,14 +8821,14 @@ return;
 }
 }
 
-void _35clofun2954(struct Cora* co) {
-Obj _35val1831 = co->args[1];
+void _35clofun3757(struct Cora* co) {
+Obj _35val2633 = co->args[1];
 Obj c = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
-pushCont(co, _35clofun2955, 2, a, _35val1831);
+pushCont(co, _35clofun3758, 2, a, _35val2633);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = c;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8760,16 +8838,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2955(struct Cora* co) {
-Obj _35val1832 = co->args[1];
+void _35clofun3758(struct Cora* co) {
+Obj _35val2634 = co->args[1];
 Obj a = co->stack[co->base + 0];
-Obj _35val1831 = co->stack[co->base + 1];
-Obj _35reg1833 = primCons(a, Nil);
-pushCont(co, _35clofun2956, 1, _35val1831);
+Obj _35val2633 = co->stack[co->base + 1];
+Obj _35reg2635 = primCons(a, Nil);
+pushCont(co, _35clofun3759, 1, _35val2633);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
-co->args[1] = _35val1832;
-co->args[2] = _35reg1833;
-co->nargs = 3;
+co->args[1] = _35val2634;
+co->args[2] = _35reg2635;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8779,13 +8857,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2956(struct Cora* co) {
-Obj _35val1834 = co->args[1];
-Obj _35val1831 = co->stack[co->base + 0];
+void _35clofun3759(struct Cora* co) {
+Obj _35val2636 = co->args[1];
+Obj _35val2633 = co->stack[co->base + 0];
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.union"));
-co->args[1] = _35val1831;
-co->args[2] = _35val1834;
-co->nargs = 3;
+co->args[1] = _35val2633;
+co->args[2] = _35val2636;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8795,26 +8873,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2944(struct Cora* co) {
-Obj _35cc1275 = makeNative(_35clofun2945, 0, 1, closureRef(co, 0));
-Obj _35reg1795 = primIsCons(closureRef(co, 0));
-if (True == _35reg1795) {
-Obj _35reg1796 = primCar(closureRef(co, 0));
-Obj _35reg1797 = primEQ(intern("%closure"), _35reg1796);
-if (True == _35reg1797) {
-Obj _35reg1798 = primCdr(closureRef(co, 0));
-Obj _35reg1799 = primIsCons(_35reg1798);
-if (True == _35reg1799) {
-Obj _35reg1800 = primCdr(closureRef(co, 0));
-Obj _35reg1801 = primCar(_35reg1800);
-Obj lam = _35reg1801;
-Obj _35reg1802 = primCdr(closureRef(co, 0));
-Obj _35reg1803 = primCdr(_35reg1802);
-Obj more = _35reg1803;
-Obj _35reg1804 = primCons(lam, more);
-co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
-co->args[1] = _35reg1804;
+void _35clofun3747(struct Cora* co) {
+Obj _35cc2077 = makeNative(_35clofun3748, 0, 1, closureRef(co, 0));
+Obj _35reg2597 = primIsCons(closureRef(co, 0));
+if (True == _35reg2597) {
+Obj _35reg2598 = primCar(closureRef(co, 0));
+Obj _35reg2599 = primEQ(intern("%closure"), _35reg2598);
+if (True == _35reg2599) {
+Obj _35reg2600 = primCdr(closureRef(co, 0));
+Obj _35reg2601 = primIsCons(_35reg2600);
+if (True == _35reg2601) {
+Obj _35reg2602 = primCdr(closureRef(co, 0));
+Obj _35reg2603 = primCar(_35reg2602);
+Obj lam = _35reg2603;
+Obj _35reg2604 = primCdr(closureRef(co, 0));
+Obj _35reg2605 = primCdr(_35reg2604);
+Obj more = _35reg2605;
+Obj _35reg2606 = primCons(lam, more);
 co->nargs = 2;
+co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
+co->args[1] = _35reg2606;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8823,8 +8901,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1275;
 co->nargs = 1;
+co->args[0] = _35cc2077;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8834,8 +8912,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1275;
 co->nargs = 1;
+co->args[0] = _35cc2077;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8845,8 +8923,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1275;
 co->nargs = 1;
+co->args[0] = _35cc2077;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8857,26 +8935,26 @@ return;
 }
 }
 
-void _35clofun2945(struct Cora* co) {
-Obj _35cc1276 = makeNative(_35clofun2946, 0, 1, closureRef(co, 0));
-Obj _35reg1785 = primIsCons(closureRef(co, 0));
-if (True == _35reg1785) {
-Obj _35reg1786 = primCar(closureRef(co, 0));
-Obj _35reg1787 = primEQ(intern("return"), _35reg1786);
-if (True == _35reg1787) {
-Obj _35reg1788 = primCdr(closureRef(co, 0));
-Obj _35reg1789 = primIsCons(_35reg1788);
-if (True == _35reg1789) {
-Obj _35reg1790 = primCdr(closureRef(co, 0));
-Obj _35reg1791 = primCar(_35reg1790);
-Obj x = _35reg1791;
-Obj _35reg1792 = primCdr(closureRef(co, 0));
-Obj _35reg1793 = primCdr(_35reg1792);
-Obj _35reg1794 = primEQ(Nil, _35reg1793);
-if (True == _35reg1794) {
+void _35clofun3748(struct Cora* co) {
+Obj _35cc2078 = makeNative(_35clofun3749, 0, 1, closureRef(co, 0));
+Obj _35reg2587 = primIsCons(closureRef(co, 0));
+if (True == _35reg2587) {
+Obj _35reg2588 = primCar(closureRef(co, 0));
+Obj _35reg2589 = primEQ(intern("return"), _35reg2588);
+if (True == _35reg2589) {
+Obj _35reg2590 = primCdr(closureRef(co, 0));
+Obj _35reg2591 = primIsCons(_35reg2590);
+if (True == _35reg2591) {
+Obj _35reg2592 = primCdr(closureRef(co, 0));
+Obj _35reg2593 = primCar(_35reg2592);
+Obj x = _35reg2593;
+Obj _35reg2594 = primCdr(closureRef(co, 0));
+Obj _35reg2595 = primCdr(_35reg2594);
+Obj _35reg2596 = primEQ(Nil, _35reg2595);
+if (True == _35reg2596) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8885,8 +8963,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1276;
 co->nargs = 1;
+co->args[0] = _35cc2078;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8896,8 +8974,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1276;
 co->nargs = 1;
+co->args[0] = _35cc2078;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8907,8 +8985,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1276;
 co->nargs = 1;
+co->args[0] = _35cc2078;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8918,8 +8996,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1276;
 co->nargs = 1;
+co->args[0] = _35cc2078;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8930,39 +9008,39 @@ return;
 }
 }
 
-void _35clofun2946(struct Cora* co) {
-Obj _35cc1277 = makeNative(_35clofun2947, 0, 1, closureRef(co, 0));
-Obj _35reg1765 = primIsCons(closureRef(co, 0));
-if (True == _35reg1765) {
-Obj _35reg1766 = primCar(closureRef(co, 0));
-Obj _35reg1767 = primEQ(intern("call"), _35reg1766);
-if (True == _35reg1767) {
-Obj _35reg1768 = primCdr(closureRef(co, 0));
-Obj _35reg1769 = primIsCons(_35reg1768);
-if (True == _35reg1769) {
-Obj _35reg1770 = primCdr(closureRef(co, 0));
-Obj _35reg1771 = primCar(_35reg1770);
-Obj exp = _35reg1771;
-Obj _35reg1772 = primCdr(closureRef(co, 0));
-Obj _35reg1773 = primCdr(_35reg1772);
-Obj _35reg1774 = primIsCons(_35reg1773);
-if (True == _35reg1774) {
-Obj _35reg1775 = primCdr(closureRef(co, 0));
-Obj _35reg1776 = primCdr(_35reg1775);
-Obj _35reg1777 = primCar(_35reg1776);
-Obj cont = _35reg1777;
-Obj _35reg1778 = primCdr(closureRef(co, 0));
-Obj _35reg1779 = primCdr(_35reg1778);
-Obj _35reg1780 = primCdr(_35reg1779);
-Obj _35reg1781 = primEQ(Nil, _35reg1780);
-if (True == _35reg1781) {
-Obj _35reg1782 = primCons(cont, Nil);
-Obj _35reg1783 = primCons(exp, _35reg1782);
-pushCont(co, _35clofun2953, 0);
+void _35clofun3749(struct Cora* co) {
+Obj _35cc2079 = makeNative(_35clofun3750, 0, 1, closureRef(co, 0));
+Obj _35reg2567 = primIsCons(closureRef(co, 0));
+if (True == _35reg2567) {
+Obj _35reg2568 = primCar(closureRef(co, 0));
+Obj _35reg2569 = primEQ(intern("call"), _35reg2568);
+if (True == _35reg2569) {
+Obj _35reg2570 = primCdr(closureRef(co, 0));
+Obj _35reg2571 = primIsCons(_35reg2570);
+if (True == _35reg2571) {
+Obj _35reg2572 = primCdr(closureRef(co, 0));
+Obj _35reg2573 = primCar(_35reg2572);
+Obj exp = _35reg2573;
+Obj _35reg2574 = primCdr(closureRef(co, 0));
+Obj _35reg2575 = primCdr(_35reg2574);
+Obj _35reg2576 = primIsCons(_35reg2575);
+if (True == _35reg2576) {
+Obj _35reg2577 = primCdr(closureRef(co, 0));
+Obj _35reg2578 = primCdr(_35reg2577);
+Obj _35reg2579 = primCar(_35reg2578);
+Obj cont = _35reg2579;
+Obj _35reg2580 = primCdr(closureRef(co, 0));
+Obj _35reg2581 = primCdr(_35reg2580);
+Obj _35reg2582 = primCdr(_35reg2581);
+Obj _35reg2583 = primEQ(Nil, _35reg2582);
+if (True == _35reg2583) {
+Obj _35reg2584 = primCons(cont, Nil);
+Obj _35reg2585 = primCons(exp, _35reg2584);
+pushCont(co, _35clofun3756, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.free-vars"));
-co->args[2] = _35reg1783;
-co->nargs = 3;
+co->args[2] = _35reg2585;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8971,8 +9049,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1277;
 co->nargs = 1;
+co->args[0] = _35cc2079;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8982,8 +9060,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1277;
 co->nargs = 1;
+co->args[0] = _35cc2079;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -8993,8 +9071,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1277;
 co->nargs = 1;
+co->args[0] = _35cc2079;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9004,8 +9082,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1277;
 co->nargs = 1;
+co->args[0] = _35cc2079;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9015,8 +9093,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1277;
 co->nargs = 1;
+co->args[0] = _35cc2079;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9027,13 +9105,13 @@ return;
 }
 }
 
-void _35clofun2953(struct Cora* co) {
-Obj _35val1784 = co->args[1];
+void _35clofun3756(struct Cora* co) {
+Obj _35val2586 = co->args[1];
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.foldl"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.union"));
 co->args[2] = Nil;
-co->args[3] = _35val1784;
-co->nargs = 4;
+co->args[3] = _35val2586;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9043,26 +9121,26 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2947(struct Cora* co) {
-Obj _35cc1278 = makeNative(_35clofun2948, 0, 1, closureRef(co, 0));
-Obj _35reg1755 = primIsCons(closureRef(co, 0));
-if (True == _35reg1755) {
-Obj _35reg1756 = primCar(closureRef(co, 0));
-Obj _35reg1757 = primEQ(intern("tailcall"), _35reg1756);
-if (True == _35reg1757) {
-Obj _35reg1758 = primCdr(closureRef(co, 0));
-Obj _35reg1759 = primIsCons(_35reg1758);
-if (True == _35reg1759) {
-Obj _35reg1760 = primCdr(closureRef(co, 0));
-Obj _35reg1761 = primCar(_35reg1760);
-Obj exp = _35reg1761;
-Obj _35reg1762 = primCdr(closureRef(co, 0));
-Obj _35reg1763 = primCdr(_35reg1762);
-Obj _35reg1764 = primEQ(Nil, _35reg1763);
-if (True == _35reg1764) {
+void _35clofun3750(struct Cora* co) {
+Obj _35cc2080 = makeNative(_35clofun3751, 0, 1, closureRef(co, 0));
+Obj _35reg2557 = primIsCons(closureRef(co, 0));
+if (True == _35reg2557) {
+Obj _35reg2558 = primCar(closureRef(co, 0));
+Obj _35reg2559 = primEQ(intern("tailcall"), _35reg2558);
+if (True == _35reg2559) {
+Obj _35reg2560 = primCdr(closureRef(co, 0));
+Obj _35reg2561 = primIsCons(_35reg2560);
+if (True == _35reg2561) {
+Obj _35reg2562 = primCdr(closureRef(co, 0));
+Obj _35reg2563 = primCar(_35reg2562);
+Obj exp = _35reg2563;
+Obj _35reg2564 = primCdr(closureRef(co, 0));
+Obj _35reg2565 = primCdr(_35reg2564);
+Obj _35reg2566 = primEQ(Nil, _35reg2565);
+if (True == _35reg2566) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = exp;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9071,8 +9149,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1278;
 co->nargs = 1;
+co->args[0] = _35cc2080;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9082,8 +9160,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1278;
 co->nargs = 1;
+co->args[0] = _35cc2080;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9093,8 +9171,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1278;
 co->nargs = 1;
+co->args[0] = _35cc2080;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9104,8 +9182,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1278;
 co->nargs = 1;
+co->args[0] = _35cc2080;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9116,36 +9194,36 @@ return;
 }
 }
 
-void _35clofun2948(struct Cora* co) {
-Obj _35cc1279 = makeNative(_35clofun2949, 0, 1, closureRef(co, 0));
-Obj _35reg1737 = primIsCons(closureRef(co, 0));
-if (True == _35reg1737) {
-Obj _35reg1738 = primCar(closureRef(co, 0));
-Obj _35reg1739 = primEQ(intern("continuation"), _35reg1738);
-if (True == _35reg1739) {
-Obj _35reg1740 = primCdr(closureRef(co, 0));
-Obj _35reg1741 = primIsCons(_35reg1740);
-if (True == _35reg1741) {
-Obj _35reg1742 = primCdr(closureRef(co, 0));
-Obj _35reg1743 = primCar(_35reg1742);
-Obj arg = _35reg1743;
-Obj _35reg1744 = primCdr(closureRef(co, 0));
-Obj _35reg1745 = primCdr(_35reg1744);
-Obj _35reg1746 = primIsCons(_35reg1745);
-if (True == _35reg1746) {
-Obj _35reg1747 = primCdr(closureRef(co, 0));
-Obj _35reg1748 = primCdr(_35reg1747);
-Obj _35reg1749 = primCar(_35reg1748);
-Obj body = _35reg1749;
-Obj _35reg1750 = primCdr(closureRef(co, 0));
-Obj _35reg1751 = primCdr(_35reg1750);
-Obj _35reg1752 = primCdr(_35reg1751);
-Obj _35reg1753 = primEQ(Nil, _35reg1752);
-if (True == _35reg1753) {
-pushCont(co, _35clofun2952, 1, arg);
+void _35clofun3751(struct Cora* co) {
+Obj _35cc2081 = makeNative(_35clofun3752, 0, 1, closureRef(co, 0));
+Obj _35reg2539 = primIsCons(closureRef(co, 0));
+if (True == _35reg2539) {
+Obj _35reg2540 = primCar(closureRef(co, 0));
+Obj _35reg2541 = primEQ(intern("continuation"), _35reg2540);
+if (True == _35reg2541) {
+Obj _35reg2542 = primCdr(closureRef(co, 0));
+Obj _35reg2543 = primIsCons(_35reg2542);
+if (True == _35reg2543) {
+Obj _35reg2544 = primCdr(closureRef(co, 0));
+Obj _35reg2545 = primCar(_35reg2544);
+Obj arg = _35reg2545;
+Obj _35reg2546 = primCdr(closureRef(co, 0));
+Obj _35reg2547 = primCdr(_35reg2546);
+Obj _35reg2548 = primIsCons(_35reg2547);
+if (True == _35reg2548) {
+Obj _35reg2549 = primCdr(closureRef(co, 0));
+Obj _35reg2550 = primCdr(_35reg2549);
+Obj _35reg2551 = primCar(_35reg2550);
+Obj body = _35reg2551;
+Obj _35reg2552 = primCdr(closureRef(co, 0));
+Obj _35reg2553 = primCdr(_35reg2552);
+Obj _35reg2554 = primCdr(_35reg2553);
+Obj _35reg2555 = primEQ(Nil, _35reg2554);
+if (True == _35reg2555) {
+pushCont(co, _35clofun3755, 1, arg);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.free-vars"));
 co->args[1] = body;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9154,8 +9232,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1279;
 co->nargs = 1;
+co->args[0] = _35cc2081;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9165,8 +9243,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1279;
 co->nargs = 1;
+co->args[0] = _35cc2081;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9176,8 +9254,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1279;
 co->nargs = 1;
+co->args[0] = _35cc2081;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9187,8 +9265,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1279;
 co->nargs = 1;
+co->args[0] = _35cc2081;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9198,8 +9276,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1279;
 co->nargs = 1;
+co->args[0] = _35cc2081;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9210,13 +9288,13 @@ return;
 }
 }
 
-void _35clofun2952(struct Cora* co) {
-Obj _35val1754 = co->args[1];
+void _35clofun3755(struct Cora* co) {
+Obj _35val2556 = co->args[1];
 Obj arg = co->stack[co->base + 0];
-co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
-co->args[1] = _35val1754;
-co->args[2] = arg;
 co->nargs = 3;
+co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
+co->args[1] = _35val2556;
+co->args[2] = arg;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9226,20 +9304,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2949(struct Cora* co) {
-Obj _35cc1280 = makeNative(_35clofun2950, 0, 0);
-Obj _35reg1732 = primIsCons(closureRef(co, 0));
-if (True == _35reg1732) {
-Obj _35reg1733 = primCar(closureRef(co, 0));
-Obj f = _35reg1733;
-Obj _35reg1734 = primCdr(closureRef(co, 0));
-Obj args = _35reg1734;
-Obj _35reg1735 = primCons(f, args);
-pushCont(co, _35clofun2951, 0);
+void _35clofun3752(struct Cora* co) {
+Obj _35cc2082 = makeNative(_35clofun3753, 0, 0);
+Obj _35reg2534 = primIsCons(closureRef(co, 0));
+if (True == _35reg2534) {
+Obj _35reg2535 = primCar(closureRef(co, 0));
+Obj f = _35reg2535;
+Obj _35reg2536 = primCdr(closureRef(co, 0));
+Obj args = _35reg2536;
+Obj _35reg2537 = primCons(f, args);
+pushCont(co, _35clofun3754, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("map"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.free-vars"));
-co->args[2] = _35reg1735;
-co->nargs = 3;
+co->args[2] = _35reg2537;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9248,8 +9326,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1280;
 co->nargs = 1;
+co->args[0] = _35cc2082;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9260,13 +9338,13 @@ return;
 }
 }
 
-void _35clofun2951(struct Cora* co) {
-Obj _35val1736 = co->args[1];
+void _35clofun3754(struct Cora* co) {
+Obj _35val2538 = co->args[1];
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.foldl"));
 co->args[1] = globalRef(intern("cora/lib/toc/include.union"));
 co->args[2] = Nil;
-co->args[3] = _35val1736;
-co->nargs = 4;
+co->args[3] = _35val2538;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9276,10 +9354,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2950(struct Cora* co) {
+void _35clofun3753(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9289,30 +9367,31 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2931(struct Cora* co) {
-Obj _35p1261 = co->args[1];
-Obj _35cc1262 = makeNative(_35clofun2932, 0, 1, _35p1261);
-Obj _35reg1721 = primIsCons(_35p1261);
-if (True == _35reg1721) {
-Obj _35reg1722 = primCar(_35p1261);
-Obj _35reg1723 = primEQ(intern("%const"), _35reg1722);
-if (True == _35reg1723) {
-Obj _35reg1724 = primCdr(_35p1261);
-Obj _35reg1725 = primIsCons(_35reg1724);
-if (True == _35reg1725) {
-Obj _35reg1726 = primCdr(_35p1261);
-Obj _35reg1727 = primCar(_35reg1726);
-Obj x = _35reg1727;
-Obj _35reg1728 = primCdr(_35p1261);
-Obj _35reg1729 = primCdr(_35reg1728);
-Obj _35reg1730 = primEQ(Nil, _35reg1729);
-if (True == _35reg1730) {
+void _35clofun3734(struct Cora* co) {
+Obj _35p2063 = co->args[1];
+Obj _35cc2064 = makeNative(_35clofun3735, 0, 1, _35p2063);
+Obj _35reg2523 = primIsCons(_35p2063);
+if (True == _35reg2523) {
+Obj _35reg2524 = primCar(_35p2063);
+Obj _35reg2525 = primEQ(intern("%const"), _35reg2524);
+if (True == _35reg2525) {
+Obj _35reg2526 = primCdr(_35p2063);
+Obj _35reg2527 = primIsCons(_35reg2526);
+if (True == _35reg2527) {
+Obj _35reg2528 = primCdr(_35p2063);
+Obj _35reg2529 = primCar(_35reg2528);
+Obj x = _35reg2529;
+Obj _35reg2530 = primCdr(_35p2063);
+Obj _35reg2531 = primCdr(_35reg2530);
+Obj _35reg2532 = primEQ(Nil, _35reg2531);
+if (True == _35reg2532) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1262;
 co->nargs = 1;
+co->args[0] = _35cc2064;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9322,8 +9401,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1262;
 co->nargs = 1;
+co->args[0] = _35cc2064;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9333,8 +9412,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1262;
 co->nargs = 1;
+co->args[0] = _35cc2064;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9344,8 +9423,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1262;
 co->nargs = 1;
+co->args[0] = _35cc2064;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9356,29 +9435,30 @@ return;
 }
 }
 
-void _35clofun2932(struct Cora* co) {
-Obj _35cc1263 = makeNative(_35clofun2933, 0, 1, closureRef(co, 0));
-Obj _35reg1711 = primIsCons(closureRef(co, 0));
-if (True == _35reg1711) {
-Obj _35reg1712 = primCar(closureRef(co, 0));
-Obj _35reg1713 = primEQ(intern("%global"), _35reg1712);
-if (True == _35reg1713) {
-Obj _35reg1714 = primCdr(closureRef(co, 0));
-Obj _35reg1715 = primIsCons(_35reg1714);
-if (True == _35reg1715) {
-Obj _35reg1716 = primCdr(closureRef(co, 0));
-Obj _35reg1717 = primCar(_35reg1716);
-Obj x = _35reg1717;
-Obj _35reg1718 = primCdr(closureRef(co, 0));
-Obj _35reg1719 = primCdr(_35reg1718);
-Obj _35reg1720 = primEQ(Nil, _35reg1719);
-if (True == _35reg1720) {
+void _35clofun3735(struct Cora* co) {
+Obj _35cc2065 = makeNative(_35clofun3736, 0, 1, closureRef(co, 0));
+Obj _35reg2513 = primIsCons(closureRef(co, 0));
+if (True == _35reg2513) {
+Obj _35reg2514 = primCar(closureRef(co, 0));
+Obj _35reg2515 = primEQ(intern("%global"), _35reg2514);
+if (True == _35reg2515) {
+Obj _35reg2516 = primCdr(closureRef(co, 0));
+Obj _35reg2517 = primIsCons(_35reg2516);
+if (True == _35reg2517) {
+Obj _35reg2518 = primCdr(closureRef(co, 0));
+Obj _35reg2519 = primCar(_35reg2518);
+Obj x = _35reg2519;
+Obj _35reg2520 = primCdr(closureRef(co, 0));
+Obj _35reg2521 = primCdr(_35reg2520);
+Obj _35reg2522 = primEQ(Nil, _35reg2521);
+if (True == _35reg2522) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1263;
 co->nargs = 1;
+co->args[0] = _35cc2065;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9388,8 +9468,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1263;
 co->nargs = 1;
+co->args[0] = _35cc2065;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9399,8 +9479,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1263;
 co->nargs = 1;
+co->args[0] = _35cc2065;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9410,8 +9490,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1263;
 co->nargs = 1;
+co->args[0] = _35cc2065;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9422,29 +9502,30 @@ return;
 }
 }
 
-void _35clofun2933(struct Cora* co) {
-Obj _35cc1264 = makeNative(_35clofun2934, 0, 1, closureRef(co, 0));
-Obj _35reg1701 = primIsCons(closureRef(co, 0));
-if (True == _35reg1701) {
-Obj _35reg1702 = primCar(closureRef(co, 0));
-Obj _35reg1703 = primEQ(intern("%builtin"), _35reg1702);
-if (True == _35reg1703) {
-Obj _35reg1704 = primCdr(closureRef(co, 0));
-Obj _35reg1705 = primIsCons(_35reg1704);
-if (True == _35reg1705) {
-Obj _35reg1706 = primCdr(closureRef(co, 0));
-Obj _35reg1707 = primCar(_35reg1706);
-Obj op = _35reg1707;
-Obj _35reg1708 = primCdr(closureRef(co, 0));
-Obj _35reg1709 = primCdr(_35reg1708);
-Obj _35reg1710 = primEQ(Nil, _35reg1709);
-if (True == _35reg1710) {
+void _35clofun3736(struct Cora* co) {
+Obj _35cc2066 = makeNative(_35clofun3737, 0, 1, closureRef(co, 0));
+Obj _35reg2503 = primIsCons(closureRef(co, 0));
+if (True == _35reg2503) {
+Obj _35reg2504 = primCar(closureRef(co, 0));
+Obj _35reg2505 = primEQ(intern("%builtin"), _35reg2504);
+if (True == _35reg2505) {
+Obj _35reg2506 = primCdr(closureRef(co, 0));
+Obj _35reg2507 = primIsCons(_35reg2506);
+if (True == _35reg2507) {
+Obj _35reg2508 = primCdr(closureRef(co, 0));
+Obj _35reg2509 = primCar(_35reg2508);
+Obj op = _35reg2509;
+Obj _35reg2510 = primCdr(closureRef(co, 0));
+Obj _35reg2511 = primCdr(_35reg2510);
+Obj _35reg2512 = primEQ(Nil, _35reg2511);
+if (True == _35reg2512) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1264;
 co->nargs = 1;
+co->args[0] = _35cc2066;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9454,8 +9535,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1264;
 co->nargs = 1;
+co->args[0] = _35cc2066;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9465,8 +9546,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1264;
 co->nargs = 1;
+co->args[0] = _35cc2066;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9476,8 +9557,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1264;
 co->nargs = 1;
+co->args[0] = _35cc2066;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9488,29 +9569,30 @@ return;
 }
 }
 
-void _35clofun2934(struct Cora* co) {
-Obj _35cc1265 = makeNative(_35clofun2935, 0, 1, closureRef(co, 0));
-Obj _35reg1691 = primIsCons(closureRef(co, 0));
-if (True == _35reg1691) {
-Obj _35reg1692 = primCar(closureRef(co, 0));
-Obj _35reg1693 = primEQ(intern("quote"), _35reg1692);
-if (True == _35reg1693) {
-Obj _35reg1694 = primCdr(closureRef(co, 0));
-Obj _35reg1695 = primIsCons(_35reg1694);
-if (True == _35reg1695) {
-Obj _35reg1696 = primCdr(closureRef(co, 0));
-Obj _35reg1697 = primCar(_35reg1696);
-Obj x = _35reg1697;
-Obj _35reg1698 = primCdr(closureRef(co, 0));
-Obj _35reg1699 = primCdr(_35reg1698);
-Obj _35reg1700 = primEQ(Nil, _35reg1699);
-if (True == _35reg1700) {
+void _35clofun3737(struct Cora* co) {
+Obj _35cc2067 = makeNative(_35clofun3738, 0, 1, closureRef(co, 0));
+Obj _35reg2493 = primIsCons(closureRef(co, 0));
+if (True == _35reg2493) {
+Obj _35reg2494 = primCar(closureRef(co, 0));
+Obj _35reg2495 = primEQ(intern("quote"), _35reg2494);
+if (True == _35reg2495) {
+Obj _35reg2496 = primCdr(closureRef(co, 0));
+Obj _35reg2497 = primIsCons(_35reg2496);
+if (True == _35reg2497) {
+Obj _35reg2498 = primCdr(closureRef(co, 0));
+Obj _35reg2499 = primCar(_35reg2498);
+Obj x = _35reg2499;
+Obj _35reg2500 = primCdr(closureRef(co, 0));
+Obj _35reg2501 = primCdr(_35reg2500);
+Obj _35reg2502 = primEQ(Nil, _35reg2501);
+if (True == _35reg2502) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1265;
 co->nargs = 1;
+co->args[0] = _35cc2067;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9520,8 +9602,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1265;
 co->nargs = 1;
+co->args[0] = _35cc2067;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9531,8 +9613,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1265;
 co->nargs = 1;
+co->args[0] = _35cc2067;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9542,8 +9624,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1265;
 co->nargs = 1;
+co->args[0] = _35cc2067;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9554,29 +9636,30 @@ return;
 }
 }
 
-void _35clofun2935(struct Cora* co) {
-Obj _35cc1266 = makeNative(_35clofun2936, 0, 1, closureRef(co, 0));
-Obj _35reg1681 = primIsCons(closureRef(co, 0));
-if (True == _35reg1681) {
-Obj _35reg1682 = primCar(closureRef(co, 0));
-Obj _35reg1683 = primEQ(intern("%closure-ref"), _35reg1682);
-if (True == _35reg1683) {
-Obj _35reg1684 = primCdr(closureRef(co, 0));
-Obj _35reg1685 = primIsCons(_35reg1684);
-if (True == _35reg1685) {
-Obj _35reg1686 = primCdr(closureRef(co, 0));
-Obj _35reg1687 = primCar(_35reg1686);
-Obj __ = _35reg1687;
-Obj _35reg1688 = primCdr(closureRef(co, 0));
-Obj _35reg1689 = primCdr(_35reg1688);
-Obj _35reg1690 = primEQ(Nil, _35reg1689);
-if (True == _35reg1690) {
+void _35clofun3738(struct Cora* co) {
+Obj _35cc2068 = makeNative(_35clofun3739, 0, 1, closureRef(co, 0));
+Obj _35reg2483 = primIsCons(closureRef(co, 0));
+if (True == _35reg2483) {
+Obj _35reg2484 = primCar(closureRef(co, 0));
+Obj _35reg2485 = primEQ(intern("%closure-ref"), _35reg2484);
+if (True == _35reg2485) {
+Obj _35reg2486 = primCdr(closureRef(co, 0));
+Obj _35reg2487 = primIsCons(_35reg2486);
+if (True == _35reg2487) {
+Obj _35reg2488 = primCdr(closureRef(co, 0));
+Obj _35reg2489 = primCar(_35reg2488);
+Obj __ = _35reg2489;
+Obj _35reg2490 = primCdr(closureRef(co, 0));
+Obj _35reg2491 = primCdr(_35reg2490);
+Obj _35reg2492 = primEQ(Nil, _35reg2491);
+if (True == _35reg2492) {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1266;
 co->nargs = 1;
+co->args[0] = _35cc2068;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9586,8 +9669,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1266;
 co->nargs = 1;
+co->args[0] = _35cc2068;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9597,8 +9680,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1266;
 co->nargs = 1;
+co->args[0] = _35cc2068;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9608,8 +9691,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1266;
 co->nargs = 1;
+co->args[0] = _35cc2068;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9620,18 +9703,19 @@ return;
 }
 }
 
-void _35clofun2936(struct Cora* co) {
-Obj _35cc1267 = makeNative(_35clofun2937, 0, 0);
+void _35clofun3739(struct Cora* co) {
+Obj _35cc2069 = makeNative(_35clofun3740, 0, 0);
 Obj x = closureRef(co, 0);
+co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2937(struct Cora* co) {
+void _35clofun3740(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9641,19 +9725,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2925(struct Cora* co) {
-Obj _35p1256 = co->args[1];
-Obj _35p1257 = co->args[2];
-Obj _35cc1258 = makeNative(_35clofun2926, 0, 2, _35p1256, _35p1257);
-Obj _35reg1679 = primEQ(Nil, _35p1256);
-if (True == _35reg1679) {
-Obj __ = _35p1257;
+void _35clofun3728(struct Cora* co) {
+Obj _35p2058 = co->args[1];
+Obj _35p2059 = co->args[2];
+Obj _35cc2060 = makeNative(_35clofun3729, 0, 2, _35p2058, _35p2059);
+Obj _35reg2481 = primEQ(Nil, _35p2058);
+if (True == _35reg2481) {
+Obj __ = _35p2059;
+co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1258;
 co->nargs = 1;
+co->args[0] = _35cc2060;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9664,20 +9749,20 @@ return;
 }
 }
 
-void _35clofun2926(struct Cora* co) {
-Obj _35cc1259 = makeNative(_35clofun2927, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1675 = primIsCons(closureRef(co, 0));
-if (True == _35reg1675) {
-Obj _35reg1676 = primCar(closureRef(co, 0));
-Obj x = _35reg1676;
-Obj _35reg1677 = primCdr(closureRef(co, 0));
-Obj y = _35reg1677;
+void _35clofun3729(struct Cora* co) {
+Obj _35cc2061 = makeNative(_35clofun3730, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2477 = primIsCons(closureRef(co, 0));
+if (True == _35reg2477) {
+Obj _35reg2478 = primCar(closureRef(co, 0));
+Obj x = _35reg2478;
+Obj _35reg2479 = primCdr(closureRef(co, 0));
+Obj y = _35reg2479;
 Obj s2 = closureRef(co, 1);
-pushCont(co, _35clofun2930, 3, y, s2, _35cc1259);
+pushCont(co, _35clofun3733, 3, y, s2, _35cc2061);
+co->nargs = 3;
 co->args[0] = globalRef(intern("elem?"));
 co->args[1] = x;
 co->args[2] = s2;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9686,8 +9771,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1259;
 co->nargs = 1;
+co->args[0] = _35cc2061;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9698,16 +9783,16 @@ return;
 }
 }
 
-void _35clofun2930(struct Cora* co) {
-Obj _35val1678 = co->args[1];
+void _35clofun3733(struct Cora* co) {
+Obj _35val2480 = co->args[1];
 Obj y = co->stack[co->base + 0];
 Obj s2 = co->stack[co->base + 1];
-Obj _35cc1259 = co->stack[co->base + 2];
-if (True == _35val1678) {
+Obj _35cc2061 = co->stack[co->base + 2];
+if (True == _35val2480) {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
 co->args[1] = y;
 co->args[2] = s2;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9716,8 +9801,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1259;
 co->nargs = 1;
+co->args[0] = _35cc2061;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9728,20 +9813,20 @@ return;
 }
 }
 
-void _35clofun2927(struct Cora* co) {
-Obj _35cc1260 = makeNative(_35clofun2928, 0, 0);
-Obj _35reg1670 = primIsCons(closureRef(co, 0));
-if (True == _35reg1670) {
-Obj _35reg1671 = primCar(closureRef(co, 0));
-Obj x = _35reg1671;
-Obj _35reg1672 = primCdr(closureRef(co, 0));
-Obj y = _35reg1672;
+void _35clofun3730(struct Cora* co) {
+Obj _35cc2062 = makeNative(_35clofun3731, 0, 0);
+Obj _35reg2472 = primIsCons(closureRef(co, 0));
+if (True == _35reg2472) {
+Obj _35reg2473 = primCar(closureRef(co, 0));
+Obj x = _35reg2473;
+Obj _35reg2474 = primCdr(closureRef(co, 0));
+Obj y = _35reg2474;
 Obj s2 = closureRef(co, 1);
-pushCont(co, _35clofun2929, 1, x);
+pushCont(co, _35clofun3732, 1, x);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.diff"));
 co->args[1] = y;
 co->args[2] = s2;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9750,8 +9835,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1260;
 co->nargs = 1;
+co->args[0] = _35cc2062;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9762,19 +9847,20 @@ return;
 }
 }
 
-void _35clofun2929(struct Cora* co) {
-Obj _35val1673 = co->args[1];
+void _35clofun3732(struct Cora* co) {
+Obj _35val2475 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35reg1674 = primCons(x, _35val1673);
-co->args[1] = _35reg1674;
+Obj _35reg2476 = primCons(x, _35val2475);
+co->nargs = 2;
+co->args[1] = _35reg2476;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2928(struct Cora* co) {
+void _35clofun3731(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9784,19 +9870,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2919(struct Cora* co) {
-Obj _35p1251 = co->args[1];
-Obj _35p1252 = co->args[2];
-Obj _35cc1253 = makeNative(_35clofun2920, 0, 2, _35p1251, _35p1252);
-Obj _35reg1668 = primEQ(Nil, _35p1251);
-if (True == _35reg1668) {
-Obj s2 = _35p1252;
+void _35clofun3722(struct Cora* co) {
+Obj _35p2053 = co->args[1];
+Obj _35p2054 = co->args[2];
+Obj _35cc2055 = makeNative(_35clofun3723, 0, 2, _35p2053, _35p2054);
+Obj _35reg2470 = primEQ(Nil, _35p2053);
+if (True == _35reg2470) {
+Obj s2 = _35p2054;
+co->nargs = 2;
 co->args[1] = s2;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1253;
 co->nargs = 1;
+co->args[0] = _35cc2055;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9807,20 +9894,20 @@ return;
 }
 }
 
-void _35clofun2920(struct Cora* co) {
-Obj _35cc1254 = makeNative(_35clofun2921, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1664 = primIsCons(closureRef(co, 0));
-if (True == _35reg1664) {
-Obj _35reg1665 = primCar(closureRef(co, 0));
-Obj x = _35reg1665;
-Obj _35reg1666 = primCdr(closureRef(co, 0));
-Obj y = _35reg1666;
+void _35clofun3723(struct Cora* co) {
+Obj _35cc2056 = makeNative(_35clofun3724, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2466 = primIsCons(closureRef(co, 0));
+if (True == _35reg2466) {
+Obj _35reg2467 = primCar(closureRef(co, 0));
+Obj x = _35reg2467;
+Obj _35reg2468 = primCdr(closureRef(co, 0));
+Obj y = _35reg2468;
 Obj s2 = closureRef(co, 1);
-pushCont(co, _35clofun2924, 3, y, s2, _35cc1254);
+pushCont(co, _35clofun3727, 3, y, s2, _35cc2056);
+co->nargs = 3;
 co->args[0] = globalRef(intern("elem?"));
 co->args[1] = x;
 co->args[2] = s2;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9829,8 +9916,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1254;
 co->nargs = 1;
+co->args[0] = _35cc2056;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9841,16 +9928,16 @@ return;
 }
 }
 
-void _35clofun2924(struct Cora* co) {
-Obj _35val1667 = co->args[1];
+void _35clofun3727(struct Cora* co) {
+Obj _35val2469 = co->args[1];
 Obj y = co->stack[co->base + 0];
 Obj s2 = co->stack[co->base + 1];
-Obj _35cc1254 = co->stack[co->base + 2];
-if (True == _35val1667) {
+Obj _35cc2056 = co->stack[co->base + 2];
+if (True == _35val2469) {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.union"));
 co->args[1] = y;
 co->args[2] = s2;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9859,8 +9946,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1254;
 co->nargs = 1;
+co->args[0] = _35cc2056;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9871,20 +9958,20 @@ return;
 }
 }
 
-void _35clofun2921(struct Cora* co) {
-Obj _35cc1255 = makeNative(_35clofun2922, 0, 0);
-Obj _35reg1659 = primIsCons(closureRef(co, 0));
-if (True == _35reg1659) {
-Obj _35reg1660 = primCar(closureRef(co, 0));
-Obj x = _35reg1660;
-Obj _35reg1661 = primCdr(closureRef(co, 0));
-Obj y = _35reg1661;
+void _35clofun3724(struct Cora* co) {
+Obj _35cc2057 = makeNative(_35clofun3725, 0, 0);
+Obj _35reg2461 = primIsCons(closureRef(co, 0));
+if (True == _35reg2461) {
+Obj _35reg2462 = primCar(closureRef(co, 0));
+Obj x = _35reg2462;
+Obj _35reg2463 = primCdr(closureRef(co, 0));
+Obj y = _35reg2463;
 Obj s2 = closureRef(co, 1);
-pushCont(co, _35clofun2923, 1, x);
+pushCont(co, _35clofun3726, 1, x);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.union"));
 co->args[1] = y;
 co->args[2] = s2;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9893,8 +9980,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1255;
 co->nargs = 1;
+co->args[0] = _35cc2057;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9905,19 +9992,20 @@ return;
 }
 }
 
-void _35clofun2923(struct Cora* co) {
-Obj _35val1662 = co->args[1];
+void _35clofun3726(struct Cora* co) {
+Obj _35val2464 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35reg1663 = primCons(x, _35val1662);
-co->args[1] = _35reg1663;
+Obj _35reg2465 = primCons(x, _35val2464);
+co->nargs = 2;
+co->args[1] = _35reg2465;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2922(struct Cora* co) {
+void _35clofun3725(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9927,16 +10015,16 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2889(struct Cora* co) {
-Obj _35p1240 = co->args[1];
-Obj _35p1241 = co->args[2];
-Obj _35cc1242 = makeNative(_35clofun2890, 0, 2, _35p1240, _35p1241);
-Obj __ = _35p1240;
-Obj x = _35p1241;
-pushCont(co, _35clofun2916, 2, x, _35cc1242);
+void _35clofun3692(struct Cora* co) {
+Obj _35p2042 = co->args[1];
+Obj _35p2043 = co->args[2];
+Obj _35cc2044 = makeNative(_35clofun3693, 0, 2, _35p2042, _35p2043);
+Obj __ = _35p2042;
+Obj x = _35p2043;
+pushCont(co, _35clofun3719, 2, x, _35cc2044);
+co->nargs = 2;
 co->args[0] = globalRef(intern("number?"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9946,20 +10034,21 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2916(struct Cora* co) {
-Obj _35val1644 = co->args[1];
+void _35clofun3719(struct Cora* co) {
+Obj _35val2446 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35cc1242 = co->stack[co->base + 1];
-if (True == _35val1644) {
+Obj _35cc2044 = co->stack[co->base + 1];
+if (True == _35val2446) {
 if (True == True) {
-Obj _35reg1645 = primCons(x, Nil);
-Obj _35reg1646 = primCons(intern("%const"), _35reg1645);
-co->args[1] = _35reg1646;
+Obj _35reg2447 = primCons(x, Nil);
+Obj _35reg2448 = primCons(intern("%const"), _35reg2447);
+co->nargs = 2;
+co->args[1] = _35reg2448;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1242;
 co->nargs = 1;
+co->args[0] = _35cc2044;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9969,17 +10058,18 @@ co->pc = coraCall;
 return;
 }
 } else {
-Obj _35reg1647 = primIsString(x);
-if (True == _35reg1647) {
+Obj _35reg2449 = primIsString(x);
+if (True == _35reg2449) {
 if (True == True) {
-Obj _35reg1648 = primCons(x, Nil);
-Obj _35reg1649 = primCons(intern("%const"), _35reg1648);
-co->args[1] = _35reg1649;
+Obj _35reg2450 = primCons(x, Nil);
+Obj _35reg2451 = primCons(intern("%const"), _35reg2450);
+co->nargs = 2;
+co->args[1] = _35reg2451;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1242;
 co->nargs = 1;
+co->args[0] = _35cc2044;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -9989,10 +10079,10 @@ co->pc = coraCall;
 return;
 }
 } else {
-pushCont(co, _35clofun2917, 2, x, _35cc1242);
+pushCont(co, _35clofun3720, 2, x, _35cc2044);
+co->nargs = 2;
 co->args[0] = globalRef(intern("boolean?"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10004,20 +10094,21 @@ return;
 }
 }
 
-void _35clofun2917(struct Cora* co) {
-Obj _35val1650 = co->args[1];
+void _35clofun3720(struct Cora* co) {
+Obj _35val2452 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35cc1242 = co->stack[co->base + 1];
-if (True == _35val1650) {
+Obj _35cc2044 = co->stack[co->base + 1];
+if (True == _35val2452) {
 if (True == True) {
-Obj _35reg1651 = primCons(x, Nil);
-Obj _35reg1652 = primCons(intern("%const"), _35reg1651);
-co->args[1] = _35reg1652;
+Obj _35reg2453 = primCons(x, Nil);
+Obj _35reg2454 = primCons(intern("%const"), _35reg2453);
+co->nargs = 2;
+co->args[1] = _35reg2454;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1242;
 co->nargs = 1;
+co->args[0] = _35cc2044;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10027,10 +10118,10 @@ co->pc = coraCall;
 return;
 }
 } else {
-pushCont(co, _35clofun2918, 2, x, _35cc1242);
+pushCont(co, _35clofun3721, 2, x, _35cc2044);
+co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = x;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10041,20 +10132,21 @@ return;
 }
 }
 
-void _35clofun2918(struct Cora* co) {
-Obj _35val1653 = co->args[1];
+void _35clofun3721(struct Cora* co) {
+Obj _35val2455 = co->args[1];
 Obj x = co->stack[co->base + 0];
-Obj _35cc1242 = co->stack[co->base + 1];
-if (True == _35val1653) {
+Obj _35cc2044 = co->stack[co->base + 1];
+if (True == _35val2455) {
 if (True == True) {
-Obj _35reg1654 = primCons(x, Nil);
-Obj _35reg1655 = primCons(intern("%const"), _35reg1654);
-co->args[1] = _35reg1655;
+Obj _35reg2456 = primCons(x, Nil);
+Obj _35reg2457 = primCons(intern("%const"), _35reg2456);
+co->nargs = 2;
+co->args[1] = _35reg2457;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1242;
 co->nargs = 1;
+co->args[0] = _35cc2044;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10065,14 +10157,15 @@ return;
 }
 } else {
 if (True == False) {
-Obj _35reg1656 = primCons(x, Nil);
-Obj _35reg1657 = primCons(intern("%const"), _35reg1656);
-co->args[1] = _35reg1657;
+Obj _35reg2458 = primCons(x, Nil);
+Obj _35reg2459 = primCons(intern("%const"), _35reg2458);
+co->nargs = 2;
+co->args[1] = _35reg2459;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1242;
 co->nargs = 1;
+co->args[0] = _35cc2044;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10084,32 +10177,33 @@ return;
 }
 }
 
-void _35clofun2890(struct Cora* co) {
-Obj _35cc1243 = makeNative(_35clofun2891, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3693(struct Cora* co) {
+Obj _35cc2045 = makeNative(_35clofun3694, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj __ = closureRef(co, 0);
-Obj _35reg1632 = primIsCons(closureRef(co, 1));
-if (True == _35reg1632) {
-Obj _35reg1633 = primCar(closureRef(co, 1));
-Obj _35reg1634 = primEQ(intern("quote"), _35reg1633);
-if (True == _35reg1634) {
-Obj _35reg1635 = primCdr(closureRef(co, 1));
-Obj _35reg1636 = primIsCons(_35reg1635);
-if (True == _35reg1636) {
-Obj _35reg1637 = primCdr(closureRef(co, 1));
-Obj _35reg1638 = primCar(_35reg1637);
-Obj x = _35reg1638;
-Obj _35reg1639 = primCdr(closureRef(co, 1));
-Obj _35reg1640 = primCdr(_35reg1639);
-Obj _35reg1641 = primEQ(Nil, _35reg1640);
-if (True == _35reg1641) {
-Obj _35reg1642 = primCons(x, Nil);
-Obj _35reg1643 = primCons(intern("%const"), _35reg1642);
-co->args[1] = _35reg1643;
+Obj _35reg2434 = primIsCons(closureRef(co, 1));
+if (True == _35reg2434) {
+Obj _35reg2435 = primCar(closureRef(co, 1));
+Obj _35reg2436 = primEQ(intern("quote"), _35reg2435);
+if (True == _35reg2436) {
+Obj _35reg2437 = primCdr(closureRef(co, 1));
+Obj _35reg2438 = primIsCons(_35reg2437);
+if (True == _35reg2438) {
+Obj _35reg2439 = primCdr(closureRef(co, 1));
+Obj _35reg2440 = primCar(_35reg2439);
+Obj x = _35reg2440;
+Obj _35reg2441 = primCdr(closureRef(co, 1));
+Obj _35reg2442 = primCdr(_35reg2441);
+Obj _35reg2443 = primEQ(Nil, _35reg2442);
+if (True == _35reg2443) {
+Obj _35reg2444 = primCons(x, Nil);
+Obj _35reg2445 = primCons(intern("%const"), _35reg2444);
+co->nargs = 2;
+co->args[1] = _35reg2445;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1243;
 co->nargs = 1;
+co->args[0] = _35cc2045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10119,8 +10213,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1243;
 co->nargs = 1;
+co->args[0] = _35cc2045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10130,8 +10224,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1243;
 co->nargs = 1;
+co->args[0] = _35cc2045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10141,8 +10235,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1243;
 co->nargs = 1;
+co->args[0] = _35cc2045;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10153,17 +10247,17 @@ return;
 }
 }
 
-void _35clofun2891(struct Cora* co) {
-Obj _35cc1244 = makeNative(_35clofun2892, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3694(struct Cora* co) {
+Obj _35cc2046 = makeNative(_35clofun3695, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1628 = primIsSymbol(x);
-if (True == _35reg1628) {
-pushCont(co, _35clofun2915, 1, x);
+Obj _35reg2430 = primIsSymbol(x);
+if (True == _35reg2430) {
+pushCont(co, _35clofun3718, 1, x);
+co->nargs = 3;
 co->args[0] = globalRef(intern("elem?"));
 co->args[1] = x;
 co->args[2] = env;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10172,8 +10266,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1244;
 co->nargs = 1;
+co->args[0] = _35cc2046;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10184,54 +10278,56 @@ return;
 }
 }
 
-void _35clofun2915(struct Cora* co) {
-Obj _35val1629 = co->args[1];
+void _35clofun3718(struct Cora* co) {
+Obj _35val2431 = co->args[1];
 Obj x = co->stack[co->base + 0];
-if (True == _35val1629) {
+if (True == _35val2431) {
+co->nargs = 2;
 co->args[1] = x;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-Obj _35reg1630 = primCons(x, Nil);
-Obj _35reg1631 = primCons(intern("%global"), _35reg1630);
-co->args[1] = _35reg1631;
+Obj _35reg2432 = primCons(x, Nil);
+Obj _35reg2433 = primCons(intern("%global"), _35reg2432);
+co->nargs = 2;
+co->args[1] = _35reg2433;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun2892(struct Cora* co) {
-Obj _35cc1245 = makeNative(_35clofun2893, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3695(struct Cora* co) {
+Obj _35cc2047 = makeNative(_35clofun3696, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg1606 = primIsCons(closureRef(co, 1));
-if (True == _35reg1606) {
-Obj _35reg1607 = primCar(closureRef(co, 1));
-Obj _35reg1608 = primEQ(intern("lambda"), _35reg1607);
-if (True == _35reg1608) {
-Obj _35reg1609 = primCdr(closureRef(co, 1));
-Obj _35reg1610 = primIsCons(_35reg1609);
-if (True == _35reg1610) {
-Obj _35reg1611 = primCdr(closureRef(co, 1));
-Obj _35reg1612 = primCar(_35reg1611);
-Obj args = _35reg1612;
-Obj _35reg1613 = primCdr(closureRef(co, 1));
-Obj _35reg1614 = primCdr(_35reg1613);
-Obj _35reg1615 = primIsCons(_35reg1614);
-if (True == _35reg1615) {
-Obj _35reg1616 = primCdr(closureRef(co, 1));
-Obj _35reg1617 = primCdr(_35reg1616);
-Obj _35reg1618 = primCar(_35reg1617);
-Obj body = _35reg1618;
-Obj _35reg1619 = primCdr(closureRef(co, 1));
-Obj _35reg1620 = primCdr(_35reg1619);
-Obj _35reg1621 = primCdr(_35reg1620);
-Obj _35reg1622 = primEQ(Nil, _35reg1621);
-if (True == _35reg1622) {
-pushCont(co, _35clofun2913, 2, body, args);
+Obj _35reg2408 = primIsCons(closureRef(co, 1));
+if (True == _35reg2408) {
+Obj _35reg2409 = primCar(closureRef(co, 1));
+Obj _35reg2410 = primEQ(intern("lambda"), _35reg2409);
+if (True == _35reg2410) {
+Obj _35reg2411 = primCdr(closureRef(co, 1));
+Obj _35reg2412 = primIsCons(_35reg2411);
+if (True == _35reg2412) {
+Obj _35reg2413 = primCdr(closureRef(co, 1));
+Obj _35reg2414 = primCar(_35reg2413);
+Obj args = _35reg2414;
+Obj _35reg2415 = primCdr(closureRef(co, 1));
+Obj _35reg2416 = primCdr(_35reg2415);
+Obj _35reg2417 = primIsCons(_35reg2416);
+if (True == _35reg2417) {
+Obj _35reg2418 = primCdr(closureRef(co, 1));
+Obj _35reg2419 = primCdr(_35reg2418);
+Obj _35reg2420 = primCar(_35reg2419);
+Obj body = _35reg2420;
+Obj _35reg2421 = primCdr(closureRef(co, 1));
+Obj _35reg2422 = primCdr(_35reg2421);
+Obj _35reg2423 = primCdr(_35reg2422);
+Obj _35reg2424 = primEQ(Nil, _35reg2423);
+if (True == _35reg2424) {
+pushCont(co, _35clofun3716, 2, body, args);
+co->nargs = 3;
 co->args[0] = globalRef(intern("append"));
 co->args[1] = args;
 co->args[2] = env;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10240,8 +10336,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1245;
 co->nargs = 1;
+co->args[0] = _35cc2047;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10251,8 +10347,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1245;
 co->nargs = 1;
+co->args[0] = _35cc2047;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10262,8 +10358,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1245;
 co->nargs = 1;
+co->args[0] = _35cc2047;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10273,8 +10369,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1245;
 co->nargs = 1;
+co->args[0] = _35cc2047;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10284,8 +10380,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1245;
 co->nargs = 1;
+co->args[0] = _35cc2047;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10296,15 +10392,15 @@ return;
 }
 }
 
-void _35clofun2913(struct Cora* co) {
-Obj _35val1623 = co->args[1];
+void _35clofun3716(struct Cora* co) {
+Obj _35val2425 = co->args[1];
 Obj body = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
-pushCont(co, _35clofun2914, 1, args);
-co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
-co->args[1] = _35val1623;
-co->args[2] = body;
+pushCont(co, _35clofun3717, 1, args);
 co->nargs = 3;
+co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
+co->args[1] = _35val2425;
+co->args[2] = body;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10314,31 +10410,32 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2914(struct Cora* co) {
-Obj _35val1624 = co->args[1];
+void _35clofun3717(struct Cora* co) {
+Obj _35val2426 = co->args[1];
 Obj args = co->stack[co->base + 0];
-Obj _35reg1625 = primCons(_35val1624, Nil);
-Obj _35reg1626 = primCons(args, _35reg1625);
-Obj _35reg1627 = primCons(intern("lambda"), _35reg1626);
-co->args[1] = _35reg1627;
+Obj _35reg2427 = primCons(_35val2426, Nil);
+Obj _35reg2428 = primCons(args, _35reg2427);
+Obj _35reg2429 = primCons(intern("lambda"), _35reg2428);
+co->nargs = 2;
+co->args[1] = _35reg2429;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2893(struct Cora* co) {
-Obj _35cc1246 = makeNative(_35clofun2894, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3696(struct Cora* co) {
+Obj _35cc2048 = makeNative(_35clofun3697, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg1599 = primIsCons(closureRef(co, 1));
-if (True == _35reg1599) {
-Obj _35reg1600 = primCar(closureRef(co, 1));
-Obj _35reg1601 = primEQ(intern("if"), _35reg1600);
-if (True == _35reg1601) {
-Obj _35reg1602 = primCdr(closureRef(co, 1));
-Obj args = _35reg1602;
-pushCont(co, _35clofun2911, 1, args);
+Obj _35reg2401 = primIsCons(closureRef(co, 1));
+if (True == _35reg2401) {
+Obj _35reg2402 = primCar(closureRef(co, 1));
+Obj _35reg2403 = primEQ(intern("if"), _35reg2402);
+if (True == _35reg2403) {
+Obj _35reg2404 = primCdr(closureRef(co, 1));
+Obj args = _35reg2404;
+pushCont(co, _35clofun3714, 1, args);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10347,8 +10444,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1246;
 co->nargs = 1;
+co->args[0] = _35cc2048;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10358,8 +10455,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1246;
 co->nargs = 1;
+co->args[0] = _35cc2048;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10370,14 +10467,14 @@ return;
 }
 }
 
-void _35clofun2911(struct Cora* co) {
-Obj _35val1603 = co->args[1];
+void _35clofun3714(struct Cora* co) {
+Obj _35val2405 = co->args[1];
 Obj args = co->stack[co->base + 0];
-pushCont(co, _35clofun2912, 0);
-co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val1603;
-co->args[2] = args;
+pushCont(co, _35clofun3715, 0);
 co->nargs = 3;
+co->args[0] = globalRef(intern("map"));
+co->args[1] = _35val2405;
+co->args[2] = args;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10387,46 +10484,47 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2912(struct Cora* co) {
-Obj _35val1604 = co->args[1];
-Obj _35reg1605 = primCons(intern("if"), _35val1604);
-co->args[1] = _35reg1605;
+void _35clofun3715(struct Cora* co) {
+Obj _35val2406 = co->args[1];
+Obj _35reg2407 = primCons(intern("if"), _35val2406);
+co->nargs = 2;
+co->args[1] = _35reg2407;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2894(struct Cora* co) {
-Obj _35cc1247 = makeNative(_35clofun2895, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3697(struct Cora* co) {
+Obj _35cc2049 = makeNative(_35clofun3698, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg1577 = primIsCons(closureRef(co, 1));
-if (True == _35reg1577) {
-Obj _35reg1578 = primCar(closureRef(co, 1));
-Obj _35reg1579 = primEQ(intern("do"), _35reg1578);
-if (True == _35reg1579) {
-Obj _35reg1580 = primCdr(closureRef(co, 1));
-Obj _35reg1581 = primIsCons(_35reg1580);
-if (True == _35reg1581) {
-Obj _35reg1582 = primCdr(closureRef(co, 1));
-Obj _35reg1583 = primCar(_35reg1582);
-Obj x = _35reg1583;
-Obj _35reg1584 = primCdr(closureRef(co, 1));
-Obj _35reg1585 = primCdr(_35reg1584);
-Obj _35reg1586 = primIsCons(_35reg1585);
-if (True == _35reg1586) {
-Obj _35reg1587 = primCdr(closureRef(co, 1));
-Obj _35reg1588 = primCdr(_35reg1587);
-Obj _35reg1589 = primCar(_35reg1588);
-Obj y = _35reg1589;
-Obj _35reg1590 = primCdr(closureRef(co, 1));
-Obj _35reg1591 = primCdr(_35reg1590);
-Obj _35reg1592 = primCdr(_35reg1591);
-Obj _35reg1593 = primEQ(Nil, _35reg1592);
-if (True == _35reg1593) {
-pushCont(co, _35clofun2909, 2, env, y);
+Obj _35reg2379 = primIsCons(closureRef(co, 1));
+if (True == _35reg2379) {
+Obj _35reg2380 = primCar(closureRef(co, 1));
+Obj _35reg2381 = primEQ(intern("do"), _35reg2380);
+if (True == _35reg2381) {
+Obj _35reg2382 = primCdr(closureRef(co, 1));
+Obj _35reg2383 = primIsCons(_35reg2382);
+if (True == _35reg2383) {
+Obj _35reg2384 = primCdr(closureRef(co, 1));
+Obj _35reg2385 = primCar(_35reg2384);
+Obj x = _35reg2385;
+Obj _35reg2386 = primCdr(closureRef(co, 1));
+Obj _35reg2387 = primCdr(_35reg2386);
+Obj _35reg2388 = primIsCons(_35reg2387);
+if (True == _35reg2388) {
+Obj _35reg2389 = primCdr(closureRef(co, 1));
+Obj _35reg2390 = primCdr(_35reg2389);
+Obj _35reg2391 = primCar(_35reg2390);
+Obj y = _35reg2391;
+Obj _35reg2392 = primCdr(closureRef(co, 1));
+Obj _35reg2393 = primCdr(_35reg2392);
+Obj _35reg2394 = primCdr(_35reg2393);
+Obj _35reg2395 = primEQ(Nil, _35reg2394);
+if (True == _35reg2395) {
+pushCont(co, _35clofun3712, 2, env, y);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
 co->args[2] = x;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10435,8 +10533,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1247;
 co->nargs = 1;
+co->args[0] = _35cc2049;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10446,8 +10544,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1247;
 co->nargs = 1;
+co->args[0] = _35cc2049;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10457,8 +10555,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1247;
 co->nargs = 1;
+co->args[0] = _35cc2049;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10468,8 +10566,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1247;
 co->nargs = 1;
+co->args[0] = _35cc2049;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10479,8 +10577,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1247;
 co->nargs = 1;
+co->args[0] = _35cc2049;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10491,15 +10589,15 @@ return;
 }
 }
 
-void _35clofun2909(struct Cora* co) {
-Obj _35val1594 = co->args[1];
+void _35clofun3712(struct Cora* co) {
+Obj _35val2396 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj y = co->stack[co->base + 1];
-pushCont(co, _35clofun2910, 1, _35val1594);
+pushCont(co, _35clofun3713, 1, _35val2396);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
 co->args[2] = y;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10509,60 +10607,61 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2910(struct Cora* co) {
-Obj _35val1595 = co->args[1];
-Obj _35val1594 = co->stack[co->base + 0];
-Obj _35reg1596 = primCons(_35val1595, Nil);
-Obj _35reg1597 = primCons(_35val1594, _35reg1596);
-Obj _35reg1598 = primCons(intern("do"), _35reg1597);
-co->args[1] = _35reg1598;
+void _35clofun3713(struct Cora* co) {
+Obj _35val2397 = co->args[1];
+Obj _35val2396 = co->stack[co->base + 0];
+Obj _35reg2398 = primCons(_35val2397, Nil);
+Obj _35reg2399 = primCons(_35val2396, _35reg2398);
+Obj _35reg2400 = primCons(intern("do"), _35reg2399);
+co->nargs = 2;
+co->args[1] = _35reg2400;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2895(struct Cora* co) {
-Obj _35cc1248 = makeNative(_35clofun2896, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3698(struct Cora* co) {
+Obj _35cc2050 = makeNative(_35clofun3699, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg1544 = primIsCons(closureRef(co, 1));
-if (True == _35reg1544) {
-Obj _35reg1545 = primCar(closureRef(co, 1));
-Obj _35reg1546 = primEQ(intern("let"), _35reg1545);
-if (True == _35reg1546) {
-Obj _35reg1547 = primCdr(closureRef(co, 1));
-Obj _35reg1548 = primIsCons(_35reg1547);
-if (True == _35reg1548) {
-Obj _35reg1549 = primCdr(closureRef(co, 1));
-Obj _35reg1550 = primCar(_35reg1549);
-Obj a = _35reg1550;
-Obj _35reg1551 = primCdr(closureRef(co, 1));
-Obj _35reg1552 = primCdr(_35reg1551);
-Obj _35reg1553 = primIsCons(_35reg1552);
-if (True == _35reg1553) {
-Obj _35reg1554 = primCdr(closureRef(co, 1));
-Obj _35reg1555 = primCdr(_35reg1554);
-Obj _35reg1556 = primCar(_35reg1555);
-Obj b = _35reg1556;
-Obj _35reg1557 = primCdr(closureRef(co, 1));
-Obj _35reg1558 = primCdr(_35reg1557);
-Obj _35reg1559 = primCdr(_35reg1558);
-Obj _35reg1560 = primIsCons(_35reg1559);
-if (True == _35reg1560) {
-Obj _35reg1561 = primCdr(closureRef(co, 1));
-Obj _35reg1562 = primCdr(_35reg1561);
-Obj _35reg1563 = primCdr(_35reg1562);
-Obj _35reg1564 = primCar(_35reg1563);
-Obj c = _35reg1564;
-Obj _35reg1565 = primCdr(closureRef(co, 1));
-Obj _35reg1566 = primCdr(_35reg1565);
-Obj _35reg1567 = primCdr(_35reg1566);
-Obj _35reg1568 = primCdr(_35reg1567);
-Obj _35reg1569 = primEQ(Nil, _35reg1568);
-if (True == _35reg1569) {
-pushCont(co, _35clofun2907, 3, env, c, a);
+Obj _35reg2346 = primIsCons(closureRef(co, 1));
+if (True == _35reg2346) {
+Obj _35reg2347 = primCar(closureRef(co, 1));
+Obj _35reg2348 = primEQ(intern("let"), _35reg2347);
+if (True == _35reg2348) {
+Obj _35reg2349 = primCdr(closureRef(co, 1));
+Obj _35reg2350 = primIsCons(_35reg2349);
+if (True == _35reg2350) {
+Obj _35reg2351 = primCdr(closureRef(co, 1));
+Obj _35reg2352 = primCar(_35reg2351);
+Obj a = _35reg2352;
+Obj _35reg2353 = primCdr(closureRef(co, 1));
+Obj _35reg2354 = primCdr(_35reg2353);
+Obj _35reg2355 = primIsCons(_35reg2354);
+if (True == _35reg2355) {
+Obj _35reg2356 = primCdr(closureRef(co, 1));
+Obj _35reg2357 = primCdr(_35reg2356);
+Obj _35reg2358 = primCar(_35reg2357);
+Obj b = _35reg2358;
+Obj _35reg2359 = primCdr(closureRef(co, 1));
+Obj _35reg2360 = primCdr(_35reg2359);
+Obj _35reg2361 = primCdr(_35reg2360);
+Obj _35reg2362 = primIsCons(_35reg2361);
+if (True == _35reg2362) {
+Obj _35reg2363 = primCdr(closureRef(co, 1));
+Obj _35reg2364 = primCdr(_35reg2363);
+Obj _35reg2365 = primCdr(_35reg2364);
+Obj _35reg2366 = primCar(_35reg2365);
+Obj c = _35reg2366;
+Obj _35reg2367 = primCdr(closureRef(co, 1));
+Obj _35reg2368 = primCdr(_35reg2367);
+Obj _35reg2369 = primCdr(_35reg2368);
+Obj _35reg2370 = primCdr(_35reg2369);
+Obj _35reg2371 = primEQ(Nil, _35reg2370);
+if (True == _35reg2371) {
+pushCont(co, _35clofun3710, 3, env, c, a);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
 co->args[2] = b;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10571,8 +10670,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1248;
 co->nargs = 1;
+co->args[0] = _35cc2050;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10582,8 +10681,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1248;
 co->nargs = 1;
+co->args[0] = _35cc2050;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10593,8 +10692,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1248;
 co->nargs = 1;
+co->args[0] = _35cc2050;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10604,8 +10703,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1248;
 co->nargs = 1;
+co->args[0] = _35cc2050;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10615,8 +10714,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1248;
 co->nargs = 1;
+co->args[0] = _35cc2050;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10626,8 +10725,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1248;
 co->nargs = 1;
+co->args[0] = _35cc2050;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10638,17 +10737,17 @@ return;
 }
 }
 
-void _35clofun2907(struct Cora* co) {
-Obj _35val1570 = co->args[1];
+void _35clofun3710(struct Cora* co) {
+Obj _35val2372 = co->args[1];
 Obj env = co->stack[co->base + 0];
 Obj c = co->stack[co->base + 1];
 Obj a = co->stack[co->base + 2];
-Obj _35reg1571 = primCons(a, env);
-pushCont(co, _35clofun2908, 2, _35val1570, a);
-co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
-co->args[1] = _35reg1571;
-co->args[2] = c;
+Obj _35reg2373 = primCons(a, env);
+pushCont(co, _35clofun3711, 2, _35val2372, a);
 co->nargs = 3;
+co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
+co->args[1] = _35reg2373;
+co->args[2] = c;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10658,32 +10757,33 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2908(struct Cora* co) {
-Obj _35val1572 = co->args[1];
-Obj _35val1570 = co->stack[co->base + 0];
+void _35clofun3711(struct Cora* co) {
+Obj _35val2374 = co->args[1];
+Obj _35val2372 = co->stack[co->base + 0];
 Obj a = co->stack[co->base + 1];
-Obj _35reg1573 = primCons(_35val1572, Nil);
-Obj _35reg1574 = primCons(_35val1570, _35reg1573);
-Obj _35reg1575 = primCons(a, _35reg1574);
-Obj _35reg1576 = primCons(intern("let"), _35reg1575);
-co->args[1] = _35reg1576;
+Obj _35reg2375 = primCons(_35val2374, Nil);
+Obj _35reg2376 = primCons(_35val2372, _35reg2375);
+Obj _35reg2377 = primCons(a, _35reg2376);
+Obj _35reg2378 = primCons(intern("let"), _35reg2377);
+co->nargs = 2;
+co->args[1] = _35reg2378;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2896(struct Cora* co) {
-Obj _35cc1249 = makeNative(_35clofun2897, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3699(struct Cora* co) {
+Obj _35cc2051 = makeNative(_35clofun3700, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg1524 = primIsCons(closureRef(co, 1));
-if (True == _35reg1524) {
-Obj _35reg1525 = primCar(closureRef(co, 1));
-Obj op = _35reg1525;
-Obj _35reg1526 = primCdr(closureRef(co, 1));
-Obj args = _35reg1526;
-pushCont(co, _35clofun2900, 4, op, args, env, _35cc1249);
+Obj _35reg2326 = primIsCons(closureRef(co, 1));
+if (True == _35reg2326) {
+Obj _35reg2327 = primCar(closureRef(co, 1));
+Obj op = _35reg2327;
+Obj _35reg2328 = primCdr(closureRef(co, 1));
+Obj args = _35reg2328;
+pushCont(co, _35clofun3703, 4, op, args, env, _35cc2051);
+co->nargs = 2;
 co->args[0] = globalRef(intern("builtin?"));
 co->args[1] = op;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10692,8 +10792,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1249;
 co->nargs = 1;
+co->args[0] = _35cc2051;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10704,17 +10804,17 @@ return;
 }
 }
 
-void _35clofun2900(struct Cora* co) {
-Obj _35val1527 = co->args[1];
+void _35clofun3703(struct Cora* co) {
+Obj _35val2329 = co->args[1];
 Obj op = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
-Obj _35cc1249 = co->stack[co->base + 3];
-if (True == _35val1527) {
-pushCont(co, _35clofun2901, 3, op, args, env);
+Obj _35cc2051 = co->stack[co->base + 3];
+if (True == _35val2329) {
+pushCont(co, _35clofun3704, 3, op, args, env);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.builtin->args"));
 co->args[1] = op;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10723,8 +10823,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1249;
 co->nargs = 1;
+co->args[0] = _35cc2051;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10735,16 +10835,16 @@ return;
 }
 }
 
-void _35clofun2901(struct Cora* co) {
-Obj _35val1528 = co->args[1];
+void _35clofun3704(struct Cora* co) {
+Obj _35val2330 = co->args[1];
 Obj op = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
-Obj required = _35val1528;
-pushCont(co, _35clofun2902, 4, required, op, args, env);
+Obj required = _35val2330;
+pushCont(co, _35clofun3705, 4, required, op, args, env);
+co->nargs = 2;
 co->args[0] = globalRef(intern("length"));
 co->args[1] = args;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10754,21 +10854,21 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2902(struct Cora* co) {
-Obj _35val1529 = co->args[1];
+void _35clofun3705(struct Cora* co) {
+Obj _35val2331 = co->args[1];
 Obj required = co->stack[co->base + 0];
 Obj op = co->stack[co->base + 1];
 Obj args = co->stack[co->base + 2];
 Obj env = co->stack[co->base + 3];
-Obj provided = _35val1529;
-Obj _35reg1530 = primEQ(required, provided);
-if (True == _35reg1530) {
-Obj _35reg1531 = primCons(op, Nil);
-Obj _35reg1532 = primCons(intern("%builtin"), _35reg1531);
-pushCont(co, _35clofun2903, 2, args, _35reg1532);
+Obj provided = _35val2331;
+Obj _35reg2332 = primEQ(required, provided);
+if (True == _35reg2332) {
+Obj _35reg2333 = primCons(op, Nil);
+Obj _35reg2334 = primCons(intern("%builtin"), _35reg2333);
+pushCont(co, _35clofun3706, 2, args, _35reg2334);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10777,14 +10877,14 @@ co->pc = coraCall;
 }
 return;
 } else {
-Obj _35reg1536 = primGT(required, provided);
-if (True == _35reg1536) {
-Obj _35reg1537 = primSub(required, provided);
-pushCont(co, _35clofun2905, 3, op, args, env);
-co->args[0] = globalRef(intern("cora/lib/toc/include.temp-list"));
-co->args[1] = _35reg1537;
-co->args[2] = Nil;
+Obj _35reg2338 = primGT(required, provided);
+if (True == _35reg2338) {
+Obj _35reg2339 = primSub(required, provided);
+pushCont(co, _35clofun3708, 3, op, args, env);
 co->nargs = 3;
+co->args[0] = globalRef(intern("cora/lib/toc/include.temp-list"));
+co->args[1] = _35reg2339;
+co->args[2] = Nil;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10793,9 +10893,9 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("primitive call mismatch");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10807,18 +10907,18 @@ return;
 }
 }
 
-void _35clofun2905(struct Cora* co) {
-Obj _35val1538 = co->args[1];
+void _35clofun3708(struct Cora* co) {
+Obj _35val2340 = co->args[1];
 Obj op = co->stack[co->base + 0];
 Obj args = co->stack[co->base + 1];
 Obj env = co->stack[co->base + 2];
-Obj tmp = _35val1538;
-Obj _35reg1539 = primCons(op, args);
-pushCont(co, _35clofun2906, 2, tmp, env);
-co->args[0] = globalRef(intern("append"));
-co->args[1] = _35reg1539;
-co->args[2] = tmp;
+Obj tmp = _35val2340;
+Obj _35reg2341 = primCons(op, args);
+pushCont(co, _35clofun3709, 2, tmp, env);
 co->nargs = 3;
+co->args[0] = globalRef(intern("append"));
+co->args[1] = _35reg2341;
+co->args[2] = tmp;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10828,17 +10928,17 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2906(struct Cora* co) {
-Obj _35val1540 = co->args[1];
+void _35clofun3709(struct Cora* co) {
+Obj _35val2342 = co->args[1];
 Obj tmp = co->stack[co->base + 0];
 Obj env = co->stack[co->base + 1];
-Obj _35reg1541 = primCons(_35val1540, Nil);
-Obj _35reg1542 = primCons(tmp, _35reg1541);
-Obj _35reg1543 = primCons(intern("lambda"), _35reg1542);
+Obj _35reg2343 = primCons(_35val2342, Nil);
+Obj _35reg2344 = primCons(tmp, _35reg2343);
+Obj _35reg2345 = primCons(intern("lambda"), _35reg2344);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
-co->args[2] = _35reg1543;
-co->nargs = 3;
+co->args[2] = _35reg2345;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10848,15 +10948,15 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2903(struct Cora* co) {
-Obj _35val1533 = co->args[1];
+void _35clofun3706(struct Cora* co) {
+Obj _35val2335 = co->args[1];
 Obj args = co->stack[co->base + 0];
-Obj _35reg1532 = co->stack[co->base + 1];
-pushCont(co, _35clofun2904, 1, _35reg1532);
-co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val1533;
-co->args[2] = args;
+Obj _35reg2334 = co->stack[co->base + 1];
+pushCont(co, _35clofun3707, 1, _35reg2334);
 co->nargs = 3;
+co->args[0] = globalRef(intern("map"));
+co->args[1] = _35val2335;
+co->args[2] = args;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10866,23 +10966,24 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2904(struct Cora* co) {
-Obj _35val1534 = co->args[1];
-Obj _35reg1532 = co->stack[co->base + 0];
-Obj _35reg1535 = primCons(_35reg1532, _35val1534);
-co->args[1] = _35reg1535;
+void _35clofun3707(struct Cora* co) {
+Obj _35val2336 = co->args[1];
+Obj _35reg2334 = co->stack[co->base + 0];
+Obj _35reg2337 = primCons(_35reg2334, _35val2336);
+co->nargs = 2;
+co->args[1] = _35reg2337;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2897(struct Cora* co) {
-Obj _35cc1250 = makeNative(_35clofun2898, 0, 0);
+void _35clofun3700(struct Cora* co) {
+Obj _35cc2052 = makeNative(_35clofun3701, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ls = closureRef(co, 1);
-pushCont(co, _35clofun2899, 1, ls);
+pushCont(co, _35clofun3702, 1, ls);
+co->nargs = 2;
 co->args[0] = globalRef(intern("cora/lib/toc/include.parse"));
 co->args[1] = env;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10892,13 +10993,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2899(struct Cora* co) {
-Obj _35val1523 = co->args[1];
+void _35clofun3702(struct Cora* co) {
+Obj _35val2325 = co->args[1];
 Obj ls = co->stack[co->base + 0];
-co->args[0] = globalRef(intern("map"));
-co->args[1] = _35val1523;
-co->args[2] = ls;
 co->nargs = 3;
+co->args[0] = globalRef(intern("map"));
+co->args[1] = _35val2325;
+co->args[2] = ls;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10908,10 +11009,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2898(struct Cora* co) {
+void _35clofun3701(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10921,19 +11022,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2886(struct Cora* co) {
-Obj _35p1236 = co->args[1];
-Obj _35p1237 = co->args[2];
-Obj _35cc1238 = makeNative(_35clofun2887, 0, 2, _35p1236, _35p1237);
-Obj _35reg1521 = primEQ(makeNumber(0), _35p1236);
-if (True == _35reg1521) {
-Obj res = _35p1237;
+void _35clofun3689(struct Cora* co) {
+Obj _35p2038 = co->args[1];
+Obj _35p2039 = co->args[2];
+Obj _35cc2040 = makeNative(_35clofun3690, 0, 2, _35p2038, _35p2039);
+Obj _35reg2323 = primEQ(makeNumber(0), _35p2038);
+if (True == _35reg2323) {
+Obj res = _35p2039;
+co->nargs = 2;
 co->args[1] = res;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1238;
 co->nargs = 1;
+co->args[0] = _35cc2040;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10944,17 +11046,17 @@ return;
 }
 }
 
-void _35clofun2887(struct Cora* co) {
-Obj _35cc1239 = makeNative(_35clofun2888, 0, 0);
+void _35clofun3690(struct Cora* co) {
+Obj _35cc2041 = makeNative(_35clofun3691, 0, 0);
 Obj n = closureRef(co, 0);
 Obj res = closureRef(co, 1);
-Obj _35reg1518 = primSub(n, makeNumber(1));
-Obj _35reg1519 = primGenSym(intern("tmp"));
-Obj _35reg1520 = primCons(_35reg1519, res);
-co->args[0] = globalRef(intern("cora/lib/toc/include.temp-list"));
-co->args[1] = _35reg1518;
-co->args[2] = _35reg1520;
+Obj _35reg2320 = primSub(n, makeNumber(1));
+Obj _35reg2321 = primGenSym(intern("tmp"));
+Obj _35reg2322 = primCons(_35reg2321, res);
 co->nargs = 3;
+co->args[0] = globalRef(intern("cora/lib/toc/include.temp-list"));
+co->args[1] = _35reg2320;
+co->args[2] = _35reg2322;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10964,10 +11066,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2888(struct Cora* co) {
+void _35clofun3691(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10977,13 +11079,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2883(struct Cora* co) {
+void _35clofun3686(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun2884, 0);
+pushCont(co, _35clofun3687, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.assq"));
 co->args[1] = x;
 co->args[2] = globalRef(intern("cora/lib/toc/include.*builtin-prims*"));
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -10993,13 +11095,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2884(struct Cora* co) {
-Obj _35val1515 = co->args[1];
-Obj find = _35val1515;
-pushCont(co, _35clofun2885, 1, find);
+void _35clofun3687(struct Cora* co) {
+Obj _35val2317 = co->args[1];
+Obj find = _35val2317;
+pushCont(co, _35clofun3688, 1, find);
+co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = find;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11009,17 +11111,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2885(struct Cora* co) {
-Obj _35val1516 = co->args[1];
+void _35clofun3688(struct Cora* co) {
+Obj _35val2318 = co->args[1];
 Obj find = co->stack[co->base + 0];
-if (True == _35val1516) {
+if (True == _35val2318) {
+co->nargs = 2;
 co->args[1] = makeString1("ERROR");
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("cadr"));
 co->args[1] = find;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11030,13 +11133,13 @@ return;
 }
 }
 
-void _35clofun2880(struct Cora* co) {
+void _35clofun3683(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun2881, 0);
+pushCont(co, _35clofun3684, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.assq"));
 co->args[1] = x;
 co->args[2] = globalRef(intern("cora/lib/toc/include.*builtin-prims*"));
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11046,13 +11149,13 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2881(struct Cora* co) {
-Obj _35val1512 = co->args[1];
-Obj find = _35val1512;
-pushCont(co, _35clofun2882, 1, find);
+void _35clofun3684(struct Cora* co) {
+Obj _35val2314 = co->args[1];
+Obj find = _35val2314;
+pushCont(co, _35clofun3685, 1, find);
+co->nargs = 2;
 co->args[0] = globalRef(intern("null?"));
 co->args[1] = find;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11062,17 +11165,18 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2882(struct Cora* co) {
-Obj _35val1513 = co->args[1];
+void _35clofun3685(struct Cora* co) {
+Obj _35val2315 = co->args[1];
 Obj find = co->stack[co->base + 0];
-if (True == _35val1513) {
+if (True == _35val2315) {
+co->nargs = 2;
 co->args[1] = makeString1("ERROR");
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
+co->nargs = 2;
 co->args[0] = globalRef(intern("caddr"));
 co->args[1] = find;
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11083,13 +11187,13 @@ return;
 }
 }
 
-void _35clofun2877(struct Cora* co) {
+void _35clofun3680(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun2878, 0);
+pushCont(co, _35clofun3681, 0);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.assq"));
 co->args[1] = x;
 co->args[2] = globalRef(intern("cora/lib/toc/include.*builtin-prims*"));
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11099,12 +11203,12 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2878(struct Cora* co) {
-Obj _35val1508 = co->args[1];
-pushCont(co, _35clofun2879, 0);
-co->args[0] = globalRef(intern("null?"));
-co->args[1] = _35val1508;
+void _35clofun3681(struct Cora* co) {
+Obj _35val2310 = co->args[1];
+pushCont(co, _35clofun3682, 0);
 co->nargs = 2;
+co->args[0] = globalRef(intern("null?"));
+co->args[1] = _35val2310;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11114,27 +11218,29 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2879(struct Cora* co) {
-Obj _35val1509 = co->args[1];
-Obj _35reg1510 = primNot(_35val1509);
-co->args[1] = _35reg1510;
+void _35clofun3682(struct Cora* co) {
+Obj _35val2311 = co->args[1];
+Obj _35reg2312 = primNot(_35val2311);
+co->nargs = 2;
+co->args[1] = _35reg2312;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 
-void _35clofun2873(struct Cora* co) {
-Obj _35p1232 = co->args[1];
-Obj _35p1233 = co->args[2];
-Obj _35cc1234 = makeNative(_35clofun2874, 0, 2, _35p1232, _35p1233);
-Obj x = _35p1232;
-Obj _35reg1437 = primEQ(Nil, _35p1233);
-if (True == _35reg1437) {
+void _35clofun3676(struct Cora* co) {
+Obj _35p2034 = co->args[1];
+Obj _35p2035 = co->args[2];
+Obj _35cc2036 = makeNative(_35clofun3677, 0, 2, _35p2034, _35p2035);
+Obj x = _35p2034;
+Obj _35reg2239 = primEQ(Nil, _35p2035);
+if (True == _35reg2239) {
+co->nargs = 2;
 co->args[1] = False;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1234;
 co->nargs = 1;
+co->args[0] = _35cc2036;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11145,20 +11251,20 @@ return;
 }
 }
 
-void _35clofun2874(struct Cora* co) {
-Obj _35cc1235 = makeNative(_35clofun2875, 0, 0);
+void _35clofun3677(struct Cora* co) {
+Obj _35cc2037 = makeNative(_35clofun3678, 0, 0);
 Obj x = closureRef(co, 0);
-Obj _35reg1432 = primIsCons(closureRef(co, 1));
-if (True == _35reg1432) {
-Obj _35reg1433 = primCar(closureRef(co, 1));
-Obj hd = _35reg1433;
-Obj _35reg1434 = primCdr(closureRef(co, 1));
-Obj tl = _35reg1434;
-pushCont(co, _35clofun2876, 2, x, tl);
+Obj _35reg2234 = primIsCons(closureRef(co, 1));
+if (True == _35reg2234) {
+Obj _35reg2235 = primCar(closureRef(co, 1));
+Obj hd = _35reg2235;
+Obj _35reg2236 = primCdr(closureRef(co, 1));
+Obj tl = _35reg2236;
+pushCont(co, _35clofun3679, 2, x, tl);
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.index"));
 co->args[1] = x;
 co->args[2] = hd;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11167,8 +11273,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1235;
 co->nargs = 1;
+co->args[0] = _35cc2037;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11179,16 +11285,16 @@ return;
 }
 }
 
-void _35clofun2876(struct Cora* co) {
-Obj _35val1435 = co->args[1];
+void _35clofun3679(struct Cora* co) {
+Obj _35val2237 = co->args[1];
 Obj x = co->stack[co->base + 0];
 Obj tl = co->stack[co->base + 1];
-Obj _35reg1436 = primLT(_35val1435, makeNumber(0));
-if (True == _35reg1436) {
+Obj _35reg2238 = primLT(_35val2237, makeNumber(0));
+if (True == _35reg2238) {
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.exist-in-env"));
 co->args[1] = x;
 co->args[2] = tl;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11197,16 +11303,17 @@ co->pc = coraCall;
 }
 return;
 } else {
+co->nargs = 2;
 co->args[1] = True;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 }
 }
 
-void _35clofun2875(struct Cora* co) {
+void _35clofun3678(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11216,14 +11323,14 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2872(struct Cora* co) {
+void _35clofun3675(struct Cora* co) {
 Obj x = co->args[1];
 Obj l = co->args[2];
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.pos-in-list0"));
 co->args[1] = makeNumber(0);
 co->args[2] = x;
 co->args[3] = l;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11233,21 +11340,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2868(struct Cora* co) {
-Obj _35p1226 = co->args[1];
-Obj _35p1227 = co->args[2];
-Obj _35p1228 = co->args[3];
-Obj _35cc1229 = makeNative(_35clofun2869, 0, 3, _35p1226, _35p1227, _35p1228);
-Obj __ = _35p1226;
-Obj x = _35p1227;
-Obj _35reg1429 = primEQ(Nil, _35p1228);
-if (True == _35reg1429) {
+void _35clofun3671(struct Cora* co) {
+Obj _35p2028 = co->args[1];
+Obj _35p2029 = co->args[2];
+Obj _35p2030 = co->args[3];
+Obj _35cc2031 = makeNative(_35clofun3672, 0, 3, _35p2028, _35p2029, _35p2030);
+Obj __ = _35p2028;
+Obj x = _35p2029;
+Obj _35reg2231 = primEQ(Nil, _35p2030);
+if (True == _35reg2231) {
+co->nargs = 2;
 co->args[1] = makeNumber(-1);
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1229;
 co->nargs = 1;
+co->args[0] = _35cc2031;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11258,24 +11366,25 @@ return;
 }
 }
 
-void _35clofun2869(struct Cora* co) {
-Obj _35cc1230 = makeNative(_35clofun2870, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3672(struct Cora* co) {
+Obj _35cc2032 = makeNative(_35clofun3673, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1425 = primIsCons(closureRef(co, 2));
-if (True == _35reg1425) {
-Obj _35reg1426 = primCar(closureRef(co, 2));
-Obj a = _35reg1426;
-Obj _35reg1427 = primCdr(closureRef(co, 2));
-Obj b = _35reg1427;
-Obj _35reg1428 = primEQ(x, a);
-if (True == _35reg1428) {
+Obj _35reg2227 = primIsCons(closureRef(co, 2));
+if (True == _35reg2227) {
+Obj _35reg2228 = primCar(closureRef(co, 2));
+Obj a = _35reg2228;
+Obj _35reg2229 = primCdr(closureRef(co, 2));
+Obj b = _35reg2229;
+Obj _35reg2230 = primEQ(x, a);
+if (True == _35reg2230) {
+co->nargs = 2;
 co->args[1] = pos;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1230;
 co->nargs = 1;
+co->args[0] = _35cc2032;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11285,8 +11394,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1230;
 co->nargs = 1;
+co->args[0] = _35cc2032;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11297,22 +11406,22 @@ return;
 }
 }
 
-void _35clofun2870(struct Cora* co) {
-Obj _35cc1231 = makeNative(_35clofun2871, 0, 0);
+void _35clofun3673(struct Cora* co) {
+Obj _35cc2033 = makeNative(_35clofun3674, 0, 0);
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1421 = primIsCons(closureRef(co, 2));
-if (True == _35reg1421) {
-Obj _35reg1422 = primCar(closureRef(co, 2));
-Obj a = _35reg1422;
-Obj _35reg1423 = primCdr(closureRef(co, 2));
-Obj b = _35reg1423;
-Obj _35reg1424 = primAdd(pos, makeNumber(1));
+Obj _35reg2223 = primIsCons(closureRef(co, 2));
+if (True == _35reg2223) {
+Obj _35reg2224 = primCar(closureRef(co, 2));
+Obj a = _35reg2224;
+Obj _35reg2225 = primCdr(closureRef(co, 2));
+Obj b = _35reg2225;
+Obj _35reg2226 = primAdd(pos, makeNumber(1));
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.pos-in-list0"));
-co->args[1] = _35reg1424;
+co->args[1] = _35reg2226;
 co->args[2] = x;
 co->args[3] = b;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11321,8 +11430,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1231;
 co->nargs = 1;
+co->args[0] = _35cc2033;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11333,10 +11442,10 @@ return;
 }
 }
 
-void _35clofun2871(struct Cora* co) {
+void _35clofun3674(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11346,21 +11455,22 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2864(struct Cora* co) {
-Obj _35p1221 = co->args[1];
-Obj _35p1222 = co->args[2];
-Obj _35p1223 = co->args[3];
-Obj _35cc1224 = makeNative(_35clofun2865, 0, 3, _35p1221, _35p1222, _35p1223);
-Obj f = _35p1221;
-Obj acc = _35p1222;
-Obj _35reg1419 = primEQ(Nil, _35p1223);
-if (True == _35reg1419) {
+void _35clofun3667(struct Cora* co) {
+Obj _35p2023 = co->args[1];
+Obj _35p2024 = co->args[2];
+Obj _35p2025 = co->args[3];
+Obj _35cc2026 = makeNative(_35clofun3668, 0, 3, _35p2023, _35p2024, _35p2025);
+Obj f = _35p2023;
+Obj acc = _35p2024;
+Obj _35reg2221 = primEQ(Nil, _35p2025);
+if (True == _35reg2221) {
+co->nargs = 2;
 co->args[1] = acc;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1224;
 co->nargs = 1;
+co->args[0] = _35cc2026;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11371,21 +11481,21 @@ return;
 }
 }
 
-void _35clofun2865(struct Cora* co) {
-Obj _35cc1225 = makeNative(_35clofun2866, 0, 0);
+void _35clofun3668(struct Cora* co) {
+Obj _35cc2027 = makeNative(_35clofun3669, 0, 0);
 Obj f = closureRef(co, 0);
 Obj acc = closureRef(co, 1);
-Obj _35reg1415 = primIsCons(closureRef(co, 2));
-if (True == _35reg1415) {
-Obj _35reg1416 = primCar(closureRef(co, 2));
-Obj x = _35reg1416;
-Obj _35reg1417 = primCdr(closureRef(co, 2));
-Obj y = _35reg1417;
-pushCont(co, _35clofun2867, 2, f, y);
+Obj _35reg2217 = primIsCons(closureRef(co, 2));
+if (True == _35reg2217) {
+Obj _35reg2218 = primCar(closureRef(co, 2));
+Obj x = _35reg2218;
+Obj _35reg2219 = primCdr(closureRef(co, 2));
+Obj y = _35reg2219;
+pushCont(co, _35clofun3670, 2, f, y);
+co->nargs = 3;
 co->args[0] = f;
 co->args[1] = acc;
 co->args[2] = x;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11394,8 +11504,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1225;
 co->nargs = 1;
+co->args[0] = _35cc2027;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11406,15 +11516,15 @@ return;
 }
 }
 
-void _35clofun2867(struct Cora* co) {
-Obj _35val1418 = co->args[1];
+void _35clofun3670(struct Cora* co) {
+Obj _35val2220 = co->args[1];
 Obj f = co->stack[co->base + 0];
 Obj y = co->stack[co->base + 1];
+co->nargs = 4;
 co->args[0] = globalRef(intern("cora/lib/toc/include.foldl"));
 co->args[1] = f;
-co->args[2] = _35val1418;
+co->args[2] = _35val2220;
 co->args[3] = y;
-co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11424,10 +11534,10 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2866(struct Cora* co) {
+void _35clofun3669(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11437,19 +11547,20 @@ co->pc = coraCall;
 return;
 }
 
-void _35clofun2860(struct Cora* co) {
-Obj _35p1216 = co->args[1];
-Obj _35p1217 = co->args[2];
-Obj _35cc1218 = makeNative(_35clofun2861, 0, 2, _35p1216, _35p1217);
-Obj var = _35p1216;
-Obj _35reg1413 = primEQ(Nil, _35p1217);
-if (True == _35reg1413) {
+void _35clofun3663(struct Cora* co) {
+Obj _35p2018 = co->args[1];
+Obj _35p2019 = co->args[2];
+Obj _35cc2020 = makeNative(_35clofun3664, 0, 2, _35p2018, _35p2019);
+Obj var = _35p2018;
+Obj _35reg2215 = primEQ(Nil, _35p2019);
+if (True == _35reg2215) {
+co->nargs = 2;
 co->args[1] = Nil;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1218;
 co->nargs = 1;
+co->args[0] = _35cc2020;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11460,31 +11571,32 @@ return;
 }
 }
 
-void _35clofun2861(struct Cora* co) {
-Obj _35cc1219 = makeNative(_35clofun2862, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3664(struct Cora* co) {
+Obj _35cc2021 = makeNative(_35clofun3665, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
-Obj _35reg1403 = primIsCons(closureRef(co, 1));
-if (True == _35reg1403) {
-Obj _35reg1404 = primCar(closureRef(co, 1));
-Obj _35reg1405 = primIsCons(_35reg1404);
-if (True == _35reg1405) {
-Obj _35reg1406 = primCar(closureRef(co, 1));
-Obj _35reg1407 = primCar(_35reg1406);
-Obj x = _35reg1407;
-Obj _35reg1408 = primCar(closureRef(co, 1));
-Obj _35reg1409 = primCdr(_35reg1408);
-Obj y = _35reg1409;
-Obj _35reg1410 = primCdr(closureRef(co, 1));
-Obj __ = _35reg1410;
-Obj _35reg1411 = primEQ(var, x);
-if (True == _35reg1411) {
-Obj _35reg1412 = primCons(x, y);
-co->args[1] = _35reg1412;
+Obj _35reg2205 = primIsCons(closureRef(co, 1));
+if (True == _35reg2205) {
+Obj _35reg2206 = primCar(closureRef(co, 1));
+Obj _35reg2207 = primIsCons(_35reg2206);
+if (True == _35reg2207) {
+Obj _35reg2208 = primCar(closureRef(co, 1));
+Obj _35reg2209 = primCar(_35reg2208);
+Obj x = _35reg2209;
+Obj _35reg2210 = primCar(closureRef(co, 1));
+Obj _35reg2211 = primCdr(_35reg2210);
+Obj y = _35reg2211;
+Obj _35reg2212 = primCdr(closureRef(co, 1));
+Obj __ = _35reg2212;
+Obj _35reg2213 = primEQ(var, x);
+if (True == _35reg2213) {
+Obj _35reg2214 = primCons(x, y);
+co->nargs = 2;
+co->args[1] = _35reg2214;
 popStack(&co->callstack, &co->pc, &co->base, &co->pos, &co->stack, &co->frees);
 return;
 } else {
-co->args[0] = _35cc1219;
 co->nargs = 1;
+co->args[0] = _35cc2021;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11494,8 +11606,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1219;
 co->nargs = 1;
+co->args[0] = _35cc2021;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11505,8 +11617,8 @@ co->pc = coraCall;
 return;
 }
 } else {
-co->args[0] = _35cc1219;
 co->nargs = 1;
+co->args[0] = _35cc2021;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11517,19 +11629,19 @@ return;
 }
 }
 
-void _35clofun2862(struct Cora* co) {
-Obj _35cc1220 = makeNative(_35clofun2863, 0, 0);
+void _35clofun3665(struct Cora* co) {
+Obj _35cc2022 = makeNative(_35clofun3666, 0, 0);
 Obj var = closureRef(co, 0);
-Obj _35reg1400 = primIsCons(closureRef(co, 1));
-if (True == _35reg1400) {
-Obj _35reg1401 = primCar(closureRef(co, 1));
-Obj __ = _35reg1401;
-Obj _35reg1402 = primCdr(closureRef(co, 1));
-Obj y = _35reg1402;
+Obj _35reg2202 = primIsCons(closureRef(co, 1));
+if (True == _35reg2202) {
+Obj _35reg2203 = primCar(closureRef(co, 1));
+Obj __ = _35reg2203;
+Obj _35reg2204 = primCdr(closureRef(co, 1));
+Obj y = _35reg2204;
+co->nargs = 3;
 co->args[0] = globalRef(intern("cora/lib/toc/include.assq"));
 co->args[1] = var;
 co->args[2] = y;
-co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11538,8 +11650,8 @@ co->pc = coraCall;
 }
 return;
 } else {
-co->args[0] = _35cc1220;
 co->nargs = 1;
+co->args[0] = _35cc2022;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];
@@ -11550,10 +11662,10 @@ return;
 }
 }
 
-void _35clofun2863(struct Cora* co) {
+void _35clofun3666(struct Cora* co) {
+co->nargs = 2;
 co->args[0] = globalRef(intern("error"));
 co->args[1] = makeString1("no match-help found!");
-co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
 co->frees = co->args[0];

--- a/toc.c
+++ b/toc.c
@@ -383,7 +383,7 @@ co->args[1] = makeString1("cora/lib/toc/internal");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -398,7 +398,7 @@ co->args[1] = makeString1("cora/lib/io");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -519,7 +519,7 @@ co->args[2] = makeNative(_35clofun3174, 1, 0);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -563,7 +563,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -575,7 +575,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -602,7 +602,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -615,7 +615,7 @@ co->args[1] = _35reg2822;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -627,7 +627,7 @@ co->args[1] = makeString1("no cond match");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -652,7 +652,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -665,7 +665,7 @@ co->args[1] = _35reg2830;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -677,7 +677,7 @@ co->args[1] = makeString1("no cond match");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -691,7 +691,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -719,7 +719,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -732,7 +732,7 @@ co->args[1] = _35reg2838;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -744,7 +744,7 @@ co->args[1] = makeString1("no cond match");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -758,7 +758,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -785,7 +785,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -798,7 +798,7 @@ co->args[1] = _35reg2846;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -810,7 +810,7 @@ co->args[1] = makeString1("no cond match");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -833,7 +833,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -846,7 +846,7 @@ co->args[1] = _35reg2853;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -858,7 +858,7 @@ co->args[1] = makeString1("no cond match");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -879,7 +879,7 @@ co->args[2] = _35reg2855;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -895,7 +895,7 @@ co->args[2] = _35val2856;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -913,7 +913,7 @@ co->args[2] = _35reg2848;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -929,7 +929,7 @@ co->args[2] = _35val2849;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -947,7 +947,7 @@ co->args[2] = _35reg2840;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -963,7 +963,7 @@ co->args[2] = _35val2841;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -981,7 +981,7 @@ co->args[2] = _35reg2832;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -997,7 +997,7 @@ co->args[2] = _35val2833;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1015,7 +1015,7 @@ co->args[2] = _35reg2824;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1031,7 +1031,7 @@ co->args[2] = _35val2825;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1187,7 +1187,7 @@ co->args[2] = pkg_45str;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1204,7 +1204,7 @@ co->args[1] = sexp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1221,7 +1221,7 @@ co->args[1] = input;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1238,7 +1238,7 @@ co->args[1] = to;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1256,7 +1256,7 @@ co->args[2] = bc;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1271,7 +1271,7 @@ co->args[1] = stream;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1288,7 +1288,7 @@ co->args[2] = makeString1("#include \"types.h\"\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1306,7 +1306,7 @@ co->args[2] = makeString1("#include \"runtime.h\"\n\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1324,7 +1324,7 @@ co->args[2] = bc;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1342,7 +1342,7 @@ co->args[2] = makeString1("\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1359,7 +1359,7 @@ co->args[2] = bc;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1374,7 +1374,7 @@ co->args[2] = x;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1391,7 +1391,7 @@ co->args[2] = _35reg2774;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1406,7 +1406,7 @@ co->args[2] = makeString1(";\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1428,7 +1428,7 @@ co->args[0] = _35cc1370;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1451,7 +1451,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1461,7 +1461,7 @@ co->args[0] = _35cc1371;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1479,7 +1479,7 @@ co->args[2] = y;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1492,7 +1492,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1507,7 +1507,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1522,7 +1522,7 @@ co->args[1] = _35val2761;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1537,7 +1537,7 @@ co->args[1] = _35val2762;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1552,7 +1552,7 @@ co->args[1] = _35val2763;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1566,7 +1566,7 @@ co->args[1] = _35val2764;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1581,7 +1581,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1598,7 +1598,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1615,7 +1615,7 @@ co->args[2] = fns;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1637,7 +1637,7 @@ co->args[0] = _35cc1366;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1662,7 +1662,7 @@ co->args[2] = more;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1672,7 +1672,7 @@ co->args[0] = _35cc1367;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1686,7 +1686,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1702,7 +1702,7 @@ co->args[3] = makeNative(_35clofun3170, 2, 0);
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1732,7 +1732,7 @@ co->args[2] = exp;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1747,7 +1747,7 @@ co->args[2] = globalRef(intern("cora/lib/toc/include.id"));
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1762,7 +1762,7 @@ co->args[2] = exp;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1777,7 +1777,7 @@ co->args[2] = exp;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1860,7 +1860,7 @@ co->args[2] = name;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1870,18 +1870,7 @@ co->args[0] = _35cc1363;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1363;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1892,7 +1881,7 @@ co->args[0] = _35cc1363;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1903,7 +1892,7 @@ co->args[0] = _35cc1363;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1914,7 +1903,7 @@ co->args[0] = _35cc1363;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1925,7 +1914,7 @@ co->args[0] = _35cc1363;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1936,7 +1925,7 @@ co->args[0] = _35cc1363;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1947,7 +1936,7 @@ co->args[0] = _35cc1363;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1958,7 +1947,18 @@ co->args[0] = _35cc1363;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1363;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -1979,7 +1979,7 @@ co->args[2] = makeString1(" {\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2002,7 +2002,7 @@ co->args[5] = params;
 co->nargs = 6;
 if (nativeRequired(co->args[0]) == 5) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2025,7 +2025,7 @@ co->args[5] = actives;
 co->nargs = 6;
 if (nativeRequired(co->args[0]) == 5) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2045,7 +2045,7 @@ co->args[3] = body;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2061,7 +2061,7 @@ co->args[2] = makeString1("}\n\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2074,7 +2074,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2102,7 +2102,7 @@ co->args[0] = _35cc1359;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2129,7 +2129,7 @@ co->args[2] = makeString1("Obj ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2139,7 +2139,7 @@ co->args[0] = _35cc1360;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2163,7 +2163,7 @@ co->args[3] = a;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2184,7 +2184,7 @@ co->args[2] = dest_45str;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2205,7 +2205,7 @@ co->args[2] = idx;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2226,7 +2226,7 @@ co->args[2] = makeString1("];\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2250,7 +2250,7 @@ co->args[5] = b;
 co->nargs = 6;
 if (nativeRequired(co->args[0]) == 5) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2263,7 +2263,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2280,7 +2280,7 @@ co->args[2] = makeString1("void ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2298,7 +2298,7 @@ co->args[2] = name;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2315,7 +2315,7 @@ co->args[2] = makeString1("(struct Cora* co");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2331,7 +2331,7 @@ co->args[2] = makeString1(")");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2350,7 +2350,7 @@ co->args[4] = l;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2376,7 +2376,7 @@ co->args[0] = _35cc1352;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2403,7 +2403,7 @@ co->args[3] = a;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2413,7 +2413,7 @@ co->args[0] = _35cc1353;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2433,7 +2433,7 @@ co->args[1] = b;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2455,7 +2455,7 @@ co->args[2] = makeString1(", ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2470,7 +2470,7 @@ co->args[4] = b;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2492,7 +2492,7 @@ co->args[4] = b;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2505,7 +2505,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2538,7 +2538,7 @@ co->args[2] = makeString1("pushCont(co, ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2548,18 +2548,7 @@ co->args[0] = _35cc1347;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1347;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2570,7 +2559,18 @@ co->args[0] = _35cc1347;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1347;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2590,7 +2590,7 @@ co->args[2] = label;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2608,7 +2608,7 @@ co->args[2] = makeString1(", ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2625,7 +2625,7 @@ co->args[1] = stacks;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2643,7 +2643,7 @@ co->args[2] = _35val2650;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2660,7 +2660,7 @@ co->args[1] = stacks;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2680,7 +2680,7 @@ co->args[2] = stacks;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2693,7 +2693,7 @@ co->args[2] = makeString1(");\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2710,7 +2710,7 @@ co->args[2] = makeString1(");\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2726,7 +2726,7 @@ co->args[2] = makeString1(", ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2743,7 +2743,7 @@ co->args[3] = x;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2756,7 +2756,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2782,7 +2782,7 @@ co->args[0] = _35cc1343;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2808,7 +2808,7 @@ co->args[2] = makeString1("co->args[");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2818,7 +2818,7 @@ co->args[0] = _35cc1344;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2840,7 +2840,7 @@ co->args[2] = idx;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2861,7 +2861,7 @@ co->args[2] = makeString1("] = ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2883,7 +2883,7 @@ co->args[3] = a;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2903,7 +2903,7 @@ co->args[2] = makeString1(";\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2925,7 +2925,7 @@ co->args[4] = b;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2938,7 +2938,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2961,7 +2961,7 @@ co->args[2] = x;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -2971,7 +2971,7 @@ co->args[0] = _35cc1325;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3005,7 +3005,7 @@ co->args[2] = makeString1("globalRef(intern(\"");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3015,18 +3015,7 @@ co->args[0] = _35cc1326;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1326;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3037,7 +3026,7 @@ co->args[0] = _35cc1326;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3048,7 +3037,18 @@ co->args[0] = _35cc1326;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1326;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3066,7 +3066,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3083,7 +3083,7 @@ co->args[2] = _35val2623;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3099,7 +3099,7 @@ co->args[2] = makeString1("\"))");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3132,7 +3132,7 @@ co->args[2] = makeString1("closureRef(co, ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3142,18 +3142,7 @@ co->args[0] = _35cc1327;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1327;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3164,7 +3153,7 @@ co->args[0] = _35cc1327;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3175,7 +3164,18 @@ co->args[0] = _35cc1327;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1327;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3194,7 +3194,7 @@ co->args[2] = idx;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3210,7 +3210,7 @@ co->args[2] = makeString1(")");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3243,7 +3243,7 @@ co->args[2] = makeString1("stackRef(co, ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3253,18 +3253,7 @@ co->args[0] = _35cc1328;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1328;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3275,7 +3264,7 @@ co->args[0] = _35cc1328;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3286,7 +3275,18 @@ co->args[0] = _35cc1328;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1328;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3305,7 +3305,7 @@ co->args[2] = idx;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3321,7 +3321,7 @@ co->args[2] = makeString1(")");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3356,7 +3356,7 @@ co->args[2] = makeString1("intern(\"");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3368,7 +3368,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3379,7 +3379,7 @@ co->args[0] = _35cc1329;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3390,7 +3390,7 @@ co->args[0] = _35cc1329;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3401,7 +3401,7 @@ co->args[0] = _35cc1329;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3412,7 +3412,7 @@ co->args[0] = _35cc1329;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3432,7 +3432,7 @@ co->args[2] = makeString1("makeNumber(");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3447,7 +3447,7 @@ co->args[2] = makeString1("makeString1(\"");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3461,7 +3461,7 @@ co->args[2] = makeString1("Nil");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3475,7 +3475,7 @@ co->args[2] = makeString1("True");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3489,7 +3489,7 @@ co->args[2] = makeString1("False");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3500,7 +3500,7 @@ co->args[1] = makeString1("no cond match");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3522,7 +3522,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3539,7 +3539,7 @@ co->args[2] = _35val2583;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3555,7 +3555,7 @@ co->args[2] = makeString1("\")");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3573,7 +3573,7 @@ co->args[2] = x;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3589,7 +3589,7 @@ co->args[2] = makeString1(")");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3606,7 +3606,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3623,7 +3623,7 @@ co->args[2] = _35val2576;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3639,7 +3639,7 @@ co->args[2] = makeString1("\")");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3692,7 +3692,7 @@ co->args[2] = env;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3702,18 +3702,7 @@ co->args[0] = _35cc1330;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1330;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3724,7 +3713,7 @@ co->args[0] = _35cc1330;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3735,7 +3724,7 @@ co->args[0] = _35cc1330;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3746,7 +3735,7 @@ co->args[0] = _35cc1330;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3757,7 +3746,18 @@ co->args[0] = _35cc1330;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1330;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3782,7 +3782,7 @@ co->args[2] = makeString1("Obj ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3796,7 +3796,7 @@ co->args[2] = a;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3818,7 +3818,7 @@ co->args[2] = makeString1(" = ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3840,7 +3840,7 @@ co->args[3] = b;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3860,7 +3860,7 @@ co->args[2] = makeString1(";\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3881,7 +3881,7 @@ co->args[3] = c;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3902,7 +3902,7 @@ co->args[2] = a;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3923,7 +3923,7 @@ co->args[2] = makeString1(" = ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3945,7 +3945,7 @@ co->args[3] = b;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3965,7 +3965,7 @@ co->args[2] = makeString1(";\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -3986,7 +3986,7 @@ co->args[3] = c;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4027,7 +4027,7 @@ co->args[1] = f;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4037,18 +4037,7 @@ co->args[0] = _35cc1331;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1331;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4059,7 +4048,7 @@ co->args[0] = _35cc1331;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4070,7 +4059,7 @@ co->args[0] = _35cc1331;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4081,7 +4070,18 @@ co->args[0] = _35cc1331;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1331;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4101,7 +4101,7 @@ co->args[2] = _35val2521;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4120,7 +4120,7 @@ co->args[2] = makeString1("(");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4140,7 +4140,7 @@ co->args[3] = args;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4156,7 +4156,7 @@ co->args[2] = makeString1(")");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4209,7 +4209,7 @@ co->args[2] = makeString1("if (True == ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4219,18 +4219,7 @@ co->args[0] = _35cc1332;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1332;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4241,7 +4230,7 @@ co->args[0] = _35cc1332;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4252,7 +4241,7 @@ co->args[0] = _35cc1332;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4263,7 +4252,7 @@ co->args[0] = _35cc1332;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4274,7 +4263,18 @@ co->args[0] = _35cc1332;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1332;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4297,7 +4297,7 @@ co->args[3] = a;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4317,7 +4317,7 @@ co->args[2] = makeString1(") {\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4338,7 +4338,7 @@ co->args[3] = b;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4357,7 +4357,7 @@ co->args[2] = makeString1("} else {\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4377,7 +4377,7 @@ co->args[3] = c;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4393,7 +4393,7 @@ co->args[2] = makeString1("}\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4434,7 +4434,7 @@ co->args[2] = makeString1("makeNative(");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4444,18 +4444,7 @@ co->args[0] = _35cc1333;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1333;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4466,7 +4455,7 @@ co->args[0] = _35cc1333;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4477,7 +4466,18 @@ co->args[0] = _35cc1333;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1333;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4499,7 +4499,7 @@ co->args[2] = label;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4519,7 +4519,7 @@ co->args[2] = makeString1(", ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4539,7 +4539,7 @@ co->args[2] = nargs;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4558,7 +4558,7 @@ co->args[2] = makeString1(", ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4576,7 +4576,7 @@ co->args[1] = frees;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4595,7 +4595,7 @@ co->args[2] = _35val2466;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4613,7 +4613,7 @@ co->args[1] = frees;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4634,7 +4634,7 @@ co->args[2] = makeString1(", ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4647,7 +4647,7 @@ co->args[2] = makeString1(")");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4668,7 +4668,7 @@ co->args[3] = frees;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4684,7 +4684,7 @@ co->args[2] = makeString1(")");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4727,7 +4727,7 @@ co->args[3] = a;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4737,18 +4737,7 @@ co->args[0] = _35cc1334;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1334;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4759,7 +4748,7 @@ co->args[0] = _35cc1334;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4770,7 +4759,7 @@ co->args[0] = _35cc1334;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4781,7 +4770,18 @@ co->args[0] = _35cc1334;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1334;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4801,7 +4801,7 @@ co->args[2] = makeString1(";\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4820,7 +4820,7 @@ co->args[3] = b;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4853,7 +4853,7 @@ co->args[2] = makeString1("co->args[1] = ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4863,18 +4863,7 @@ co->args[0] = _35cc1335;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1335;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4885,7 +4874,7 @@ co->args[0] = _35cc1335;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4896,7 +4885,18 @@ co->args[0] = _35cc1335;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1335;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4917,7 +4917,7 @@ co->args[3] = x;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4934,7 +4934,7 @@ co->args[2] = makeString1(";\npopStack(&co->callstack, &co->pc, &co->base, &co->
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4950,7 +4950,7 @@ co->args[2] = makeString1("\nreturn;\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4983,7 +4983,7 @@ co->args[3] = exp;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -4993,18 +4993,7 @@ co->args[0] = _35cc1336;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1336;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5015,7 +5004,7 @@ co->args[0] = _35cc1336;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5026,7 +5015,18 @@ co->args[0] = _35cc1336;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1336;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5069,7 +5069,7 @@ co->args[2] = cont;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5079,18 +5079,7 @@ co->args[0] = _35cc1337;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1337;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5101,7 +5090,7 @@ co->args[0] = _35cc1337;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5112,7 +5101,7 @@ co->args[0] = _35cc1337;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5123,7 +5112,18 @@ co->args[0] = _35cc1337;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1337;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5143,7 +5143,7 @@ co->args[3] = exp;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5170,7 +5170,7 @@ co->args[4] = _35reg2370;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5180,7 +5180,7 @@ co->args[0] = _35cc1338;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5200,7 +5200,7 @@ co->args[2] = makeString1("co->nargs = ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5219,7 +5219,7 @@ co->args[1] = _35reg2373;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5237,7 +5237,7 @@ co->args[2] = _35val2374;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5255,7 +5255,7 @@ co->args[2] = makeString1(";\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5273,7 +5273,7 @@ co->args[2] = makeString1("if (nativeRequired(co->args[0]) == ");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5290,7 +5290,7 @@ co->args[1] = args;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5307,7 +5307,7 @@ co->args[2] = _35val2378;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5324,7 +5324,7 @@ co->args[2] = makeString1(") {\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5341,7 +5341,7 @@ co->args[2] = makeString1("co->pc = nativeFuncPtr(co->args[0]);\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5354,11 +5354,11 @@ Obj w = co->stack[co->base + 0];
 pushCont(co, _35clofun3065, 1, w);
 co->args[0] = globalRef(intern("cora/lib/toc/internal.generate-str"));
 co->args[1] = w;
-co->args[2] = makeString1("co->frees = nativeData(co->args[0]);\n");
+co->args[2] = makeString1("co->frees = co->args[0];\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5375,7 +5375,7 @@ co->args[2] = makeString1("} else {\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5392,7 +5392,7 @@ co->args[2] = makeString1("co->pc = coraCall;\n}\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5408,7 +5408,7 @@ co->args[2] = makeString1("return;\n");
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5421,7 +5421,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5439,7 +5439,7 @@ co->args[1] = tmp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5476,7 +5476,7 @@ co->args[1] = res;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5486,7 +5486,7 @@ co->args[0] = _35cc1320;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5504,7 +5504,7 @@ co->args[2] = _35val2358;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5529,7 +5529,7 @@ co->args[3] = makeNative(_35clofun3036, 2, 3, res, y, k);
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5539,7 +5539,7 @@ co->args[0] = _35cc1321;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5559,7 +5559,7 @@ co->args[4] = closureRef(co, 2);
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5572,7 +5572,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5646,7 +5646,7 @@ co->args[3] = makeNative(_35clofun3027, 2, 5, k, params, clo_45or_45cont, name, 
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5656,7 +5656,7 @@ co->args[0] = _35cc1313;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5675,7 +5675,7 @@ co->args[3] = makeNative(_35clofun3029, 2, 5, k, params, clo_45or_45cont, name, 
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5685,7 +5685,7 @@ co->args[0] = _35cc1313;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5702,7 +5702,7 @@ co->args[3] = makeNative(_35clofun3031, 2, 5, k, params, clo_45or_45cont, name, 
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5712,7 +5712,7 @@ co->args[0] = _35cc1313;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5725,18 +5725,7 @@ co->args[0] = _35cc1313;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1313;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5747,7 +5736,7 @@ co->args[0] = _35cc1313;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5758,7 +5747,7 @@ co->args[0] = _35cc1313;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5769,7 +5758,7 @@ co->args[0] = _35cc1313;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5780,7 +5769,7 @@ co->args[0] = _35cc1313;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5791,7 +5780,18 @@ co->args[0] = _35cc1313;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1313;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5817,7 +5817,7 @@ co->args[1] = closureRef(co, 1);
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5838,7 +5838,7 @@ co->args[2] = _35reg2351;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5858,7 +5858,7 @@ co->args[2] = _35reg2342;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5883,7 +5883,7 @@ co->args[1] = closureRef(co, 1);
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5904,7 +5904,7 @@ co->args[2] = _35reg2329;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5924,7 +5924,7 @@ co->args[2] = _35reg2320;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5949,7 +5949,7 @@ co->args[1] = closureRef(co, 1);
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5970,7 +5970,7 @@ co->args[2] = _35reg2306;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -5990,7 +5990,7 @@ co->args[2] = _35reg2297;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6012,7 +6012,7 @@ co->args[4] = k;
 co->nargs = 5;
 if (nativeRequired(co->args[0]) == 4) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6022,7 +6022,7 @@ co->args[0] = _35cc1314;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6041,7 +6041,7 @@ co->args[2] = x;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6054,7 +6054,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6073,7 +6073,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6093,7 +6093,7 @@ co->args[0] = _35cc1304;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6115,7 +6115,7 @@ co->args[0] = _35cc1305;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6157,7 +6157,7 @@ co->args[2] = body;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6167,18 +6167,7 @@ co->args[0] = _35cc1306;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1306;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6189,7 +6178,7 @@ co->args[0] = _35cc1306;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6200,7 +6189,7 @@ co->args[0] = _35cc1306;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6211,7 +6200,18 @@ co->args[0] = _35cc1306;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1306;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6263,7 +6263,7 @@ co->args[1] = body;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6273,18 +6273,7 @@ co->args[0] = _35cc1307;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1307;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6295,7 +6284,7 @@ co->args[0] = _35cc1307;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6306,7 +6295,7 @@ co->args[0] = _35cc1307;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6317,7 +6306,18 @@ co->args[0] = _35cc1307;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1307;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6337,7 +6337,7 @@ co->args[2] = val;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6356,7 +6356,7 @@ co->args[1] = fvs;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6375,7 +6375,7 @@ co->args[2] = fvs1;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6395,7 +6395,7 @@ co->args[2] = body;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6449,7 +6449,7 @@ co->args[1] = fvs;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6459,18 +6459,7 @@ co->args[0] = _35cc1308;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1308;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6481,7 +6470,7 @@ co->args[0] = _35cc1308;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6492,7 +6481,7 @@ co->args[0] = _35cc1308;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6503,7 +6492,18 @@ co->args[0] = _35cc1308;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1308;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6523,7 +6523,7 @@ co->args[2] = exp;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6541,7 +6541,7 @@ co->args[2] = cont;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6574,7 +6574,7 @@ co->args[1] = fvs;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6584,7 +6584,7 @@ co->args[0] = _35cc1309;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6603,7 +6603,7 @@ co->args[2] = _35reg2171;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6616,7 +6616,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6638,7 +6638,7 @@ co->args[1] = ls;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6648,7 +6648,7 @@ co->args[0] = _35cc1300;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6667,7 +6667,7 @@ co->args[1] = _35reg2126;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6685,7 +6685,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6698,7 +6698,7 @@ co->args[2] = next;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6721,7 +6721,7 @@ co->args[1] = val;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6759,7 +6759,7 @@ co->args[2] = next;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6782,7 +6782,7 @@ co->args[1] = val;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6797,7 +6797,7 @@ co->args[2] = next;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6820,7 +6820,7 @@ co->args[1] = val;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6876,7 +6876,7 @@ co->args[2] = makeNative(_35clofun2998, 1, 3, tl, ls, next);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6886,7 +6886,7 @@ co->args[0] = _35cc1301;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6904,7 +6904,7 @@ co->args[3] = closureRef(co, 2);
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6917,7 +6917,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6938,7 +6938,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6948,7 +6948,7 @@ co->args[0] = _35cc1290;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6961,7 +6961,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6981,7 +6981,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -6991,7 +6991,7 @@ co->args[0] = _35cc1290;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7004,7 +7004,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7014,7 +7014,7 @@ co->args[0] = _35cc1290;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7033,7 +7033,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7053,7 +7053,7 @@ co->args[0] = _35cc1291;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7105,7 +7105,7 @@ co->args[2] = makeNative(_35clofun2990, 1, 3, b, c, next);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7115,18 +7115,7 @@ co->args[0] = _35cc1292;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1292;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7137,7 +7126,7 @@ co->args[0] = _35cc1292;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7148,7 +7137,7 @@ co->args[0] = _35cc1292;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7159,7 +7148,7 @@ co->args[0] = _35cc1292;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7170,7 +7159,18 @@ co->args[0] = _35cc1292;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1292;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7187,7 +7187,7 @@ co->args[2] = closureRef(co, 2);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7204,7 +7204,7 @@ co->args[2] = closureRef(co, 2);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7257,7 +7257,7 @@ co->args[2] = makeNative(_35clofun2988, 1, 2, b, next);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7267,18 +7267,7 @@ co->args[0] = _35cc1293;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1293;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7289,7 +7278,7 @@ co->args[0] = _35cc1293;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7300,7 +7289,7 @@ co->args[0] = _35cc1293;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7311,7 +7300,18 @@ co->args[0] = _35cc1293;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1293;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7329,7 +7329,7 @@ co->args[2] = closureRef(co, 1);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7342,7 +7342,7 @@ co->args[2] = closureRef(co, 1);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7405,7 +7405,7 @@ co->args[2] = makeNative(_35clofun2986, 1, 3, a, c, next);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7415,18 +7415,7 @@ co->args[0] = _35cc1294;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1294;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7437,7 +7426,7 @@ co->args[0] = _35cc1294;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7448,7 +7437,7 @@ co->args[0] = _35cc1294;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7459,7 +7448,7 @@ co->args[0] = _35cc1294;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7470,7 +7459,18 @@ co->args[0] = _35cc1294;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1294;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7487,7 +7487,7 @@ co->args[2] = closureRef(co, 2);
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7565,7 +7565,7 @@ co->args[2] = globalRef(intern("cora/lib/toc/include.id"));
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7575,18 +7575,7 @@ co->args[0] = _35cc1295;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1295;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7597,7 +7586,7 @@ co->args[0] = _35cc1295;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7608,7 +7597,7 @@ co->args[0] = _35cc1295;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7619,7 +7608,7 @@ co->args[0] = _35cc1295;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7630,7 +7619,7 @@ co->args[0] = _35cc1295;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7641,7 +7630,7 @@ co->args[0] = _35cc1295;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7652,7 +7641,18 @@ co->args[0] = _35cc1295;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1295;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7675,7 +7675,7 @@ co->args[1] = _35reg2030;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7699,7 +7699,7 @@ co->args[3] = next;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7709,7 +7709,7 @@ co->args[0] = _35cc1296;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7723,7 +7723,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7751,7 +7751,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7771,7 +7771,7 @@ co->args[0] = _35cc1283;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7792,7 +7792,7 @@ co->args[2] = fvs;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7802,7 +7802,7 @@ co->args[0] = _35cc1284;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7864,7 +7864,7 @@ co->args[1] = _35reg1963;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7874,18 +7874,7 @@ co->args[0] = _35cc1285;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1285;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7896,7 +7885,7 @@ co->args[0] = _35cc1285;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7907,7 +7896,7 @@ co->args[0] = _35cc1285;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7918,7 +7907,18 @@ co->args[0] = _35cc1285;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1285;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7939,7 +7939,7 @@ co->args[2] = body;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7960,7 +7960,7 @@ co->args[1] = fvs;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -7978,7 +7978,7 @@ co->args[2] = fvs1;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8040,7 +8040,7 @@ co->args[2] = b;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8050,18 +8050,7 @@ co->args[0] = _35cc1286;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1286;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8072,7 +8061,7 @@ co->args[0] = _35cc1286;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8083,7 +8072,7 @@ co->args[0] = _35cc1286;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8094,7 +8083,7 @@ co->args[0] = _35cc1286;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8105,7 +8094,18 @@ co->args[0] = _35cc1286;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1286;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8125,7 +8125,7 @@ co->args[2] = c;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8160,7 +8160,7 @@ co->args[1] = fvs;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8170,7 +8170,7 @@ co->args[0] = _35cc1287;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8189,7 +8189,7 @@ co->args[2] = _35reg1911;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8202,7 +8202,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8219,7 +8219,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8238,7 +8238,7 @@ co->args[0] = _35cc1269;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8260,7 +8260,7 @@ co->args[0] = _35cc1270;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8300,7 +8300,7 @@ co->args[1] = body;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8310,18 +8310,7 @@ co->args[0] = _35cc1271;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1271;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8332,7 +8321,7 @@ co->args[0] = _35cc1271;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8343,7 +8332,7 @@ co->args[0] = _35cc1271;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8354,7 +8343,18 @@ co->args[0] = _35cc1271;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1271;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8371,7 +8371,7 @@ co->args[2] = args;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8425,7 +8425,7 @@ co->args[2] = _35reg1883;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8435,18 +8435,7 @@ co->args[0] = _35cc1272;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1272;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8457,7 +8446,7 @@ co->args[0] = _35cc1272;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8468,7 +8457,7 @@ co->args[0] = _35cc1272;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8479,7 +8468,7 @@ co->args[0] = _35cc1272;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8490,7 +8479,18 @@ co->args[0] = _35cc1272;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1272;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8507,7 +8507,7 @@ co->args[3] = _35val1884;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8549,7 +8549,7 @@ co->args[2] = _35reg1853;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8559,18 +8559,7 @@ co->args[0] = _35cc1273;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1273;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8581,7 +8570,7 @@ co->args[0] = _35cc1273;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8592,7 +8581,7 @@ co->args[0] = _35cc1273;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8603,7 +8592,18 @@ co->args[0] = _35cc1273;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1273;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8620,7 +8620,7 @@ co->args[3] = _35val1854;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8670,7 +8670,7 @@ co->args[1] = b;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8680,18 +8680,7 @@ co->args[0] = _35cc1274;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1274;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8702,7 +8691,7 @@ co->args[0] = _35cc1274;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8713,7 +8702,7 @@ co->args[0] = _35cc1274;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8724,7 +8713,7 @@ co->args[0] = _35cc1274;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8735,7 +8724,18 @@ co->args[0] = _35cc1274;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1274;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8753,7 +8753,7 @@ co->args[1] = c;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8772,7 +8772,7 @@ co->args[2] = _35reg1833;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8788,7 +8788,7 @@ co->args[2] = _35val1834;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8817,7 +8817,7 @@ co->args[1] = _35reg1804;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8827,18 +8827,7 @@ co->args[0] = _35cc1275;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1275;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8849,7 +8838,18 @@ co->args[0] = _35cc1275;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1275;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8879,7 +8879,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8889,18 +8889,7 @@ co->args[0] = _35cc1276;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1276;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8911,7 +8900,7 @@ co->args[0] = _35cc1276;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8922,7 +8911,18 @@ co->args[0] = _35cc1276;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1276;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8965,7 +8965,7 @@ co->args[2] = _35reg1783;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8975,18 +8975,7 @@ co->args[0] = _35cc1277;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1277;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -8997,7 +8986,7 @@ co->args[0] = _35cc1277;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9008,7 +8997,7 @@ co->args[0] = _35cc1277;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9019,7 +9008,18 @@ co->args[0] = _35cc1277;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1277;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9036,7 +9036,7 @@ co->args[3] = _35val1784;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9065,7 +9065,7 @@ co->args[1] = exp;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9075,18 +9075,7 @@ co->args[0] = _35cc1278;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1278;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9097,7 +9086,7 @@ co->args[0] = _35cc1278;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9108,7 +9097,18 @@ co->args[0] = _35cc1278;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1278;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9148,7 +9148,7 @@ co->args[1] = body;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9158,18 +9158,7 @@ co->args[0] = _35cc1279;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1279;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9180,7 +9169,7 @@ co->args[0] = _35cc1279;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9191,7 +9180,7 @@ co->args[0] = _35cc1279;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9202,7 +9191,18 @@ co->args[0] = _35cc1279;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1279;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9219,7 +9219,7 @@ co->args[2] = arg;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9242,7 +9242,7 @@ co->args[2] = _35reg1735;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9252,7 +9252,7 @@ co->args[0] = _35cc1280;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9269,7 +9269,7 @@ co->args[3] = _35val1736;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9282,7 +9282,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9315,7 +9315,7 @@ co->args[0] = _35cc1262;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9326,7 +9326,7 @@ co->args[0] = _35cc1262;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9337,7 +9337,7 @@ co->args[0] = _35cc1262;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9348,7 +9348,7 @@ co->args[0] = _35cc1262;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9381,7 +9381,7 @@ co->args[0] = _35cc1263;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9392,7 +9392,7 @@ co->args[0] = _35cc1263;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9403,7 +9403,7 @@ co->args[0] = _35cc1263;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9414,7 +9414,7 @@ co->args[0] = _35cc1263;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9447,7 +9447,7 @@ co->args[0] = _35cc1264;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9458,7 +9458,7 @@ co->args[0] = _35cc1264;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9469,7 +9469,7 @@ co->args[0] = _35cc1264;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9480,7 +9480,7 @@ co->args[0] = _35cc1264;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9513,7 +9513,7 @@ co->args[0] = _35cc1265;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9524,7 +9524,7 @@ co->args[0] = _35cc1265;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9535,7 +9535,7 @@ co->args[0] = _35cc1265;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9546,7 +9546,7 @@ co->args[0] = _35cc1265;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9579,7 +9579,7 @@ co->args[0] = _35cc1266;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9590,7 +9590,7 @@ co->args[0] = _35cc1266;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9601,7 +9601,7 @@ co->args[0] = _35cc1266;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9612,7 +9612,7 @@ co->args[0] = _35cc1266;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9634,7 +9634,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9656,7 +9656,7 @@ co->args[0] = _35cc1258;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9680,7 +9680,7 @@ co->args[2] = s2;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9690,7 +9690,7 @@ co->args[0] = _35cc1259;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9710,7 +9710,7 @@ co->args[2] = s2;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9720,7 +9720,7 @@ co->args[0] = _35cc1259;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9744,7 +9744,7 @@ co->args[2] = s2;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9754,7 +9754,7 @@ co->args[0] = _35cc1260;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9777,7 +9777,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9799,7 +9799,7 @@ co->args[0] = _35cc1253;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9823,7 +9823,7 @@ co->args[2] = s2;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9833,7 +9833,7 @@ co->args[0] = _35cc1254;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9853,7 +9853,7 @@ co->args[2] = s2;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9863,7 +9863,7 @@ co->args[0] = _35cc1254;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9887,7 +9887,7 @@ co->args[2] = s2;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9897,7 +9897,7 @@ co->args[0] = _35cc1255;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9920,7 +9920,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9939,7 +9939,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9962,7 +9962,7 @@ co->args[0] = _35cc1242;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9982,7 +9982,7 @@ co->args[0] = _35cc1242;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -9995,7 +9995,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10020,7 +10020,7 @@ co->args[0] = _35cc1242;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10033,7 +10033,7 @@ co->args[1] = x;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10057,7 +10057,7 @@ co->args[0] = _35cc1242;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10075,7 +10075,7 @@ co->args[0] = _35cc1242;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10112,7 +10112,7 @@ co->args[0] = _35cc1243;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10123,7 +10123,7 @@ co->args[0] = _35cc1243;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10134,7 +10134,7 @@ co->args[0] = _35cc1243;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10145,7 +10145,7 @@ co->args[0] = _35cc1243;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10166,7 +10166,7 @@ co->args[2] = env;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10176,7 +10176,7 @@ co->args[0] = _35cc1244;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10234,7 +10234,7 @@ co->args[2] = env;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10244,18 +10244,7 @@ co->args[0] = _35cc1245;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1245;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10266,7 +10255,7 @@ co->args[0] = _35cc1245;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10277,7 +10266,7 @@ co->args[0] = _35cc1245;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10288,7 +10277,18 @@ co->args[0] = _35cc1245;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1245;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10307,7 +10307,7 @@ co->args[2] = body;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10341,7 +10341,7 @@ co->args[1] = env;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10351,7 +10351,7 @@ co->args[0] = _35cc1246;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10362,7 +10362,7 @@ co->args[0] = _35cc1246;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10380,7 +10380,7 @@ co->args[2] = args;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10429,7 +10429,7 @@ co->args[2] = x;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10439,18 +10439,7 @@ co->args[0] = _35cc1247;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1247;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10461,7 +10450,7 @@ co->args[0] = _35cc1247;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10472,7 +10461,7 @@ co->args[0] = _35cc1247;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10483,7 +10472,18 @@ co->args[0] = _35cc1247;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1247;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10502,7 +10502,7 @@ co->args[2] = y;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10565,7 +10565,7 @@ co->args[2] = b;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10575,18 +10575,7 @@ co->args[0] = _35cc1248;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
-} else {
-co->pc = coraCall;
-}
-return;
-}
-} else {
-co->args[0] = _35cc1248;
-co->nargs = 1;
-if (nativeRequired(co->args[0]) == 0) {
-co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10597,7 +10586,7 @@ co->args[0] = _35cc1248;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10608,7 +10597,7 @@ co->args[0] = _35cc1248;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10619,7 +10608,7 @@ co->args[0] = _35cc1248;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10630,7 +10619,18 @@ co->args[0] = _35cc1248;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
+} else {
+co->pc = coraCall;
+}
+return;
+}
+} else {
+co->args[0] = _35cc1248;
+co->nargs = 1;
+if (nativeRequired(co->args[0]) == 0) {
+co->pc = nativeFuncPtr(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10651,7 +10651,7 @@ co->args[2] = c;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10686,7 +10686,7 @@ co->args[1] = op;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10696,7 +10696,7 @@ co->args[0] = _35cc1249;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10717,7 +10717,7 @@ co->args[1] = op;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10727,7 +10727,7 @@ co->args[0] = _35cc1249;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10747,7 +10747,7 @@ co->args[1] = args;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10771,7 +10771,7 @@ co->args[1] = env;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10787,7 +10787,7 @@ co->args[2] = Nil;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10798,7 +10798,7 @@ co->args[1] = makeString1("primitive call mismatch");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10821,7 +10821,7 @@ co->args[2] = tmp;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10841,7 +10841,7 @@ co->args[2] = _35reg1543;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10859,7 +10859,7 @@ co->args[2] = args;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10885,7 +10885,7 @@ co->args[1] = env;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10901,7 +10901,7 @@ co->args[2] = ls;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10914,7 +10914,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10936,7 +10936,7 @@ co->args[0] = _35cc1238;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10957,7 +10957,7 @@ co->args[2] = _35reg1520;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10970,7 +10970,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -10986,7 +10986,7 @@ co->args[2] = globalRef(intern("cora/lib/toc/include.*builtin-prims*"));
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11002,7 +11002,7 @@ co->args[1] = find;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11022,7 +11022,7 @@ co->args[1] = find;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11039,7 +11039,7 @@ co->args[2] = globalRef(intern("cora/lib/toc/include.*builtin-prims*"));
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11055,7 +11055,7 @@ co->args[1] = find;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11075,7 +11075,7 @@ co->args[1] = find;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11092,7 +11092,7 @@ co->args[2] = globalRef(intern("cora/lib/toc/include.*builtin-prims*"));
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11107,7 +11107,7 @@ co->args[1] = _35val1508;
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11137,7 +11137,7 @@ co->args[0] = _35cc1234;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11161,7 +11161,7 @@ co->args[2] = hd;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11171,7 +11171,7 @@ co->args[0] = _35cc1235;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11191,7 +11191,7 @@ co->args[2] = tl;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11209,7 +11209,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11226,7 +11226,7 @@ co->args[3] = l;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11250,7 +11250,7 @@ co->args[0] = _35cc1229;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11278,7 +11278,7 @@ co->args[0] = _35cc1230;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11289,7 +11289,7 @@ co->args[0] = _35cc1230;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11315,7 +11315,7 @@ co->args[3] = b;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11325,7 +11325,7 @@ co->args[0] = _35cc1231;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11339,7 +11339,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11363,7 +11363,7 @@ co->args[0] = _35cc1224;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11388,7 +11388,7 @@ co->args[2] = x;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11398,7 +11398,7 @@ co->args[0] = _35cc1225;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11417,7 +11417,7 @@ co->args[3] = y;
 co->nargs = 4;
 if (nativeRequired(co->args[0]) == 3) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11430,7 +11430,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11452,7 +11452,7 @@ co->args[0] = _35cc1218;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11487,7 +11487,7 @@ co->args[0] = _35cc1219;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11498,7 +11498,7 @@ co->args[0] = _35cc1219;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11509,7 +11509,7 @@ co->args[0] = _35cc1219;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11532,7 +11532,7 @@ co->args[2] = y;
 co->nargs = 3;
 if (nativeRequired(co->args[0]) == 2) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11542,7 +11542,7 @@ co->args[0] = _35cc1220;
 co->nargs = 1;
 if (nativeRequired(co->args[0]) == 0) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }
@@ -11556,7 +11556,7 @@ co->args[1] = makeString1("no match-help found!");
 co->nargs = 2;
 if (nativeRequired(co->args[0]) == 1) {
 co->pc = nativeFuncPtr(co->args[0]);
-co->frees = nativeData(co->args[0]);
+co->frees = co->args[0];
 } else {
 co->pc = coraCall;
 }


### PR DESCRIPTION
Some lesson learned:

1. for a moving GC, reference object's internal substruct is unsafe.

For example, store closure->data to struct Cora:

```
struct scmNative {
  scmHead head;
  basicBlock fn;
  // required is the argument number of the nativeFunc.
  int required;
  // captured is the size of the data, it's immutable after makeNative.
  int captured;
  Obj data[];
};
```

The referenced scmNative may be moved by GC, and the closure->data in struct  Cora is not updated correspondingly

2. safepoint is important

    The following code is unsafe, if the GC is triggered in makeNative
    at that time co->nargs = 4 is not set yet,
    so co->args[0],[1],[2],[3] is not protected from been GC!
    For example, after GC, exp is moved to some other place,
    but co->args[3] is not updated to the new place because co->nargs is not set to 4 yet

```    
        Obj exp = co->args[1];
        co->args[0] = globalRef(intern("cora/lib/toc/include.collect-lambda"));
        co->args[1] = Nil;
        co->args[2] = exp;
        co->args[3] = makeNative(_35clofun3170, 2, 0);
        co->nargs = 4;
```

3. Always keep in mind there must be some path from the GC root to the current data

```
    co->nargs = 2      // If here is not set, co->args[1] is not protected from GC!!!
    co->args[1] = xxx
    popStack(...)
```

4. Be careful when C code reference the cora Obj in its structure.

```
    Reference Obj in C is not safe. Nothing prevent the GC to move it!
    struct SexpReader {
      /* Obj pkgMapping; */
      char *selfPath;
    };
```