### PR TITLE
gc: evolve the stop-copying GC to mostly-copying GC

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -168,7 +168,7 @@ coraGCFunc(struct GC *gc, struct Cora *co) {
     /* printf("coraGC fun, args[%d] %p -> %p\n", i, before, co->args[i]); */
   }
   // Closure register.
-  Obj save = co->frees;
+  /* Obj save = co->frees; */
   co->frees = gcCopy(gc, co->frees);
   /* printf("coraGC frees = %p -> %p\n", save, co->frees); */
   // Return stack


### PR DESCRIPTION
This commit evolve the stop-copying GC to the mostly-copying GC.

See the "mostly-copying" algorithm in 
"Compacting Garbage Collection with Ambiguous Roots",   Joel F. Bartlett 1988


To adopt the new algorithm, list the changes below:

- rewrite the old recursion gcCopy, essentially it changes from DFS to BFS 
- change the area's blocks representation from dynamic array to double linked list
- change the gcStack() function from gcCopy to gcCopyBlock
