### PR TITLE
gc: change GC from DFS to BFS, get rid of the recursion

### DIFF
--- a/main.c
+++ b/main.c
@@ -24,7 +24,7 @@ int main(int argc, char *argv[]) {
   trampoline(co, builtinLoadSo);
   symbolSet(imported, cons(makeString1("cora/lib/toc/include"), symbolGet(imported)));
   
-  struct SexpReader r = {.pkgMapping = Nil};
+  struct SexpReader r = {};
   int errCode = 0;
 
   for (int i=0; ; i++) {

--- a/src/gc.h
+++ b/src/gc.h
@@ -27,7 +27,7 @@ void* gcAlloc(struct GC* gc, int size);
 bool gcCheck(struct GC* gc);
 void gcRun(struct GC *gc);
 
-typedef void (*gcFunc)(struct GC *gc, void* from, void* to);
+typedef void (*gcFunc)(struct GC *gc, void* from);
 bool gcRegistForType(uint8_t type, gcFunc fn);
 
 extern struct GC gc;

--- a/src/types.c
+++ b/src/types.c
@@ -73,11 +73,11 @@ bool iscons(Obj o) {
 }
 
 static void
-consGCFunc(struct GC *gc, void* f, void* t) {
+consGCFunc(struct GC *gc, void* f) {
   struct scmCons *from = f;
-  struct scmCons *to = t;
-  to->car = gcCopy(gc, from->car);
-  to->cdr = gcCopy(gc, from->cdr);
+  assert(from->head.forwarding == 0);
+  from->car = gcCopy(gc, from->car);
+  from->cdr = gcCopy(gc, from->cdr);
 }
 
 Obj
@@ -172,7 +172,7 @@ isstring(Obj o) {
 }
 
 static void
-stringGCFunc(struct GC *gc, void* f, void* t) {
+stringGCFunc(struct GC *gc, void* f) {
   // TODO:
 }
 
@@ -255,11 +255,11 @@ makeNative(basicBlock fn, int required, int captured, ...) {
 }
 
 static void
-nativeGCFunc(struct GC *gc, void* f, void* t) {
+nativeGCFunc(struct GC *gc, void* f) {
   struct scmNative *from = f;
-  struct scmNative *to = t;
+  assert(from->head.forwarding == 0);
   for (int i=0; i<from->captured; i++) {
-    to->data[i] = gcCopy(gc, from->data[i]);
+    from->data[i] = gcCopy(gc, from->data[i]);
   }
 }
 
@@ -345,11 +345,11 @@ isvector(Obj o) {
 
 
 static void
-vectorGCFunc(struct GC *gc, void* f, void* t) {
+vectorGCFunc(struct GC *gc, void* f) {
   struct scmVector *from = f;
-  struct scmVector *to = t;
+  assert(from->head.forwarding == 0);
   for (int i=0; i<from->size; i++) {
-    to->data[i] = gcCopy(gc, from->data[i]);
+    from->data[i] = gcCopy(gc, from->data[i]);
   }
 }
 


### PR DESCRIPTION
The old code use gcCopy() recusive to implement GC is DFS (depth first search) Now it's rewritten use non-recursive way, and change to BFS (breadth first search) Remove recursion is very important towards the incremental GC.