### PR TITLE
runtime: move GC trigger place from safepoint to each allocation

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -273,8 +273,14 @@ gcAllocReturn(struct GC *gc, scmHead *head) {
   return head;
 }
 
+static void gcRun(struct GC *gc);
+
 void*
 gcAlloc(struct GC *gc, int size) {
+  if (gc->state != gcStateNone) {
+    gcRun(gc);
+  }
+
   size = aligntonext(size, TAG_SHIFT);
   assert(size > sizeof(scmHead));
   assert(size < MEM_BLOCK_SIZE);
@@ -489,7 +495,7 @@ gcRunMark(struct GC *gc) {
 
 static void
 gcRunIncremental(struct GC *gc) {
-  int N = 100;
+  int N = 20;
   // breadth first.
   scmHead *curr = gcDequeue(gc);
   while(curr != NULL) {
@@ -518,7 +524,7 @@ gcRunIncremental(struct GC *gc) {
   gc->currOffset = 0;
 }
 
-void
+static void
 gcRun(struct GC *gc) {
   switch (gc->state) {
   case gcStateNone:
@@ -530,11 +536,6 @@ gcRun(struct GC *gc) {
     gcRunIncremental(gc);
     break;
   }
-}
-
-bool
-gcCheck(struct GC* gc) {
-  return gc->state != gcStateNone;
 }
 
 void

--- a/src/gc.h
+++ b/src/gc.h
@@ -39,13 +39,10 @@ typedef struct {
 
 extern struct GC gc;
 void gcInit(struct GC* gc, uintptr_t* mark);
-void gcMark(struct GC *gc, uintptr_t head);
 void* gcAlloc(struct GC* gc, int size);
 
 void writeBarrier(uintptr_t *slot, uintptr_t val);
-
-bool gcCheck(struct GC* gc);
-void gcRun(struct GC *gc);
+void gcMark(struct GC *gc, uintptr_t head);
 void gcInuseSizeInc(struct GC *gc, int size);
 
 typedef void (*gcFunc)(struct GC *gc, void* from);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -192,16 +192,8 @@ void
 trampoline(struct Cora *co, basicBlock pc) {
   pushCont(co, NULL, 0);
   co->pc = pc;
-  int i = 0;
   while(co->pc != NULL) {
     co->pc(co);
-    i++;
-    if (i == 100) {
-      i = 0;
-      if (gcCheck(&gc)) {
-	gcRun(&gc);
-      }
-    }
   }
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -111,11 +111,12 @@ int nativeRequired(Obj o);
 basicBlock nativeFuncPtr(Obj o);
 
 struct returnAddr {
-  basicBlock pc;
-  Obj frees;
+  Obj *stack;
   int base;
   int pos;
-  Obj *stack;
+
+  basicBlock pc;
+  Obj frees;
 };
 
 struct callStack {


### PR DESCRIPTION
Now as the GC implementation is stable than before, it's unnecessary to limit the trigger to the safepoint.
This could improve the trampoline performance.