### PR TITLE
runtime: introduce heapArena and use mmap, now two-layer allocation

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -380,9 +380,15 @@ checkPointer(struct GC *gc, uintptr_t p) {
   if (from->version == gc->version || from->version+1 == gc->version) {
     return false;
   }
-  assert(from->size > 0);
-  assert(from->type <= 7);
-  return true;
+
+  if (from->type >=1 && from->type <= 7) {
+    return true;
+  }
+
+  // Not a cora Object?
+  printf("WARNING: some thing is wrong when checkPointer? %p {type=%d, size=%d, version=%d}\n",
+	 from, from->type, from->size, from->version);
+  return false;
 }
 
 void

--- a/src/gc.c
+++ b/src/gc.c
@@ -266,6 +266,9 @@ gcAlloc(struct GC *gc, int size) {
     if (inuse(gc, next)) {
       // Meet inuse object, fragments cause allocation fail.
       gc->currOffset = (char*)next + next->size - gc->currBlock->data;
+      if ((char*)&gc->currBlock->data[gc->currOffset] >= (char*)gc->currBlock + MEM_BLOCK_SIZE) {
+	moveToNextBlock(gc);
+      }
       head = moveToFirstUnused(gc);
       continue;
     }
@@ -445,7 +448,7 @@ gcRunIncremental(struct GC *gc) {
     curr = gcDequeue(gc);
   }
 
-  printf("run gc, before size = %d, inuse size = %d, incremental size=%d\n", gc->nextSize, gc->inuseSize, gc->allocated);
+  /* printf("run gc, before size = %d, inuse size = %d, incremental size=%d\n", gc->nextSize, gc->inuseSize, gc->allocated); */
   gc->nextSize = 2 * gc->inuseSize + gc->allocated;
   if (gc->nextSize < MEM_BLOCK_SIZE) {
     // Because a block is at least that size, GC smaller then this is meanless.

--- a/src/gc.c
+++ b/src/gc.c
@@ -248,8 +248,9 @@ gcAlloc(struct GC *gc, int size) {
     }
     if (inuse(gc, next)) {
       // Meet inuse object, fragments cause allocation fail.
-      assert(false);
-      break;
+      gc->currOffset = (char*)next + next->size - gc->currBlock->data;
+      head = moveToFirstUnused(gc);
+      continue;
     }
     head->size += next->size;
   }
@@ -434,6 +435,8 @@ gcRunIncremental(struct GC *gc) {
     gc->nextSize = MEM_BLOCK_SIZE;
   }
   gc->state = gcStateNone;
+  gc->currBlock = gc->data.head;
+  gc->currOffset = 0;
 }
 
 void


### PR DESCRIPTION
The point of introducing mmap for blocks allocation is that the address are aligned.

Now it's two-layer allocation for the memory management:
- Each heapArena is 64MB, allocated using mmap
- Each block is 4KB, allocated from heapArena
