### PR TITLE
runtime: pack stack / pc / frees fields etc together into one struct 

### DIFF
--- a/init.c
+++ b/init.c
@@ -225,7 +225,7 @@ Obj _35reg64 = primSet(intern("cdddr"), makeNative(_35clofun1013, 1, 0));
 Obj _35reg72 = primSet(intern("rcons"), makeNative(_35clofun1014, 1, 0));
 Obj _35reg74 = primSet(intern("pair?"), makeNative(_35clofun1016, 1, 0));
 Obj _35reg79 = primSet(intern("cora/init.reverse-h"), makeNative(_35clofun1017, 2, 0));
-pushCont(co, _35clofun1018, 0);
+pushCont(co, 0, _35clofun1018, 0);
 coraCall(co, 2, globalRef(intern("cora/init.reverse-h")), Nil);
 }
 
@@ -244,19 +244,19 @@ Obj _35reg111 = primSet(intern("cora/init.macroexpand1"), makeNative(_35clofun10
 Obj _35reg128 = primSet(intern("cora/init.macroexpand-boot"), makeNative(_35clofun1027, 1, 0));
 Obj _35reg129 = primSet(intern("macroexpand"), globalRef(intern("cora/init.macroexpand-boot")));
 Obj _35reg140 = primSet(intern("defmacro-macro"), makeNative(_35clofun1033, 1, 0));
-pushCont(co, _35clofun1037, 0);
+pushCont(co, 0, _35clofun1037, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("defmacro"), globalRef(intern("defmacro-macro")));
 }
 
 void _35clofun1037(struct Cora* co) {
 Obj _35val141 = co->args[1];
-pushCont(co, _35clofun1039, 0);
+pushCont(co, 0, _35clofun1039, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("list"), makeNative(_35clofun1038, 1, 0));
 }
 
 void _35clofun1039(struct Cora* co) {
 Obj _35val143 = co->args[1];
-pushCont(co, _35clofun1044, 0);
+pushCont(co, 0, _35clofun1044, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("defun"), makeNative(_35clofun1040, 1, 0));
 }
 
@@ -265,27 +265,27 @@ Obj _35val155 = co->args[1];
 Obj _35reg160 = primSet(intern("elem?"), makeNative(_35clofun1045, 2, 0));
 Obj _35reg163 = primSet(intern("atom?"), makeNative(_35clofun1046, 1, 0));
 Obj _35reg175 = primSet(intern("cora/init.rewrite-let"), makeNative(_35clofun1047, 1, 0));
-pushCont(co, _35clofun1053, 0);
+pushCont(co, 0, _35clofun1053, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("let"), makeNative(_35clofun1052, 1, 0));
 }
 
 void _35clofun1053(struct Cora* co) {
 Obj _35val177 = co->args[1];
-pushCont(co, _35clofun1058, 0);
+pushCont(co, 0, _35clofun1058, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("cond"), makeNative(_35clofun1054, 1, 0));
 }
 
 void _35clofun1058(struct Cora* co) {
 Obj _35val191 = co->args[1];
 Obj _35reg203 = primSet(intern("cora/init.rewrite-or"), makeNative(_35clofun1059, 1, 0));
-pushCont(co, _35clofun1062, 0);
+pushCont(co, 0, _35clofun1062, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("or"), makeNative(_35clofun1061, 1, 0));
 }
 
 void _35clofun1062(struct Cora* co) {
 Obj _35val205 = co->args[1];
 Obj _35reg217 = primSet(intern("cora/init.rewrite-and"), makeNative(_35clofun1063, 1, 0));
-pushCont(co, _35clofun1066, 0);
+pushCont(co, 0, _35clofun1066, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("and"), makeNative(_35clofun1065, 1, 0));
 }
 
@@ -293,7 +293,7 @@ void _35clofun1066(struct Cora* co) {
 Obj _35val219 = co->args[1];
 Obj _35reg222 = primSet(intern("boolean?"), makeNative(_35clofun1067, 1, 0));
 Obj _35reg232 = primSet(intern("cora/init.rcons1"), makeNative(_35clofun1068, 1, 0));
-pushCont(co, _35clofun1072, 0);
+pushCont(co, 0, _35clofun1072, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("list-rest"), makeNative(_35clofun1071, 1, 0));
 }
 
@@ -304,7 +304,7 @@ Obj _35reg321 = primSet(intern("cora/init.match1"), makeNative(_35clofun1091, 4,
 Obj _35reg348 = primSet(intern("cora/init.extract-rule-action"), makeNative(_35clofun1097, 2, 0));
 Obj _35reg400 = primSet(intern("cora/init.match-helper"), makeNative(_35clofun1105, 2, 0));
 Obj _35reg426 = primSet(intern("cora/init.rewrite-match"), makeNative(_35clofun1121, 1, 0));
-pushCont(co, _35clofun1129, 0);
+pushCont(co, 0, _35clofun1129, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("match"), makeNative(_35clofun1128, 1, 0));
 }
 
@@ -320,7 +320,7 @@ Obj _35reg499 = primSet(intern("filter"), makeNative(_35clofun1145, 2, 0));
 Obj _35reg505 = primSet(intern("append"), makeNative(_35clofun1146, 2, 0));
 Obj _35reg516 = primSet(intern("cora/init.rules-arg-count"), makeNative(_35clofun1148, 1, 0));
 Obj _35reg522 = primSet(intern("cora/init.gen-parameters"), makeNative(_35clofun1155, 1, 0));
-pushCont(co, _35clofun1163, 0);
+pushCont(co, 0, _35clofun1163, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("func"), makeNative(_35clofun1157, 1, 0));
 }
 
@@ -330,7 +330,7 @@ Obj _35reg798 = primSet(intern("cora/init.propagate-boolean0"), makeNative(_35cl
 Obj _35reg956 = primSet(intern("cora/init.propagate-boolean"), makeNative(_35clofun1176, 1, 0));
 Obj _35reg958 = primSet(intern("macroexpand"), makeNative(_35clofun1199, 1, 0));
 Obj _35reg982 = primSet(intern("cora/init.rewrite-begin"), makeNative(_35clofun1201, 1, 0));
-pushCont(co, _35clofun1207, 0);
+pushCont(co, 0, _35clofun1207, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("begin"), makeNative(_35clofun1206, 1, 0));
 }
 
@@ -342,7 +342,7 @@ coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("backquot
 
 void _35clofun1214(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun1215, 0);
+pushCont(co, 0, _35clofun1215, 0);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
@@ -408,7 +408,7 @@ Obj x = _35reg986;
 Obj _35reg987 = primCdr(closureRef(co, 0));
 Obj more = _35reg987;
 Obj _35reg988 = primCons(x, more);
-pushCont(co, _35clofun1213, 0);
+pushCont(co, 0, _35clofun1213, 0);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/init.rewrite-backquote")), _35reg988);
 } else {
 coraCall(co, 1, _35cc36);
@@ -499,7 +499,7 @@ Obj _35reg960 = primCar(closureRef(co, 0));
 Obj x = _35reg960;
 Obj _35reg961 = primCdr(closureRef(co, 0));
 Obj y = _35reg961;
-pushCont(co, _35clofun1205, 1, x);
+pushCont(co, 0, _35clofun1205, 1, x);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-begin")), y);
 } else {
 coraCall(co, 1, _35cc32);
@@ -522,7 +522,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 
 void _35clofun1199(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun1200, 0);
+pushCont(co, 0, _35clofun1200, 0);
 coraCall(co, 2, globalRef(intern("cora/init.macroexpand-boot")), exp);
 }
 
@@ -584,7 +584,7 @@ Obj _35reg938 = primCdr(closureRef(co, 0));
 Obj _35reg939 = primCdr(_35reg938);
 Obj _35reg940 = primEQ(Nil, _35reg939);
 if (True == _35reg940) {
-pushCont(co, _35clofun1198, 0);
+pushCont(co, 0, _35clofun1198, 0);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc19);
@@ -625,7 +625,7 @@ Obj _35reg925 = primCdr(closureRef(co, 0));
 Obj _35reg926 = primCdr(_35reg925);
 Obj _35reg927 = primEQ(Nil, _35reg926);
 if (True == _35reg927) {
-pushCont(co, _35clofun1197, 0);
+pushCont(co, 0, _35clofun1197, 0);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc20);
@@ -666,7 +666,7 @@ Obj _35reg912 = primCdr(closureRef(co, 0));
 Obj _35reg913 = primCdr(_35reg912);
 Obj _35reg914 = primEQ(Nil, _35reg913);
 if (True == _35reg914) {
-pushCont(co, _35clofun1196, 0);
+pushCont(co, 0, _35clofun1196, 0);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc21);
@@ -716,7 +716,7 @@ Obj _35reg897 = primCdr(_35reg896);
 Obj _35reg898 = primCdr(_35reg897);
 Obj _35reg899 = primEQ(Nil, _35reg898);
 if (True == _35reg899) {
-pushCont(co, _35clofun1194, 1, y);
+pushCont(co, 0, _35clofun1194, 1, y);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc22);
@@ -739,7 +739,7 @@ void _35clofun1194(struct Cora* co) {
 Obj _35val900 = co->args[1];
 Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj x1 = _35val900;
-pushCont(co, _35clofun1195, 1, x1);
+pushCont(co, 0, _35clofun1195, 1, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
 }
 
@@ -770,7 +770,7 @@ Obj _35reg877 = primCdr(closureRef(co, 0));
 Obj _35reg878 = primCdr(_35reg877);
 Obj _35reg879 = primEQ(Nil, _35reg878);
 if (True == _35reg879) {
-pushCont(co, _35clofun1193, 0);
+pushCont(co, 0, _35clofun1193, 0);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc23);
@@ -811,7 +811,7 @@ Obj _35reg864 = primCdr(closureRef(co, 0));
 Obj _35reg865 = primCdr(_35reg864);
 Obj _35reg866 = primEQ(Nil, _35reg865);
 if (True == _35reg866) {
-pushCont(co, _35clofun1192, 0);
+pushCont(co, 0, _35clofun1192, 0);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc24);
@@ -872,7 +872,7 @@ Obj _35reg847 = primCdr(_35reg846);
 Obj _35reg848 = primCdr(_35reg847);
 Obj _35reg849 = primEQ(Nil, _35reg848);
 if (True == _35reg849) {
-pushCont(co, _35clofun1189, 2, y, z);
+pushCont(co, 0, _35clofun1189, 2, y, z);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc25);
@@ -899,7 +899,7 @@ Obj _35val850 = co->args[1];
 Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj z = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj x1 = _35val850;
-pushCont(co, _35clofun1190, 2, z, x1);
+pushCont(co, 0, _35clofun1190, 2, z, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
 }
 
@@ -908,7 +908,7 @@ Obj _35val851 = co->args[1];
 Obj z = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj x1 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj y1 = _35val851;
-pushCont(co, _35clofun1191, 2, y1, x1);
+pushCont(co, 0, _35clofun1191, 2, y1, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), z);
 }
 
@@ -950,7 +950,7 @@ Obj _35reg817 = primCdr(_35reg816);
 Obj _35reg818 = primCdr(_35reg817);
 Obj _35reg819 = primEQ(Nil, _35reg818);
 if (True == _35reg819) {
-pushCont(co, _35clofun1188, 1, args);
+pushCont(co, 0, _35clofun1188, 1, args);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), body);
 } else {
 coraCall(co, 1, _35cc26);
@@ -1641,14 +1641,14 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 
 void _35clofun1157(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun1158, 1, exp);
+pushCont(co, 0, _35clofun1158, 1, exp);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
 void _35clofun1158(struct Cora* co) {
 Obj _35val523 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-pushCont(co, _35clofun1159, 1, exp);
+pushCont(co, 0, _35clofun1159, 1, exp);
 coraCall(co, 2, globalRef(intern("cora/init.extract-rules")), _35val523);
 }
 
@@ -1656,7 +1656,7 @@ void _35clofun1159(struct Cora* co) {
 Obj _35val524 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj body = _35val524;
-pushCont(co, _35clofun1160, 2, exp, body);
+pushCont(co, 0, _35clofun1160, 2, exp, body);
 coraCall(co, 2, globalRef(intern("cora/init.rules-arg-count")), body);
 }
 
@@ -1665,7 +1665,7 @@ Obj _35val525 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj nargs = _35val525;
-pushCont(co, _35clofun1161, 2, exp, body);
+pushCont(co, 0, _35clofun1161, 2, exp, body);
 coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), nargs);
 }
 
@@ -1674,7 +1674,7 @@ Obj _35val526 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj args = _35val526;
-pushCont(co, _35clofun1162, 2, body, args);
+pushCont(co, 0, _35clofun1162, 2, body, args);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
@@ -1702,7 +1702,7 @@ return;
 } else {
 Obj _35reg518 = primGenSym(intern("p"));
 Obj _35reg519 = primSub(n, makeNumber(1));
-pushCont(co, _35clofun1156, 1, _35reg518);
+pushCont(co, 0, _35clofun1156, 1, _35reg518);
 coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), _35reg519);
 }
 }
@@ -1717,7 +1717,7 @@ return;
 
 void _35clofun1148(struct Cora* co) {
 Obj rules = co->args[1];
-pushCont(co, _35clofun1149, 0);
+pushCont(co, 0, _35clofun1149, 0);
 coraCall(co, 3, globalRef(intern("cora/init.rules-patterns")), Nil, rules);
 }
 
@@ -1725,7 +1725,7 @@ void _35clofun1149(struct Cora* co) {
 Obj _35val506 = co->args[1];
 Obj pats = _35val506;
 Obj len = makeNative(_35clofun1150, 1, 0);
-pushCont(co, _35clofun1151, 0);
+pushCont(co, 0, _35clofun1151, 0);
 coraCall(co, 3, globalRef(intern("map")), len, pats);
 }
 
@@ -1736,14 +1736,14 @@ Obj _35reg509 = primCar(counts);
 Obj n = _35reg509;
 Obj dif = makeNative(_35clofun1152, 1, 1, n);
 Obj _35reg512 = primCdr(counts);
-pushCont(co, _35clofun1153, 1, n);
+pushCont(co, 0, _35clofun1153, 1, n);
 coraCall(co, 3, globalRef(intern("filter")), dif, _35reg512);
 }
 
 void _35clofun1153(struct Cora* co) {
 Obj _35val513 = co->args[1];
 Obj n = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-pushCont(co, _35clofun1154, 1, n);
+pushCont(co, 0, _35clofun1154, 1, n);
 coraCall(co, 2, globalRef(intern("null?")), _35val513);
 }
 
@@ -1783,7 +1783,7 @@ return;
 } else {
 Obj _35reg501 = primCar(l1);
 Obj _35reg502 = primCdr(l1);
-pushCont(co, _35clofun1147, 1, _35reg501);
+pushCont(co, 0, _35clofun1147, 1, _35reg501);
 coraCall(co, 3, globalRef(intern("append")), _35reg502, l2);
 }
 }
@@ -1809,7 +1809,7 @@ Obj l = co->args[3];
 Obj _35reg491 = primIsCons(l);
 if (True == _35reg491) {
 Obj _35reg492 = primCar(l);
-pushCont(co, _35clofun1144, 3, l, res, fn);
+pushCont(co, 0, _35clofun1144, 3, l, res, fn);
 coraCall(co, 2, fn, _35reg492);
 } else {
 coraCall(co, 2, globalRef(intern("reverse")), res);
@@ -1854,7 +1854,7 @@ coraCall(co, 3, globalRef(intern("cora/init.length-h")), _35reg487, _35reg488);
 void _35clofun1138(struct Cora* co) {
 Obj res = co->args[1];
 Obj rules = co->args[2];
-pushCont(co, _35clofun1139, 2, res, rules);
+pushCont(co, 0, _35clofun1139, 2, res, rules);
 coraCall(co, 2, globalRef(intern("null?")), rules);
 }
 
@@ -1867,7 +1867,7 @@ coraCall(co, 2, globalRef(intern("reverse")), res);
 } else {
 Obj _35reg482 = primCar(rules);
 Obj _35reg483 = primCons(_35reg482, res);
-pushCont(co, _35clofun1140, 1, _35reg483);
+pushCont(co, 0, _35clofun1140, 1, _35reg483);
 coraCall(co, 2, globalRef(intern("cddr")), rules);
 }
 }
@@ -1933,7 +1933,7 @@ Obj _35reg468 = primCdr(_35reg467);
 Obj _35reg469 = primCdr(_35reg468);
 Obj _35reg470 = primCdr(_35reg469);
 Obj remain = _35reg470;
-pushCont(co, _35clofun1136, 3, act, pred, remain);
+pushCont(co, 0, _35clofun1136, 3, act, pred, remain);
 coraCall(co, 2, globalRef(intern("reverse")), closureRef(co, 1));
 } else {
 coraCall(co, 1, _35cc2);
@@ -1986,7 +1986,7 @@ Obj act = _35reg438;
 Obj _35reg439 = primCdr(closureRef(co, 0));
 Obj _35reg440 = primCdr(_35reg439);
 Obj remain = _35reg440;
-pushCont(co, _35clofun1135, 2, act, remain);
+pushCont(co, 0, _35clofun1135, 2, act, remain);
 coraCall(co, 2, globalRef(intern("reverse")), closureRef(co, 1));
 } else {
 coraCall(co, 1, _35cc3);
@@ -2036,14 +2036,14 @@ coraCall(co, 2, globalRef(intern("cora/init.rewrite-match")), exp);
 
 void _35clofun1121(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun1122, 1, exp);
+pushCont(co, 0, _35clofun1122, 1, exp);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
 void _35clofun1122(struct Cora* co) {
 Obj _35val401 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-pushCont(co, _35clofun1123, 1, exp);
+pushCont(co, 0, _35clofun1123, 1, exp);
 coraCall(co, 2, globalRef(intern("macroexpand")), _35val401);
 }
 
@@ -2051,7 +2051,7 @@ void _35clofun1123(struct Cora* co) {
 Obj _35val402 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj value = _35val402;
-pushCont(co, _35clofun1124, 1, value);
+pushCont(co, 0, _35clofun1124, 1, value);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
@@ -2068,7 +2068,7 @@ if (True == _35reg407) {
 if (True == True) {
 Obj _35reg408 = primGenSym(intern("val"));
 Obj val = _35reg408;
-pushCont(co, _35clofun1125, 2, value, val);
+pushCont(co, 0, _35clofun1125, 2, value, val);
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), val, rules);
 } else {
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
@@ -2077,7 +2077,7 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
 if (True == False) {
 Obj _35reg414 = primGenSym(intern("val"));
 Obj val = _35reg414;
-pushCont(co, _35clofun1126, 2, value, val);
+pushCont(co, 0, _35clofun1126, 2, value, val);
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), val, rules);
 } else {
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
@@ -2087,7 +2087,7 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
 if (True == False) {
 Obj _35reg420 = primGenSym(intern("val"));
 Obj val = _35reg420;
-pushCont(co, _35clofun1127, 2, value, val);
+pushCont(co, 0, _35clofun1127, 2, value, val);
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), val, rules);
 } else {
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
@@ -2134,7 +2134,7 @@ return;
 void _35clofun1105(struct Cora* co) {
 Obj value = co->args[1];
 Obj rules = co->args[2];
-pushCont(co, _35clofun1106, 2, rules, value);
+pushCont(co, 0, _35clofun1106, 2, rules, value);
 coraCall(co, 2, globalRef(intern("null?")), rules);
 }
 
@@ -2148,7 +2148,7 @@ Obj _35reg351 = primCons(intern("error"), _35reg350);
 coraReturn(co, _35reg351);
 return;
 } else {
-pushCont(co, _35clofun1107, 2, rules, value);
+pushCont(co, 0, _35clofun1107, 2, rules, value);
 coraCall(co, 2, globalRef(intern("pair?")), rules);
 }
 }
@@ -2159,7 +2159,7 @@ Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 if (True == _35val352) {
 Obj _35reg353 = primCdr(rules);
-pushCont(co, _35clofun1108, 2, rules, value);
+pushCont(co, 0, _35clofun1108, 2, rules, value);
 coraCall(co, 2, globalRef(intern("pair?")), _35reg353);
 } else {
 if (True == False) {
@@ -2167,7 +2167,7 @@ Obj _35reg385 = primCar(rules);
 Obj pat = _35reg385;
 Obj _35reg386 = primGenSym(intern("cc"));
 Obj cc = _35reg386;
-pushCont(co, _35clofun1117, 4, pat, rules, value, cc);
+pushCont(co, 0, _35clofun1117, 4, pat, rules, value, cc);
 coraCall(co, 3, globalRef(intern("cora/init.extract-rule-action")), rules, cc);
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
@@ -2182,7 +2182,7 @@ Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj action = _35val387;
-pushCont(co, _35clofun1118, 4, action, rules, value, cc);
+pushCont(co, 0, _35clofun1118, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 }
 
@@ -2192,7 +2192,7 @@ Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
-pushCont(co, _35clofun1119, 3, rules, value, cc);
+pushCont(co, 0, _35clofun1119, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val388, value, action, cc);
 }
 
@@ -2204,7 +2204,7 @@ Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj curr = _35val389;
 Obj _35reg390 = primCdr(rules);
 Obj _35reg391 = primCdr(_35reg390);
-pushCont(co, _35clofun1120, 2, curr, cc);
+pushCont(co, 0, _35clofun1120, 2, curr, cc);
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg391);
 }
 
@@ -2234,7 +2234,7 @@ Obj _35reg355 = primCar(rules);
 Obj pat = _35reg355;
 Obj _35reg356 = primGenSym(intern("cc"));
 Obj cc = _35reg356;
-pushCont(co, _35clofun1109, 4, pat, rules, value, cc);
+pushCont(co, 0, _35clofun1109, 4, pat, rules, value, cc);
 coraCall(co, 3, globalRef(intern("cora/init.extract-rule-action")), rules, cc);
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
@@ -2245,7 +2245,7 @@ Obj _35reg370 = primCar(rules);
 Obj pat = _35reg370;
 Obj _35reg371 = primGenSym(intern("cc"));
 Obj cc = _35reg371;
-pushCont(co, _35clofun1113, 4, pat, rules, value, cc);
+pushCont(co, 0, _35clofun1113, 4, pat, rules, value, cc);
 coraCall(co, 3, globalRef(intern("cora/init.extract-rule-action")), rules, cc);
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
@@ -2260,7 +2260,7 @@ Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj action = _35val372;
-pushCont(co, _35clofun1114, 4, action, rules, value, cc);
+pushCont(co, 0, _35clofun1114, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 }
 
@@ -2270,7 +2270,7 @@ Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
-pushCont(co, _35clofun1115, 3, rules, value, cc);
+pushCont(co, 0, _35clofun1115, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val373, value, action, cc);
 }
 
@@ -2282,7 +2282,7 @@ Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj curr = _35val374;
 Obj _35reg375 = primCdr(rules);
 Obj _35reg376 = primCdr(_35reg375);
-pushCont(co, _35clofun1116, 2, curr, cc);
+pushCont(co, 0, _35clofun1116, 2, curr, cc);
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg376);
 }
 
@@ -2309,7 +2309,7 @@ Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj action = _35val357;
-pushCont(co, _35clofun1110, 4, action, rules, value, cc);
+pushCont(co, 0, _35clofun1110, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 }
 
@@ -2319,7 +2319,7 @@ Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
-pushCont(co, _35clofun1111, 3, rules, value, cc);
+pushCont(co, 0, _35clofun1111, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val358, value, action, cc);
 }
 
@@ -2331,7 +2331,7 @@ Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj curr = _35val359;
 Obj _35reg360 = primCdr(rules);
 Obj _35reg361 = primCdr(_35reg360);
-pushCont(co, _35clofun1112, 2, curr, cc);
+pushCont(co, 0, _35clofun1112, 2, curr, cc);
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg361);
 }
 
@@ -2357,7 +2357,7 @@ Obj cc = co->args[2];
 Obj _35reg322 = primCdr(rules);
 Obj _35reg323 = primCar(_35reg322);
 Obj action = _35reg323;
-pushCont(co, _35clofun1098, 2, cc, action);
+pushCont(co, 0, _35clofun1098, 2, cc, action);
 coraCall(co, 2, globalRef(intern("pair?")), action);
 }
 
@@ -2370,7 +2370,7 @@ Obj _35reg325 = primCar(action);
 Obj _35reg326 = primEQ(_35reg325, intern("where"));
 if (True == _35reg326) {
 if (True == True) {
-pushCont(co, _35clofun1099, 2, action, cc);
+pushCont(co, 0, _35clofun1099, 2, action, cc);
 coraCall(co, 2, globalRef(intern("cadr")), action);
 } else {
 coraReturn(co, action);
@@ -2378,7 +2378,7 @@ return;
 }
 } else {
 if (True == False) {
-pushCont(co, _35clofun1101, 2, action, cc);
+pushCont(co, 0, _35clofun1101, 2, action, cc);
 coraCall(co, 2, globalRef(intern("cadr")), action);
 } else {
 coraReturn(co, action);
@@ -2387,7 +2387,7 @@ return;
 }
 } else {
 if (True == False) {
-pushCont(co, _35clofun1103, 2, action, cc);
+pushCont(co, 0, _35clofun1103, 2, action, cc);
 coraCall(co, 2, globalRef(intern("cadr")), action);
 } else {
 coraReturn(co, action);
@@ -2400,7 +2400,7 @@ void _35clofun1103(struct Cora* co) {
 Obj _35val341 = co->args[1];
 Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-pushCont(co, _35clofun1104, 2, cc, _35val341);
+pushCont(co, 0, _35clofun1104, 2, cc, _35val341);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
@@ -2421,7 +2421,7 @@ void _35clofun1101(struct Cora* co) {
 Obj _35val334 = co->args[1];
 Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-pushCont(co, _35clofun1102, 2, cc, _35val334);
+pushCont(co, 0, _35clofun1102, 2, cc, _35val334);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
@@ -2442,7 +2442,7 @@ void _35clofun1099(struct Cora* co) {
 Obj _35val327 = co->args[1];
 Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-pushCont(co, _35clofun1100, 2, cc, _35val327);
+pushCont(co, 0, _35clofun1100, 2, cc, _35val327);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
@@ -2465,7 +2465,7 @@ Obj expr = co->args[2];
 Obj body = co->args[3];
 Obj cc = co->args[4];
 Obj literal_63 = makeNative(_35clofun1092, 1, 0);
-pushCont(co, _35clofun1094, 4, expr, body, cc, pat);
+pushCont(co, 0, _35clofun1094, 4, expr, body, cc, pat);
 coraCall(co, 2, literal_63, pat);
 }
 
@@ -2502,7 +2502,7 @@ Obj _35reg306 = primCons(intern("let"), _35reg305);
 coraReturn(co, _35reg306);
 return;
 } else {
-pushCont(co, _35clofun1095, 4, expr, body, cc, pat);
+pushCont(co, 0, _35clofun1095, 4, expr, body, cc, pat);
 coraCall(co, 2, globalRef(intern("pair?")), pat);
 }
 }
@@ -2538,7 +2538,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 } else {
-pushCont(co, _35clofun1096, 0);
+pushCont(co, 0, _35clofun1096, 0);
 coraCall(co, 3, globalRef(intern("str")), makeString1("match fail "), pat);
 }
 }
@@ -2550,7 +2550,7 @@ coraCall(co, 2, globalRef(intern("error")), _35val320);
 
 void _35clofun1092(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun1093, 1, x);
+pushCont(co, 0, _35clofun1093, 1, x);
 coraCall(co, 2, globalRef(intern("atom?")), x);
 }
 
@@ -2578,7 +2578,7 @@ Obj pat = co->args[1];
 Obj expr = co->args[2];
 Obj body = co->args[3];
 Obj cc = co->args[4];
-pushCont(co, _35clofun1074, 4, pat, expr, body, cc);
+pushCont(co, 0, _35clofun1074, 4, pat, expr, body, cc);
 coraCall(co, 2, globalRef(intern("cadr")), pat);
 }
 
@@ -2589,7 +2589,7 @@ Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj x = _35val235;
-pushCont(co, _35clofun1075, 4, expr, body, x, cc);
+pushCont(co, 0, _35clofun1075, 4, expr, body, x, cc);
 coraCall(co, 2, globalRef(intern("caddr")), pat);
 }
 
@@ -2606,7 +2606,7 @@ Obj _35reg238 = primCar(expr);
 Obj _35reg239 = primEQ(_35reg238, intern("cons"));
 if (True == _35reg239) {
 if (True == True) {
-pushCont(co, _35clofun1076, 5, expr, y, body, x, cc);
+pushCont(co, 0, _35clofun1076, 5, expr, y, body, x, cc);
 coraCall(co, 2, globalRef(intern("cadr")), expr);
 } else {
 Obj _35reg243 = primCons(expr, Nil);
@@ -2615,12 +2615,12 @@ Obj _35reg245 = primCons(expr, Nil);
 Obj _35reg246 = primCons(intern("car"), _35reg245);
 Obj _35reg247 = primCons(expr, Nil);
 Obj _35reg248 = primCons(intern("cdr"), _35reg247);
-pushCont(co, _35clofun1079, 4, x, _35reg246, cc, _35reg244);
+pushCont(co, 0, _35clofun1079, 4, x, _35reg246, cc, _35reg244);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, _35reg248, body, cc);
 }
 } else {
 if (True == False) {
-pushCont(co, _35clofun1081, 5, expr, y, body, x, cc);
+pushCont(co, 0, _35clofun1081, 5, expr, y, body, x, cc);
 coraCall(co, 2, globalRef(intern("cadr")), expr);
 } else {
 Obj _35reg259 = primCons(expr, Nil);
@@ -2629,13 +2629,13 @@ Obj _35reg261 = primCons(expr, Nil);
 Obj _35reg262 = primCons(intern("car"), _35reg261);
 Obj _35reg263 = primCons(expr, Nil);
 Obj _35reg264 = primCons(intern("cdr"), _35reg263);
-pushCont(co, _35clofun1084, 4, x, _35reg262, cc, _35reg260);
+pushCont(co, 0, _35clofun1084, 4, x, _35reg262, cc, _35reg260);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, _35reg264, body, cc);
 }
 }
 } else {
 if (True == False) {
-pushCont(co, _35clofun1086, 5, expr, y, body, x, cc);
+pushCont(co, 0, _35clofun1086, 5, expr, y, body, x, cc);
 coraCall(co, 2, globalRef(intern("cadr")), expr);
 } else {
 Obj _35reg275 = primCons(expr, Nil);
@@ -2644,7 +2644,7 @@ Obj _35reg277 = primCons(expr, Nil);
 Obj _35reg278 = primCons(intern("car"), _35reg277);
 Obj _35reg279 = primCons(expr, Nil);
 Obj _35reg280 = primCons(intern("cdr"), _35reg279);
-pushCont(co, _35clofun1089, 4, x, _35reg278, cc, _35reg276);
+pushCont(co, 0, _35clofun1089, 4, x, _35reg278, cc, _35reg276);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, _35reg280, body, cc);
 }
 }
@@ -2656,7 +2656,7 @@ Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg278 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj _35reg276 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
-pushCont(co, _35clofun1090, 2, cc, _35reg276);
+pushCont(co, 0, _35clofun1090, 2, cc, _35reg276);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg278, _35val281, cc);
 }
 
@@ -2681,7 +2681,7 @@ Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
 Obj e1 = _35val272;
-pushCont(co, _35clofun1087, 5, y, body, x, e1, cc);
+pushCont(co, 0, _35clofun1087, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
 }
 
@@ -2693,7 +2693,7 @@ Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
 Obj e2 = _35val273;
-pushCont(co, _35clofun1088, 3, x, e1, cc);
+pushCont(co, 0, _35clofun1088, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 }
 
@@ -2711,7 +2711,7 @@ Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg262 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj _35reg260 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
-pushCont(co, _35clofun1085, 2, cc, _35reg260);
+pushCont(co, 0, _35clofun1085, 2, cc, _35reg260);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg262, _35val265, cc);
 }
 
@@ -2736,7 +2736,7 @@ Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
 Obj e1 = _35val256;
-pushCont(co, _35clofun1082, 5, y, body, x, e1, cc);
+pushCont(co, 0, _35clofun1082, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
 }
 
@@ -2748,7 +2748,7 @@ Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
 Obj e2 = _35val257;
-pushCont(co, _35clofun1083, 3, x, e1, cc);
+pushCont(co, 0, _35clofun1083, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 }
 
@@ -2766,7 +2766,7 @@ Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg246 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj _35reg244 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
-pushCont(co, _35clofun1080, 2, cc, _35reg244);
+pushCont(co, 0, _35clofun1080, 2, cc, _35reg244);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg246, _35val249, cc);
 }
 
@@ -2791,7 +2791,7 @@ Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
 Obj e1 = _35val240;
-pushCont(co, _35clofun1077, 5, y, body, x, e1, cc);
+pushCont(co, 0, _35clofun1077, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
 }
 
@@ -2803,7 +2803,7 @@ Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
 Obj e2 = _35val241;
-pushCont(co, _35clofun1078, 3, x, e1, cc);
+pushCont(co, 0, _35clofun1078, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 }
 
@@ -2824,7 +2824,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rcons1")), _35reg233);
 void _35clofun1068(struct Cora* co) {
 Obj pat = co->args[1];
 Obj _35reg223 = primCdr(pat);
-pushCont(co, _35clofun1069, 1, pat);
+pushCont(co, 0, _35clofun1069, 1, pat);
 coraCall(co, 2, globalRef(intern("null?")), _35reg223);
 }
 
@@ -2838,7 +2838,7 @@ return;
 } else {
 Obj _35reg226 = primCar(pat);
 Obj _35reg227 = primCdr(pat);
-pushCont(co, _35clofun1070, 1, _35reg226);
+pushCont(co, 0, _35clofun1070, 1, _35reg226);
 coraCall(co, 2, globalRef(intern("cora/init.rcons1")), _35reg227);
 }
 }
@@ -2891,7 +2891,7 @@ coraReturn(co, False);
 return;
 } else {
 Obj _35reg209 = primCdr(l);
-pushCont(co, _35clofun1064, 1, l);
+pushCont(co, 0, _35clofun1064, 1, l);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-and")), _35reg209);
 }
 }
@@ -2936,7 +2936,7 @@ coraReturn(co, True);
 return;
 } else {
 Obj _35reg195 = primCdr(l);
-pushCont(co, _35clofun1060, 1, l);
+pushCont(co, 0, _35clofun1060, 1, l);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-or")), _35reg195);
 }
 }
@@ -2971,7 +2971,7 @@ Obj _35reg181 = primCons(intern("error"), _35reg180);
 coraReturn(co, _35reg181);
 return;
 } else {
-pushCont(co, _35clofun1055, 1, exp);
+pushCont(co, 0, _35clofun1055, 1, exp);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 }
@@ -2981,7 +2981,7 @@ Obj _35val182 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj curr = _35val182;
 Obj _35reg183 = primCar(curr);
-pushCont(co, _35clofun1056, 2, exp, _35reg183);
+pushCont(co, 0, _35clofun1056, 2, exp, _35reg183);
 coraCall(co, 2, globalRef(intern("cadr")), curr);
 }
 
@@ -2989,7 +2989,7 @@ void _35clofun1056(struct Cora* co) {
 Obj _35val184 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg183 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-pushCont(co, _35clofun1057, 2, _35val184, _35reg183);
+pushCont(co, 0, _35clofun1057, 2, _35val184, _35reg183);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
@@ -3015,7 +3015,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rewrite-let")), _35reg176);
 void _35clofun1047(struct Cora* co) {
 Obj exp = co->args[1];
 Obj _35reg164 = primCdr(exp);
-pushCont(co, _35clofun1048, 1, exp);
+pushCont(co, 0, _35clofun1048, 1, exp);
 coraCall(co, 2, globalRef(intern("null?")), _35reg164);
 }
 
@@ -3028,7 +3028,7 @@ coraReturn(co, _35reg166);
 return;
 } else {
 Obj _35reg167 = primCar(exp);
-pushCont(co, _35clofun1049, 2, exp, _35reg167);
+pushCont(co, 0, _35clofun1049, 2, exp, _35reg167);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 }
@@ -3037,7 +3037,7 @@ void _35clofun1049(struct Cora* co) {
 Obj _35val168 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg167 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-pushCont(co, _35clofun1050, 2, _35val168, _35reg167);
+pushCont(co, 0, _35clofun1050, 2, _35val168, _35reg167);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
@@ -3045,7 +3045,7 @@ void _35clofun1050(struct Cora* co) {
 Obj _35val169 = co->args[1];
 Obj _35val168 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg167 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-pushCont(co, _35clofun1051, 2, _35val168, _35reg167);
+pushCont(co, 0, _35clofun1051, 2, _35val168, _35reg167);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-let")), _35val169);
 }
 
@@ -3091,7 +3091,7 @@ return;
 
 void _35clofun1040(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun1041, 1, exp);
+pushCont(co, 0, _35clofun1041, 1, exp);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
@@ -3100,7 +3100,7 @@ Obj _35val144 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg145 = primCons(_35val144, Nil);
 Obj _35reg146 = primCons(intern("quote"), _35reg145);
-pushCont(co, _35clofun1042, 2, exp, _35reg146);
+pushCont(co, 0, _35clofun1042, 2, exp, _35reg146);
 coraCall(co, 2, globalRef(intern("caddr")), exp);
 }
 
@@ -3108,7 +3108,7 @@ void _35clofun1042(struct Cora* co) {
 Obj _35val147 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg146 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-pushCont(co, _35clofun1043, 2, _35val147, _35reg146);
+pushCont(co, 0, _35clofun1043, 2, _35val147, _35reg146);
 coraCall(co, 2, globalRef(intern("cadddr")), exp);
 }
 
@@ -3134,7 +3134,7 @@ coraCall(co, 2, globalRef(intern("rcons")), _35reg142);
 
 void _35clofun1033(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun1034, 1, exp);
+pushCont(co, 0, _35clofun1034, 1, exp);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
@@ -3143,7 +3143,7 @@ Obj _35val130 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg131 = primCons(_35val130, Nil);
 Obj _35reg132 = primCons(intern("quote"), _35reg131);
-pushCont(co, _35clofun1035, 2, exp, _35reg132);
+pushCont(co, 0, _35clofun1035, 2, exp, _35reg132);
 coraCall(co, 2, globalRef(intern("caddr")), exp);
 }
 
@@ -3151,7 +3151,7 @@ void _35clofun1035(struct Cora* co) {
 Obj _35val133 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg132 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-pushCont(co, _35clofun1036, 2, _35val133, _35reg132);
+pushCont(co, 0, _35clofun1036, 2, _35val133, _35reg132);
 coraCall(co, 2, globalRef(intern("cdddr")), exp);
 }
 
@@ -3182,7 +3182,7 @@ return;
 Obj _35reg116 = primCar(exp);
 Obj _35reg117 = primEQ(_35reg116, intern("lambda"));
 if (True == _35reg117) {
-pushCont(co, _35clofun1028, 1, exp);
+pushCont(co, 0, _35clofun1028, 1, exp);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
 Obj _35reg124 = primCar(exp);
@@ -3191,7 +3191,7 @@ if (True == _35reg125) {
 coraReturn(co, exp);
 return;
 } else {
-pushCont(co, _35clofun1031, 1, exp);
+pushCont(co, 0, _35clofun1031, 1, exp);
 coraCall(co, 2, globalRef(intern("cora/init.macroexpand1")), exp);
 }
 }
@@ -3221,14 +3221,14 @@ coraCall(co, 2, globalRef(intern("cora/init.macroexpand-boot")), exp1);
 void _35clofun1028(struct Cora* co) {
 Obj _35val118 = co->args[1];
 Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-pushCont(co, _35clofun1029, 1, _35val118);
+pushCont(co, 0, _35clofun1029, 1, _35val118);
 coraCall(co, 2, globalRef(intern("caddr")), exp);
 }
 
 void _35clofun1029(struct Cora* co) {
 Obj _35val119 = co->args[1];
 Obj _35val118 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-pushCont(co, _35clofun1030, 1, _35val118);
+pushCont(co, 0, _35clofun1030, 1, _35val118);
 coraCall(co, 2, globalRef(intern("cora/init.macroexpand-boot")), _35val119);
 }
 
@@ -3325,7 +3325,7 @@ Obj l = co->args[3];
 Obj _35reg82 = primIsCons(l);
 if (True == _35reg82) {
 Obj _35reg83 = primCar(l);
-pushCont(co, _35clofun1020, 3, res, l, f);
+pushCont(co, 0, _35clofun1020, 3, res, l, f);
 coraCall(co, 2, f, _35reg83);
 } else {
 coraCall(co, 2, globalRef(intern("reverse")), res);
@@ -3370,7 +3370,7 @@ Obj _35reg65 = primIsCons(exp);
 if (True == _35reg65) {
 Obj _35reg66 = primCar(exp);
 Obj _35reg67 = primCdr(exp);
-pushCont(co, _35clofun1015, 1, _35reg66);
+pushCont(co, 0, _35clofun1015, 1, _35reg66);
 coraCall(co, 2, globalRef(intern("rcons")), _35reg67);
 } else {
 coraReturn(co, Nil);

--- a/init.c
+++ b/init.c
@@ -508,7 +508,7 @@ coraCall(co, 1, _35cc32);
 
 void _35clofun1205(struct Cora* co) {
 Obj _35val962 = co->args[1];
-Obj x = co->stack[co->base + 0];
+Obj x = co->stk.stack[co->stk.base + 0];
 Obj _35reg963 = primCons(_35val962, Nil);
 Obj _35reg964 = primCons(x, _35reg963);
 Obj _35reg965 = primCons(intern("do"), _35reg964);
@@ -737,7 +737,7 @@ coraCall(co, 1, _35cc22);
 
 void _35clofun1194(struct Cora* co) {
 Obj _35val900 = co->args[1];
-Obj y = co->stack[co->base + 0];
+Obj y = co->stk.stack[ co->stk.base + 0];
 Obj x1 = _35val900;
 pushCont(co, _35clofun1195, 1, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
@@ -745,7 +745,7 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
 
 void _35clofun1195(struct Cora* co) {
 Obj _35val901 = co->args[1];
-Obj x1 = co->stack[co->base + 0];
+Obj x1 = co->stk.stack[ co->stk.base + 0];
 Obj y1 = _35val901;
 Obj _35reg902 = primCons(y1, Nil);
 Obj _35reg903 = primCons(x1, _35reg902);
@@ -896,8 +896,8 @@ coraCall(co, 1, _35cc25);
 
 void _35clofun1189(struct Cora* co) {
 Obj _35val850 = co->args[1];
-Obj y = co->stack[co->base + 0];
-Obj z = co->stack[co->base + 1];
+Obj y = co->stk.stack[ co->stk.base + 0];
+Obj z = co->stk.stack[ co->stk.base + 1];
 Obj x1 = _35val850;
 pushCont(co, _35clofun1190, 2, z, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
@@ -905,8 +905,8 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
 
 void _35clofun1190(struct Cora* co) {
 Obj _35val851 = co->args[1];
-Obj z = co->stack[co->base + 0];
-Obj x1 = co->stack[co->base + 1];
+Obj z = co->stk.stack[ co->stk.base + 0];
+Obj x1 = co->stk.stack[ co->stk.base + 1];
 Obj y1 = _35val851;
 pushCont(co, _35clofun1191, 2, y1, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), z);
@@ -914,8 +914,8 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), z);
 
 void _35clofun1191(struct Cora* co) {
 Obj _35val852 = co->args[1];
-Obj y1 = co->stack[co->base + 0];
-Obj x1 = co->stack[co->base + 1];
+Obj y1 = co->stk.stack[ co->stk.base + 0];
+Obj x1 = co->stk.stack[ co->stk.base + 1];
 Obj z1 = _35val852;
 Obj _35reg853 = primCons(z1, Nil);
 Obj _35reg854 = primCons(y1, _35reg853);
@@ -971,7 +971,7 @@ coraCall(co, 1, _35cc26);
 
 void _35clofun1188(struct Cora* co) {
 Obj _35val820 = co->args[1];
-Obj args = co->stack[co->base + 0];
+Obj args = co->stk.stack[ co->stk.base + 0];
 Obj _35reg821 = primCons(_35val820, Nil);
 Obj _35reg822 = primCons(args, _35reg821);
 Obj _35reg823 = primCons(intern("lambda"), _35reg822);
@@ -1647,14 +1647,14 @@ coraCall(co, 2, globalRef(intern("cddr")), exp);
 
 void _35clofun1158(struct Cora* co) {
 Obj _35val523 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[ co->stk.base + 0];
 pushCont(co, _35clofun1159, 1, exp);
 coraCall(co, 2, globalRef(intern("cora/init.extract-rules")), _35val523);
 }
 
 void _35clofun1159(struct Cora* co) {
 Obj _35val524 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[ co->stk.base + 0];
 Obj body = _35val524;
 pushCont(co, _35clofun1160, 2, exp, body);
 coraCall(co, 2, globalRef(intern("cora/init.rules-arg-count")), body);
@@ -1662,8 +1662,8 @@ coraCall(co, 2, globalRef(intern("cora/init.rules-arg-count")), body);
 
 void _35clofun1160(struct Cora* co) {
 Obj _35val525 = co->args[1];
-Obj exp = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
+Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj body = co->stk.stack[ co->stk.base + 1];
 Obj nargs = _35val525;
 pushCont(co, _35clofun1161, 2, exp, body);
 coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), nargs);
@@ -1671,8 +1671,8 @@ coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), nargs);
 
 void _35clofun1161(struct Cora* co) {
 Obj _35val526 = co->args[1];
-Obj exp = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
+Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj body = co->stk.stack[ co->stk.base + 1];
 Obj args = _35val526;
 pushCont(co, _35clofun1162, 2, body, args);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
@@ -1680,8 +1680,8 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1162(struct Cora* co) {
 Obj _35val527 = co->args[1];
-Obj body = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
+Obj body = co->stk.stack[ co->stk.base + 0];
+Obj args = co->stk.stack[ co->stk.base + 1];
 Obj _35reg528 = primCons(intern("list"), args);
 Obj _35reg529 = primCons(_35reg528, body);
 Obj _35reg530 = primCons(intern("match"), _35reg529);
@@ -1709,7 +1709,7 @@ coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), _35reg519);
 
 void _35clofun1156(struct Cora* co) {
 Obj _35val520 = co->args[1];
-Obj _35reg518 = co->stack[co->base + 0];
+Obj _35reg518 = co->stk.stack[ co->stk.base + 0];
 Obj _35reg521 = primCons(_35reg518, _35val520);
 coraReturn(co, _35reg521);
 return;
@@ -1742,14 +1742,14 @@ coraCall(co, 3, globalRef(intern("filter")), dif, _35reg512);
 
 void _35clofun1153(struct Cora* co) {
 Obj _35val513 = co->args[1];
-Obj n = co->stack[co->base + 0];
+Obj n = co->stk.stack[ co->stk.base + 0];
 pushCont(co, _35clofun1154, 1, n);
 coraCall(co, 2, globalRef(intern("null?")), _35val513);
 }
 
 void _35clofun1154(struct Cora* co) {
 Obj _35val514 = co->args[1];
-Obj n = co->stack[co->base + 0];
+Obj n = co->stk.stack[ co->stk.base + 0];
 Obj _35reg515 = primNot(_35val514);
 if (True == _35reg515) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("inconsistent func rule args count"));
@@ -1790,7 +1790,7 @@ coraCall(co, 3, globalRef(intern("append")), _35reg502, l2);
 
 void _35clofun1147(struct Cora* co) {
 Obj _35val503 = co->args[1];
-Obj _35reg501 = co->stack[co->base + 0];
+Obj _35reg501 = co->stk.stack[ co->stk.base + 0];
 Obj _35reg504 = primCons(_35reg501, _35val503);
 coraReturn(co, _35reg504);
 return;
@@ -1818,9 +1818,9 @@ coraCall(co, 2, globalRef(intern("reverse")), res);
 
 void _35clofun1144(struct Cora* co) {
 Obj _35val493 = co->args[1];
-Obj l = co->stack[co->base + 0];
-Obj res = co->stack[co->base + 1];
-Obj fn = co->stack[co->base + 2];
+Obj l = co->stk.stack[ co->stk.base + 0];
+Obj res = co->stk.stack[ co->stk.base + 1];
+Obj fn = co->stk.stack[ co->stk.base + 2];
 if (True == _35val493) {
 Obj _35reg494 = primCar(l);
 Obj _35reg495 = primCons(_35reg494, res);
@@ -1860,8 +1860,8 @@ coraCall(co, 2, globalRef(intern("null?")), rules);
 
 void _35clofun1139(struct Cora* co) {
 Obj _35val481 = co->args[1];
-Obj res = co->stack[co->base + 0];
-Obj rules = co->stack[co->base + 1];
+Obj res = co->stk.stack[ co->stk.base + 0];
+Obj rules = co->stk.stack[ co->stk.base + 1];
 if (True == _35val481) {
 coraCall(co, 2, globalRef(intern("reverse")), res);
 } else {
@@ -1874,7 +1874,7 @@ coraCall(co, 2, globalRef(intern("cddr")), rules);
 
 void _35clofun1140(struct Cora* co) {
 Obj _35val484 = co->args[1];
-Obj _35reg483 = co->stack[co->base + 0];
+Obj _35reg483 = co->stk.stack[ co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/init.rules-patterns")), _35reg483, _35val484);
 }
 
@@ -1957,9 +1957,9 @@ coraCall(co, 1, _35cc2);
 
 void _35clofun1136(struct Cora* co) {
 Obj _35val471 = co->args[1];
-Obj act = co->stack[co->base + 0];
-Obj pred = co->stack[co->base + 1];
-Obj remain = co->stack[co->base + 2];
+Obj act = co->stk.stack[ co->stk.base + 0];
+Obj pred = co->stk.stack[ co->stk.base + 1];
+Obj remain = co->stk.stack[ co->stk.base + 2];
 Obj _35reg472 = primCons(intern("list"), _35val471);
 Obj pat = _35reg472;
 Obj _35reg473 = primCons(act, Nil);
@@ -2001,8 +2001,8 @@ coraCall(co, 1, _35cc3);
 
 void _35clofun1135(struct Cora* co) {
 Obj _35val441 = co->args[1];
-Obj act = co->stack[co->base + 0];
-Obj remain = co->stack[co->base + 1];
+Obj act = co->stk.stack[ co->stk.base + 0];
+Obj remain = co->stk.stack[ co->stk.base + 1];
 Obj _35reg442 = primCons(intern("list"), _35val441);
 Obj pat = _35reg442;
 Obj _35reg443 = primCons(pat, closureRef(co, 2));
@@ -2042,14 +2042,14 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1122(struct Cora* co) {
 Obj _35val401 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[ co->stk.base + 0];
 pushCont(co, _35clofun1123, 1, exp);
 coraCall(co, 2, globalRef(intern("macroexpand")), _35val401);
 }
 
 void _35clofun1123(struct Cora* co) {
 Obj _35val402 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[ co->stk.base + 0];
 Obj value = _35val402;
 pushCont(co, _35clofun1124, 1, value);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
@@ -2057,7 +2057,7 @@ coraCall(co, 2, globalRef(intern("cddr")), exp);
 
 void _35clofun1124(struct Cora* co) {
 Obj _35val403 = co->args[1];
-Obj value = co->stack[co->base + 0];
+Obj value = co->stk.stack[ co->stk.base + 0];
 Obj rules = _35val403;
 Obj _35reg404 = primIsCons(value);
 if (True == _35reg404) {
@@ -2097,8 +2097,8 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
 
 void _35clofun1127(struct Cora* co) {
 Obj _35val421 = co->args[1];
-Obj value = co->stack[co->base + 0];
-Obj val = co->stack[co->base + 1];
+Obj value = co->stk.stack[ co->stk.base + 0];
+Obj val = co->stk.stack[ co->stk.base + 1];
 Obj _35reg422 = primCons(_35val421, Nil);
 Obj _35reg423 = primCons(value, _35reg422);
 Obj _35reg424 = primCons(val, _35reg423);
@@ -2109,8 +2109,8 @@ return;
 
 void _35clofun1126(struct Cora* co) {
 Obj _35val415 = co->args[1];
-Obj value = co->stack[co->base + 0];
-Obj val = co->stack[co->base + 1];
+Obj value = co->stk.stack[ co->stk.base + 0];
+Obj val = co->stk.stack[ co->stk.base + 1];
 Obj _35reg416 = primCons(_35val415, Nil);
 Obj _35reg417 = primCons(value, _35reg416);
 Obj _35reg418 = primCons(val, _35reg417);
@@ -2121,8 +2121,8 @@ return;
 
 void _35clofun1125(struct Cora* co) {
 Obj _35val409 = co->args[1];
-Obj value = co->stack[co->base + 0];
-Obj val = co->stack[co->base + 1];
+Obj value = co->stk.stack[ co->stk.base + 0];
+Obj val = co->stk.stack[ co->stk.base + 1];
 Obj _35reg410 = primCons(_35val409, Nil);
 Obj _35reg411 = primCons(value, _35reg410);
 Obj _35reg412 = primCons(val, _35reg411);
@@ -2140,8 +2140,8 @@ coraCall(co, 2, globalRef(intern("null?")), rules);
 
 void _35clofun1106(struct Cora* co) {
 Obj _35val349 = co->args[1];
-Obj rules = co->stack[co->base + 0];
-Obj value = co->stack[co->base + 1];
+Obj rules = co->stk.stack[ co->stk.base + 0];
+Obj value = co->stk.stack[ co->stk.base + 1];
 if (True == _35val349) {
 Obj _35reg350 = primCons(makeString1("no match-help found!"), Nil);
 Obj _35reg351 = primCons(intern("error"), _35reg350);
@@ -2155,8 +2155,8 @@ coraCall(co, 2, globalRef(intern("pair?")), rules);
 
 void _35clofun1107(struct Cora* co) {
 Obj _35val352 = co->args[1];
-Obj rules = co->stack[co->base + 0];
-Obj value = co->stack[co->base + 1];
+Obj rules = co->stk.stack[ co->stk.base + 0];
+Obj value = co->stk.stack[ co->stk.base + 1];
 if (True == _35val352) {
 Obj _35reg353 = primCdr(rules);
 pushCont(co, _35clofun1108, 2, rules, value);
@@ -2177,10 +2177,10 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 
 void _35clofun1117(struct Cora* co) {
 Obj _35val387 = co->args[1];
-Obj pat = co->stack[co->base + 0];
-Obj rules = co->stack[co->base + 1];
-Obj value = co->stack[co->base + 2];
-Obj cc = co->stack[co->base + 3];
+Obj pat = co->stk.stack[ co->stk.base + 0];
+Obj rules = co->stk.stack[ co->stk.base + 1];
+Obj value = co->stk.stack[ co->stk.base + 2];
+Obj cc = co->stk.stack[ co->stk.base + 3];
 Obj action = _35val387;
 pushCont(co, _35clofun1118, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
@@ -2188,19 +2188,19 @@ coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 
 void _35clofun1118(struct Cora* co) {
 Obj _35val388 = co->args[1];
-Obj action = co->stack[co->base + 0];
-Obj rules = co->stack[co->base + 1];
-Obj value = co->stack[co->base + 2];
-Obj cc = co->stack[co->base + 3];
+Obj action = co->stk.stack[ co->stk.base + 0];
+Obj rules = co->stk.stack[ co->stk.base + 1];
+Obj value = co->stk.stack[ co->stk.base + 2];
+Obj cc = co->stk.stack[ co->stk.base + 3];
 pushCont(co, _35clofun1119, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val388, value, action, cc);
 }
 
 void _35clofun1119(struct Cora* co) {
 Obj _35val389 = co->args[1];
-Obj rules = co->stack[co->base + 0];
-Obj value = co->stack[co->base + 1];
-Obj cc = co->stack[co->base + 2];
+Obj rules = co->stk.stack[ co->stk.base + 0];
+Obj value = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 2];
 Obj curr = _35val389;
 Obj _35reg390 = primCdr(rules);
 Obj _35reg391 = primCdr(_35reg390);
@@ -2210,8 +2210,8 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg391);
 
 void _35clofun1120(struct Cora* co) {
 Obj _35val392 = co->args[1];
-Obj curr = co->stack[co->base + 0];
-Obj cc = co->stack[co->base + 1];
+Obj curr = co->stk.stack[ co->stk.base + 0];
+Obj cc = co->stk.stack[ co->stk.base + 1];
 Obj rest = _35val392;
 Obj _35reg393 = primCons(rest, Nil);
 Obj _35reg394 = primCons(Nil, _35reg393);
@@ -2226,8 +2226,8 @@ return;
 
 void _35clofun1108(struct Cora* co) {
 Obj _35val354 = co->args[1];
-Obj rules = co->stack[co->base + 0];
-Obj value = co->stack[co->base + 1];
+Obj rules = co->stk.stack[ co->stk.base + 0];
+Obj value = co->stk.stack[ co->stk.base + 1];
 if (True == _35val354) {
 if (True == True) {
 Obj _35reg355 = primCar(rules);
@@ -2255,10 +2255,10 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 
 void _35clofun1113(struct Cora* co) {
 Obj _35val372 = co->args[1];
-Obj pat = co->stack[co->base + 0];
-Obj rules = co->stack[co->base + 1];
-Obj value = co->stack[co->base + 2];
-Obj cc = co->stack[co->base + 3];
+Obj pat = co->stk.stack[ co->stk.base + 0];
+Obj rules = co->stk.stack[ co->stk.base + 1];
+Obj value = co->stk.stack[ co->stk.base + 2];
+Obj cc = co->stk.stack[ co->stk.base + 3];
 Obj action = _35val372;
 pushCont(co, _35clofun1114, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
@@ -2266,19 +2266,19 @@ coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 
 void _35clofun1114(struct Cora* co) {
 Obj _35val373 = co->args[1];
-Obj action = co->stack[co->base + 0];
-Obj rules = co->stack[co->base + 1];
-Obj value = co->stack[co->base + 2];
-Obj cc = co->stack[co->base + 3];
+Obj action = co->stk.stack[ co->stk.base + 0];
+Obj rules = co->stk.stack[ co->stk.base + 1];
+Obj value = co->stk.stack[ co->stk.base + 2];
+Obj cc = co->stk.stack[ co->stk.base + 3];
 pushCont(co, _35clofun1115, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val373, value, action, cc);
 }
 
 void _35clofun1115(struct Cora* co) {
 Obj _35val374 = co->args[1];
-Obj rules = co->stack[co->base + 0];
-Obj value = co->stack[co->base + 1];
-Obj cc = co->stack[co->base + 2];
+Obj rules = co->stk.stack[ co->stk.base + 0];
+Obj value = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 2];
 Obj curr = _35val374;
 Obj _35reg375 = primCdr(rules);
 Obj _35reg376 = primCdr(_35reg375);
@@ -2288,8 +2288,8 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg376);
 
 void _35clofun1116(struct Cora* co) {
 Obj _35val377 = co->args[1];
-Obj curr = co->stack[co->base + 0];
-Obj cc = co->stack[co->base + 1];
+Obj curr = co->stk.stack[ co->stk.base + 0];
+Obj cc = co->stk.stack[ co->stk.base + 1];
 Obj rest = _35val377;
 Obj _35reg378 = primCons(rest, Nil);
 Obj _35reg379 = primCons(Nil, _35reg378);
@@ -2304,10 +2304,10 @@ return;
 
 void _35clofun1109(struct Cora* co) {
 Obj _35val357 = co->args[1];
-Obj pat = co->stack[co->base + 0];
-Obj rules = co->stack[co->base + 1];
-Obj value = co->stack[co->base + 2];
-Obj cc = co->stack[co->base + 3];
+Obj pat = co->stk.stack[ co->stk.base + 0];
+Obj rules = co->stk.stack[ co->stk.base + 1];
+Obj value = co->stk.stack[ co->stk.base + 2];
+Obj cc = co->stk.stack[ co->stk.base + 3];
 Obj action = _35val357;
 pushCont(co, _35clofun1110, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
@@ -2315,19 +2315,19 @@ coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 
 void _35clofun1110(struct Cora* co) {
 Obj _35val358 = co->args[1];
-Obj action = co->stack[co->base + 0];
-Obj rules = co->stack[co->base + 1];
-Obj value = co->stack[co->base + 2];
-Obj cc = co->stack[co->base + 3];
+Obj action = co->stk.stack[ co->stk.base + 0];
+Obj rules = co->stk.stack[ co->stk.base + 1];
+Obj value = co->stk.stack[ co->stk.base + 2];
+Obj cc = co->stk.stack[ co->stk.base + 3];
 pushCont(co, _35clofun1111, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val358, value, action, cc);
 }
 
 void _35clofun1111(struct Cora* co) {
 Obj _35val359 = co->args[1];
-Obj rules = co->stack[co->base + 0];
-Obj value = co->stack[co->base + 1];
-Obj cc = co->stack[co->base + 2];
+Obj rules = co->stk.stack[ co->stk.base + 0];
+Obj value = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 2];
 Obj curr = _35val359;
 Obj _35reg360 = primCdr(rules);
 Obj _35reg361 = primCdr(_35reg360);
@@ -2337,8 +2337,8 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg361);
 
 void _35clofun1112(struct Cora* co) {
 Obj _35val362 = co->args[1];
-Obj curr = co->stack[co->base + 0];
-Obj cc = co->stack[co->base + 1];
+Obj curr = co->stk.stack[ co->stk.base + 0];
+Obj cc = co->stk.stack[ co->stk.base + 1];
 Obj rest = _35val362;
 Obj _35reg363 = primCons(rest, Nil);
 Obj _35reg364 = primCons(Nil, _35reg363);
@@ -2363,8 +2363,8 @@ coraCall(co, 2, globalRef(intern("pair?")), action);
 
 void _35clofun1098(struct Cora* co) {
 Obj _35val324 = co->args[1];
-Obj cc = co->stack[co->base + 0];
-Obj action = co->stack[co->base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 0];
+Obj action = co->stk.stack[ co->stk.base + 1];
 if (True == _35val324) {
 Obj _35reg325 = primCar(action);
 Obj _35reg326 = primEQ(_35reg325, intern("where"));
@@ -2398,16 +2398,16 @@ return;
 
 void _35clofun1103(struct Cora* co) {
 Obj _35val341 = co->args[1];
-Obj action = co->stack[co->base + 0];
-Obj cc = co->stack[co->base + 1];
+Obj action = co->stk.stack[ co->stk.base + 0];
+Obj cc = co->stk.stack[ co->stk.base + 1];
 pushCont(co, _35clofun1104, 2, cc, _35val341);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
 void _35clofun1104(struct Cora* co) {
 Obj _35val342 = co->args[1];
-Obj cc = co->stack[co->base + 0];
-Obj _35val341 = co->stack[co->base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 0];
+Obj _35val341 = co->stk.stack[ co->stk.base + 1];
 Obj _35reg343 = primCons(cc, Nil);
 Obj _35reg344 = primCons(_35reg343, Nil);
 Obj _35reg345 = primCons(_35val342, _35reg344);
@@ -2419,16 +2419,16 @@ return;
 
 void _35clofun1101(struct Cora* co) {
 Obj _35val334 = co->args[1];
-Obj action = co->stack[co->base + 0];
-Obj cc = co->stack[co->base + 1];
+Obj action = co->stk.stack[ co->stk.base + 0];
+Obj cc = co->stk.stack[ co->stk.base + 1];
 pushCont(co, _35clofun1102, 2, cc, _35val334);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
 void _35clofun1102(struct Cora* co) {
 Obj _35val335 = co->args[1];
-Obj cc = co->stack[co->base + 0];
-Obj _35val334 = co->stack[co->base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 0];
+Obj _35val334 = co->stk.stack[ co->stk.base + 1];
 Obj _35reg336 = primCons(cc, Nil);
 Obj _35reg337 = primCons(_35reg336, Nil);
 Obj _35reg338 = primCons(_35val335, _35reg337);
@@ -2440,16 +2440,16 @@ return;
 
 void _35clofun1099(struct Cora* co) {
 Obj _35val327 = co->args[1];
-Obj action = co->stack[co->base + 0];
-Obj cc = co->stack[co->base + 1];
+Obj action = co->stk.stack[ co->stk.base + 0];
+Obj cc = co->stk.stack[ co->stk.base + 1];
 pushCont(co, _35clofun1100, 2, cc, _35val327);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
 void _35clofun1100(struct Cora* co) {
 Obj _35val328 = co->args[1];
-Obj cc = co->stack[co->base + 0];
-Obj _35val327 = co->stack[co->base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 0];
+Obj _35val327 = co->stk.stack[ co->stk.base + 1];
 Obj _35reg329 = primCons(cc, Nil);
 Obj _35reg330 = primCons(_35reg329, Nil);
 Obj _35reg331 = primCons(_35val328, _35reg330);
@@ -2471,10 +2471,10 @@ coraCall(co, 2, literal_63, pat);
 
 void _35clofun1094(struct Cora* co) {
 Obj _35val292 = co->args[1];
-Obj expr = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
-Obj cc = co->stack[co->base + 2];
-Obj pat = co->stack[co->base + 3];
+Obj expr = co->stk.stack[ co->stk.base + 0];
+Obj body = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 2];
+Obj pat = co->stk.stack[ co->stk.base + 3];
 if (True == _35val292) {
 Obj _35reg293 = primEQ(pat, expr);
 if (True == _35reg293) {
@@ -2510,10 +2510,10 @@ coraCall(co, 2, globalRef(intern("pair?")), pat);
 
 void _35clofun1095(struct Cora* co) {
 Obj _35val307 = co->args[1];
-Obj expr = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
-Obj cc = co->stack[co->base + 2];
-Obj pat = co->stack[co->base + 3];
+Obj expr = co->stk.stack[ co->stk.base + 0];
+Obj body = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 2];
+Obj pat = co->stk.stack[ co->stk.base + 3];
 if (True == _35val307) {
 Obj _35reg308 = primCar(pat);
 Obj _35reg309 = primEQ(_35reg308, intern("quote"));
@@ -2556,7 +2556,7 @@ coraCall(co, 2, globalRef(intern("atom?")), x);
 
 void _35clofun1093(struct Cora* co) {
 Obj _35val289 = co->args[1];
-Obj x = co->stack[co->base + 0];
+Obj x = co->stk.stack[ co->stk.base + 0];
 if (True == _35val289) {
 Obj _35reg290 = primIsSymbol(x);
 Obj _35reg291 = primNot(_35reg290);
@@ -2584,10 +2584,10 @@ coraCall(co, 2, globalRef(intern("cadr")), pat);
 
 void _35clofun1074(struct Cora* co) {
 Obj _35val235 = co->args[1];
-Obj pat = co->stack[co->base + 0];
-Obj expr = co->stack[co->base + 1];
-Obj body = co->stack[co->base + 2];
-Obj cc = co->stack[co->base + 3];
+Obj pat = co->stk.stack[ co->stk.base + 0];
+Obj expr = co->stk.stack[ co->stk.base + 1];
+Obj body = co->stk.stack[ co->stk.base + 2];
+Obj cc = co->stk.stack[ co->stk.base + 3];
 Obj x = _35val235;
 pushCont(co, _35clofun1075, 4, expr, body, x, cc);
 coraCall(co, 2, globalRef(intern("caddr")), pat);
@@ -2595,10 +2595,10 @@ coraCall(co, 2, globalRef(intern("caddr")), pat);
 
 void _35clofun1075(struct Cora* co) {
 Obj _35val236 = co->args[1];
-Obj expr = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
-Obj x = co->stack[co->base + 2];
-Obj cc = co->stack[co->base + 3];
+Obj expr = co->stk.stack[ co->stk.base + 0];
+Obj body = co->stk.stack[ co->stk.base + 1];
+Obj x = co->stk.stack[ co->stk.base + 2];
+Obj cc = co->stk.stack[ co->stk.base + 3];
 Obj y = _35val236;
 Obj _35reg237 = primIsCons(expr);
 if (True == _35reg237) {
@@ -2652,18 +2652,18 @@ coraCall(co, 5, globalRef(intern("cora/init.match1")), y, _35reg280, body, cc);
 
 void _35clofun1089(struct Cora* co) {
 Obj _35val281 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj _35reg278 = co->stack[co->base + 1];
-Obj cc = co->stack[co->base + 2];
-Obj _35reg276 = co->stack[co->base + 3];
+Obj x = co->stk.stack[ co->stk.base + 0];
+Obj _35reg278 = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 2];
+Obj _35reg276 = co->stk.stack[ co->stk.base + 3];
 pushCont(co, _35clofun1090, 2, cc, _35reg276);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg278, _35val281, cc);
 }
 
 void _35clofun1090(struct Cora* co) {
 Obj _35val282 = co->args[1];
-Obj cc = co->stack[co->base + 0];
-Obj _35reg276 = co->stack[co->base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 0];
+Obj _35reg276 = co->stk.stack[ co->stk.base + 1];
 Obj _35reg283 = primCons(cc, Nil);
 Obj _35reg284 = primCons(_35reg283, Nil);
 Obj _35reg285 = primCons(_35val282, _35reg284);
@@ -2675,11 +2675,11 @@ return;
 
 void _35clofun1086(struct Cora* co) {
 Obj _35val272 = co->args[1];
-Obj expr = co->stack[co->base + 0];
-Obj y = co->stack[co->base + 1];
-Obj body = co->stack[co->base + 2];
-Obj x = co->stack[co->base + 3];
-Obj cc = co->stack[co->base + 4];
+Obj expr = co->stk.stack[ co->stk.base + 0];
+Obj y = co->stk.stack[ co->stk.base + 1];
+Obj body = co->stk.stack[ co->stk.base + 2];
+Obj x = co->stk.stack[ co->stk.base + 3];
+Obj cc = co->stk.stack[ co->stk.base + 4];
 Obj e1 = _35val272;
 pushCont(co, _35clofun1087, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
@@ -2687,11 +2687,11 @@ coraCall(co, 2, globalRef(intern("caddr")), expr);
 
 void _35clofun1087(struct Cora* co) {
 Obj _35val273 = co->args[1];
-Obj y = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
-Obj x = co->stack[co->base + 2];
-Obj e1 = co->stack[co->base + 3];
-Obj cc = co->stack[co->base + 4];
+Obj y = co->stk.stack[ co->stk.base + 0];
+Obj body = co->stk.stack[ co->stk.base + 1];
+Obj x = co->stk.stack[ co->stk.base + 2];
+Obj e1 = co->stk.stack[ co->stk.base + 3];
+Obj cc = co->stk.stack[ co->stk.base + 4];
 Obj e2 = _35val273;
 pushCont(co, _35clofun1088, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
@@ -2699,26 +2699,26 @@ coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 
 void _35clofun1088(struct Cora* co) {
 Obj _35val274 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj e1 = co->stack[co->base + 1];
-Obj cc = co->stack[co->base + 2];
+Obj x = co->stk.stack[ co->stk.base + 0];
+Obj e1 = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 2];
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, e1, _35val274, cc);
 }
 
 void _35clofun1084(struct Cora* co) {
 Obj _35val265 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj _35reg262 = co->stack[co->base + 1];
-Obj cc = co->stack[co->base + 2];
-Obj _35reg260 = co->stack[co->base + 3];
+Obj x = co->stk.stack[ co->stk.base + 0];
+Obj _35reg262 = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 2];
+Obj _35reg260 = co->stk.stack[ co->stk.base + 3];
 pushCont(co, _35clofun1085, 2, cc, _35reg260);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg262, _35val265, cc);
 }
 
 void _35clofun1085(struct Cora* co) {
 Obj _35val266 = co->args[1];
-Obj cc = co->stack[co->base + 0];
-Obj _35reg260 = co->stack[co->base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 0];
+Obj _35reg260 = co->stk.stack[ co->stk.base + 1];
 Obj _35reg267 = primCons(cc, Nil);
 Obj _35reg268 = primCons(_35reg267, Nil);
 Obj _35reg269 = primCons(_35val266, _35reg268);
@@ -2730,11 +2730,11 @@ return;
 
 void _35clofun1081(struct Cora* co) {
 Obj _35val256 = co->args[1];
-Obj expr = co->stack[co->base + 0];
-Obj y = co->stack[co->base + 1];
-Obj body = co->stack[co->base + 2];
-Obj x = co->stack[co->base + 3];
-Obj cc = co->stack[co->base + 4];
+Obj expr = co->stk.stack[ co->stk.base + 0];
+Obj y = co->stk.stack[ co->stk.base + 1];
+Obj body = co->stk.stack[ co->stk.base + 2];
+Obj x = co->stk.stack[ co->stk.base + 3];
+Obj cc = co->stk.stack[ co->stk.base + 4];
 Obj e1 = _35val256;
 pushCont(co, _35clofun1082, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
@@ -2742,11 +2742,11 @@ coraCall(co, 2, globalRef(intern("caddr")), expr);
 
 void _35clofun1082(struct Cora* co) {
 Obj _35val257 = co->args[1];
-Obj y = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
-Obj x = co->stack[co->base + 2];
-Obj e1 = co->stack[co->base + 3];
-Obj cc = co->stack[co->base + 4];
+Obj y = co->stk.stack[ co->stk.base + 0];
+Obj body = co->stk.stack[ co->stk.base + 1];
+Obj x = co->stk.stack[ co->stk.base + 2];
+Obj e1 = co->stk.stack[ co->stk.base + 3];
+Obj cc = co->stk.stack[ co->stk.base + 4];
 Obj e2 = _35val257;
 pushCont(co, _35clofun1083, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
@@ -2754,26 +2754,26 @@ coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 
 void _35clofun1083(struct Cora* co) {
 Obj _35val258 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj e1 = co->stack[co->base + 1];
-Obj cc = co->stack[co->base + 2];
+Obj x = co->stk.stack[ co->stk.base + 0];
+Obj e1 = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 2];
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, e1, _35val258, cc);
 }
 
 void _35clofun1079(struct Cora* co) {
 Obj _35val249 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj _35reg246 = co->stack[co->base + 1];
-Obj cc = co->stack[co->base + 2];
-Obj _35reg244 = co->stack[co->base + 3];
+Obj x = co->stk.stack[ co->stk.base + 0];
+Obj _35reg246 = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 2];
+Obj _35reg244 = co->stk.stack[ co->stk.base + 3];
 pushCont(co, _35clofun1080, 2, cc, _35reg244);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg246, _35val249, cc);
 }
 
 void _35clofun1080(struct Cora* co) {
 Obj _35val250 = co->args[1];
-Obj cc = co->stack[co->base + 0];
-Obj _35reg244 = co->stack[co->base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 0];
+Obj _35reg244 = co->stk.stack[ co->stk.base + 1];
 Obj _35reg251 = primCons(cc, Nil);
 Obj _35reg252 = primCons(_35reg251, Nil);
 Obj _35reg253 = primCons(_35val250, _35reg252);
@@ -2785,11 +2785,11 @@ return;
 
 void _35clofun1076(struct Cora* co) {
 Obj _35val240 = co->args[1];
-Obj expr = co->stack[co->base + 0];
-Obj y = co->stack[co->base + 1];
-Obj body = co->stack[co->base + 2];
-Obj x = co->stack[co->base + 3];
-Obj cc = co->stack[co->base + 4];
+Obj expr = co->stk.stack[ co->stk.base + 0];
+Obj y = co->stk.stack[ co->stk.base + 1];
+Obj body = co->stk.stack[ co->stk.base + 2];
+Obj x = co->stk.stack[ co->stk.base + 3];
+Obj cc = co->stk.stack[ co->stk.base + 4];
 Obj e1 = _35val240;
 pushCont(co, _35clofun1077, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
@@ -2797,11 +2797,11 @@ coraCall(co, 2, globalRef(intern("caddr")), expr);
 
 void _35clofun1077(struct Cora* co) {
 Obj _35val241 = co->args[1];
-Obj y = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
-Obj x = co->stack[co->base + 2];
-Obj e1 = co->stack[co->base + 3];
-Obj cc = co->stack[co->base + 4];
+Obj y = co->stk.stack[ co->stk.base + 0];
+Obj body = co->stk.stack[ co->stk.base + 1];
+Obj x = co->stk.stack[ co->stk.base + 2];
+Obj e1 = co->stk.stack[ co->stk.base + 3];
+Obj cc = co->stk.stack[ co->stk.base + 4];
 Obj e2 = _35val241;
 pushCont(co, _35clofun1078, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
@@ -2809,9 +2809,9 @@ coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 
 void _35clofun1078(struct Cora* co) {
 Obj _35val242 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj e1 = co->stack[co->base + 1];
-Obj cc = co->stack[co->base + 2];
+Obj x = co->stk.stack[ co->stk.base + 0];
+Obj e1 = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->stk.stack[ co->stk.base + 2];
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, e1, _35val242, cc);
 }
 
@@ -2830,7 +2830,7 @@ coraCall(co, 2, globalRef(intern("null?")), _35reg223);
 
 void _35clofun1069(struct Cora* co) {
 Obj _35val224 = co->args[1];
-Obj pat = co->stack[co->base + 0];
+Obj pat = co->stk.stack[ co->stk.base + 0];
 if (True == _35val224) {
 Obj _35reg225 = primCar(pat);
 coraReturn(co, _35reg225);
@@ -2845,7 +2845,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rcons1")), _35reg227);
 
 void _35clofun1070(struct Cora* co) {
 Obj _35val228 = co->args[1];
-Obj _35reg226 = co->stack[co->base + 0];
+Obj _35reg226 = co->stk.stack[ co->stk.base + 0];
 Obj _35reg229 = primCons(_35val228, Nil);
 Obj _35reg230 = primCons(_35reg226, _35reg229);
 Obj _35reg231 = primCons(intern("cons"), _35reg230);
@@ -2899,7 +2899,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rewrite-and")), _35reg209);
 
 void _35clofun1064(struct Cora* co) {
 Obj _35val210 = co->args[1];
-Obj l = co->stack[co->base + 0];
+Obj l = co->stk.stack[ co->stk.base + 0];
 Obj more = _35val210;
 Obj _35reg211 = primEQ(more, False);
 if (True == _35reg211) {
@@ -2944,7 +2944,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rewrite-or")), _35reg195);
 
 void _35clofun1060(struct Cora* co) {
 Obj _35val196 = co->args[1];
-Obj l = co->stack[co->base + 0];
+Obj l = co->stk.stack[ co->stk.base + 0];
 Obj more = _35val196;
 Obj _35reg197 = primEQ(more, True);
 if (True == _35reg197) {
@@ -2978,7 +2978,7 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1055(struct Cora* co) {
 Obj _35val182 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[ co->stk.base + 0];
 Obj curr = _35val182;
 Obj _35reg183 = primCar(curr);
 pushCont(co, _35clofun1056, 2, exp, _35reg183);
@@ -2987,16 +2987,16 @@ coraCall(co, 2, globalRef(intern("cadr")), curr);
 
 void _35clofun1056(struct Cora* co) {
 Obj _35val184 = co->args[1];
-Obj exp = co->stack[co->base + 0];
-Obj _35reg183 = co->stack[co->base + 1];
+Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj _35reg183 = co->stk.stack[ co->stk.base + 1];
 pushCont(co, _35clofun1057, 2, _35val184, _35reg183);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
 void _35clofun1057(struct Cora* co) {
 Obj _35val185 = co->args[1];
-Obj _35val184 = co->stack[co->base + 0];
-Obj _35reg183 = co->stack[co->base + 1];
+Obj _35val184 = co->stk.stack[ co->stk.base + 0];
+Obj _35reg183 = co->stk.stack[ co->stk.base + 1];
 Obj _35reg186 = primCons(intern("cond"), _35val185);
 Obj _35reg187 = primCons(_35reg186, Nil);
 Obj _35reg188 = primCons(_35val184, _35reg187);
@@ -3021,7 +3021,7 @@ coraCall(co, 2, globalRef(intern("null?")), _35reg164);
 
 void _35clofun1048(struct Cora* co) {
 Obj _35val165 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[ co->stk.base + 0];
 if (True == _35val165) {
 Obj _35reg166 = primCar(exp);
 coraReturn(co, _35reg166);
@@ -3035,24 +3035,24 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1049(struct Cora* co) {
 Obj _35val168 = co->args[1];
-Obj exp = co->stack[co->base + 0];
-Obj _35reg167 = co->stack[co->base + 1];
+Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj _35reg167 = co->stk.stack[ co->stk.base + 1];
 pushCont(co, _35clofun1050, 2, _35val168, _35reg167);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
 void _35clofun1050(struct Cora* co) {
 Obj _35val169 = co->args[1];
-Obj _35val168 = co->stack[co->base + 0];
-Obj _35reg167 = co->stack[co->base + 1];
+Obj _35val168 = co->stk.stack[ co->stk.base + 0];
+Obj _35reg167 = co->stk.stack[ co->stk.base + 1];
 pushCont(co, _35clofun1051, 2, _35val168, _35reg167);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-let")), _35val169);
 }
 
 void _35clofun1051(struct Cora* co) {
 Obj _35val170 = co->args[1];
-Obj _35val168 = co->stack[co->base + 0];
-Obj _35reg167 = co->stack[co->base + 1];
+Obj _35val168 = co->stk.stack[ co->stk.base + 0];
+Obj _35reg167 = co->stk.stack[ co->stk.base + 1];
 Obj _35reg171 = primCons(_35val170, Nil);
 Obj _35reg172 = primCons(_35val168, _35reg171);
 Obj _35reg173 = primCons(_35reg167, _35reg172);
@@ -3097,7 +3097,7 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1041(struct Cora* co) {
 Obj _35val144 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[ co->stk.base + 0];
 Obj _35reg145 = primCons(_35val144, Nil);
 Obj _35reg146 = primCons(intern("quote"), _35reg145);
 pushCont(co, _35clofun1042, 2, exp, _35reg146);
@@ -3106,16 +3106,16 @@ coraCall(co, 2, globalRef(intern("caddr")), exp);
 
 void _35clofun1042(struct Cora* co) {
 Obj _35val147 = co->args[1];
-Obj exp = co->stack[co->base + 0];
-Obj _35reg146 = co->stack[co->base + 1];
+Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj _35reg146 = co->stk.stack[ co->stk.base + 1];
 pushCont(co, _35clofun1043, 2, _35val147, _35reg146);
 coraCall(co, 2, globalRef(intern("cadddr")), exp);
 }
 
 void _35clofun1043(struct Cora* co) {
 Obj _35val148 = co->args[1];
-Obj _35val147 = co->stack[co->base + 0];
-Obj _35reg146 = co->stack[co->base + 1];
+Obj _35val147 = co->stk.stack[ co->stk.base + 0];
+Obj _35reg146 = co->stk.stack[ co->stk.base + 1];
 Obj _35reg149 = primCons(_35val148, Nil);
 Obj _35reg150 = primCons(_35val147, _35reg149);
 Obj _35reg151 = primCons(intern("lambda"), _35reg150);
@@ -3140,7 +3140,7 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1034(struct Cora* co) {
 Obj _35val130 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[ co->stk.base + 0];
 Obj _35reg131 = primCons(_35val130, Nil);
 Obj _35reg132 = primCons(intern("quote"), _35reg131);
 pushCont(co, _35clofun1035, 2, exp, _35reg132);
@@ -3149,16 +3149,16 @@ coraCall(co, 2, globalRef(intern("caddr")), exp);
 
 void _35clofun1035(struct Cora* co) {
 Obj _35val133 = co->args[1];
-Obj exp = co->stack[co->base + 0];
-Obj _35reg132 = co->stack[co->base + 1];
+Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj _35reg132 = co->stk.stack[ co->stk.base + 1];
 pushCont(co, _35clofun1036, 2, _35val133, _35reg132);
 coraCall(co, 2, globalRef(intern("cdddr")), exp);
 }
 
 void _35clofun1036(struct Cora* co) {
 Obj _35val134 = co->args[1];
-Obj _35val133 = co->stack[co->base + 0];
-Obj _35reg132 = co->stack[co->base + 1];
+Obj _35val133 = co->stk.stack[ co->stk.base + 0];
+Obj _35reg132 = co->stk.stack[ co->stk.base + 1];
 Obj _35reg135 = primCons(_35val133, _35val134);
 Obj _35reg136 = primCons(intern("lambda"), _35reg135);
 Obj _35reg137 = primCons(_35reg136, Nil);
@@ -3204,7 +3204,7 @@ return;
 
 void _35clofun1031(struct Cora* co) {
 Obj _35val127 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[ co->stk.base + 0];
 coraCall(co, 2, makeNative(_35clofun1032, 1, 1, exp), _35val127);
 }
 
@@ -3220,21 +3220,21 @@ coraCall(co, 2, globalRef(intern("cora/init.macroexpand-boot")), exp1);
 
 void _35clofun1028(struct Cora* co) {
 Obj _35val118 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[ co->stk.base + 0];
 pushCont(co, _35clofun1029, 1, _35val118);
 coraCall(co, 2, globalRef(intern("caddr")), exp);
 }
 
 void _35clofun1029(struct Cora* co) {
 Obj _35val119 = co->args[1];
-Obj _35val118 = co->stack[co->base + 0];
+Obj _35val118 = co->stk.stack[ co->stk.base + 0];
 pushCont(co, _35clofun1030, 1, _35val118);
 coraCall(co, 2, globalRef(intern("cora/init.macroexpand-boot")), _35val119);
 }
 
 void _35clofun1030(struct Cora* co) {
 Obj _35val120 = co->args[1];
-Obj _35val118 = co->stack[co->base + 0];
+Obj _35val118 = co->stk.stack[ co->stk.base + 0];
 Obj _35reg121 = primCons(_35val120, Nil);
 Obj _35reg122 = primCons(_35val118, _35reg121);
 Obj _35reg123 = primCons(intern("lambda"), _35reg122);
@@ -3334,9 +3334,9 @@ coraCall(co, 2, globalRef(intern("reverse")), res);
 
 void _35clofun1020(struct Cora* co) {
 Obj _35val84 = co->args[1];
-Obj res = co->stack[co->base + 0];
-Obj l = co->stack[co->base + 1];
-Obj f = co->stack[co->base + 2];
+Obj res = co->stk.stack[ co->stk.base + 0];
+Obj l = co->stk.stack[ co->stk.base + 1];
+Obj f = co->stk.stack[ co->stk.base + 2];
 Obj _35reg85 = primCons(_35val84, res);
 Obj _35reg86 = primCdr(l);
 coraCall(co, 4, globalRef(intern("map-h")), _35reg85, f, _35reg86);
@@ -3380,7 +3380,7 @@ return;
 
 void _35clofun1015(struct Cora* co) {
 Obj _35val68 = co->args[1];
-Obj _35reg66 = co->stack[co->base + 0];
+Obj _35reg66 = co->stk.stack[ co->stk.base + 0];
 Obj _35reg69 = primCons(_35val68, Nil);
 Obj _35reg70 = primCons(_35reg66, _35reg69);
 Obj _35reg71 = primCons(intern("cons"), _35reg70);

--- a/init.c
+++ b/init.c
@@ -508,7 +508,7 @@ coraCall(co, 1, _35cc32);
 
 void _35clofun1205(struct Cora* co) {
 Obj _35val962 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg963 = primCons(_35val962, Nil);
 Obj _35reg964 = primCons(x, _35reg963);
 Obj _35reg965 = primCons(intern("do"), _35reg964);
@@ -737,7 +737,7 @@ coraCall(co, 1, _35cc22);
 
 void _35clofun1194(struct Cora* co) {
 Obj _35val900 = co->args[1];
-Obj y = co->stk.stack[ co->stk.base + 0];
+Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj x1 = _35val900;
 pushCont(co, _35clofun1195, 1, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
@@ -745,7 +745,7 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
 
 void _35clofun1195(struct Cora* co) {
 Obj _35val901 = co->args[1];
-Obj x1 = co->stk.stack[ co->stk.base + 0];
+Obj x1 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj y1 = _35val901;
 Obj _35reg902 = primCons(y1, Nil);
 Obj _35reg903 = primCons(x1, _35reg902);
@@ -896,8 +896,8 @@ coraCall(co, 1, _35cc25);
 
 void _35clofun1189(struct Cora* co) {
 Obj _35val850 = co->args[1];
-Obj y = co->stk.stack[ co->stk.base + 0];
-Obj z = co->stk.stack[ co->stk.base + 1];
+Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj z = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj x1 = _35val850;
 pushCont(co, _35clofun1190, 2, z, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
@@ -905,8 +905,8 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
 
 void _35clofun1190(struct Cora* co) {
 Obj _35val851 = co->args[1];
-Obj z = co->stk.stack[ co->stk.base + 0];
-Obj x1 = co->stk.stack[ co->stk.base + 1];
+Obj z = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj x1 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj y1 = _35val851;
 pushCont(co, _35clofun1191, 2, y1, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), z);
@@ -914,8 +914,8 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), z);
 
 void _35clofun1191(struct Cora* co) {
 Obj _35val852 = co->args[1];
-Obj y1 = co->stk.stack[ co->stk.base + 0];
-Obj x1 = co->stk.stack[ co->stk.base + 1];
+Obj y1 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj x1 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj z1 = _35val852;
 Obj _35reg853 = primCons(z1, Nil);
 Obj _35reg854 = primCons(y1, _35reg853);
@@ -971,7 +971,7 @@ coraCall(co, 1, _35cc26);
 
 void _35clofun1188(struct Cora* co) {
 Obj _35val820 = co->args[1];
-Obj args = co->stk.stack[ co->stk.base + 0];
+Obj args = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg821 = primCons(_35val820, Nil);
 Obj _35reg822 = primCons(args, _35reg821);
 Obj _35reg823 = primCons(intern("lambda"), _35reg822);
@@ -1647,14 +1647,14 @@ coraCall(co, 2, globalRef(intern("cddr")), exp);
 
 void _35clofun1158(struct Cora* co) {
 Obj _35val523 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 pushCont(co, _35clofun1159, 1, exp);
 coraCall(co, 2, globalRef(intern("cora/init.extract-rules")), _35val523);
 }
 
 void _35clofun1159(struct Cora* co) {
 Obj _35val524 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj body = _35val524;
 pushCont(co, _35clofun1160, 2, exp, body);
 coraCall(co, 2, globalRef(intern("cora/init.rules-arg-count")), body);
@@ -1662,8 +1662,8 @@ coraCall(co, 2, globalRef(intern("cora/init.rules-arg-count")), body);
 
 void _35clofun1160(struct Cora* co) {
 Obj _35val525 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
-Obj body = co->stk.stack[ co->stk.base + 1];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj nargs = _35val525;
 pushCont(co, _35clofun1161, 2, exp, body);
 coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), nargs);
@@ -1671,8 +1671,8 @@ coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), nargs);
 
 void _35clofun1161(struct Cora* co) {
 Obj _35val526 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
-Obj body = co->stk.stack[ co->stk.base + 1];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj args = _35val526;
 pushCont(co, _35clofun1162, 2, body, args);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
@@ -1680,8 +1680,8 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1162(struct Cora* co) {
 Obj _35val527 = co->args[1];
-Obj body = co->stk.stack[ co->stk.base + 0];
-Obj args = co->stk.stack[ co->stk.base + 1];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg528 = primCons(intern("list"), args);
 Obj _35reg529 = primCons(_35reg528, body);
 Obj _35reg530 = primCons(intern("match"), _35reg529);
@@ -1709,7 +1709,7 @@ coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), _35reg519);
 
 void _35clofun1156(struct Cora* co) {
 Obj _35val520 = co->args[1];
-Obj _35reg518 = co->stk.stack[ co->stk.base + 0];
+Obj _35reg518 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg521 = primCons(_35reg518, _35val520);
 coraReturn(co, _35reg521);
 return;
@@ -1742,14 +1742,14 @@ coraCall(co, 3, globalRef(intern("filter")), dif, _35reg512);
 
 void _35clofun1153(struct Cora* co) {
 Obj _35val513 = co->args[1];
-Obj n = co->stk.stack[ co->stk.base + 0];
+Obj n = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 pushCont(co, _35clofun1154, 1, n);
 coraCall(co, 2, globalRef(intern("null?")), _35val513);
 }
 
 void _35clofun1154(struct Cora* co) {
 Obj _35val514 = co->args[1];
-Obj n = co->stk.stack[ co->stk.base + 0];
+Obj n = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg515 = primNot(_35val514);
 if (True == _35reg515) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("inconsistent func rule args count"));
@@ -1790,7 +1790,7 @@ coraCall(co, 3, globalRef(intern("append")), _35reg502, l2);
 
 void _35clofun1147(struct Cora* co) {
 Obj _35val503 = co->args[1];
-Obj _35reg501 = co->stk.stack[ co->stk.base + 0];
+Obj _35reg501 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg504 = primCons(_35reg501, _35val503);
 coraReturn(co, _35reg504);
 return;
@@ -1818,9 +1818,9 @@ coraCall(co, 2, globalRef(intern("reverse")), res);
 
 void _35clofun1144(struct Cora* co) {
 Obj _35val493 = co->args[1];
-Obj l = co->stk.stack[ co->stk.base + 0];
-Obj res = co->stk.stack[ co->stk.base + 1];
-Obj fn = co->stk.stack[ co->stk.base + 2];
+Obj l = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj res = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj fn = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 if (True == _35val493) {
 Obj _35reg494 = primCar(l);
 Obj _35reg495 = primCons(_35reg494, res);
@@ -1860,8 +1860,8 @@ coraCall(co, 2, globalRef(intern("null?")), rules);
 
 void _35clofun1139(struct Cora* co) {
 Obj _35val481 = co->args[1];
-Obj res = co->stk.stack[ co->stk.base + 0];
-Obj rules = co->stk.stack[ co->stk.base + 1];
+Obj res = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 if (True == _35val481) {
 coraCall(co, 2, globalRef(intern("reverse")), res);
 } else {
@@ -1874,7 +1874,7 @@ coraCall(co, 2, globalRef(intern("cddr")), rules);
 
 void _35clofun1140(struct Cora* co) {
 Obj _35val484 = co->args[1];
-Obj _35reg483 = co->stk.stack[ co->stk.base + 0];
+Obj _35reg483 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/init.rules-patterns")), _35reg483, _35val484);
 }
 
@@ -1957,9 +1957,9 @@ coraCall(co, 1, _35cc2);
 
 void _35clofun1136(struct Cora* co) {
 Obj _35val471 = co->args[1];
-Obj act = co->stk.stack[ co->stk.base + 0];
-Obj pred = co->stk.stack[ co->stk.base + 1];
-Obj remain = co->stk.stack[ co->stk.base + 2];
+Obj act = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj pred = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj remain = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj _35reg472 = primCons(intern("list"), _35val471);
 Obj pat = _35reg472;
 Obj _35reg473 = primCons(act, Nil);
@@ -2001,8 +2001,8 @@ coraCall(co, 1, _35cc3);
 
 void _35clofun1135(struct Cora* co) {
 Obj _35val441 = co->args[1];
-Obj act = co->stk.stack[ co->stk.base + 0];
-Obj remain = co->stk.stack[ co->stk.base + 1];
+Obj act = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj remain = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg442 = primCons(intern("list"), _35val441);
 Obj pat = _35reg442;
 Obj _35reg443 = primCons(pat, closureRef(co, 2));
@@ -2042,14 +2042,14 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1122(struct Cora* co) {
 Obj _35val401 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 pushCont(co, _35clofun1123, 1, exp);
 coraCall(co, 2, globalRef(intern("macroexpand")), _35val401);
 }
 
 void _35clofun1123(struct Cora* co) {
 Obj _35val402 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj value = _35val402;
 pushCont(co, _35clofun1124, 1, value);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
@@ -2057,7 +2057,7 @@ coraCall(co, 2, globalRef(intern("cddr")), exp);
 
 void _35clofun1124(struct Cora* co) {
 Obj _35val403 = co->args[1];
-Obj value = co->stk.stack[ co->stk.base + 0];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj rules = _35val403;
 Obj _35reg404 = primIsCons(value);
 if (True == _35reg404) {
@@ -2097,8 +2097,8 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
 
 void _35clofun1127(struct Cora* co) {
 Obj _35val421 = co->args[1];
-Obj value = co->stk.stack[ co->stk.base + 0];
-Obj val = co->stk.stack[ co->stk.base + 1];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj val = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg422 = primCons(_35val421, Nil);
 Obj _35reg423 = primCons(value, _35reg422);
 Obj _35reg424 = primCons(val, _35reg423);
@@ -2109,8 +2109,8 @@ return;
 
 void _35clofun1126(struct Cora* co) {
 Obj _35val415 = co->args[1];
-Obj value = co->stk.stack[ co->stk.base + 0];
-Obj val = co->stk.stack[ co->stk.base + 1];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj val = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg416 = primCons(_35val415, Nil);
 Obj _35reg417 = primCons(value, _35reg416);
 Obj _35reg418 = primCons(val, _35reg417);
@@ -2121,8 +2121,8 @@ return;
 
 void _35clofun1125(struct Cora* co) {
 Obj _35val409 = co->args[1];
-Obj value = co->stk.stack[ co->stk.base + 0];
-Obj val = co->stk.stack[ co->stk.base + 1];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj val = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg410 = primCons(_35val409, Nil);
 Obj _35reg411 = primCons(value, _35reg410);
 Obj _35reg412 = primCons(val, _35reg411);
@@ -2140,8 +2140,8 @@ coraCall(co, 2, globalRef(intern("null?")), rules);
 
 void _35clofun1106(struct Cora* co) {
 Obj _35val349 = co->args[1];
-Obj rules = co->stk.stack[ co->stk.base + 0];
-Obj value = co->stk.stack[ co->stk.base + 1];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 if (True == _35val349) {
 Obj _35reg350 = primCons(makeString1("no match-help found!"), Nil);
 Obj _35reg351 = primCons(intern("error"), _35reg350);
@@ -2155,8 +2155,8 @@ coraCall(co, 2, globalRef(intern("pair?")), rules);
 
 void _35clofun1107(struct Cora* co) {
 Obj _35val352 = co->args[1];
-Obj rules = co->stk.stack[ co->stk.base + 0];
-Obj value = co->stk.stack[ co->stk.base + 1];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 if (True == _35val352) {
 Obj _35reg353 = primCdr(rules);
 pushCont(co, _35clofun1108, 2, rules, value);
@@ -2177,10 +2177,10 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 
 void _35clofun1117(struct Cora* co) {
 Obj _35val387 = co->args[1];
-Obj pat = co->stk.stack[ co->stk.base + 0];
-Obj rules = co->stk.stack[ co->stk.base + 1];
-Obj value = co->stk.stack[ co->stk.base + 2];
-Obj cc = co->stk.stack[ co->stk.base + 3];
+Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj action = _35val387;
 pushCont(co, _35clofun1118, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
@@ -2188,19 +2188,19 @@ coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 
 void _35clofun1118(struct Cora* co) {
 Obj _35val388 = co->args[1];
-Obj action = co->stk.stack[ co->stk.base + 0];
-Obj rules = co->stk.stack[ co->stk.base + 1];
-Obj value = co->stk.stack[ co->stk.base + 2];
-Obj cc = co->stk.stack[ co->stk.base + 3];
+Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 pushCont(co, _35clofun1119, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val388, value, action, cc);
 }
 
 void _35clofun1119(struct Cora* co) {
 Obj _35val389 = co->args[1];
-Obj rules = co->stk.stack[ co->stk.base + 0];
-Obj value = co->stk.stack[ co->stk.base + 1];
-Obj cc = co->stk.stack[ co->stk.base + 2];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj curr = _35val389;
 Obj _35reg390 = primCdr(rules);
 Obj _35reg391 = primCdr(_35reg390);
@@ -2210,8 +2210,8 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg391);
 
 void _35clofun1120(struct Cora* co) {
 Obj _35val392 = co->args[1];
-Obj curr = co->stk.stack[ co->stk.base + 0];
-Obj cc = co->stk.stack[ co->stk.base + 1];
+Obj curr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj rest = _35val392;
 Obj _35reg393 = primCons(rest, Nil);
 Obj _35reg394 = primCons(Nil, _35reg393);
@@ -2226,8 +2226,8 @@ return;
 
 void _35clofun1108(struct Cora* co) {
 Obj _35val354 = co->args[1];
-Obj rules = co->stk.stack[ co->stk.base + 0];
-Obj value = co->stk.stack[ co->stk.base + 1];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 if (True == _35val354) {
 if (True == True) {
 Obj _35reg355 = primCar(rules);
@@ -2255,10 +2255,10 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 
 void _35clofun1113(struct Cora* co) {
 Obj _35val372 = co->args[1];
-Obj pat = co->stk.stack[ co->stk.base + 0];
-Obj rules = co->stk.stack[ co->stk.base + 1];
-Obj value = co->stk.stack[ co->stk.base + 2];
-Obj cc = co->stk.stack[ co->stk.base + 3];
+Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj action = _35val372;
 pushCont(co, _35clofun1114, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
@@ -2266,19 +2266,19 @@ coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 
 void _35clofun1114(struct Cora* co) {
 Obj _35val373 = co->args[1];
-Obj action = co->stk.stack[ co->stk.base + 0];
-Obj rules = co->stk.stack[ co->stk.base + 1];
-Obj value = co->stk.stack[ co->stk.base + 2];
-Obj cc = co->stk.stack[ co->stk.base + 3];
+Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 pushCont(co, _35clofun1115, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val373, value, action, cc);
 }
 
 void _35clofun1115(struct Cora* co) {
 Obj _35val374 = co->args[1];
-Obj rules = co->stk.stack[ co->stk.base + 0];
-Obj value = co->stk.stack[ co->stk.base + 1];
-Obj cc = co->stk.stack[ co->stk.base + 2];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj curr = _35val374;
 Obj _35reg375 = primCdr(rules);
 Obj _35reg376 = primCdr(_35reg375);
@@ -2288,8 +2288,8 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg376);
 
 void _35clofun1116(struct Cora* co) {
 Obj _35val377 = co->args[1];
-Obj curr = co->stk.stack[ co->stk.base + 0];
-Obj cc = co->stk.stack[ co->stk.base + 1];
+Obj curr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj rest = _35val377;
 Obj _35reg378 = primCons(rest, Nil);
 Obj _35reg379 = primCons(Nil, _35reg378);
@@ -2304,10 +2304,10 @@ return;
 
 void _35clofun1109(struct Cora* co) {
 Obj _35val357 = co->args[1];
-Obj pat = co->stk.stack[ co->stk.base + 0];
-Obj rules = co->stk.stack[ co->stk.base + 1];
-Obj value = co->stk.stack[ co->stk.base + 2];
-Obj cc = co->stk.stack[ co->stk.base + 3];
+Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj action = _35val357;
 pushCont(co, _35clofun1110, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
@@ -2315,19 +2315,19 @@ coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 
 void _35clofun1110(struct Cora* co) {
 Obj _35val358 = co->args[1];
-Obj action = co->stk.stack[ co->stk.base + 0];
-Obj rules = co->stk.stack[ co->stk.base + 1];
-Obj value = co->stk.stack[ co->stk.base + 2];
-Obj cc = co->stk.stack[ co->stk.base + 3];
+Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 pushCont(co, _35clofun1111, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val358, value, action, cc);
 }
 
 void _35clofun1111(struct Cora* co) {
 Obj _35val359 = co->args[1];
-Obj rules = co->stk.stack[ co->stk.base + 0];
-Obj value = co->stk.stack[ co->stk.base + 1];
-Obj cc = co->stk.stack[ co->stk.base + 2];
+Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj curr = _35val359;
 Obj _35reg360 = primCdr(rules);
 Obj _35reg361 = primCdr(_35reg360);
@@ -2337,8 +2337,8 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg361);
 
 void _35clofun1112(struct Cora* co) {
 Obj _35val362 = co->args[1];
-Obj curr = co->stk.stack[ co->stk.base + 0];
-Obj cc = co->stk.stack[ co->stk.base + 1];
+Obj curr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj rest = _35val362;
 Obj _35reg363 = primCons(rest, Nil);
 Obj _35reg364 = primCons(Nil, _35reg363);
@@ -2363,8 +2363,8 @@ coraCall(co, 2, globalRef(intern("pair?")), action);
 
 void _35clofun1098(struct Cora* co) {
 Obj _35val324 = co->args[1];
-Obj cc = co->stk.stack[ co->stk.base + 0];
-Obj action = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 if (True == _35val324) {
 Obj _35reg325 = primCar(action);
 Obj _35reg326 = primEQ(_35reg325, intern("where"));
@@ -2398,16 +2398,16 @@ return;
 
 void _35clofun1103(struct Cora* co) {
 Obj _35val341 = co->args[1];
-Obj action = co->stk.stack[ co->stk.base + 0];
-Obj cc = co->stk.stack[ co->stk.base + 1];
+Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 pushCont(co, _35clofun1104, 2, cc, _35val341);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
 void _35clofun1104(struct Cora* co) {
 Obj _35val342 = co->args[1];
-Obj cc = co->stk.stack[ co->stk.base + 0];
-Obj _35val341 = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35val341 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg343 = primCons(cc, Nil);
 Obj _35reg344 = primCons(_35reg343, Nil);
 Obj _35reg345 = primCons(_35val342, _35reg344);
@@ -2419,16 +2419,16 @@ return;
 
 void _35clofun1101(struct Cora* co) {
 Obj _35val334 = co->args[1];
-Obj action = co->stk.stack[ co->stk.base + 0];
-Obj cc = co->stk.stack[ co->stk.base + 1];
+Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 pushCont(co, _35clofun1102, 2, cc, _35val334);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
 void _35clofun1102(struct Cora* co) {
 Obj _35val335 = co->args[1];
-Obj cc = co->stk.stack[ co->stk.base + 0];
-Obj _35val334 = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35val334 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg336 = primCons(cc, Nil);
 Obj _35reg337 = primCons(_35reg336, Nil);
 Obj _35reg338 = primCons(_35val335, _35reg337);
@@ -2440,16 +2440,16 @@ return;
 
 void _35clofun1099(struct Cora* co) {
 Obj _35val327 = co->args[1];
-Obj action = co->stk.stack[ co->stk.base + 0];
-Obj cc = co->stk.stack[ co->stk.base + 1];
+Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 pushCont(co, _35clofun1100, 2, cc, _35val327);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
 void _35clofun1100(struct Cora* co) {
 Obj _35val328 = co->args[1];
-Obj cc = co->stk.stack[ co->stk.base + 0];
-Obj _35val327 = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35val327 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg329 = primCons(cc, Nil);
 Obj _35reg330 = primCons(_35reg329, Nil);
 Obj _35reg331 = primCons(_35val328, _35reg330);
@@ -2471,10 +2471,10 @@ coraCall(co, 2, literal_63, pat);
 
 void _35clofun1094(struct Cora* co) {
 Obj _35val292 = co->args[1];
-Obj expr = co->stk.stack[ co->stk.base + 0];
-Obj body = co->stk.stack[ co->stk.base + 1];
-Obj cc = co->stk.stack[ co->stk.base + 2];
-Obj pat = co->stk.stack[ co->stk.base + 3];
+Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 if (True == _35val292) {
 Obj _35reg293 = primEQ(pat, expr);
 if (True == _35reg293) {
@@ -2510,10 +2510,10 @@ coraCall(co, 2, globalRef(intern("pair?")), pat);
 
 void _35clofun1095(struct Cora* co) {
 Obj _35val307 = co->args[1];
-Obj expr = co->stk.stack[ co->stk.base + 0];
-Obj body = co->stk.stack[ co->stk.base + 1];
-Obj cc = co->stk.stack[ co->stk.base + 2];
-Obj pat = co->stk.stack[ co->stk.base + 3];
+Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 if (True == _35val307) {
 Obj _35reg308 = primCar(pat);
 Obj _35reg309 = primEQ(_35reg308, intern("quote"));
@@ -2556,7 +2556,7 @@ coraCall(co, 2, globalRef(intern("atom?")), x);
 
 void _35clofun1093(struct Cora* co) {
 Obj _35val289 = co->args[1];
-Obj x = co->stk.stack[ co->stk.base + 0];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 if (True == _35val289) {
 Obj _35reg290 = primIsSymbol(x);
 Obj _35reg291 = primNot(_35reg290);
@@ -2584,10 +2584,10 @@ coraCall(co, 2, globalRef(intern("cadr")), pat);
 
 void _35clofun1074(struct Cora* co) {
 Obj _35val235 = co->args[1];
-Obj pat = co->stk.stack[ co->stk.base + 0];
-Obj expr = co->stk.stack[ co->stk.base + 1];
-Obj body = co->stk.stack[ co->stk.base + 2];
-Obj cc = co->stk.stack[ co->stk.base + 3];
+Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj x = _35val235;
 pushCont(co, _35clofun1075, 4, expr, body, x, cc);
 coraCall(co, 2, globalRef(intern("caddr")), pat);
@@ -2595,10 +2595,10 @@ coraCall(co, 2, globalRef(intern("caddr")), pat);
 
 void _35clofun1075(struct Cora* co) {
 Obj _35val236 = co->args[1];
-Obj expr = co->stk.stack[ co->stk.base + 0];
-Obj body = co->stk.stack[ co->stk.base + 1];
-Obj x = co->stk.stack[ co->stk.base + 2];
-Obj cc = co->stk.stack[ co->stk.base + 3];
+Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 Obj y = _35val236;
 Obj _35reg237 = primIsCons(expr);
 if (True == _35reg237) {
@@ -2652,18 +2652,18 @@ coraCall(co, 5, globalRef(intern("cora/init.match1")), y, _35reg280, body, cc);
 
 void _35clofun1089(struct Cora* co) {
 Obj _35val281 = co->args[1];
-Obj x = co->stk.stack[ co->stk.base + 0];
-Obj _35reg278 = co->stk.stack[ co->stk.base + 1];
-Obj cc = co->stk.stack[ co->stk.base + 2];
-Obj _35reg276 = co->stk.stack[ co->stk.base + 3];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg278 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj _35reg276 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 pushCont(co, _35clofun1090, 2, cc, _35reg276);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg278, _35val281, cc);
 }
 
 void _35clofun1090(struct Cora* co) {
 Obj _35val282 = co->args[1];
-Obj cc = co->stk.stack[ co->stk.base + 0];
-Obj _35reg276 = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg276 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg283 = primCons(cc, Nil);
 Obj _35reg284 = primCons(_35reg283, Nil);
 Obj _35reg285 = primCons(_35val282, _35reg284);
@@ -2675,11 +2675,11 @@ return;
 
 void _35clofun1086(struct Cora* co) {
 Obj _35val272 = co->args[1];
-Obj expr = co->stk.stack[ co->stk.base + 0];
-Obj y = co->stk.stack[ co->stk.base + 1];
-Obj body = co->stk.stack[ co->stk.base + 2];
-Obj x = co->stk.stack[ co->stk.base + 3];
-Obj cc = co->stk.stack[ co->stk.base + 4];
+Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
 Obj e1 = _35val272;
 pushCont(co, _35clofun1087, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
@@ -2687,11 +2687,11 @@ coraCall(co, 2, globalRef(intern("caddr")), expr);
 
 void _35clofun1087(struct Cora* co) {
 Obj _35val273 = co->args[1];
-Obj y = co->stk.stack[ co->stk.base + 0];
-Obj body = co->stk.stack[ co->stk.base + 1];
-Obj x = co->stk.stack[ co->stk.base + 2];
-Obj e1 = co->stk.stack[ co->stk.base + 3];
-Obj cc = co->stk.stack[ co->stk.base + 4];
+Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
 Obj e2 = _35val273;
 pushCont(co, _35clofun1088, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
@@ -2699,26 +2699,26 @@ coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 
 void _35clofun1088(struct Cora* co) {
 Obj _35val274 = co->args[1];
-Obj x = co->stk.stack[ co->stk.base + 0];
-Obj e1 = co->stk.stack[ co->stk.base + 1];
-Obj cc = co->stk.stack[ co->stk.base + 2];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, e1, _35val274, cc);
 }
 
 void _35clofun1084(struct Cora* co) {
 Obj _35val265 = co->args[1];
-Obj x = co->stk.stack[ co->stk.base + 0];
-Obj _35reg262 = co->stk.stack[ co->stk.base + 1];
-Obj cc = co->stk.stack[ co->stk.base + 2];
-Obj _35reg260 = co->stk.stack[ co->stk.base + 3];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg262 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj _35reg260 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 pushCont(co, _35clofun1085, 2, cc, _35reg260);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg262, _35val265, cc);
 }
 
 void _35clofun1085(struct Cora* co) {
 Obj _35val266 = co->args[1];
-Obj cc = co->stk.stack[ co->stk.base + 0];
-Obj _35reg260 = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg260 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg267 = primCons(cc, Nil);
 Obj _35reg268 = primCons(_35reg267, Nil);
 Obj _35reg269 = primCons(_35val266, _35reg268);
@@ -2730,11 +2730,11 @@ return;
 
 void _35clofun1081(struct Cora* co) {
 Obj _35val256 = co->args[1];
-Obj expr = co->stk.stack[ co->stk.base + 0];
-Obj y = co->stk.stack[ co->stk.base + 1];
-Obj body = co->stk.stack[ co->stk.base + 2];
-Obj x = co->stk.stack[ co->stk.base + 3];
-Obj cc = co->stk.stack[ co->stk.base + 4];
+Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
 Obj e1 = _35val256;
 pushCont(co, _35clofun1082, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
@@ -2742,11 +2742,11 @@ coraCall(co, 2, globalRef(intern("caddr")), expr);
 
 void _35clofun1082(struct Cora* co) {
 Obj _35val257 = co->args[1];
-Obj y = co->stk.stack[ co->stk.base + 0];
-Obj body = co->stk.stack[ co->stk.base + 1];
-Obj x = co->stk.stack[ co->stk.base + 2];
-Obj e1 = co->stk.stack[ co->stk.base + 3];
-Obj cc = co->stk.stack[ co->stk.base + 4];
+Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
 Obj e2 = _35val257;
 pushCont(co, _35clofun1083, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
@@ -2754,26 +2754,26 @@ coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 
 void _35clofun1083(struct Cora* co) {
 Obj _35val258 = co->args[1];
-Obj x = co->stk.stack[ co->stk.base + 0];
-Obj e1 = co->stk.stack[ co->stk.base + 1];
-Obj cc = co->stk.stack[ co->stk.base + 2];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, e1, _35val258, cc);
 }
 
 void _35clofun1079(struct Cora* co) {
 Obj _35val249 = co->args[1];
-Obj x = co->stk.stack[ co->stk.base + 0];
-Obj _35reg246 = co->stk.stack[ co->stk.base + 1];
-Obj cc = co->stk.stack[ co->stk.base + 2];
-Obj _35reg244 = co->stk.stack[ co->stk.base + 3];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg246 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj _35reg244 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
 pushCont(co, _35clofun1080, 2, cc, _35reg244);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg246, _35val249, cc);
 }
 
 void _35clofun1080(struct Cora* co) {
 Obj _35val250 = co->args[1];
-Obj cc = co->stk.stack[ co->stk.base + 0];
-Obj _35reg244 = co->stk.stack[ co->stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg244 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg251 = primCons(cc, Nil);
 Obj _35reg252 = primCons(_35reg251, Nil);
 Obj _35reg253 = primCons(_35val250, _35reg252);
@@ -2785,11 +2785,11 @@ return;
 
 void _35clofun1076(struct Cora* co) {
 Obj _35val240 = co->args[1];
-Obj expr = co->stk.stack[ co->stk.base + 0];
-Obj y = co->stk.stack[ co->stk.base + 1];
-Obj body = co->stk.stack[ co->stk.base + 2];
-Obj x = co->stk.stack[ co->stk.base + 3];
-Obj cc = co->stk.stack[ co->stk.base + 4];
+Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
 Obj e1 = _35val240;
 pushCont(co, _35clofun1077, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
@@ -2797,11 +2797,11 @@ coraCall(co, 2, globalRef(intern("caddr")), expr);
 
 void _35clofun1077(struct Cora* co) {
 Obj _35val241 = co->args[1];
-Obj y = co->stk.stack[ co->stk.base + 0];
-Obj body = co->stk.stack[ co->stk.base + 1];
-Obj x = co->stk.stack[ co->stk.base + 2];
-Obj e1 = co->stk.stack[ co->stk.base + 3];
-Obj cc = co->stk.stack[ co->stk.base + 4];
+Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
 Obj e2 = _35val241;
 pushCont(co, _35clofun1078, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
@@ -2809,9 +2809,9 @@ coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 
 void _35clofun1078(struct Cora* co) {
 Obj _35val242 = co->args[1];
-Obj x = co->stk.stack[ co->stk.base + 0];
-Obj e1 = co->stk.stack[ co->stk.base + 1];
-Obj cc = co->stk.stack[ co->stk.base + 2];
+Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, e1, _35val242, cc);
 }
 
@@ -2830,7 +2830,7 @@ coraCall(co, 2, globalRef(intern("null?")), _35reg223);
 
 void _35clofun1069(struct Cora* co) {
 Obj _35val224 = co->args[1];
-Obj pat = co->stk.stack[ co->stk.base + 0];
+Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 if (True == _35val224) {
 Obj _35reg225 = primCar(pat);
 coraReturn(co, _35reg225);
@@ -2845,7 +2845,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rcons1")), _35reg227);
 
 void _35clofun1070(struct Cora* co) {
 Obj _35val228 = co->args[1];
-Obj _35reg226 = co->stk.stack[ co->stk.base + 0];
+Obj _35reg226 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg229 = primCons(_35val228, Nil);
 Obj _35reg230 = primCons(_35reg226, _35reg229);
 Obj _35reg231 = primCons(intern("cons"), _35reg230);
@@ -2899,7 +2899,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rewrite-and")), _35reg209);
 
 void _35clofun1064(struct Cora* co) {
 Obj _35val210 = co->args[1];
-Obj l = co->stk.stack[ co->stk.base + 0];
+Obj l = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj more = _35val210;
 Obj _35reg211 = primEQ(more, False);
 if (True == _35reg211) {
@@ -2944,7 +2944,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rewrite-or")), _35reg195);
 
 void _35clofun1060(struct Cora* co) {
 Obj _35val196 = co->args[1];
-Obj l = co->stk.stack[ co->stk.base + 0];
+Obj l = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj more = _35val196;
 Obj _35reg197 = primEQ(more, True);
 if (True == _35reg197) {
@@ -2978,7 +2978,7 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1055(struct Cora* co) {
 Obj _35val182 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj curr = _35val182;
 Obj _35reg183 = primCar(curr);
 pushCont(co, _35clofun1056, 2, exp, _35reg183);
@@ -2987,16 +2987,16 @@ coraCall(co, 2, globalRef(intern("cadr")), curr);
 
 void _35clofun1056(struct Cora* co) {
 Obj _35val184 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
-Obj _35reg183 = co->stk.stack[ co->stk.base + 1];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg183 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 pushCont(co, _35clofun1057, 2, _35val184, _35reg183);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
 void _35clofun1057(struct Cora* co) {
 Obj _35val185 = co->args[1];
-Obj _35val184 = co->stk.stack[ co->stk.base + 0];
-Obj _35reg183 = co->stk.stack[ co->stk.base + 1];
+Obj _35val184 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg183 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg186 = primCons(intern("cond"), _35val185);
 Obj _35reg187 = primCons(_35reg186, Nil);
 Obj _35reg188 = primCons(_35val184, _35reg187);
@@ -3021,7 +3021,7 @@ coraCall(co, 2, globalRef(intern("null?")), _35reg164);
 
 void _35clofun1048(struct Cora* co) {
 Obj _35val165 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 if (True == _35val165) {
 Obj _35reg166 = primCar(exp);
 coraReturn(co, _35reg166);
@@ -3035,24 +3035,24 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1049(struct Cora* co) {
 Obj _35val168 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
-Obj _35reg167 = co->stk.stack[ co->stk.base + 1];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg167 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 pushCont(co, _35clofun1050, 2, _35val168, _35reg167);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
 void _35clofun1050(struct Cora* co) {
 Obj _35val169 = co->args[1];
-Obj _35val168 = co->stk.stack[ co->stk.base + 0];
-Obj _35reg167 = co->stk.stack[ co->stk.base + 1];
+Obj _35val168 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg167 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 pushCont(co, _35clofun1051, 2, _35val168, _35reg167);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-let")), _35val169);
 }
 
 void _35clofun1051(struct Cora* co) {
 Obj _35val170 = co->args[1];
-Obj _35val168 = co->stk.stack[ co->stk.base + 0];
-Obj _35reg167 = co->stk.stack[ co->stk.base + 1];
+Obj _35val168 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg167 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg171 = primCons(_35val170, Nil);
 Obj _35reg172 = primCons(_35val168, _35reg171);
 Obj _35reg173 = primCons(_35reg167, _35reg172);
@@ -3097,7 +3097,7 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1041(struct Cora* co) {
 Obj _35val144 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg145 = primCons(_35val144, Nil);
 Obj _35reg146 = primCons(intern("quote"), _35reg145);
 pushCont(co, _35clofun1042, 2, exp, _35reg146);
@@ -3106,16 +3106,16 @@ coraCall(co, 2, globalRef(intern("caddr")), exp);
 
 void _35clofun1042(struct Cora* co) {
 Obj _35val147 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
-Obj _35reg146 = co->stk.stack[ co->stk.base + 1];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg146 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 pushCont(co, _35clofun1043, 2, _35val147, _35reg146);
 coraCall(co, 2, globalRef(intern("cadddr")), exp);
 }
 
 void _35clofun1043(struct Cora* co) {
 Obj _35val148 = co->args[1];
-Obj _35val147 = co->stk.stack[ co->stk.base + 0];
-Obj _35reg146 = co->stk.stack[ co->stk.base + 1];
+Obj _35val147 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg146 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg149 = primCons(_35val148, Nil);
 Obj _35reg150 = primCons(_35val147, _35reg149);
 Obj _35reg151 = primCons(intern("lambda"), _35reg150);
@@ -3140,7 +3140,7 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1034(struct Cora* co) {
 Obj _35val130 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg131 = primCons(_35val130, Nil);
 Obj _35reg132 = primCons(intern("quote"), _35reg131);
 pushCont(co, _35clofun1035, 2, exp, _35reg132);
@@ -3149,16 +3149,16 @@ coraCall(co, 2, globalRef(intern("caddr")), exp);
 
 void _35clofun1035(struct Cora* co) {
 Obj _35val133 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
-Obj _35reg132 = co->stk.stack[ co->stk.base + 1];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg132 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 pushCont(co, _35clofun1036, 2, _35val133, _35reg132);
 coraCall(co, 2, globalRef(intern("cdddr")), exp);
 }
 
 void _35clofun1036(struct Cora* co) {
 Obj _35val134 = co->args[1];
-Obj _35val133 = co->stk.stack[ co->stk.base + 0];
-Obj _35reg132 = co->stk.stack[ co->stk.base + 1];
+Obj _35val133 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg132 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
 Obj _35reg135 = primCons(_35val133, _35val134);
 Obj _35reg136 = primCons(intern("lambda"), _35reg135);
 Obj _35reg137 = primCons(_35reg136, Nil);
@@ -3204,7 +3204,7 @@ return;
 
 void _35clofun1031(struct Cora* co) {
 Obj _35val127 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 coraCall(co, 2, makeNative(_35clofun1032, 1, 1, exp), _35val127);
 }
 
@@ -3220,21 +3220,21 @@ coraCall(co, 2, globalRef(intern("cora/init.macroexpand-boot")), exp1);
 
 void _35clofun1028(struct Cora* co) {
 Obj _35val118 = co->args[1];
-Obj exp = co->stk.stack[ co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 pushCont(co, _35clofun1029, 1, _35val118);
 coraCall(co, 2, globalRef(intern("caddr")), exp);
 }
 
 void _35clofun1029(struct Cora* co) {
 Obj _35val119 = co->args[1];
-Obj _35val118 = co->stk.stack[ co->stk.base + 0];
+Obj _35val118 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 pushCont(co, _35clofun1030, 1, _35val118);
 coraCall(co, 2, globalRef(intern("cora/init.macroexpand-boot")), _35val119);
 }
 
 void _35clofun1030(struct Cora* co) {
 Obj _35val120 = co->args[1];
-Obj _35val118 = co->stk.stack[ co->stk.base + 0];
+Obj _35val118 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg121 = primCons(_35val120, Nil);
 Obj _35reg122 = primCons(_35val118, _35reg121);
 Obj _35reg123 = primCons(intern("lambda"), _35reg122);
@@ -3334,9 +3334,9 @@ coraCall(co, 2, globalRef(intern("reverse")), res);
 
 void _35clofun1020(struct Cora* co) {
 Obj _35val84 = co->args[1];
-Obj res = co->stk.stack[ co->stk.base + 0];
-Obj l = co->stk.stack[ co->stk.base + 1];
-Obj f = co->stk.stack[ co->stk.base + 2];
+Obj res = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj l = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj f = co->ctx.stk.stack[ co->ctx.stk.base + 2];
 Obj _35reg85 = primCons(_35val84, res);
 Obj _35reg86 = primCdr(l);
 coraCall(co, 4, globalRef(intern("map-h")), _35reg85, f, _35reg86);
@@ -3380,7 +3380,7 @@ return;
 
 void _35clofun1015(struct Cora* co) {
 Obj _35val68 = co->args[1];
-Obj _35reg66 = co->stk.stack[ co->stk.base + 0];
+Obj _35reg66 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
 Obj _35reg69 = primCons(_35val68, Nil);
 Obj _35reg70 = primCons(_35reg66, _35reg69);
 Obj _35reg71 = primCons(intern("cons"), _35reg70);

--- a/init.c
+++ b/init.c
@@ -214,17 +214,17 @@ void _35clofun1007(struct Cora* co);
 void _35clofun1006(struct Cora* co);
 
 void entry(struct Cora* co) {
-Obj _35reg39 = primSet(intern("null?"), makeNative(_35clofun1006, 1, 0));
-Obj _35reg42 = primSet(intern("cadr"), makeNative(_35clofun1007, 1, 0));
-Obj _35reg45 = primSet(intern("caar"), makeNative(_35clofun1008, 1, 0));
-Obj _35reg48 = primSet(intern("cdar"), makeNative(_35clofun1009, 1, 0));
-Obj _35reg51 = primSet(intern("cddr"), makeNative(_35clofun1010, 1, 0));
-Obj _35reg55 = primSet(intern("caddr"), makeNative(_35clofun1011, 1, 0));
-Obj _35reg60 = primSet(intern("cadddr"), makeNative(_35clofun1012, 1, 0));
-Obj _35reg64 = primSet(intern("cdddr"), makeNative(_35clofun1013, 1, 0));
-Obj _35reg72 = primSet(intern("rcons"), makeNative(_35clofun1014, 1, 0));
-Obj _35reg74 = primSet(intern("pair?"), makeNative(_35clofun1016, 1, 0));
-Obj _35reg79 = primSet(intern("cora/init.reverse-h"), makeNative(_35clofun1017, 2, 0));
+Obj _35reg39 = primSet(intern("null?"), makeNative(0, _35clofun1006, 1, 0));
+Obj _35reg42 = primSet(intern("cadr"), makeNative(0, _35clofun1007, 1, 0));
+Obj _35reg45 = primSet(intern("caar"), makeNative(0, _35clofun1008, 1, 0));
+Obj _35reg48 = primSet(intern("cdar"), makeNative(0, _35clofun1009, 1, 0));
+Obj _35reg51 = primSet(intern("cddr"), makeNative(0, _35clofun1010, 1, 0));
+Obj _35reg55 = primSet(intern("caddr"), makeNative(0, _35clofun1011, 1, 0));
+Obj _35reg60 = primSet(intern("cadddr"), makeNative(0, _35clofun1012, 1, 0));
+Obj _35reg64 = primSet(intern("cdddr"), makeNative(0, _35clofun1013, 1, 0));
+Obj _35reg72 = primSet(intern("rcons"), makeNative(0, _35clofun1014, 1, 0));
+Obj _35reg74 = primSet(intern("pair?"), makeNative(0, _35clofun1016, 1, 0));
+Obj _35reg79 = primSet(intern("cora/init.reverse-h"), makeNative(0, _35clofun1017, 2, 0));
 pushCont(co, 0, _35clofun1018, 0);
 coraCall(co, 2, globalRef(intern("cora/init.reverse-h")), Nil);
 }
@@ -232,18 +232,18 @@ coraCall(co, 2, globalRef(intern("cora/init.reverse-h")), Nil);
 void _35clofun1018(struct Cora* co) {
 Obj _35val80 = co->args[1];
 Obj _35reg81 = primSet(intern("reverse"), _35val80);
-Obj _35reg87 = primSet(intern("map-h"), makeNative(_35clofun1019, 3, 0));
-Obj _35reg88 = primSet(intern("map"), makeNative(_35clofun1021, 2, 0));
+Obj _35reg87 = primSet(intern("map-h"), makeNative(0, _35clofun1019, 3, 0));
+Obj _35reg88 = primSet(intern("map"), makeNative(0, _35clofun1021, 2, 0));
 Obj _35reg89 = primSet(intern("*macros*"), Nil);
 Obj _35reg90 = primGenSym(intern("protect"));
 Obj _35reg91 = primSet(intern("*protect-symbol*"), _35reg90);
-Obj _35reg93 = primSet(intern("cora/init.protect"), makeNative(_35clofun1022, 1, 0));
-Obj _35reg97 = primSet(intern("cora/init.add-to-*macros*"), makeNative(_35clofun1023, 2, 0));
-Obj _35reg110 = primSet(intern("cora/init.macroexpand1-h"), makeNative(_35clofun1024, 2, 0));
-Obj _35reg111 = primSet(intern("cora/init.macroexpand1"), makeNative(_35clofun1026, 1, 0));
-Obj _35reg128 = primSet(intern("cora/init.macroexpand-boot"), makeNative(_35clofun1027, 1, 0));
+Obj _35reg93 = primSet(intern("cora/init.protect"), makeNative(0, _35clofun1022, 1, 0));
+Obj _35reg97 = primSet(intern("cora/init.add-to-*macros*"), makeNative(0, _35clofun1023, 2, 0));
+Obj _35reg110 = primSet(intern("cora/init.macroexpand1-h"), makeNative(0, _35clofun1024, 2, 0));
+Obj _35reg111 = primSet(intern("cora/init.macroexpand1"), makeNative(0, _35clofun1026, 1, 0));
+Obj _35reg128 = primSet(intern("cora/init.macroexpand-boot"), makeNative(0, _35clofun1027, 1, 0));
 Obj _35reg129 = primSet(intern("macroexpand"), globalRef(intern("cora/init.macroexpand-boot")));
-Obj _35reg140 = primSet(intern("defmacro-macro"), makeNative(_35clofun1033, 1, 0));
+Obj _35reg140 = primSet(intern("defmacro-macro"), makeNative(0, _35clofun1033, 1, 0));
 pushCont(co, 0, _35clofun1037, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("defmacro"), globalRef(intern("defmacro-macro")));
 }
@@ -251,93 +251,93 @@ coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("defmacro
 void _35clofun1037(struct Cora* co) {
 Obj _35val141 = co->args[1];
 pushCont(co, 0, _35clofun1039, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("list"), makeNative(_35clofun1038, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("list"), makeNative(0, _35clofun1038, 1, 0));
 }
 
 void _35clofun1039(struct Cora* co) {
 Obj _35val143 = co->args[1];
 pushCont(co, 0, _35clofun1044, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("defun"), makeNative(_35clofun1040, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("defun"), makeNative(0, _35clofun1040, 1, 0));
 }
 
 void _35clofun1044(struct Cora* co) {
 Obj _35val155 = co->args[1];
-Obj _35reg160 = primSet(intern("elem?"), makeNative(_35clofun1045, 2, 0));
-Obj _35reg163 = primSet(intern("atom?"), makeNative(_35clofun1046, 1, 0));
-Obj _35reg175 = primSet(intern("cora/init.rewrite-let"), makeNative(_35clofun1047, 1, 0));
+Obj _35reg160 = primSet(intern("elem?"), makeNative(0, _35clofun1045, 2, 0));
+Obj _35reg163 = primSet(intern("atom?"), makeNative(0, _35clofun1046, 1, 0));
+Obj _35reg175 = primSet(intern("cora/init.rewrite-let"), makeNative(0, _35clofun1047, 1, 0));
 pushCont(co, 0, _35clofun1053, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("let"), makeNative(_35clofun1052, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("let"), makeNative(0, _35clofun1052, 1, 0));
 }
 
 void _35clofun1053(struct Cora* co) {
 Obj _35val177 = co->args[1];
 pushCont(co, 0, _35clofun1058, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("cond"), makeNative(_35clofun1054, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("cond"), makeNative(0, _35clofun1054, 1, 0));
 }
 
 void _35clofun1058(struct Cora* co) {
 Obj _35val191 = co->args[1];
-Obj _35reg203 = primSet(intern("cora/init.rewrite-or"), makeNative(_35clofun1059, 1, 0));
+Obj _35reg203 = primSet(intern("cora/init.rewrite-or"), makeNative(0, _35clofun1059, 1, 0));
 pushCont(co, 0, _35clofun1062, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("or"), makeNative(_35clofun1061, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("or"), makeNative(0, _35clofun1061, 1, 0));
 }
 
 void _35clofun1062(struct Cora* co) {
 Obj _35val205 = co->args[1];
-Obj _35reg217 = primSet(intern("cora/init.rewrite-and"), makeNative(_35clofun1063, 1, 0));
+Obj _35reg217 = primSet(intern("cora/init.rewrite-and"), makeNative(0, _35clofun1063, 1, 0));
 pushCont(co, 0, _35clofun1066, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("and"), makeNative(_35clofun1065, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("and"), makeNative(0, _35clofun1065, 1, 0));
 }
 
 void _35clofun1066(struct Cora* co) {
 Obj _35val219 = co->args[1];
-Obj _35reg222 = primSet(intern("boolean?"), makeNative(_35clofun1067, 1, 0));
-Obj _35reg232 = primSet(intern("cora/init.rcons1"), makeNative(_35clofun1068, 1, 0));
+Obj _35reg222 = primSet(intern("boolean?"), makeNative(0, _35clofun1067, 1, 0));
+Obj _35reg232 = primSet(intern("cora/init.rcons1"), makeNative(0, _35clofun1068, 1, 0));
 pushCont(co, 0, _35clofun1072, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("list-rest"), makeNative(_35clofun1071, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("list-rest"), makeNative(0, _35clofun1071, 1, 0));
 }
 
 void _35clofun1072(struct Cora* co) {
 Obj _35val234 = co->args[1];
-Obj _35reg288 = primSet(intern("cora/init.match-cons-expander"), makeNative(_35clofun1073, 4, 0));
-Obj _35reg321 = primSet(intern("cora/init.match1"), makeNative(_35clofun1091, 4, 0));
-Obj _35reg348 = primSet(intern("cora/init.extract-rule-action"), makeNative(_35clofun1097, 2, 0));
-Obj _35reg400 = primSet(intern("cora/init.match-helper"), makeNative(_35clofun1105, 2, 0));
-Obj _35reg426 = primSet(intern("cora/init.rewrite-match"), makeNative(_35clofun1121, 1, 0));
+Obj _35reg288 = primSet(intern("cora/init.match-cons-expander"), makeNative(0, _35clofun1073, 4, 0));
+Obj _35reg321 = primSet(intern("cora/init.match1"), makeNative(0, _35clofun1091, 4, 0));
+Obj _35reg348 = primSet(intern("cora/init.extract-rule-action"), makeNative(0, _35clofun1097, 2, 0));
+Obj _35reg400 = primSet(intern("cora/init.match-helper"), makeNative(0, _35clofun1105, 2, 0));
+Obj _35reg426 = primSet(intern("cora/init.rewrite-match"), makeNative(0, _35clofun1121, 1, 0));
 pushCont(co, 0, _35clofun1129, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("match"), makeNative(_35clofun1128, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("match"), makeNative(0, _35clofun1128, 1, 0));
 }
 
 void _35clofun1129(struct Cora* co) {
 Obj _35val427 = co->args[1];
-Obj _35reg479 = primSet(intern("cora/init.extract-rules1"), makeNative(_35clofun1130, 3, 0));
-Obj _35reg480 = primSet(intern("cora/init.extract-rules"), makeNative(_35clofun1137, 1, 0));
-Obj _35reg485 = primSet(intern("cora/init.rules-patterns"), makeNative(_35clofun1138, 2, 0));
-Obj _35reg489 = primSet(intern("cora/init.length-h"), makeNative(_35clofun1141, 2, 0));
-Obj _35reg490 = primSet(intern("length"), makeNative(_35clofun1142, 1, 0));
-Obj _35reg498 = primSet(intern("cora/init.filter-h"), makeNative(_35clofun1143, 3, 0));
-Obj _35reg499 = primSet(intern("filter"), makeNative(_35clofun1145, 2, 0));
-Obj _35reg505 = primSet(intern("append"), makeNative(_35clofun1146, 2, 0));
-Obj _35reg516 = primSet(intern("cora/init.rules-arg-count"), makeNative(_35clofun1148, 1, 0));
-Obj _35reg522 = primSet(intern("cora/init.gen-parameters"), makeNative(_35clofun1155, 1, 0));
+Obj _35reg479 = primSet(intern("cora/init.extract-rules1"), makeNative(0, _35clofun1130, 3, 0));
+Obj _35reg480 = primSet(intern("cora/init.extract-rules"), makeNative(0, _35clofun1137, 1, 0));
+Obj _35reg485 = primSet(intern("cora/init.rules-patterns"), makeNative(0, _35clofun1138, 2, 0));
+Obj _35reg489 = primSet(intern("cora/init.length-h"), makeNative(0, _35clofun1141, 2, 0));
+Obj _35reg490 = primSet(intern("length"), makeNative(0, _35clofun1142, 1, 0));
+Obj _35reg498 = primSet(intern("cora/init.filter-h"), makeNative(0, _35clofun1143, 3, 0));
+Obj _35reg499 = primSet(intern("filter"), makeNative(0, _35clofun1145, 2, 0));
+Obj _35reg505 = primSet(intern("append"), makeNative(0, _35clofun1146, 2, 0));
+Obj _35reg516 = primSet(intern("cora/init.rules-arg-count"), makeNative(0, _35clofun1148, 1, 0));
+Obj _35reg522 = primSet(intern("cora/init.gen-parameters"), makeNative(0, _35clofun1155, 1, 0));
 pushCont(co, 0, _35clofun1163, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("func"), makeNative(_35clofun1157, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("func"), makeNative(0, _35clofun1157, 1, 0));
 }
 
 void _35clofun1163(struct Cora* co) {
 Obj _35val535 = co->args[1];
-Obj _35reg798 = primSet(intern("cora/init.propagate-boolean0"), makeNative(_35clofun1164, 1, 0));
-Obj _35reg956 = primSet(intern("cora/init.propagate-boolean"), makeNative(_35clofun1176, 1, 0));
-Obj _35reg958 = primSet(intern("macroexpand"), makeNative(_35clofun1199, 1, 0));
-Obj _35reg982 = primSet(intern("cora/init.rewrite-begin"), makeNative(_35clofun1201, 1, 0));
+Obj _35reg798 = primSet(intern("cora/init.propagate-boolean0"), makeNative(0, _35clofun1164, 1, 0));
+Obj _35reg956 = primSet(intern("cora/init.propagate-boolean"), makeNative(0, _35clofun1176, 1, 0));
+Obj _35reg958 = primSet(intern("macroexpand"), makeNative(0, _35clofun1199, 1, 0));
+Obj _35reg982 = primSet(intern("cora/init.rewrite-begin"), makeNative(0, _35clofun1201, 1, 0));
 pushCont(co, 0, _35clofun1207, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("begin"), makeNative(_35clofun1206, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("begin"), makeNative(0, _35clofun1206, 1, 0));
 }
 
 void _35clofun1207(struct Cora* co) {
 Obj _35val984 = co->args[1];
-Obj _35reg1004 = primSet(intern("cora/init.rewrite-backquote"), makeNative(_35clofun1208, 1, 0));
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("backquote"), makeNative(_35clofun1214, 1, 0));
+Obj _35reg1004 = primSet(intern("cora/init.rewrite-backquote"), makeNative(0, _35clofun1208, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("backquote"), makeNative(0, _35clofun1214, 1, 0));
 }
 
 void _35clofun1214(struct Cora* co) {
@@ -353,7 +353,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rewrite-backquote")), _35val1005);
 
 void _35clofun1208(struct Cora* co) {
 Obj _35p33 = co->args[1];
-Obj _35cc34 = makeNative(_35clofun1209, 0, 1, _35p33);
+Obj _35cc34 = makeNative(0, _35clofun1209, 0, 1, _35p33);
 Obj x = _35p33;
 Obj _35reg1001 = primIsSymbol(x);
 if (True == _35reg1001) {
@@ -367,7 +367,7 @@ coraCall(co, 1, _35cc34);
 }
 
 void _35clofun1209(struct Cora* co) {
-Obj _35cc35 = makeNative(_35clofun1210, 0, 1, closureRef(co, 0));
+Obj _35cc35 = makeNative(0, _35clofun1210, 0, 1, closureRef(co, 0));
 Obj _35reg991 = primIsCons(closureRef(co, 0));
 if (True == _35reg991) {
 Obj _35reg992 = primCar(closureRef(co, 0));
@@ -400,7 +400,7 @@ coraCall(co, 1, _35cc35);
 }
 
 void _35clofun1210(struct Cora* co) {
-Obj _35cc36 = makeNative(_35clofun1211, 0, 1, closureRef(co, 0));
+Obj _35cc36 = makeNative(0, _35clofun1211, 0, 1, closureRef(co, 0));
 Obj _35reg985 = primIsCons(closureRef(co, 0));
 if (True == _35reg985) {
 Obj _35reg986 = primCar(closureRef(co, 0));
@@ -423,7 +423,7 @@ return;
 }
 
 void _35clofun1211(struct Cora* co) {
-Obj _35cc37 = makeNative(_35clofun1212, 0, 0);
+Obj _35cc37 = makeNative(0, _35clofun1212, 0, 0);
 Obj x = closureRef(co, 0);
 coraReturn(co, x);
 return;
@@ -441,7 +441,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rewrite-begin")), _35reg983);
 
 void _35clofun1201(struct Cora* co) {
 Obj _35p29 = co->args[1];
-Obj _35cc30 = makeNative(_35clofun1202, 0, 1, _35p29);
+Obj _35cc30 = makeNative(0, _35clofun1202, 0, 1, _35p29);
 Obj _35reg978 = primIsCons(_35p29);
 if (True == _35reg978) {
 Obj _35reg979 = primCar(_35p29);
@@ -460,7 +460,7 @@ coraCall(co, 1, _35cc30);
 }
 
 void _35clofun1202(struct Cora* co) {
-Obj _35cc31 = makeNative(_35clofun1203, 0, 1, closureRef(co, 0));
+Obj _35cc31 = makeNative(0, _35clofun1203, 0, 1, closureRef(co, 0));
 Obj _35reg966 = primIsCons(closureRef(co, 0));
 if (True == _35reg966) {
 Obj _35reg967 = primCar(closureRef(co, 0));
@@ -492,7 +492,7 @@ coraCall(co, 1, _35cc31);
 }
 
 void _35clofun1203(struct Cora* co) {
-Obj _35cc32 = makeNative(_35clofun1204, 0, 0);
+Obj _35cc32 = makeNative(0, _35clofun1204, 0, 0);
 Obj _35reg959 = primIsCons(closureRef(co, 0));
 if (True == _35reg959) {
 Obj _35reg960 = primCar(closureRef(co, 0));
@@ -533,7 +533,7 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), _35val957);
 
 void _35clofun1176(struct Cora* co) {
 Obj _35p17 = co->args[1];
-Obj _35cc18 = makeNative(_35clofun1177, 0, 1, _35p17);
+Obj _35cc18 = makeNative(0, _35clofun1177, 0, 1, _35p17);
 Obj _35reg944 = primIsCons(_35p17);
 if (True == _35reg944) {
 Obj _35reg945 = primCar(_35p17);
@@ -568,7 +568,7 @@ coraCall(co, 1, _35cc18);
 }
 
 void _35clofun1177(struct Cora* co) {
-Obj _35cc19 = makeNative(_35clofun1178, 0, 1, closureRef(co, 0));
+Obj _35cc19 = makeNative(0, _35clofun1178, 0, 1, closureRef(co, 0));
 Obj _35reg931 = primIsCons(closureRef(co, 0));
 if (True == _35reg931) {
 Obj _35reg932 = primCar(closureRef(co, 0));
@@ -609,7 +609,7 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg943);
 }
 
 void _35clofun1178(struct Cora* co) {
-Obj _35cc20 = makeNative(_35clofun1179, 0, 1, closureRef(co, 0));
+Obj _35cc20 = makeNative(0, _35clofun1179, 0, 1, closureRef(co, 0));
 Obj _35reg918 = primIsCons(closureRef(co, 0));
 if (True == _35reg918) {
 Obj _35reg919 = primCar(closureRef(co, 0));
@@ -650,7 +650,7 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg930);
 }
 
 void _35clofun1179(struct Cora* co) {
-Obj _35cc21 = makeNative(_35clofun1180, 0, 1, closureRef(co, 0));
+Obj _35cc21 = makeNative(0, _35clofun1180, 0, 1, closureRef(co, 0));
 Obj _35reg905 = primIsCons(closureRef(co, 0));
 if (True == _35reg905) {
 Obj _35reg906 = primCar(closureRef(co, 0));
@@ -691,7 +691,7 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg917);
 }
 
 void _35clofun1180(struct Cora* co) {
-Obj _35cc22 = makeNative(_35clofun1181, 0, 1, closureRef(co, 0));
+Obj _35cc22 = makeNative(0, _35clofun1181, 0, 1, closureRef(co, 0));
 Obj _35reg883 = primIsCons(closureRef(co, 0));
 if (True == _35reg883) {
 Obj _35reg884 = primCar(closureRef(co, 0));
@@ -754,7 +754,7 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg904);
 }
 
 void _35clofun1181(struct Cora* co) {
-Obj _35cc23 = makeNative(_35clofun1182, 0, 1, closureRef(co, 0));
+Obj _35cc23 = makeNative(0, _35clofun1182, 0, 1, closureRef(co, 0));
 Obj _35reg870 = primIsCons(closureRef(co, 0));
 if (True == _35reg870) {
 Obj _35reg871 = primCar(closureRef(co, 0));
@@ -795,7 +795,7 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg882);
 }
 
 void _35clofun1182(struct Cora* co) {
-Obj _35cc24 = makeNative(_35clofun1183, 0, 1, closureRef(co, 0));
+Obj _35cc24 = makeNative(0, _35clofun1183, 0, 1, closureRef(co, 0));
 Obj _35reg857 = primIsCons(closureRef(co, 0));
 if (True == _35reg857) {
 Obj _35reg858 = primCar(closureRef(co, 0));
@@ -836,7 +836,7 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg869);
 }
 
 void _35clofun1183(struct Cora* co) {
-Obj _35cc25 = makeNative(_35clofun1184, 0, 1, closureRef(co, 0));
+Obj _35cc25 = makeNative(0, _35clofun1184, 0, 1, closureRef(co, 0));
 Obj _35reg824 = primIsCons(closureRef(co, 0));
 if (True == _35reg824) {
 Obj _35reg825 = primCar(closureRef(co, 0));
@@ -925,7 +925,7 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg856);
 }
 
 void _35clofun1184(struct Cora* co) {
-Obj _35cc26 = makeNative(_35clofun1185, 0, 1, closureRef(co, 0));
+Obj _35cc26 = makeNative(0, _35clofun1185, 0, 1, closureRef(co, 0));
 Obj _35reg803 = primIsCons(closureRef(co, 0));
 if (True == _35reg803) {
 Obj _35reg804 = primCar(closureRef(co, 0));
@@ -980,7 +980,7 @@ return;
 }
 
 void _35clofun1185(struct Cora* co) {
-Obj _35cc27 = makeNative(_35clofun1186, 0, 1, closureRef(co, 0));
+Obj _35cc27 = makeNative(0, _35clofun1186, 0, 1, closureRef(co, 0));
 Obj _35reg799 = primIsCons(closureRef(co, 0));
 if (True == _35reg799) {
 Obj _35reg800 = primCar(closureRef(co, 0));
@@ -995,7 +995,7 @@ coraCall(co, 1, _35cc27);
 }
 
 void _35clofun1186(struct Cora* co) {
-Obj _35cc28 = makeNative(_35clofun1187, 0, 0);
+Obj _35cc28 = makeNative(0, _35clofun1187, 0, 0);
 Obj x = closureRef(co, 0);
 coraReturn(co, x);
 return;
@@ -1007,7 +1007,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 
 void _35clofun1164(struct Cora* co) {
 Obj _35p5 = co->args[1];
-Obj _35cc6 = makeNative(_35clofun1165, 0, 1, _35p5);
+Obj _35cc6 = makeNative(0, _35clofun1165, 0, 1, _35p5);
 Obj _35reg759 = primIsCons(_35p5);
 if (True == _35reg759) {
 Obj _35reg760 = primCar(_35p5);
@@ -1090,7 +1090,7 @@ coraCall(co, 1, _35cc6);
 }
 
 void _35clofun1165(struct Cora* co) {
-Obj _35cc7 = makeNative(_35clofun1166, 0, 1, closureRef(co, 0));
+Obj _35cc7 = makeNative(0, _35clofun1166, 0, 1, closureRef(co, 0));
 Obj _35reg720 = primIsCons(closureRef(co, 0));
 if (True == _35reg720) {
 Obj _35reg721 = primCar(closureRef(co, 0));
@@ -1173,7 +1173,7 @@ coraCall(co, 1, _35cc7);
 }
 
 void _35clofun1166(struct Cora* co) {
-Obj _35cc8 = makeNative(_35clofun1167, 0, 1, closureRef(co, 0));
+Obj _35cc8 = makeNative(0, _35clofun1167, 0, 1, closureRef(co, 0));
 Obj _35reg681 = primIsCons(closureRef(co, 0));
 if (True == _35reg681) {
 Obj _35reg682 = primCar(closureRef(co, 0));
@@ -1256,7 +1256,7 @@ coraCall(co, 1, _35cc8);
 }
 
 void _35clofun1167(struct Cora* co) {
-Obj _35cc9 = makeNative(_35clofun1168, 0, 1, closureRef(co, 0));
+Obj _35cc9 = makeNative(0, _35clofun1168, 0, 1, closureRef(co, 0));
 Obj _35reg662 = primIsCons(closureRef(co, 0));
 if (True == _35reg662) {
 Obj _35reg663 = primCar(closureRef(co, 0));
@@ -1309,7 +1309,7 @@ coraCall(co, 1, _35cc9);
 }
 
 void _35clofun1168(struct Cora* co) {
-Obj _35cc10 = makeNative(_35clofun1169, 0, 1, closureRef(co, 0));
+Obj _35cc10 = makeNative(0, _35clofun1169, 0, 1, closureRef(co, 0));
 Obj _35reg651 = primIsCons(closureRef(co, 0));
 if (True == _35reg651) {
 Obj _35reg652 = primCar(closureRef(co, 0));
@@ -1346,7 +1346,7 @@ coraCall(co, 1, _35cc10);
 }
 
 void _35clofun1169(struct Cora* co) {
-Obj _35cc11 = makeNative(_35clofun1170, 0, 1, closureRef(co, 0));
+Obj _35cc11 = makeNative(0, _35clofun1170, 0, 1, closureRef(co, 0));
 Obj _35reg612 = primIsCons(closureRef(co, 0));
 if (True == _35reg612) {
 Obj _35reg613 = primCar(closureRef(co, 0));
@@ -1429,7 +1429,7 @@ coraCall(co, 1, _35cc11);
 }
 
 void _35clofun1170(struct Cora* co) {
-Obj _35cc12 = makeNative(_35clofun1171, 0, 1, closureRef(co, 0));
+Obj _35cc12 = makeNative(0, _35clofun1171, 0, 1, closureRef(co, 0));
 Obj _35reg601 = primIsCons(closureRef(co, 0));
 if (True == _35reg601) {
 Obj _35reg602 = primCar(closureRef(co, 0));
@@ -1466,7 +1466,7 @@ coraCall(co, 1, _35cc12);
 }
 
 void _35clofun1171(struct Cora* co) {
-Obj _35cc13 = makeNative(_35clofun1172, 0, 1, closureRef(co, 0));
+Obj _35cc13 = makeNative(0, _35clofun1172, 0, 1, closureRef(co, 0));
 Obj _35reg590 = primIsCons(closureRef(co, 0));
 if (True == _35reg590) {
 Obj _35reg591 = primCar(closureRef(co, 0));
@@ -1503,7 +1503,7 @@ coraCall(co, 1, _35cc13);
 }
 
 void _35clofun1172(struct Cora* co) {
-Obj _35cc14 = makeNative(_35clofun1173, 0, 1, closureRef(co, 0));
+Obj _35cc14 = makeNative(0, _35clofun1173, 0, 1, closureRef(co, 0));
 Obj _35reg563 = primIsCons(closureRef(co, 0));
 if (True == _35reg563) {
 Obj _35reg564 = primCar(closureRef(co, 0));
@@ -1566,7 +1566,7 @@ coraCall(co, 1, _35cc14);
 }
 
 void _35clofun1173(struct Cora* co) {
-Obj _35cc15 = makeNative(_35clofun1174, 0, 1, closureRef(co, 0));
+Obj _35cc15 = makeNative(0, _35clofun1174, 0, 1, closureRef(co, 0));
 Obj _35reg536 = primIsCons(closureRef(co, 0));
 if (True == _35reg536) {
 Obj _35reg537 = primCar(closureRef(co, 0));
@@ -1629,7 +1629,7 @@ coraCall(co, 1, _35cc15);
 }
 
 void _35clofun1174(struct Cora* co) {
-Obj _35cc16 = makeNative(_35clofun1175, 0, 0);
+Obj _35cc16 = makeNative(0, _35clofun1175, 0, 0);
 Obj x = closureRef(co, 0);
 coraReturn(co, x);
 return;
@@ -1724,7 +1724,7 @@ coraCall(co, 3, globalRef(intern("cora/init.rules-patterns")), Nil, rules);
 void _35clofun1149(struct Cora* co) {
 Obj _35val506 = co->args[1];
 Obj pats = _35val506;
-Obj len = makeNative(_35clofun1150, 1, 0);
+Obj len = makeNative(0, _35clofun1150, 1, 0);
 pushCont(co, 0, _35clofun1151, 0);
 coraCall(co, 3, globalRef(intern("map")), len, pats);
 }
@@ -1734,7 +1734,7 @@ Obj _35val508 = co->args[1];
 Obj counts = _35val508;
 Obj _35reg509 = primCar(counts);
 Obj n = _35reg509;
-Obj dif = makeNative(_35clofun1152, 1, 1, n);
+Obj dif = makeNative(0, _35clofun1152, 1, 1, n);
 Obj _35reg512 = primCdr(counts);
 pushCont(co, 0, _35clofun1153, 1, n);
 coraCall(co, 3, globalRef(intern("filter")), dif, _35reg512);
@@ -1887,7 +1887,7 @@ void _35clofun1130(struct Cora* co) {
 Obj input = co->args[1];
 Obj current = co->args[2];
 Obj result = co->args[3];
-Obj _35cc1 = makeNative(_35clofun1131, 0, 3, input, current, result);
+Obj _35cc1 = makeNative(0, _35clofun1131, 0, 3, input, current, result);
 Obj _35reg478 = primEQ(Nil, input);
 if (True == _35reg478) {
 coraCall(co, 2, globalRef(intern("reverse")), result);
@@ -1897,7 +1897,7 @@ coraCall(co, 1, _35cc1);
 }
 
 void _35clofun1131(struct Cora* co) {
-Obj _35cc2 = makeNative(_35clofun1132, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc2 = makeNative(0, _35clofun1132, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj _35reg445 = primIsCons(closureRef(co, 0));
 if (True == _35reg445) {
 Obj _35reg446 = primCar(closureRef(co, 0));
@@ -1971,7 +1971,7 @@ coraCall(co, 4, globalRef(intern("cora/init.extract-rules1")), remain, Nil, _35r
 }
 
 void _35clofun1132(struct Cora* co) {
-Obj _35cc3 = makeNative(_35clofun1133, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc3 = makeNative(0, _35clofun1133, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj _35reg432 = primIsCons(closureRef(co, 0));
 if (True == _35reg432) {
 Obj _35reg433 = primCar(closureRef(co, 0));
@@ -2011,7 +2011,7 @@ coraCall(co, 4, globalRef(intern("cora/init.extract-rules1")), remain, Nil, _35r
 }
 
 void _35clofun1133(struct Cora* co) {
-Obj _35cc4 = makeNative(_35clofun1134, 0, 0);
+Obj _35cc4 = makeNative(0, _35clofun1134, 0, 0);
 Obj _35reg428 = primIsCons(closureRef(co, 0));
 if (True == _35reg428) {
 Obj _35reg429 = primCar(closureRef(co, 0));
@@ -2464,7 +2464,7 @@ Obj pat = co->args[1];
 Obj expr = co->args[2];
 Obj body = co->args[3];
 Obj cc = co->args[4];
-Obj literal_63 = makeNative(_35clofun1092, 1, 0);
+Obj literal_63 = makeNative(0, _35clofun1092, 1, 0);
 pushCont(co, 0, _35clofun1094, 4, expr, body, cc, pat);
 coraCall(co, 2, literal_63, pat);
 }
@@ -3205,7 +3205,7 @@ return;
 void _35clofun1031(struct Cora* co) {
 Obj _35val127 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 2, makeNative(_35clofun1032, 1, 1, exp), _35val127);
+coraCall(co, 2, makeNative(0, _35clofun1032, 1, 1, exp), _35val127);
 }
 
 void _35clofun1032(struct Cora* co) {
@@ -3256,7 +3256,7 @@ coraReturn(co, exp);
 return;
 } else {
 Obj _35reg109 = primCar(macros);
-coraCall(co, 2, makeNative(_35clofun1025, 1, 2, exp, macros), _35reg109);
+coraCall(co, 2, makeNative(0, _35clofun1025, 1, 2, exp, macros), _35reg109);
 }
 }
 

--- a/init.c
+++ b/init.c
@@ -737,7 +737,7 @@ coraCall(co, 1, _35cc22);
 
 void _35clofun1194(struct Cora* co) {
 Obj _35val900 = co->args[1];
-Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x1 = _35val900;
 pushCont(co, 0, _35clofun1195, 1, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
@@ -745,7 +745,7 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
 
 void _35clofun1195(struct Cora* co) {
 Obj _35val901 = co->args[1];
-Obj x1 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj x1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y1 = _35val901;
 Obj _35reg902 = primCons(y1, Nil);
 Obj _35reg903 = primCons(x1, _35reg902);
@@ -896,8 +896,8 @@ coraCall(co, 1, _35cc25);
 
 void _35clofun1189(struct Cora* co) {
 Obj _35val850 = co->args[1];
-Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj z = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj z = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj x1 = _35val850;
 pushCont(co, 0, _35clofun1190, 2, z, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
@@ -905,8 +905,8 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
 
 void _35clofun1190(struct Cora* co) {
 Obj _35val851 = co->args[1];
-Obj z = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj x1 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj z = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x1 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj y1 = _35val851;
 pushCont(co, 0, _35clofun1191, 2, y1, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), z);
@@ -914,8 +914,8 @@ coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), z);
 
 void _35clofun1191(struct Cora* co) {
 Obj _35val852 = co->args[1];
-Obj y1 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj x1 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj y1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x1 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj z1 = _35val852;
 Obj _35reg853 = primCons(z1, Nil);
 Obj _35reg854 = primCons(y1, _35reg853);
@@ -971,7 +971,7 @@ coraCall(co, 1, _35cc26);
 
 void _35clofun1188(struct Cora* co) {
 Obj _35val820 = co->args[1];
-Obj args = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg821 = primCons(_35val820, Nil);
 Obj _35reg822 = primCons(args, _35reg821);
 Obj _35reg823 = primCons(intern("lambda"), _35reg822);
@@ -1647,14 +1647,14 @@ coraCall(co, 2, globalRef(intern("cddr")), exp);
 
 void _35clofun1158(struct Cora* co) {
 Obj _35val523 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 pushCont(co, 0, _35clofun1159, 1, exp);
 coraCall(co, 2, globalRef(intern("cora/init.extract-rules")), _35val523);
 }
 
 void _35clofun1159(struct Cora* co) {
 Obj _35val524 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = _35val524;
 pushCont(co, 0, _35clofun1160, 2, exp, body);
 coraCall(co, 2, globalRef(intern("cora/init.rules-arg-count")), body);
@@ -1662,8 +1662,8 @@ coraCall(co, 2, globalRef(intern("cora/init.rules-arg-count")), body);
 
 void _35clofun1160(struct Cora* co) {
 Obj _35val525 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj nargs = _35val525;
 pushCont(co, 0, _35clofun1161, 2, exp, body);
 coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), nargs);
@@ -1671,8 +1671,8 @@ coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), nargs);
 
 void _35clofun1161(struct Cora* co) {
 Obj _35val526 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args = _35val526;
 pushCont(co, 0, _35clofun1162, 2, body, args);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
@@ -1680,8 +1680,8 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1162(struct Cora* co) {
 Obj _35val527 = co->args[1];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj args = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg528 = primCons(intern("list"), args);
 Obj _35reg529 = primCons(_35reg528, body);
 Obj _35reg530 = primCons(intern("match"), _35reg529);
@@ -1709,7 +1709,7 @@ coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), _35reg519);
 
 void _35clofun1156(struct Cora* co) {
 Obj _35val520 = co->args[1];
-Obj _35reg518 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg518 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg521 = primCons(_35reg518, _35val520);
 coraReturn(co, _35reg521);
 return;
@@ -1742,14 +1742,14 @@ coraCall(co, 3, globalRef(intern("filter")), dif, _35reg512);
 
 void _35clofun1153(struct Cora* co) {
 Obj _35val513 = co->args[1];
-Obj n = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj n = co->ctx.stk.stack[co->ctx.stk.base + 0];
 pushCont(co, 0, _35clofun1154, 1, n);
 coraCall(co, 2, globalRef(intern("null?")), _35val513);
 }
 
 void _35clofun1154(struct Cora* co) {
 Obj _35val514 = co->args[1];
-Obj n = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj n = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg515 = primNot(_35val514);
 if (True == _35reg515) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("inconsistent func rule args count"));
@@ -1790,7 +1790,7 @@ coraCall(co, 3, globalRef(intern("append")), _35reg502, l2);
 
 void _35clofun1147(struct Cora* co) {
 Obj _35val503 = co->args[1];
-Obj _35reg501 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg501 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg504 = primCons(_35reg501, _35val503);
 coraReturn(co, _35reg504);
 return;
@@ -1818,9 +1818,9 @@ coraCall(co, 2, globalRef(intern("reverse")), res);
 
 void _35clofun1144(struct Cora* co) {
 Obj _35val493 = co->args[1];
-Obj l = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj res = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj fn = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj l = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj res = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 2];
 if (True == _35val493) {
 Obj _35reg494 = primCar(l);
 Obj _35reg495 = primCons(_35reg494, res);
@@ -1860,8 +1860,8 @@ coraCall(co, 2, globalRef(intern("null?")), rules);
 
 void _35clofun1139(struct Cora* co) {
 Obj _35val481 = co->args[1];
-Obj res = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj res = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val481) {
 coraCall(co, 2, globalRef(intern("reverse")), res);
 } else {
@@ -1874,7 +1874,7 @@ coraCall(co, 2, globalRef(intern("cddr")), rules);
 
 void _35clofun1140(struct Cora* co) {
 Obj _35val484 = co->args[1];
-Obj _35reg483 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg483 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/init.rules-patterns")), _35reg483, _35val484);
 }
 
@@ -1957,9 +1957,9 @@ coraCall(co, 1, _35cc2);
 
 void _35clofun1136(struct Cora* co) {
 Obj _35val471 = co->args[1];
-Obj act = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj pred = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj remain = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj act = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj pred = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj remain = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg472 = primCons(intern("list"), _35val471);
 Obj pat = _35reg472;
 Obj _35reg473 = primCons(act, Nil);
@@ -2001,8 +2001,8 @@ coraCall(co, 1, _35cc3);
 
 void _35clofun1135(struct Cora* co) {
 Obj _35val441 = co->args[1];
-Obj act = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj remain = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj act = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj remain = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg442 = primCons(intern("list"), _35val441);
 Obj pat = _35reg442;
 Obj _35reg443 = primCons(pat, closureRef(co, 2));
@@ -2042,14 +2042,14 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1122(struct Cora* co) {
 Obj _35val401 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 pushCont(co, 0, _35clofun1123, 1, exp);
 coraCall(co, 2, globalRef(intern("macroexpand")), _35val401);
 }
 
 void _35clofun1123(struct Cora* co) {
 Obj _35val402 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj value = _35val402;
 pushCont(co, 0, _35clofun1124, 1, value);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
@@ -2057,7 +2057,7 @@ coraCall(co, 2, globalRef(intern("cddr")), exp);
 
 void _35clofun1124(struct Cora* co) {
 Obj _35val403 = co->args[1];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj rules = _35val403;
 Obj _35reg404 = primIsCons(value);
 if (True == _35reg404) {
@@ -2097,8 +2097,8 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
 
 void _35clofun1127(struct Cora* co) {
 Obj _35val421 = co->args[1];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj val = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg422 = primCons(_35val421, Nil);
 Obj _35reg423 = primCons(value, _35reg422);
 Obj _35reg424 = primCons(val, _35reg423);
@@ -2109,8 +2109,8 @@ return;
 
 void _35clofun1126(struct Cora* co) {
 Obj _35val415 = co->args[1];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj val = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg416 = primCons(_35val415, Nil);
 Obj _35reg417 = primCons(value, _35reg416);
 Obj _35reg418 = primCons(val, _35reg417);
@@ -2121,8 +2121,8 @@ return;
 
 void _35clofun1125(struct Cora* co) {
 Obj _35val409 = co->args[1];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj val = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg410 = primCons(_35val409, Nil);
 Obj _35reg411 = primCons(value, _35reg410);
 Obj _35reg412 = primCons(val, _35reg411);
@@ -2140,8 +2140,8 @@ coraCall(co, 2, globalRef(intern("null?")), rules);
 
 void _35clofun1106(struct Cora* co) {
 Obj _35val349 = co->args[1];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val349) {
 Obj _35reg350 = primCons(makeString1("no match-help found!"), Nil);
 Obj _35reg351 = primCons(intern("error"), _35reg350);
@@ -2155,8 +2155,8 @@ coraCall(co, 2, globalRef(intern("pair?")), rules);
 
 void _35clofun1107(struct Cora* co) {
 Obj _35val352 = co->args[1];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val352) {
 Obj _35reg353 = primCdr(rules);
 pushCont(co, 0, _35clofun1108, 2, rules, value);
@@ -2177,10 +2177,10 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 
 void _35clofun1117(struct Cora* co) {
 Obj _35val387 = co->args[1];
-Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj pat = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj action = _35val387;
 pushCont(co, 0, _35clofun1118, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
@@ -2188,19 +2188,19 @@ coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 
 void _35clofun1118(struct Cora* co) {
 Obj _35val388 = co->args[1];
-Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj action = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, 0, _35clofun1119, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val388, value, action, cc);
 }
 
 void _35clofun1119(struct Cora* co) {
 Obj _35val389 = co->args[1];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj curr = _35val389;
 Obj _35reg390 = primCdr(rules);
 Obj _35reg391 = primCdr(_35reg390);
@@ -2210,8 +2210,8 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg391);
 
 void _35clofun1120(struct Cora* co) {
 Obj _35val392 = co->args[1];
-Obj curr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj curr = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj rest = _35val392;
 Obj _35reg393 = primCons(rest, Nil);
 Obj _35reg394 = primCons(Nil, _35reg393);
@@ -2226,8 +2226,8 @@ return;
 
 void _35clofun1108(struct Cora* co) {
 Obj _35val354 = co->args[1];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val354) {
 if (True == True) {
 Obj _35reg355 = primCar(rules);
@@ -2255,10 +2255,10 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 
 void _35clofun1113(struct Cora* co) {
 Obj _35val372 = co->args[1];
-Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj pat = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj action = _35val372;
 pushCont(co, 0, _35clofun1114, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
@@ -2266,19 +2266,19 @@ coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 
 void _35clofun1114(struct Cora* co) {
 Obj _35val373 = co->args[1];
-Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj action = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, 0, _35clofun1115, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val373, value, action, cc);
 }
 
 void _35clofun1115(struct Cora* co) {
 Obj _35val374 = co->args[1];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj curr = _35val374;
 Obj _35reg375 = primCdr(rules);
 Obj _35reg376 = primCdr(_35reg375);
@@ -2288,8 +2288,8 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg376);
 
 void _35clofun1116(struct Cora* co) {
 Obj _35val377 = co->args[1];
-Obj curr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj curr = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj rest = _35val377;
 Obj _35reg378 = primCons(rest, Nil);
 Obj _35reg379 = primCons(Nil, _35reg378);
@@ -2304,10 +2304,10 @@ return;
 
 void _35clofun1109(struct Cora* co) {
 Obj _35val357 = co->args[1];
-Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj pat = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj action = _35val357;
 pushCont(co, 0, _35clofun1110, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
@@ -2315,19 +2315,19 @@ coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 
 void _35clofun1110(struct Cora* co) {
 Obj _35val358 = co->args[1];
-Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj action = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, 0, _35clofun1111, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val358, value, action, cc);
 }
 
 void _35clofun1111(struct Cora* co) {
 Obj _35val359 = co->args[1];
-Obj rules = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj value = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj curr = _35val359;
 Obj _35reg360 = primCdr(rules);
 Obj _35reg361 = primCdr(_35reg360);
@@ -2337,8 +2337,8 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg361);
 
 void _35clofun1112(struct Cora* co) {
 Obj _35val362 = co->args[1];
-Obj curr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj curr = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj rest = _35val362;
 Obj _35reg363 = primCons(rest, Nil);
 Obj _35reg364 = primCons(Nil, _35reg363);
@@ -2363,8 +2363,8 @@ coraCall(co, 2, globalRef(intern("pair?")), action);
 
 void _35clofun1098(struct Cora* co) {
 Obj _35val324 = co->args[1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj action = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val324) {
 Obj _35reg325 = primCar(action);
 Obj _35reg326 = primEQ(_35reg325, intern("where"));
@@ -2398,16 +2398,16 @@ return;
 
 void _35clofun1103(struct Cora* co) {
 Obj _35val341 = co->args[1];
-Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj action = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, 0, _35clofun1104, 2, cc, _35val341);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
 void _35clofun1104(struct Cora* co) {
 Obj _35val342 = co->args[1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35val341 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val341 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg343 = primCons(cc, Nil);
 Obj _35reg344 = primCons(_35reg343, Nil);
 Obj _35reg345 = primCons(_35val342, _35reg344);
@@ -2419,16 +2419,16 @@ return;
 
 void _35clofun1101(struct Cora* co) {
 Obj _35val334 = co->args[1];
-Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj action = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, 0, _35clofun1102, 2, cc, _35val334);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
 void _35clofun1102(struct Cora* co) {
 Obj _35val335 = co->args[1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35val334 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val334 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg336 = primCons(cc, Nil);
 Obj _35reg337 = primCons(_35reg336, Nil);
 Obj _35reg338 = primCons(_35val335, _35reg337);
@@ -2440,16 +2440,16 @@ return;
 
 void _35clofun1099(struct Cora* co) {
 Obj _35val327 = co->args[1];
-Obj action = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj action = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, 0, _35clofun1100, 2, cc, _35val327);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
 void _35clofun1100(struct Cora* co) {
 Obj _35val328 = co->args[1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35val327 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val327 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg329 = primCons(cc, Nil);
 Obj _35reg330 = primCons(_35reg329, Nil);
 Obj _35reg331 = primCons(_35val328, _35reg330);
@@ -2471,10 +2471,10 @@ coraCall(co, 2, literal_63, pat);
 
 void _35clofun1094(struct Cora* co) {
 Obj _35val292 = co->args[1];
-Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj pat = co->ctx.stk.stack[co->ctx.stk.base + 3];
 if (True == _35val292) {
 Obj _35reg293 = primEQ(pat, expr);
 if (True == _35reg293) {
@@ -2510,10 +2510,10 @@ coraCall(co, 2, globalRef(intern("pair?")), pat);
 
 void _35clofun1095(struct Cora* co) {
 Obj _35val307 = co->args[1];
-Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj pat = co->ctx.stk.stack[co->ctx.stk.base + 3];
 if (True == _35val307) {
 Obj _35reg308 = primCar(pat);
 Obj _35reg309 = primEQ(_35reg308, intern("quote"));
@@ -2556,7 +2556,7 @@ coraCall(co, 2, globalRef(intern("atom?")), x);
 
 void _35clofun1093(struct Cora* co) {
 Obj _35val289 = co->args[1];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val289) {
 Obj _35reg290 = primIsSymbol(x);
 Obj _35reg291 = primNot(_35reg290);
@@ -2584,10 +2584,10 @@ coraCall(co, 2, globalRef(intern("cadr")), pat);
 
 void _35clofun1074(struct Cora* co) {
 Obj _35val235 = co->args[1];
-Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj pat = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj x = _35val235;
 pushCont(co, 0, _35clofun1075, 4, expr, body, x, cc);
 coraCall(co, 2, globalRef(intern("caddr")), pat);
@@ -2595,10 +2595,10 @@ coraCall(co, 2, globalRef(intern("caddr")), pat);
 
 void _35clofun1075(struct Cora* co) {
 Obj _35val236 = co->args[1];
-Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj y = _35val236;
 Obj _35reg237 = primIsCons(expr);
 if (True == _35reg237) {
@@ -2652,18 +2652,18 @@ coraCall(co, 5, globalRef(intern("cora/init.match1")), y, _35reg280, body, cc);
 
 void _35clofun1089(struct Cora* co) {
 Obj _35val281 = co->args[1];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg278 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj _35reg276 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg278 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg276 = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, 0, _35clofun1090, 2, cc, _35reg276);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg278, _35val281, cc);
 }
 
 void _35clofun1090(struct Cora* co) {
 Obj _35val282 = co->args[1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg276 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg276 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg283 = primCons(cc, Nil);
 Obj _35reg284 = primCons(_35reg283, Nil);
 Obj _35reg285 = primCons(_35val282, _35reg284);
@@ -2675,11 +2675,11 @@ return;
 
 void _35clofun1086(struct Cora* co) {
 Obj _35val272 = co->args[1];
-Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 3];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
+Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e1 = _35val272;
 pushCont(co, 0, _35clofun1087, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
@@ -2687,11 +2687,11 @@ coraCall(co, 2, globalRef(intern("caddr")), expr);
 
 void _35clofun1087(struct Cora* co) {
 Obj _35val273 = co->args[1];
-Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj e1 = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e2 = _35val273;
 pushCont(co, 0, _35clofun1088, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
@@ -2699,26 +2699,26 @@ coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 
 void _35clofun1088(struct Cora* co) {
 Obj _35val274 = co->args[1];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj e1 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, e1, _35val274, cc);
 }
 
 void _35clofun1084(struct Cora* co) {
 Obj _35val265 = co->args[1];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg262 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj _35reg260 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg262 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg260 = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, 0, _35clofun1085, 2, cc, _35reg260);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg262, _35val265, cc);
 }
 
 void _35clofun1085(struct Cora* co) {
 Obj _35val266 = co->args[1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg260 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg260 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg267 = primCons(cc, Nil);
 Obj _35reg268 = primCons(_35reg267, Nil);
 Obj _35reg269 = primCons(_35val266, _35reg268);
@@ -2730,11 +2730,11 @@ return;
 
 void _35clofun1081(struct Cora* co) {
 Obj _35val256 = co->args[1];
-Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 3];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
+Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e1 = _35val256;
 pushCont(co, 0, _35clofun1082, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
@@ -2742,11 +2742,11 @@ coraCall(co, 2, globalRef(intern("caddr")), expr);
 
 void _35clofun1082(struct Cora* co) {
 Obj _35val257 = co->args[1];
-Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj e1 = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e2 = _35val257;
 pushCont(co, 0, _35clofun1083, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
@@ -2754,26 +2754,26 @@ coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 
 void _35clofun1083(struct Cora* co) {
 Obj _35val258 = co->args[1];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj e1 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, e1, _35val258, cc);
 }
 
 void _35clofun1079(struct Cora* co) {
 Obj _35val249 = co->args[1];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg246 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj _35reg244 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg246 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg244 = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, 0, _35clofun1080, 2, cc, _35reg244);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg246, _35val249, cc);
 }
 
 void _35clofun1080(struct Cora* co) {
 Obj _35val250 = co->args[1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg244 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg244 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg251 = primCons(cc, Nil);
 Obj _35reg252 = primCons(_35reg251, Nil);
 Obj _35reg253 = primCons(_35val250, _35reg252);
@@ -2785,11 +2785,11 @@ return;
 
 void _35clofun1076(struct Cora* co) {
 Obj _35val240 = co->args[1];
-Obj expr = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 3];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
+Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e1 = _35val240;
 pushCont(co, 0, _35clofun1077, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
@@ -2797,11 +2797,11 @@ coraCall(co, 2, globalRef(intern("caddr")), expr);
 
 void _35clofun1077(struct Cora* co) {
 Obj _35val241 = co->args[1];
-Obj y = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 2];
-Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 3];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 4];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj e1 = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e2 = _35val241;
 pushCont(co, 0, _35clofun1078, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
@@ -2809,9 +2809,9 @@ coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 
 void _35clofun1078(struct Cora* co) {
 Obj _35val242 = co->args[1];
-Obj x = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj e1 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj cc = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj e1 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, e1, _35val242, cc);
 }
 
@@ -2830,7 +2830,7 @@ coraCall(co, 2, globalRef(intern("null?")), _35reg223);
 
 void _35clofun1069(struct Cora* co) {
 Obj _35val224 = co->args[1];
-Obj pat = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj pat = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val224) {
 Obj _35reg225 = primCar(pat);
 coraReturn(co, _35reg225);
@@ -2845,7 +2845,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rcons1")), _35reg227);
 
 void _35clofun1070(struct Cora* co) {
 Obj _35val228 = co->args[1];
-Obj _35reg226 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg226 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg229 = primCons(_35val228, Nil);
 Obj _35reg230 = primCons(_35reg226, _35reg229);
 Obj _35reg231 = primCons(intern("cons"), _35reg230);
@@ -2899,7 +2899,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rewrite-and")), _35reg209);
 
 void _35clofun1064(struct Cora* co) {
 Obj _35val210 = co->args[1];
-Obj l = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj l = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj more = _35val210;
 Obj _35reg211 = primEQ(more, False);
 if (True == _35reg211) {
@@ -2944,7 +2944,7 @@ coraCall(co, 2, globalRef(intern("cora/init.rewrite-or")), _35reg195);
 
 void _35clofun1060(struct Cora* co) {
 Obj _35val196 = co->args[1];
-Obj l = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj l = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj more = _35val196;
 Obj _35reg197 = primEQ(more, True);
 if (True == _35reg197) {
@@ -2978,7 +2978,7 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1055(struct Cora* co) {
 Obj _35val182 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj curr = _35val182;
 Obj _35reg183 = primCar(curr);
 pushCont(co, 0, _35clofun1056, 2, exp, _35reg183);
@@ -2987,16 +2987,16 @@ coraCall(co, 2, globalRef(intern("cadr")), curr);
 
 void _35clofun1056(struct Cora* co) {
 Obj _35val184 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg183 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg183 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, 0, _35clofun1057, 2, _35val184, _35reg183);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
 void _35clofun1057(struct Cora* co) {
 Obj _35val185 = co->args[1];
-Obj _35val184 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg183 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj _35val184 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg183 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg186 = primCons(intern("cond"), _35val185);
 Obj _35reg187 = primCons(_35reg186, Nil);
 Obj _35reg188 = primCons(_35val184, _35reg187);
@@ -3021,7 +3021,7 @@ coraCall(co, 2, globalRef(intern("null?")), _35reg164);
 
 void _35clofun1048(struct Cora* co) {
 Obj _35val165 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val165) {
 Obj _35reg166 = primCar(exp);
 coraReturn(co, _35reg166);
@@ -3035,24 +3035,24 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1049(struct Cora* co) {
 Obj _35val168 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg167 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg167 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, 0, _35clofun1050, 2, _35val168, _35reg167);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
 void _35clofun1050(struct Cora* co) {
 Obj _35val169 = co->args[1];
-Obj _35val168 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg167 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj _35val168 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg167 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, 0, _35clofun1051, 2, _35val168, _35reg167);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-let")), _35val169);
 }
 
 void _35clofun1051(struct Cora* co) {
 Obj _35val170 = co->args[1];
-Obj _35val168 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg167 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj _35val168 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg167 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg171 = primCons(_35val170, Nil);
 Obj _35reg172 = primCons(_35val168, _35reg171);
 Obj _35reg173 = primCons(_35reg167, _35reg172);
@@ -3097,7 +3097,7 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1041(struct Cora* co) {
 Obj _35val144 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg145 = primCons(_35val144, Nil);
 Obj _35reg146 = primCons(intern("quote"), _35reg145);
 pushCont(co, 0, _35clofun1042, 2, exp, _35reg146);
@@ -3106,16 +3106,16 @@ coraCall(co, 2, globalRef(intern("caddr")), exp);
 
 void _35clofun1042(struct Cora* co) {
 Obj _35val147 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg146 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg146 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, 0, _35clofun1043, 2, _35val147, _35reg146);
 coraCall(co, 2, globalRef(intern("cadddr")), exp);
 }
 
 void _35clofun1043(struct Cora* co) {
 Obj _35val148 = co->args[1];
-Obj _35val147 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg146 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj _35val147 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg146 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg149 = primCons(_35val148, Nil);
 Obj _35reg150 = primCons(_35val147, _35reg149);
 Obj _35reg151 = primCons(intern("lambda"), _35reg150);
@@ -3140,7 +3140,7 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun1034(struct Cora* co) {
 Obj _35val130 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg131 = primCons(_35val130, Nil);
 Obj _35reg132 = primCons(intern("quote"), _35reg131);
 pushCont(co, 0, _35clofun1035, 2, exp, _35reg132);
@@ -3149,16 +3149,16 @@ coraCall(co, 2, globalRef(intern("caddr")), exp);
 
 void _35clofun1035(struct Cora* co) {
 Obj _35val133 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg132 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg132 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, 0, _35clofun1036, 2, _35val133, _35reg132);
 coraCall(co, 2, globalRef(intern("cdddr")), exp);
 }
 
 void _35clofun1036(struct Cora* co) {
 Obj _35val134 = co->args[1];
-Obj _35val133 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj _35reg132 = co->ctx.stk.stack[ co->ctx.stk.base + 1];
+Obj _35val133 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg132 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg135 = primCons(_35val133, _35val134);
 Obj _35reg136 = primCons(intern("lambda"), _35reg135);
 Obj _35reg137 = primCons(_35reg136, Nil);
@@ -3204,7 +3204,7 @@ return;
 
 void _35clofun1031(struct Cora* co) {
 Obj _35val127 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 2, makeNative(_35clofun1032, 1, 1, exp), _35val127);
 }
 
@@ -3220,21 +3220,21 @@ coraCall(co, 2, globalRef(intern("cora/init.macroexpand-boot")), exp1);
 
 void _35clofun1028(struct Cora* co) {
 Obj _35val118 = co->args[1];
-Obj exp = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 pushCont(co, 0, _35clofun1029, 1, _35val118);
 coraCall(co, 2, globalRef(intern("caddr")), exp);
 }
 
 void _35clofun1029(struct Cora* co) {
 Obj _35val119 = co->args[1];
-Obj _35val118 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35val118 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 pushCont(co, 0, _35clofun1030, 1, _35val118);
 coraCall(co, 2, globalRef(intern("cora/init.macroexpand-boot")), _35val119);
 }
 
 void _35clofun1030(struct Cora* co) {
 Obj _35val120 = co->args[1];
-Obj _35val118 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35val118 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg121 = primCons(_35val120, Nil);
 Obj _35reg122 = primCons(_35val118, _35reg121);
 Obj _35reg123 = primCons(intern("lambda"), _35reg122);
@@ -3334,9 +3334,9 @@ coraCall(co, 2, globalRef(intern("reverse")), res);
 
 void _35clofun1020(struct Cora* co) {
 Obj _35val84 = co->args[1];
-Obj res = co->ctx.stk.stack[ co->ctx.stk.base + 0];
-Obj l = co->ctx.stk.stack[ co->ctx.stk.base + 1];
-Obj f = co->ctx.stk.stack[ co->ctx.stk.base + 2];
+Obj res = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj l = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj f = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg85 = primCons(_35val84, res);
 Obj _35reg86 = primCdr(l);
 coraCall(co, 4, globalRef(intern("map-h")), _35reg85, f, _35reg86);
@@ -3380,7 +3380,7 @@ return;
 
 void _35clofun1015(struct Cora* co) {
 Obj _35val68 = co->args[1];
-Obj _35reg66 = co->ctx.stk.stack[ co->ctx.stk.base + 0];
+Obj _35reg66 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg69 = primCons(_35val68, Nil);
 Obj _35reg70 = primCons(_35reg66, _35reg69);
 Obj _35reg71 = primCons(intern("cons"), _35reg70);

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -290,7 +290,7 @@
 
 (func .generate-cont
       w ['%continuation label . stacks] => (begin
-					    (c.generate-str w "pushCont(co, ")
+					    (c.generate-str w "pushCont(co, 0, ")
 					    (c.generate-sym w label)
 					    (c.generate-str w ", ")
 					    (c.generate-num w (length stacks))
@@ -343,7 +343,7 @@
 						(.code-gen-func-declare w name)
 						(c.generate-str w " {\n")
 						(.generate-call-args-reverse () w " = co->args[" 1 params)
-						(.generate-call-args-reverse () w " = co->stack[co->base + " 0 actives)
+						(.generate-call-args-reverse () w " = co->ctx.stk.stack[co->ctx.stk.base + " 0 actives)
 						(.generate-inst params w body)
 						(c.generate-str w "}\n\n")))
 

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -244,7 +244,7 @@
 			    (.generate-inst env w c)
 			    (c.generate-str w "}\n"))
       env w ['%closure label nargs . frees] => (begin
-						(c.generate-str w "makeNative(")
+						(c.generate-str w "makeNative(0, ")
 						(c.generate-sym w label)
 						(c.generate-str w ", ")
 						(c.generate-num w nargs)

--- a/main.c
+++ b/main.c
@@ -12,7 +12,7 @@ int main(int argc, char *argv[]) {
   co->args[1] = makeString1("init.so");
   co->args[2] = makeString1("cora/init");
   co->nargs = 3;
-  trampoline(co, builtinLoadSo);
+  trampoline(co, 0, builtinLoadSo);
   symbolSet(imported, cons(makeString1("cora/init"), Nil));
 
   symbolSet(imported, cons(makeString1("cora/lib/toc/internal"), symbolGet(imported)));
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) {
   co->args[1] = makeString1("toc.so");
   co->args[2] = makeString1("");
   co->nargs = 3;
-  trampoline(co, builtinLoadSo);
+  trampoline(co, 0, builtinLoadSo);
   symbolSet(imported, cons(makeString1("cora/lib/toc"), symbolGet(imported)));
   
   struct SexpReader r = {};
@@ -42,7 +42,7 @@ int main(int argc, char *argv[]) {
     co->args[0] = globalRef(intern("macroexpand"));
     co->args[1] = exp;
     co->nargs = 2;
-    trampoline(co, coraDispatch);
+    trampoline(co, 0, coraDispatch);
     exp = co->args[1];
 
     /* printf("after macro expand =="); */
@@ -53,7 +53,7 @@ int main(int argc, char *argv[]) {
     co->args[0] = globalRef(intern("cora/lib/toc.eval0"));
     co->args[1] = exp;
     co->nargs = 2;
-    trampoline(co, coraDispatch);
+    trampoline(co, 0, coraDispatch);
 
     sexpWrite(stdout, co->args[1]);
     printf("\n");

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -68,7 +68,7 @@ pushCont(struct Cora *co, int label, basicBlock cb, int nstack, ...) {
 static void
 popStack(struct Cora *co) {
   struct callStack *cs = &co->callstack;
-  co->ctx = cs->data[cs->len--];
+  co->ctx = cs->data[--cs->len];
   return;
 }
 
@@ -900,7 +900,7 @@ int main(int argc, char *argv[]) {
   uintptr_t dummy;
   coraInit(&dummy);
   struct Cora* co = coraNew();
-  trampoline(co, entry);
+  trampoline(co, 0, entry);
   printObj(stdout, co->args[1]);
   return 0;
 }

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -438,7 +438,7 @@ builtinThrow(struct Cora *co) {
   }
 
   // Now that we get the current continuation, disguise as a closure.
-  Obj clo = makeNative(continuationAsClosure, 1, 1, cont);
+  Obj clo = makeNative(0, continuationAsClosure, 1, 1, cont);
 
   // Reset to the stack before try.
   co->callstack.len = p;
@@ -631,7 +631,7 @@ builtinImport(struct Cora *co) {
   tmp = strShrink(tmp, 3);
   tmp = strCat(tmp, cstr(".cora"));
   co->nargs = 3;
-  co->args[0] = makeNative(builtinLoad, 2, 0);
+  co->args[0] = makeNative(0, builtinLoad, 2, 0);
   co->args[1] = makeString1(toCStr(tmp));
   co->args[2] = pkg;
   trampoline(co, 0, coraDispatch);
@@ -848,7 +848,7 @@ registerAPI(struct registerModule* m, str pkg) {
     } else {
       sym = intern(entry.name);
     }
-    symbolSet(sym, makeNative(entry.func, entry.args, 0));
+    symbolSet(sym, makeNative(0, entry.func, entry.args, 0));
   }
 }
 
@@ -863,33 +863,33 @@ coraInit(uintptr_t *mark) {
   symUnQuote = intern("unquote");
   primSet(intern("*imported*"), Nil);
   primSet(intern("*package-mapping*"), Nil);
-  primSet(intern("symbol->string"), makeNative(symbolToString, 1, 0));
-  primSet(intern("string-append"), makeNative(stringAppend, 2, 0));
-  primSet(intern("intern"), makeNative(builtinIntern, 1, 0));
-  primSet(intern("number?"), makeNative(builtinIsNumber, 1, 0));
-  primSet(intern("read-file-as-sexp"), makeNative(builtinReadFileAsSexp, 2, 0));
-  primSet(intern("value"), makeNative(builtinValue, 1, 0));
-  primSet(intern("apply"), makeNative(builtinApply, 2, 0));
-  primSet(intern("load-so"), makeNative(builtinLoadSo, 2, 0));
-  primSet(intern("import"), makeNative(builtinImport, 1, 0));
-  primSet(intern("load"), makeNative(builtinLoad, 2, 0));
+  primSet(intern("symbol->string"), makeNative(0, symbolToString, 1, 0));
+  primSet(intern("string-append"), makeNative(0, stringAppend, 2, 0));
+  primSet(intern("intern"), makeNative(0, builtinIntern, 1, 0));
+  primSet(intern("number?"), makeNative(0, builtinIsNumber, 1, 0));
+  primSet(intern("read-file-as-sexp"), makeNative(0, builtinReadFileAsSexp, 2, 0));
+  primSet(intern("value"), makeNative(0, builtinValue, 1, 0));
+  primSet(intern("apply"), makeNative(0, builtinApply, 2, 0));
+  primSet(intern("load-so"), makeNative(0, builtinLoadSo, 2, 0));
+  primSet(intern("import"), makeNative(0, builtinImport, 1, 0));
+  primSet(intern("load"), makeNative(0, builtinLoad, 2, 0));
 
-  primSet(intern("vector"), makeNative(builtinVector, 1, 0));
-  primSet(intern("vector-set!"), makeNative(builtinVectorSet, 3, 0));
-  primSet(intern("vector-ref"), makeNative(builtinVectorRef, 2, 0));
-  primSet(intern("vector-length"), makeNative(builtinVectorLength, 1, 0));
-  primSet(intern("try"), makeNative(builtinTryCatch, 2, 0));
-  primSet(intern("throw"), makeNative(builtinThrow, 1, 0));
+  primSet(intern("vector"), makeNative(0, builtinVector, 1, 0));
+  primSet(intern("vector-set!"), makeNative(0, builtinVectorSet, 3, 0));
+  primSet(intern("vector-ref"), makeNative(0, builtinVectorRef, 2, 0));
+  primSet(intern("vector-length"), makeNative(0, builtinVectorLength, 1, 0));
+  primSet(intern("try"), makeNative(0, builtinTryCatch, 2, 0));
+  primSet(intern("throw"), makeNative(0, builtinThrow, 1, 0));
 
-  primSet(intern("cora/lib/toc/internal.generate-str"), makeNative(builtinGenerateStr, 2, 0));
-  primSet(intern("cora/lib/toc/internal.generate-sym"), makeNative(builtinGenerateSym, 2, 0));
-  primSet(intern("cora/lib/toc/internal.generate-num"), makeNative(builtinGenerateNum, 2, 0));
-  primSet(intern("cora/lib/toc/internal.escape-str"), makeNative(builtinEscapeStr, 1, 0));
+  primSet(intern("cora/lib/toc/internal.generate-str"), makeNative(0, builtinGenerateStr, 2, 0));
+  primSet(intern("cora/lib/toc/internal.generate-sym"), makeNative(0, builtinGenerateSym, 2, 0));
+  primSet(intern("cora/lib/toc/internal.generate-num"), makeNative(0, builtinGenerateNum, 2, 0));
+  primSet(intern("cora/lib/toc/internal.escape-str"), makeNative(0, builtinEscapeStr, 1, 0));
 
-  primSet(intern("cora/lib/io.open-output-file"), makeNative(builtinOpenOutputFile, 1, 0));
-  primSet(intern("cora/lib/io.close-output-file"), makeNative(builtinCloseOutputFile, 1, 0));
+  primSet(intern("cora/lib/io.open-output-file"), makeNative(0, builtinOpenOutputFile, 1, 0));
+  primSet(intern("cora/lib/io.close-output-file"), makeNative(0, builtinCloseOutputFile, 1, 0));
 
-  primSet(intern("cora/lib/os.exec"), makeNative(builtinOSExec, 1, 0));
+  primSet(intern("cora/lib/os.exec"), makeNative(0, builtinOSExec, 1, 0));
 }
 
 #ifdef ForTest

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -65,10 +65,9 @@ pushCont(struct Cora *co, int label, basicBlock cb, int nstack, ...) {
   co->ctx.stk.base = co->ctx.stk.pos;
 }
 
-static void
+static inline void
 popStack(struct Cora *co) {
-  struct callStack *cs = &co->callstack;
-  co->ctx = cs->data[--cs->len];
+  co->ctx = co->callstack.data[--co->callstack.len];
   return;
 }
 

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -9,13 +9,11 @@
 #include "reader.h"
 
 struct Cora {
-  struct stackState stk;
+  struct returnAddr ctx;
   struct callStack callstack;
 
-  Obj frees;
   Obj args[32];
   int nargs;
-  basicBlock pc;
 };
 
 void trampoline(struct Cora *co, basicBlock pc);

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -16,13 +16,13 @@ struct Cora {
   int nargs;
 };
 
-void trampoline(struct Cora *co, basicBlock pc);
+void trampoline(struct Cora *co, int label, basicBlock pc);
 void coraDispatch(struct Cora *co);
 void coraReturn(struct Cora *co, Obj val);
 Obj coraGet(struct Cora *co, int i);
 void coraCall(struct Cora *co, int nargs, ...);
 
-void pushCont(struct Cora *co, basicBlock cb, int nstack, ...);
+void pushCont(struct Cora *co, int label, basicBlock cb, int nstack, ...);
 Obj globalRef(Obj sym);
 Obj closureRef(struct Cora *co, int idx);
 

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -9,10 +9,7 @@
 #include "reader.h"
 
 struct Cora {
-  Obj *stack;
-  int base;
-  int pos;
-
+  struct stackState stk;
   struct callStack callstack;
 
   Obj frees;

--- a/src/types.c
+++ b/src/types.c
@@ -418,8 +418,8 @@ void
 gcMarkCallStack(struct GC *gc, struct callStack *stack) {
   for (int i=0; i<stack->len; i++) {
     struct returnAddr* addr = &stack->data[i];
-    for (int j=addr->base; j<addr->pos; j++) {
-      gcMark(gc, addr->stack[j]);
+    for (int j=addr->stk.base; j<addr->stk.pos; j++) {
+      gcMark(gc, addr->stk.stack[j]);
     }
     // Don't forget this one!
     gcMark(gc, addr->frees);

--- a/src/types.c
+++ b/src/types.c
@@ -240,10 +240,11 @@ symbolStr(Obj sym) {
 }
 
 Obj
-makeNative(basicBlock fn, int required, int captured, ...) {
+makeNative(/* int label,  */basicBlock fn, int required, int captured, ...) {
   int sz = sizeof(struct scmNative) + captured*sizeof(Obj);
   struct scmNative* clo = newObj(scmHeadNative, sz);
-  clo->fn = fn;
+  clo->code.func = fn;
+  /* clo->code.label = label; */
   clo->required = required;
   clo->captured = captured;
   if (captured > 0) {
@@ -294,11 +295,11 @@ nativeCaptured(Obj o) {
   return native->captured;
 }
 
-basicBlock
+struct pcState*
 nativeFuncPtr(Obj o) {
   struct scmNative* native = ptr(o);
   assert(native->head.type == scmHeadNative);
-  return native->fn;
+  return &native->code;
 }
 
 int

--- a/src/types.c
+++ b/src/types.c
@@ -240,11 +240,11 @@ symbolStr(Obj sym) {
 }
 
 Obj
-makeNative(/* int label,  */basicBlock fn, int required, int captured, ...) {
+makeNative(int label,basicBlock fn, int required, int captured, ...) {
   int sz = sizeof(struct scmNative) + captured*sizeof(Obj);
   struct scmNative* clo = newObj(scmHeadNative, sz);
   clo->code.func = fn;
-  /* clo->code.label = label; */
+  clo->code.label = label;
   clo->required = required;
   clo->captured = captured;
   if (captured > 0) {

--- a/src/types.h
+++ b/src/types.h
@@ -110,11 +110,14 @@ int nativeCaptured(Obj o);
 int nativeRequired(Obj o);
 basicBlock nativeFuncPtr(Obj o);
 
-struct returnAddr {
+struct stackState {
   Obj *stack;
   int base;
   int pos;
+};
 
+struct returnAddr {
+  struct stackState stk;
   basicBlock pc;
   Obj frees;
 };

--- a/src/types.h
+++ b/src/types.h
@@ -109,7 +109,7 @@ struct scmNative {
   Obj data[];
 };
 
-Obj makeNative(basicBlock fn, int required, int captured, ...);
+Obj makeNative(int label, basicBlock fn, int required, int captured, ...);
 Obj* nativeData(Obj o);
 int nativeCaptured(Obj o);
 int nativeRequired(Obj o);

--- a/src/types.h
+++ b/src/types.h
@@ -94,9 +94,14 @@ struct Cora;
 
 typedef void (*basicBlock)(struct Cora *co);
 
+struct pcState {
+  basicBlock func;
+  int label;
+};
+
 struct scmNative {
   scmHead head;
-  basicBlock fn;
+  struct pcState code;
   // required is the argument number of the nativeFunc.
   int required;
   // captured is the size of the data, it's immutable after makeNative.
@@ -108,7 +113,7 @@ Obj makeNative(basicBlock fn, int required, int captured, ...);
 Obj* nativeData(Obj o);
 int nativeCaptured(Obj o);
 int nativeRequired(Obj o);
-basicBlock nativeFuncPtr(Obj o);
+struct pcState* nativeFuncPtr(Obj o);
 
 struct stackState {
   Obj *stack;
@@ -118,7 +123,7 @@ struct stackState {
 
 struct returnAddr {
   struct stackState stk;
-  basicBlock pc;
+  struct pcState pc;
   Obj frees;
 };
 

--- a/toc.c
+++ b/toc.c
@@ -369,13 +369,13 @@ void _35clofun2853(struct Cora* co);
 void _35clofun2854(struct Cora* co);
 
 void entry(struct Cora* co) {
-pushCont(co, _35clofun2849, 0);
+pushCont(co, 0, _35clofun2849, 0);
 coraCall(co, 2, globalRef(intern("import")), makeString1("cora/lib/toc/internal"));
 }
 
 void _35clofun2849(struct Cora* co) {
 Obj _35val1398 = co->args[1];
-pushCont(co, _35clofun2850, 0);
+pushCont(co, 0, _35clofun2850, 0);
 coraCall(co, 2, globalRef(intern("import")), makeString1("cora/lib/io"));
 }
 
@@ -486,7 +486,7 @@ Obj _35reg2732 = primSet(intern("cora/lib/toc.tailify-pass"), makeNative(_35clof
 Obj _35reg2733 = primSet(intern("cora/lib/toc.explicit-stack-pass"), makeNative(_35clofun3151, 1, 0));
 Obj _35reg2741 = primSet(intern("cora/lib/toc.collect-lambda-pass"), makeNative(_35clofun3152, 1, 0));
 Obj _35reg2748 = primSet(intern("cora/lib/toc.rewrite-->macro"), makeNative(_35clofun3154, 2, 0));
-pushCont(co, _35clofun3160, 0);
+pushCont(co, 0, _35clofun3160, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("->"), makeNative(_35clofun3157, 1, 0));
 }
 
@@ -523,7 +523,7 @@ Obj _35reg2808 = primIsSymbol(exp);
 if (True == _35reg2808) {
 coraCall(co, 2, globalRef(intern("value")), exp);
 } else {
-pushCont(co, _35clofun3201, 1, exp);
+pushCont(co, 0, _35clofun3201, 1, exp);
 coraCall(co, 2, globalRef(intern("number?")), exp);
 }
 }
@@ -544,7 +544,7 @@ if (True == _35reg2812) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
 Obj _35reg2813 = primCar(exp);
-pushCont(co, _35clofun3202, 1, exp);
+pushCont(co, 0, _35clofun3202, 1, exp);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2813);
 }
 } else {
@@ -566,7 +566,7 @@ if (True == _35reg2820) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
 Obj _35reg2821 = primCar(exp);
-pushCont(co, _35clofun3204, 1, exp);
+pushCont(co, 0, _35clofun3204, 1, exp);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2821);
 }
 } else {
@@ -574,7 +574,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 } else {
-pushCont(co, _35clofun3206, 1, exp);
+pushCont(co, 0, _35clofun3206, 1, exp);
 coraCall(co, 2, globalRef(intern("boolean?")), exp);
 }
 }
@@ -596,7 +596,7 @@ if (True == _35reg2828) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
 Obj _35reg2829 = primCar(exp);
-pushCont(co, _35clofun3207, 1, exp);
+pushCont(co, 0, _35clofun3207, 1, exp);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2829);
 }
 } else {
@@ -604,7 +604,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 } else {
-pushCont(co, _35clofun3209, 1, exp);
+pushCont(co, 0, _35clofun3209, 1, exp);
 coraCall(co, 2, globalRef(intern("null?")), exp);
 }
 }
@@ -625,7 +625,7 @@ if (True == _35reg2836) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
 Obj _35reg2837 = primCar(exp);
-pushCont(co, _35clofun3210, 1, exp);
+pushCont(co, 0, _35clofun3210, 1, exp);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2837);
 }
 } else {
@@ -645,7 +645,7 @@ if (True == _35reg2843) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
 Obj _35reg2844 = primCar(exp);
-pushCont(co, _35clofun3212, 1, exp);
+pushCont(co, 0, _35clofun3212, 1, exp);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2844);
 }
 } else {
@@ -659,7 +659,7 @@ void _35clofun3212(struct Cora* co) {
 Obj _35val2845 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2846 = primCdr(exp);
-pushCont(co, _35clofun3213, 1, _35val2845);
+pushCont(co, 0, _35clofun3213, 1, _35val2845);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2846);
 }
 
@@ -673,7 +673,7 @@ void _35clofun3210(struct Cora* co) {
 Obj _35val2838 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2839 = primCdr(exp);
-pushCont(co, _35clofun3211, 1, _35val2838);
+pushCont(co, 0, _35clofun3211, 1, _35val2838);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2839);
 }
 
@@ -687,7 +687,7 @@ void _35clofun3207(struct Cora* co) {
 Obj _35val2830 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2831 = primCdr(exp);
-pushCont(co, _35clofun3208, 1, _35val2830);
+pushCont(co, 0, _35clofun3208, 1, _35val2830);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2831);
 }
 
@@ -701,7 +701,7 @@ void _35clofun3204(struct Cora* co) {
 Obj _35val2822 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2823 = primCdr(exp);
-pushCont(co, _35clofun3205, 1, _35val2822);
+pushCont(co, 0, _35clofun3205, 1, _35val2822);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2823);
 }
 
@@ -715,7 +715,7 @@ void _35clofun3202(struct Cora* co) {
 Obj _35val2814 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2815 = primCdr(exp);
-pushCont(co, _35clofun3203, 1, _35val2814);
+pushCont(co, 0, _35clofun3203, 1, _35val2814);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2815);
 }
 
@@ -851,7 +851,7 @@ void _35clofun3178(struct Cora* co) {
 Obj from = co->args[1];
 Obj to = co->args[2];
 Obj pkg_45str = co->args[3];
-pushCont(co, _35clofun3179, 1, to);
+pushCont(co, 0, _35clofun3179, 1, to);
 coraCall(co, 3, globalRef(intern("read-file-as-sexp")), from, pkg_45str);
 }
 
@@ -859,7 +859,7 @@ void _35clofun3179(struct Cora* co) {
 Obj _35val2770 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj sexp = _35val2770;
-pushCont(co, _35clofun3180, 1, to);
+pushCont(co, 0, _35clofun3180, 1, to);
 coraCall(co, 2, globalRef(intern("macroexpand")), sexp);
 }
 
@@ -867,7 +867,7 @@ void _35clofun3180(struct Cora* co) {
 Obj _35val2771 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj input = _35val2771;
-pushCont(co, _35clofun3181, 1, to);
+pushCont(co, 0, _35clofun3181, 1, to);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.compile")), input);
 }
 
@@ -875,7 +875,7 @@ void _35clofun3181(struct Cora* co) {
 Obj _35val2772 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = _35val2772;
-pushCont(co, _35clofun3182, 1, bc);
+pushCont(co, 0, _35clofun3182, 1, bc);
 coraCall(co, 2, globalRef(intern("cora/lib/io.open-output-file")), to);
 }
 
@@ -883,7 +883,7 @@ void _35clofun3182(struct Cora* co) {
 Obj _35val2773 = co->args[1];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stream = _35val2773;
-pushCont(co, _35clofun3183, 1, stream);
+pushCont(co, 0, _35clofun3183, 1, stream);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.generate-c")), stream, bc);
 }
 
@@ -896,7 +896,7 @@ coraCall(co, 2, globalRef(intern("cora/lib/io.close-output-file")), stream);
 void _35clofun3170(struct Cora* co) {
 Obj to = co->args[1];
 Obj bc = co->args[2];
-pushCont(co, _35clofun3171, 2, to, bc);
+pushCont(co, 0, _35clofun3171, 2, to, bc);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("#include \"types.h\"\n"));
 }
 
@@ -904,7 +904,7 @@ void _35clofun3171(struct Cora* co) {
 Obj _35val2763 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3172, 2, to, bc);
+pushCont(co, 0, _35clofun3172, 2, to, bc);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("#include \"runtime.h\"\n\n"));
 }
 
@@ -912,7 +912,7 @@ void _35clofun3172(struct Cora* co) {
 Obj _35val2764 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3175, 2, to, bc);
+pushCont(co, 0, _35clofun3175, 2, to, bc);
 coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3173, 1, 1, to), bc);
 }
 
@@ -920,7 +920,7 @@ void _35clofun3175(struct Cora* co) {
 Obj _35val2767 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3176, 2, to, bc);
+pushCont(co, 0, _35clofun3176, 2, to, bc);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("\n"));
 }
 
@@ -939,7 +939,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.code-gen-toplevel")), closureRef(
 void _35clofun3173(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg2765 = primCar(x);
-pushCont(co, _35clofun3174, 0);
+pushCont(co, 0, _35clofun3174, 0);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.code-gen-func-declare")), closureRef(co, 0), _35reg2765);
 }
 
@@ -971,7 +971,7 @@ Obj _35reg2758 = primCar(closureRef(co, 1));
 Obj x = _35reg2758;
 Obj _35reg2759 = primCdr(closureRef(co, 1));
 Obj y = _35reg2759;
-pushCont(co, _35clofun3169, 2, fn, y);
+pushCont(co, 0, _35clofun3169, 2, fn, y);
 coraCall(co, 2, fn, x);
 } else {
 coraCall(co, 1, _35cc1371);
@@ -991,25 +991,25 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 
 void _35clofun3161(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun3162, 0);
+pushCont(co, 0, _35clofun3162, 0);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.parse-pass")), exp);
 }
 
 void _35clofun3162(struct Cora* co) {
 Obj _35val2752 = co->args[1];
-pushCont(co, _35clofun3163, 0);
+pushCont(co, 0, _35clofun3163, 0);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert-pass")), _35val2752);
 }
 
 void _35clofun3163(struct Cora* co) {
 Obj _35val2753 = co->args[1];
-pushCont(co, _35clofun3164, 0);
+pushCont(co, 0, _35clofun3164, 0);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.tailify-pass")), _35val2753);
 }
 
 void _35clofun3164(struct Cora* co) {
 Obj _35val2754 = co->args[1];
-pushCont(co, _35clofun3165, 0);
+pushCont(co, 0, _35clofun3165, 0);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack-pass")), _35val2754);
 }
 
@@ -1020,7 +1020,7 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.collect-lambda-pass")), _35val275
 
 void _35clofun3157(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, _35clofun3158, 1, exp);
+pushCont(co, 0, _35clofun3158, 1, exp);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
@@ -1028,7 +1028,7 @@ void _35clofun3158(struct Cora* co) {
 Obj _35val2749 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj obj = _35val2749;
-pushCont(co, _35clofun3159, 1, obj);
+pushCont(co, 0, _35clofun3159, 1, obj);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
@@ -1182,7 +1182,7 @@ Obj _35reg2721 = primCdr(_35p1362);
 Obj _35reg2722 = primCdr(_35reg2721);
 Obj _35reg2723 = primEQ(Nil, _35reg2722);
 if (True == _35reg2723) {
-pushCont(co, _35clofun3143, 4, actives, params, body, w);
+pushCont(co, 0, _35clofun3143, 4, actives, params, body, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.code-gen-func-declare")), w, name);
 } else {
 coraCall(co, 1, _35cc1363);
@@ -1219,7 +1219,7 @@ Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, _35clofun3144, 4, actives, params, body, w);
+pushCont(co, 0, _35clofun3144, 4, actives, params, body, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" {\n"));
 }
 
@@ -1229,7 +1229,7 @@ Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, _35clofun3145, 4, actives, params, body, w);
+pushCont(co, 0, _35clofun3145, 4, actives, params, body, w);
 coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->args["), makeNumber(1), params);
 }
 
@@ -1239,7 +1239,7 @@ Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, _35clofun3146, 3, params, body, w);
+pushCont(co, 0, _35clofun3146, 3, params, body, w);
 coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->ctx.stk.stack[co->ctx.stk.base + "), makeNumber(0), actives);
 }
 
@@ -1248,7 +1248,7 @@ Obj _35val2727 = co->args[1];
 Obj params = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3147, 1, w);
+pushCont(co, 0, _35clofun3147, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), params, w, body);
 }
 
@@ -1294,7 +1294,7 @@ Obj _35reg2663 = primCar(closureRef(co, 4));
 Obj a = _35reg2663;
 Obj _35reg2664 = primCdr(closureRef(co, 4));
 Obj b = _35reg2664;
-pushCont(co, _35clofun3136, 6, a, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3136, 6, a, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("Obj "));
 } else {
 coraCall(co, 1, _35cc1360);
@@ -1309,7 +1309,7 @@ Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, _35clofun3137, 5, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3137, 5, idx, env, w, dest_45str, b);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
@@ -1320,7 +1320,7 @@ Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3138, 5, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3138, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, dest_45str);
 }
 
@@ -1331,7 +1331,7 @@ Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3139, 5, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3139, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
@@ -1342,7 +1342,7 @@ Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3140, 5, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3140, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("];\n"));
 }
 
@@ -1364,7 +1364,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 void _35clofun3129(struct Cora* co) {
 Obj w = co->args[1];
 Obj name = co->args[2];
-pushCont(co, _35clofun3130, 2, name, w);
+pushCont(co, 0, _35clofun3130, 2, name, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("void "));
 }
 
@@ -1372,14 +1372,14 @@ void _35clofun3130(struct Cora* co) {
 Obj _35val2658 = co->args[1];
 Obj name = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3131, 1, w);
+pushCont(co, 0, _35clofun3131, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, name);
 }
 
 void _35clofun3131(struct Cora* co) {
 Obj _35val2659 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, _35clofun3132, 1, w);
+pushCont(co, 0, _35clofun3132, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("(struct Cora* co"));
 }
 
@@ -1425,7 +1425,7 @@ Obj _35reg2649 = primCar(closureRef(co, 3));
 Obj a = _35reg2649;
 Obj _35reg2650 = primCdr(closureRef(co, 3));
 Obj b = _35reg2650;
-pushCont(co, _35clofun3125, 4, env, fn, w, b);
+pushCont(co, 0, _35clofun3125, 4, env, fn, w, b);
 coraCall(co, 4, fn, env, w, a);
 } else {
 coraCall(co, 1, _35cc1353);
@@ -1438,7 +1438,7 @@ Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, _35clofun3126, 4, env, fn, w, b);
+pushCont(co, 0, _35clofun3126, 4, env, fn, w, b);
 coraCall(co, 2, globalRef(intern("null?")), b);
 }
 
@@ -1450,7 +1450,7 @@ Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj _35reg2653 = primNot(_35val2652);
 if (True == _35reg2653) {
-pushCont(co, _35clofun3127, 4, env, fn, w, b);
+pushCont(co, 0, _35clofun3127, 4, env, fn, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 } else {
 Nil;
@@ -1490,8 +1490,8 @@ Obj label = _35reg2635;
 Obj _35reg2636 = primCdr(_35p1346);
 Obj _35reg2637 = primCdr(_35reg2636);
 Obj stacks = _35reg2637;
-pushCont(co, _35clofun3113, 3, label, stacks, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("pushCont(co, "));
+pushCont(co, 0, _35clofun3113, 3, label, stacks, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("pushCont(co, 0, "));
 } else {
 coraCall(co, 1, _35cc1347);
 }
@@ -1508,7 +1508,7 @@ Obj _35val2638 = co->args[1];
 Obj label = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3114, 2, stacks, w);
+pushCont(co, 0, _35clofun3114, 2, stacks, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, label);
 }
 
@@ -1516,7 +1516,7 @@ void _35clofun3114(struct Cora* co) {
 Obj _35val2639 = co->args[1];
 Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3115, 2, stacks, w);
+pushCont(co, 0, _35clofun3115, 2, stacks, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 }
 
@@ -1524,7 +1524,7 @@ void _35clofun3115(struct Cora* co) {
 Obj _35val2640 = co->args[1];
 Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3116, 2, stacks, w);
+pushCont(co, 0, _35clofun3116, 2, stacks, w);
 coraCall(co, 2, globalRef(intern("length")), stacks);
 }
 
@@ -1532,7 +1532,7 @@ void _35clofun3116(struct Cora* co) {
 Obj _35val2641 = co->args[1];
 Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3117, 2, stacks, w);
+pushCont(co, 0, _35clofun3117, 2, stacks, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2641);
 }
 
@@ -1540,7 +1540,7 @@ void _35clofun3117(struct Cora* co) {
 Obj _35val2642 = co->args[1];
 Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3118, 2, stacks, w);
+pushCont(co, 0, _35clofun3118, 2, stacks, w);
 coraCall(co, 2, globalRef(intern("null?")), stacks);
 }
 
@@ -1550,7 +1550,7 @@ Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg2644 = primNot(_35val2643);
 if (True == _35reg2644) {
-pushCont(co, _35clofun3121, 1, w);
+pushCont(co, 0, _35clofun3121, 1, w);
 coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3119, 1, 1, w), stacks);
 } else {
 Nil;
@@ -1566,7 +1566,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 
 void _35clofun3119(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun3120, 1, x);
+pushCont(co, 0, _35clofun3120, 1, x);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closureRef(co, 0), makeString1(", "));
 }
 
@@ -1609,7 +1609,7 @@ Obj _35reg2619 = primCar(closureRef(co, 3));
 Obj a = _35reg2619;
 Obj _35reg2620 = primCdr(closureRef(co, 3));
 Obj b = _35reg2620;
-pushCont(co, _35clofun3106, 5, a, idx, env, w, b);
+pushCont(co, 0, _35clofun3106, 5, a, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("co->args["));
 } else {
 coraCall(co, 1, _35cc1344);
@@ -1623,7 +1623,7 @@ Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3107, 5, a, idx, env, w, b);
+pushCont(co, 0, _35clofun3107, 5, a, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
@@ -1634,7 +1634,7 @@ Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3108, 5, a, idx, env, w, b);
+pushCont(co, 0, _35clofun3108, 5, a, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("] = "));
 }
 
@@ -1645,7 +1645,7 @@ Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3109, 4, idx, env, w, b);
+pushCont(co, 0, _35clofun3109, 4, idx, env, w, b);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
@@ -1655,7 +1655,7 @@ Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, _35clofun3110, 4, idx, env, w, b);
+pushCont(co, 0, _35clofun3110, 4, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
@@ -1708,7 +1708,7 @@ Obj _35reg2610 = primCdr(closureRef(co, 2));
 Obj _35reg2611 = primCdr(_35reg2610);
 Obj _35reg2612 = primEQ(Nil, _35reg2611);
 if (True == _35reg2612) {
-pushCont(co, _35clofun3100, 2, x, w);
+pushCont(co, 0, _35clofun3100, 2, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("globalRef(intern(\""));
 } else {
 coraCall(co, 1, _35cc1326);
@@ -1728,14 +1728,14 @@ void _35clofun3100(struct Cora* co) {
 Obj _35val2613 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3101, 1, w);
+pushCont(co, 0, _35clofun3101, 1, w);
 coraCall(co, 2, globalRef(intern("symbol->string")), x);
 }
 
 void _35clofun3101(struct Cora* co) {
 Obj _35val2614 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, _35clofun3102, 1, w);
+pushCont(co, 0, _35clofun3102, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2614);
 }
 
@@ -1764,7 +1764,7 @@ Obj _35reg2598 = primCdr(closureRef(co, 2));
 Obj _35reg2599 = primCdr(_35reg2598);
 Obj _35reg2600 = primEQ(Nil, _35reg2599);
 if (True == _35reg2600) {
-pushCont(co, _35clofun3098, 2, idx, w);
+pushCont(co, 0, _35clofun3098, 2, idx, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("closureRef(co, "));
 } else {
 coraCall(co, 1, _35cc1327);
@@ -1784,7 +1784,7 @@ void _35clofun3098(struct Cora* co) {
 Obj _35val2601 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3099, 1, w);
+pushCont(co, 0, _35clofun3099, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
@@ -1813,7 +1813,7 @@ Obj _35reg2586 = primCdr(closureRef(co, 2));
 Obj _35reg2587 = primCdr(_35reg2586);
 Obj _35reg2588 = primEQ(Nil, _35reg2587);
 if (True == _35reg2588) {
-pushCont(co, _35clofun3096, 2, idx, w);
+pushCont(co, 0, _35clofun3096, 2, idx, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("stackRef(co, "));
 } else {
 coraCall(co, 1, _35cc1328);
@@ -1833,7 +1833,7 @@ void _35clofun3096(struct Cora* co) {
 Obj _35val2589 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3097, 1, w);
+pushCont(co, 0, _35clofun3097, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
@@ -1864,10 +1864,10 @@ Obj _35reg2564 = primEQ(Nil, _35reg2563);
 if (True == _35reg2564) {
 Obj _35reg2565 = primIsSymbol(x);
 if (True == _35reg2565) {
-pushCont(co, _35clofun3087, 2, x, w);
+pushCont(co, 0, _35clofun3087, 2, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("intern(\""));
 } else {
-pushCont(co, _35clofun3090, 2, x, w);
+pushCont(co, 0, _35clofun3090, 2, x, w);
 coraCall(co, 2, globalRef(intern("number?")), x);
 }
 } else {
@@ -1889,12 +1889,12 @@ Obj _35val2569 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val2569) {
-pushCont(co, _35clofun3091, 2, x, w);
+pushCont(co, 0, _35clofun3091, 2, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeNumber("));
 } else {
 Obj _35reg2572 = primIsString(x);
 if (True == _35reg2572) {
-pushCont(co, _35clofun3093, 2, x, w);
+pushCont(co, 0, _35clofun3093, 2, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeString1(\""));
 } else {
 Obj _35reg2576 = primEQ(x, Nil);
@@ -1921,14 +1921,14 @@ void _35clofun3093(struct Cora* co) {
 Obj _35val2573 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3094, 1, w);
+pushCont(co, 0, _35clofun3094, 1, w);
 coraCall(co, 2, globalRef(intern("cora/lib/toc/internal.escape-str")), x);
 }
 
 void _35clofun3094(struct Cora* co) {
 Obj _35val2574 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, _35clofun3095, 1, w);
+pushCont(co, 0, _35clofun3095, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2574);
 }
 
@@ -1942,7 +1942,7 @@ void _35clofun3091(struct Cora* co) {
 Obj _35val2570 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3092, 1, w);
+pushCont(co, 0, _35clofun3092, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, x);
 }
 
@@ -1956,14 +1956,14 @@ void _35clofun3087(struct Cora* co) {
 Obj _35val2566 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3088, 1, w);
+pushCont(co, 0, _35clofun3088, 1, w);
 coraCall(co, 2, globalRef(intern("symbol->string")), x);
 }
 
 void _35clofun3088(struct Cora* co) {
 Obj _35val2567 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, _35clofun3089, 1, w);
+pushCont(co, 0, _35clofun3089, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2567);
 }
 
@@ -2012,7 +2012,7 @@ Obj _35reg2539 = primCdr(_35reg2538);
 Obj _35reg2540 = primCdr(_35reg2539);
 Obj _35reg2541 = primEQ(Nil, _35reg2540);
 if (True == _35reg2541) {
-pushCont(co, _35clofun3077, 5, b, a, env, w, c);
+pushCont(co, 0, _35clofun3077, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.index")), a, env);
 } else {
 coraCall(co, 1, _35cc1330);
@@ -2044,11 +2044,11 @@ Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj idx = _35val2542;
 Obj _35reg2543 = primLT(idx, makeNumber(0));
 if (True == _35reg2543) {
-pushCont(co, _35clofun3078, 5, b, a, env, w, c);
+pushCont(co, 0, _35clofun3078, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("Obj "));
 } else {
 Nil;
-pushCont(co, _35clofun3083, 5, b, a, env, w, c);
+pushCont(co, 0, _35clofun3083, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
 }
 }
@@ -2060,7 +2060,7 @@ Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3084, 5, b, a, env, w, c);
+pushCont(co, 0, _35clofun3084, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
 }
 
@@ -2071,7 +2071,7 @@ Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3085, 4, a, env, w, c);
+pushCont(co, 0, _35clofun3085, 4, a, env, w, c);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
@@ -2081,7 +2081,7 @@ Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, _35clofun3086, 4, a, env, w, c);
+pushCont(co, 0, _35clofun3086, 4, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
@@ -2102,7 +2102,7 @@ Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3079, 5, b, a, env, w, c);
+pushCont(co, 0, _35clofun3079, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
 }
 
@@ -2113,7 +2113,7 @@ Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3080, 5, b, a, env, w, c);
+pushCont(co, 0, _35clofun3080, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
 }
 
@@ -2124,7 +2124,7 @@ Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3081, 4, a, env, w, c);
+pushCont(co, 0, _35clofun3081, 4, a, env, w, c);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
@@ -2134,7 +2134,7 @@ Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, _35clofun3082, 4, a, env, w, c);
+pushCont(co, 0, _35clofun3082, 4, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
@@ -2176,7 +2176,7 @@ Obj _35reg2510 = primEQ(Nil, _35reg2509);
 if (True == _35reg2510) {
 Obj _35reg2511 = primCdr(closureRef(co, 2));
 Obj args = _35reg2511;
-pushCont(co, _35clofun3073, 3, env, args, w);
+pushCont(co, 0, _35clofun3073, 3, env, args, w);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.builtin->name")), f);
 } else {
 coraCall(co, 1, _35cc1331);
@@ -2200,7 +2200,7 @@ Obj _35val2512 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3074, 3, env, args, w);
+pushCont(co, 0, _35clofun3074, 3, env, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, _35val2512);
 }
 
@@ -2209,7 +2209,7 @@ Obj _35val2513 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3075, 3, env, args, w);
+pushCont(co, 0, _35clofun3075, 3, env, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("("));
 }
 
@@ -2218,7 +2218,7 @@ Obj _35val2514 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3076, 1, w);
+pushCont(co, 0, _35clofun3076, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst-list")), env, w, args);
 }
 
@@ -2267,7 +2267,7 @@ Obj _35reg2486 = primCdr(_35reg2485);
 Obj _35reg2487 = primCdr(_35reg2486);
 Obj _35reg2488 = primEQ(Nil, _35reg2487);
 if (True == _35reg2488) {
-pushCont(co, _35clofun3067, 5, a, b, env, c, w);
+pushCont(co, 0, _35clofun3067, 5, a, b, env, c, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("if (True == "));
 } else {
 coraCall(co, 1, _35cc1332);
@@ -2296,7 +2296,7 @@ Obj b = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3068, 4, b, env, c, w);
+pushCont(co, 0, _35clofun3068, 4, b, env, c, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
@@ -2306,7 +2306,7 @@ Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, _35clofun3069, 4, b, env, c, w);
+pushCont(co, 0, _35clofun3069, 4, b, env, c, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(") {\n"));
 }
 
@@ -2316,7 +2316,7 @@ Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, _35clofun3070, 3, env, c, w);
+pushCont(co, 0, _35clofun3070, 3, env, c, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
@@ -2325,7 +2325,7 @@ Obj _35val2492 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3071, 3, env, c, w);
+pushCont(co, 0, _35clofun3071, 3, env, c, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("} else {\n"));
 }
 
@@ -2334,7 +2334,7 @@ Obj _35val2493 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3072, 1, w);
+pushCont(co, 0, _35clofun3072, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, c);
 }
 
@@ -2371,7 +2371,7 @@ Obj _35reg2449 = primCdr(closureRef(co, 2));
 Obj _35reg2450 = primCdr(_35reg2449);
 Obj _35reg2451 = primCdr(_35reg2450);
 Obj frees = _35reg2451;
-pushCont(co, _35clofun3057, 5, label, nargs, env, frees, w);
+pushCont(co, 0, _35clofun3057, 5, label, nargs, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeNative("));
 } else {
 coraCall(co, 1, _35cc1333);
@@ -2394,7 +2394,7 @@ Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, _35clofun3058, 4, nargs, env, frees, w);
+pushCont(co, 0, _35clofun3058, 4, nargs, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, label);
 }
 
@@ -2404,7 +2404,7 @@ Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, _35clofun3059, 4, nargs, env, frees, w);
+pushCont(co, 0, _35clofun3059, 4, nargs, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 }
 
@@ -2414,7 +2414,7 @@ Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, _35clofun3060, 3, env, frees, w);
+pushCont(co, 0, _35clofun3060, 3, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, nargs);
 }
 
@@ -2423,7 +2423,7 @@ Obj _35val2455 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3061, 3, env, frees, w);
+pushCont(co, 0, _35clofun3061, 3, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 }
 
@@ -2432,7 +2432,7 @@ Obj _35val2456 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3062, 3, env, frees, w);
+pushCont(co, 0, _35clofun3062, 3, env, frees, w);
 coraCall(co, 2, globalRef(intern("length")), frees);
 }
 
@@ -2441,7 +2441,7 @@ Obj _35val2457 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3063, 3, env, frees, w);
+pushCont(co, 0, _35clofun3063, 3, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2457);
 }
 
@@ -2450,7 +2450,7 @@ Obj _35val2458 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3064, 3, env, frees, w);
+pushCont(co, 0, _35clofun3064, 3, env, frees, w);
 coraCall(co, 2, globalRef(intern("null?")), frees);
 }
 
@@ -2461,7 +2461,7 @@ Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg2460 = primNot(_35val2459);
 if (True == _35reg2460) {
-pushCont(co, _35clofun3065, 3, env, frees, w);
+pushCont(co, 0, _35clofun3065, 3, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 } else {
 Nil;
@@ -2474,7 +2474,7 @@ Obj _35val2461 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3066, 1, w);
+pushCont(co, 0, _35clofun3066, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst-list")), env, w, frees);
 }
 
@@ -2512,7 +2512,7 @@ Obj _35reg2431 = primCdr(_35reg2430);
 Obj _35reg2432 = primCdr(_35reg2431);
 Obj _35reg2433 = primEQ(Nil, _35reg2432);
 if (True == _35reg2433) {
-pushCont(co, _35clofun3055, 3, env, w, b);
+pushCont(co, 0, _35clofun3055, 3, env, w, b);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 } else {
 coraCall(co, 1, _35cc1334);
@@ -2536,7 +2536,7 @@ Obj _35val2434 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3056, 3, env, w, b);
+pushCont(co, 0, _35clofun3056, 3, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
@@ -2567,7 +2567,7 @@ Obj _35reg2412 = primCdr(closureRef(co, 2));
 Obj _35reg2413 = primCdr(_35reg2412);
 Obj _35reg2414 = primEQ(Nil, _35reg2413);
 if (True == _35reg2414) {
-pushCont(co, _35clofun3053, 3, env, x, w);
+pushCont(co, 0, _35clofun3053, 3, env, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("coraReturn(co, "));
 } else {
 coraCall(co, 1, _35cc1335);
@@ -2588,7 +2588,7 @@ Obj _35val2415 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3054, 1, w);
+pushCont(co, 0, _35clofun3054, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, x);
 }
 
@@ -2660,7 +2660,7 @@ Obj _35reg2391 = primCdr(_35reg2390);
 Obj _35reg2392 = primCdr(_35reg2391);
 Obj _35reg2393 = primEQ(Nil, _35reg2392);
 if (True == _35reg2393) {
-pushCont(co, _35clofun3052, 3, env, w, exp);
+pushCont(co, 0, _35clofun3052, 3, env, w, exp);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.generate-cont")), w, cont);
 } else {
 coraCall(co, 1, _35cc1337);
@@ -2697,7 +2697,7 @@ Obj _35reg2368 = primCar(closureRef(co, 2));
 Obj f = _35reg2368;
 Obj _35reg2369 = primCdr(closureRef(co, 2));
 Obj args = _35reg2369;
-pushCont(co, _35clofun3046, 3, f, args, w);
+pushCont(co, 0, _35clofun3046, 3, f, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("coraCall(co, "));
 } else {
 coraCall(co, 1, _35cc1338);
@@ -2709,7 +2709,7 @@ Obj _35val2370 = co->args[1];
 Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3047, 3, f, args, w);
+pushCont(co, 0, _35clofun3047, 3, f, args, w);
 coraCall(co, 2, globalRef(intern("length")), args);
 }
 
@@ -2719,7 +2719,7 @@ Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg2372 = primAdd(makeNumber(1), _35val2371);
-pushCont(co, _35clofun3048, 3, f, args, w);
+pushCont(co, 0, _35clofun3048, 3, f, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35reg2372);
 }
 
@@ -2729,7 +2729,7 @@ Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg2375 = primCons(f, args);
-pushCont(co, _35clofun3051, 1, w);
+pushCont(co, 0, _35clofun3051, 1, w);
 coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3049, 1, 1, w), _35reg2375);
 }
 
@@ -2741,7 +2741,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 
 void _35clofun3049(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun3050, 1, x);
+pushCont(co, 0, _35clofun3050, 1, x);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closureRef(co, 0), makeString1(", "));
 }
 
@@ -2760,7 +2760,7 @@ Obj x = co->args[1];
 Obj k = co->args[2];
 Obj _35reg2360 = primGenSym(intern("reg"));
 Obj tmp = _35reg2360;
-pushCont(co, _35clofun3030, 2, x, tmp);
+pushCont(co, 0, _35clofun3030, 2, x, tmp);
 coraCall(co, 2, k, tmp);
 }
 
@@ -2787,7 +2787,7 @@ Obj init = _35p1317;
 Obj _35reg2357 = primEQ(Nil, _35p1318);
 if (True == _35reg2357) {
 Obj k = _35p1319;
-pushCont(co, _35clofun3028, 2, k, init);
+pushCont(co, 0, _35clofun3028, 2, k, init);
 coraCall(co, 2, globalRef(intern("reverse")), res);
 } else {
 coraCall(co, 1, _35cc1320);
@@ -2948,7 +2948,7 @@ Obj _35reg2335 = primCons(intern("lambda"), _35reg2334);
 Obj _35reg2336 = primCons(_35reg2335, Nil);
 Obj _35reg2337 = primCons(closureRef(co, 3), _35reg2336);
 Obj _35reg2338 = primCons(_35reg2337, res1);
-pushCont(co, _35clofun3023, 1, _35reg2338);
+pushCont(co, 0, _35clofun3023, 1, _35reg2338);
 coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
 } else {
 Obj _35reg2343 = primCons(body1, Nil);
@@ -2985,7 +2985,7 @@ Obj _35reg2313 = primCons(intern("lambda"), _35reg2312);
 Obj _35reg2314 = primCons(_35reg2313, Nil);
 Obj _35reg2315 = primCons(closureRef(co, 3), _35reg2314);
 Obj _35reg2316 = primCons(_35reg2315, res1);
-pushCont(co, _35clofun3021, 1, _35reg2316);
+pushCont(co, 0, _35clofun3021, 1, _35reg2316);
 coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
 } else {
 Obj _35reg2321 = primCons(body1, Nil);
@@ -3022,7 +3022,7 @@ Obj _35reg2290 = primCons(intern("lambda"), _35reg2289);
 Obj _35reg2291 = primCons(_35reg2290, Nil);
 Obj _35reg2292 = primCons(closureRef(co, 3), _35reg2291);
 Obj _35reg2293 = primCons(_35reg2292, res1);
-pushCont(co, _35clofun3019, 1, _35reg2293);
+pushCont(co, 0, _35clofun3019, 1, _35reg2293);
 coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
 } else {
 Obj _35reg2298 = primCons(body1, Nil);
@@ -3078,7 +3078,7 @@ Obj _35p1303 = co->args[2];
 Obj _35cc1304 = makeNative(_35clofun2997, 0, 2, _35p1302, _35p1303);
 Obj __ = _35p1302;
 Obj x = _35p1303;
-pushCont(co, _35clofun3013, 2, x, _35cc1304);
+pushCont(co, 0, _35clofun3013, 2, x, _35cc1304);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 
@@ -3134,7 +3134,7 @@ Obj _35reg2236 = primCdr(_35reg2235);
 Obj _35reg2237 = primCdr(_35reg2236);
 Obj _35reg2238 = primEQ(Nil, _35reg2237);
 if (True == _35reg2238) {
-pushCont(co, _35clofun3012, 1, args);
+pushCont(co, 0, _35clofun3012, 1, args);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs, body);
 } else {
 coraCall(co, 1, _35cc1306);
@@ -3190,7 +3190,7 @@ Obj _35reg2209 = primCdr(_35reg2208);
 Obj _35reg2210 = primCdr(_35reg2209);
 Obj _35reg2211 = primEQ(Nil, _35reg2210);
 if (True == _35reg2211) {
-pushCont(co, _35clofun3007, 3, fvs, body, val);
+pushCont(co, 0, _35clofun3007, 3, fvs, body, val);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), body);
 } else {
 coraCall(co, 1, _35cc1307);
@@ -3214,7 +3214,7 @@ Obj _35val2212 = co->args[1];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3008, 3, fvs, body, val);
+pushCont(co, 0, _35clofun3008, 3, fvs, body, val);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val2212, val);
 }
 
@@ -3224,7 +3224,7 @@ Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs1 = _35val2213;
-pushCont(co, _35clofun3009, 3, fvs1, body, val);
+pushCont(co, 0, _35clofun3009, 3, fvs1, body, val);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
 }
 
@@ -3233,7 +3233,7 @@ Obj _35val2214 = co->args[1];
 Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3010, 3, fvs1, body, val);
+pushCont(co, 0, _35clofun3010, 3, fvs1, body, val);
 coraCall(co, 3, globalRef(intern("map")), _35val2214, fvs1);
 }
 
@@ -3243,7 +3243,7 @@ Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs2 = _35val2215;
-pushCont(co, _35clofun3011, 2, val, fvs2);
+pushCont(co, 0, _35clofun3011, 2, val, fvs2);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs1, body);
 }
 
@@ -3287,7 +3287,7 @@ Obj _35reg2186 = primCdr(_35reg2185);
 Obj _35reg2187 = primCdr(_35reg2186);
 Obj _35reg2188 = primEQ(Nil, _35reg2187);
 if (True == _35reg2188) {
-pushCont(co, _35clofun3004, 3, exp, fvs, cont);
+pushCont(co, 0, _35clofun3004, 3, exp, fvs, cont);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
 } else {
 coraCall(co, 1, _35cc1308);
@@ -3311,7 +3311,7 @@ Obj _35val2189 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cont = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun3005, 2, fvs, cont);
+pushCont(co, 0, _35clofun3005, 2, fvs, cont);
 coraCall(co, 3, globalRef(intern("map")), _35val2189, exp);
 }
 
@@ -3319,7 +3319,7 @@ void _35clofun3005(struct Cora* co) {
 Obj _35val2190 = co->args[1];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cont = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun3006, 1, _35val2190);
+pushCont(co, 0, _35clofun3006, 1, _35val2190);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs, cont);
 }
 
@@ -3342,7 +3342,7 @@ Obj _35reg2168 = primCar(closureRef(co, 1));
 Obj f = _35reg2168;
 Obj _35reg2169 = primCdr(closureRef(co, 1));
 Obj args = _35reg2169;
-pushCont(co, _35clofun3003, 2, f, args);
+pushCont(co, 0, _35clofun3003, 2, f, args);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
 } else {
 coraCall(co, 1, _35cc1309);
@@ -3370,7 +3370,7 @@ Obj _35reg2124 = primEQ(Nil, _35p1297);
 if (True == _35reg2124) {
 Obj ls = _35p1298;
 Obj next = _35p1299;
-pushCont(co, _35clofun2990, 1, next);
+pushCont(co, 0, _35clofun2990, 1, next);
 coraCall(co, 2, globalRef(intern("reverse")), ls);
 } else {
 coraCall(co, 1, _35cc1300);
@@ -3382,7 +3382,7 @@ Obj _35val2125 = co->args[1];
 Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = _35val2125;
 Obj _35reg2126 = primCar(exp);
-pushCont(co, _35clofun2991, 2, next, exp);
+pushCont(co, 0, _35clofun2991, 2, next, exp);
 coraCall(co, 2, globalRef(intern("pair?")), _35reg2126);
 }
 
@@ -3391,7 +3391,7 @@ Obj _35val2127 = co->args[1];
 Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val2127) {
-pushCont(co, _35clofun2992, 2, next, exp);
+pushCont(co, 0, _35clofun2992, 2, next, exp);
 coraCall(co, 2, globalRef(intern("caar")), exp);
 } else {
 if (True == False) {
@@ -3407,7 +3407,7 @@ return;
 Obj _35reg2157 = primGenSym(intern("val"));
 Obj val = _35reg2157;
 Obj _35reg2158 = primCons(val, Nil);
-pushCont(co, _35clofun2995, 2, _35reg2158, exp);
+pushCont(co, 0, _35clofun2995, 2, _35reg2158, exp);
 coraCall(co, 2, next, val);
 }
 }
@@ -3447,7 +3447,7 @@ return;
 Obj _35reg2133 = primGenSym(intern("val"));
 Obj val = _35reg2133;
 Obj _35reg2134 = primCons(val, Nil);
-pushCont(co, _35clofun2993, 2, _35reg2134, exp);
+pushCont(co, 0, _35clofun2993, 2, _35reg2134, exp);
 coraCall(co, 2, next, val);
 }
 }
@@ -3465,7 +3465,7 @@ return;
 Obj _35reg2145 = primGenSym(intern("val"));
 Obj val = _35reg2145;
 Obj _35reg2146 = primCons(val, Nil);
-pushCont(co, _35clofun2994, 2, _35reg2146, exp);
+pushCont(co, 0, _35clofun2994, 2, _35reg2146, exp);
 coraCall(co, 2, next, val);
 }
 }
@@ -3540,7 +3540,7 @@ coraCall(co, 2, next, x);
 coraCall(co, 1, _35cc1290);
 }
 } else {
-pushCont(co, _35clofun2985, 3, next, x, _35cc1290);
+pushCont(co, 0, _35clofun2985, 3, next, x, _35cc1290);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 }
@@ -3569,7 +3569,7 @@ void _35clofun2969(struct Cora* co) {
 Obj _35cc1291 = makeNative(_35clofun2970, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj x = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
-pushCont(co, _35clofun2984, 2, x, _35cc1291);
+pushCont(co, 0, _35clofun2984, 2, x, _35cc1291);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 
@@ -3646,14 +3646,14 @@ coraCall(co, 1, _35cc1292);
 
 void _35clofun2981(struct Cora* co) {
 Obj ra = co->args[1];
-pushCont(co, _35clofun2982, 1, ra);
+pushCont(co, 0, _35clofun2982, 1, ra);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), closureRef(co, 2));
 }
 
 void _35clofun2982(struct Cora* co) {
 Obj _35val2110 = co->args[1];
 Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, _35clofun2983, 2, _35val2110, ra);
+pushCont(co, 0, _35clofun2983, 2, _35val2110, ra);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 1), closureRef(co, 2));
 }
 
@@ -3720,7 +3720,7 @@ Obj _35reg2079 = primIsSymbol(ra);
 if (True == _35reg2079) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), closureRef(co, 1));
 } else {
-pushCont(co, _35clofun2980, 1, ra);
+pushCont(co, 0, _35clofun2980, 1, ra);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), closureRef(co, 1));
 }
 }
@@ -3796,7 +3796,7 @@ coraCall(co, 1, _35cc1294);
 
 void _35clofun2977(struct Cora* co) {
 Obj rb = co->args[1];
-pushCont(co, _35clofun2978, 1, rb);
+pushCont(co, 0, _35clofun2978, 1, rb);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 1), closureRef(co, 2));
 }
 
@@ -3863,7 +3863,7 @@ Obj _35reg2023 = primCdr(closureRef(co, 0));
 Obj _35reg2024 = primCdr(_35reg2023);
 Obj frees = _35reg2024;
 Obj next = closureRef(co, 1);
-pushCont(co, _35clofun2976, 3, args, frees, next);
+pushCont(co, 0, _35clofun2976, 3, args, frees, next);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), body, globalRef(intern("cora/lib/toc.id")));
 } else {
 coraCall(co, 1, _35cc1295);
@@ -3938,7 +3938,7 @@ Obj _35p1282 = co->args[2];
 Obj _35cc1283 = makeNative(_35clofun2953, 0, 2, _35p1281, _35p1282);
 Obj __ = _35p1281;
 Obj x = _35p1282;
-pushCont(co, _35clofun2966, 2, x, _35cc1283);
+pushCont(co, 0, _35clofun2966, 2, x, _35cc1283);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 
@@ -3960,7 +3960,7 @@ Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
 Obj _35reg1973 = primIsSymbol(var);
 if (True == _35reg1973) {
-pushCont(co, _35clofun2965, 1, var);
+pushCont(co, 0, _35clofun2965, 1, var);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.index")), var, fvs);
 } else {
 coraCall(co, 1, _35cc1284);
@@ -4013,7 +4013,7 @@ if (True == _35reg1960) {
 Obj _35reg1961 = primCons(body, Nil);
 Obj _35reg1962 = primCons(args, _35reg1961);
 Obj _35reg1963 = primCons(intern("lambda"), _35reg1962);
-pushCont(co, _35clofun2961, 3, body, args, fvs);
+pushCont(co, 0, _35clofun2961, 3, body, args, fvs);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), _35reg1963);
 } else {
 coraCall(co, 1, _35cc1285);
@@ -4038,7 +4038,7 @@ Obj body = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs1 = _35val1964;
-pushCont(co, _35clofun2962, 3, args, fvs, fvs1);
+pushCont(co, 0, _35clofun2962, 3, args, fvs, fvs1);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs1, body);
 }
 
@@ -4050,7 +4050,7 @@ Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg1966 = primCons(_35val1965, Nil);
 Obj _35reg1967 = primCons(args, _35reg1966);
 Obj _35reg1968 = primCons(intern("lambda"), _35reg1967);
-pushCont(co, _35clofun2963, 2, fvs1, _35reg1968);
+pushCont(co, 0, _35clofun2963, 2, fvs1, _35reg1968);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert")), fvs);
 }
 
@@ -4058,7 +4058,7 @@ void _35clofun2963(struct Cora* co) {
 Obj _35val1969 = co->args[1];
 Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg1968 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun2964, 1, _35reg1968);
+pushCont(co, 0, _35clofun2964, 1, _35reg1968);
 coraCall(co, 3, globalRef(intern("map")), _35val1969, fvs1);
 }
 
@@ -4109,7 +4109,7 @@ Obj _35reg1935 = primCdr(_35reg1934);
 Obj _35reg1936 = primCdr(_35reg1935);
 Obj _35reg1937 = primEQ(Nil, _35reg1936);
 if (True == _35reg1937) {
-pushCont(co, _35clofun2959, 3, fvs, c, a);
+pushCont(co, 0, _35clofun2959, 3, fvs, c, a);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs, b);
 } else {
 coraCall(co, 1, _35cc1286);
@@ -4136,7 +4136,7 @@ Obj _35val1938 = co->args[1];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, _35clofun2960, 2, _35val1938, a);
+pushCont(co, 0, _35clofun2960, 2, _35val1938, a);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs, c);
 }
 
@@ -4161,7 +4161,7 @@ Obj _35reg1908 = primCar(closureRef(co, 1));
 Obj f = _35reg1908;
 Obj _35reg1909 = primCdr(closureRef(co, 1));
 Obj args = _35reg1909;
-pushCont(co, _35clofun2958, 2, f, args);
+pushCont(co, 0, _35clofun2958, 2, f, args);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert")), fvs);
 } else {
 coraCall(co, 1, _35cc1287);
@@ -4184,7 +4184,7 @@ void _35clofun2929(struct Cora* co) {
 Obj _35p1268 = co->args[1];
 Obj _35cc1269 = makeNative(_35clofun2930, 0, 1, _35p1268);
 Obj x = _35p1268;
-pushCont(co, _35clofun2951, 1, _35cc1269);
+pushCont(co, 0, _35clofun2951, 1, _35cc1269);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 
@@ -4238,7 +4238,7 @@ Obj _35reg1899 = primCdr(_35reg1898);
 Obj _35reg1900 = primCdr(_35reg1899);
 Obj _35reg1901 = primEQ(Nil, _35reg1900);
 if (True == _35reg1901) {
-pushCont(co, _35clofun2950, 1, args);
+pushCont(co, 0, _35clofun2950, 1, args);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), body);
 } else {
 coraCall(co, 1, _35cc1271);
@@ -4303,7 +4303,7 @@ if (True == _35reg1880) {
 Obj _35reg1881 = primCons(z, Nil);
 Obj _35reg1882 = primCons(y, _35reg1881);
 Obj _35reg1883 = primCons(x, _35reg1882);
-pushCont(co, _35clofun2949, 0);
+pushCont(co, 0, _35clofun2949, 0);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1883);
 } else {
 coraCall(co, 1, _35cc1272);
@@ -4358,7 +4358,7 @@ Obj _35reg1851 = primEQ(Nil, _35reg1850);
 if (True == _35reg1851) {
 Obj _35reg1852 = primCons(y, Nil);
 Obj _35reg1853 = primCons(x, _35reg1852);
-pushCont(co, _35clofun2948, 0);
+pushCont(co, 0, _35clofun2948, 0);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1853);
 } else {
 coraCall(co, 1, _35cc1273);
@@ -4419,7 +4419,7 @@ Obj _35reg1828 = primCdr(_35reg1827);
 Obj _35reg1829 = primCdr(_35reg1828);
 Obj _35reg1830 = primEQ(Nil, _35reg1829);
 if (True == _35reg1830) {
-pushCont(co, _35clofun2945, 2, c, a);
+pushCont(co, 0, _35clofun2945, 2, c, a);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), b);
 } else {
 coraCall(co, 1, _35cc1274);
@@ -4445,7 +4445,7 @@ void _35clofun2945(struct Cora* co) {
 Obj _35val1831 = co->args[1];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun2946, 2, a, _35val1831);
+pushCont(co, 0, _35clofun2946, 2, a, _35val1831);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), c);
 }
 
@@ -4454,7 +4454,7 @@ Obj _35val1832 = co->args[1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35val1831 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg1833 = primCons(a, Nil);
-pushCont(co, _35clofun2947, 1, _35val1831);
+pushCont(co, 0, _35clofun2947, 1, _35val1831);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1832, _35reg1833);
 }
 
@@ -4553,7 +4553,7 @@ Obj _35reg1781 = primEQ(Nil, _35reg1780);
 if (True == _35reg1781) {
 Obj _35reg1782 = primCons(cont, Nil);
 Obj _35reg1783 = primCons(exp, _35reg1782);
-pushCont(co, _35clofun2944, 0);
+pushCont(co, 0, _35clofun2944, 0);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1783);
 } else {
 coraCall(co, 1, _35cc1277);
@@ -4635,7 +4635,7 @@ Obj _35reg1751 = primCdr(_35reg1750);
 Obj _35reg1752 = primCdr(_35reg1751);
 Obj _35reg1753 = primEQ(Nil, _35reg1752);
 if (True == _35reg1753) {
-pushCont(co, _35clofun2943, 1, arg);
+pushCont(co, 0, _35clofun2943, 1, arg);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), body);
 } else {
 coraCall(co, 1, _35cc1279);
@@ -4669,7 +4669,7 @@ Obj f = _35reg1733;
 Obj _35reg1734 = primCdr(closureRef(co, 0));
 Obj args = _35reg1734;
 Obj _35reg1735 = primCons(f, args);
-pushCont(co, _35clofun2942, 0);
+pushCont(co, 0, _35clofun2942, 0);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1735);
 } else {
 coraCall(co, 1, _35cc1280);
@@ -4885,7 +4885,7 @@ Obj x = _35reg1676;
 Obj _35reg1677 = primCdr(closureRef(co, 0));
 Obj y = _35reg1677;
 Obj s2 = closureRef(co, 1);
-pushCont(co, _35clofun2921, 3, y, s2, _35cc1259);
+pushCont(co, 0, _35clofun2921, 3, y, s2, _35cc1259);
 coraCall(co, 3, globalRef(intern("elem?")), x, s2);
 } else {
 coraCall(co, 1, _35cc1259);
@@ -4913,7 +4913,7 @@ Obj x = _35reg1671;
 Obj _35reg1672 = primCdr(closureRef(co, 0));
 Obj y = _35reg1672;
 Obj s2 = closureRef(co, 1);
-pushCont(co, _35clofun2920, 1, x);
+pushCont(co, 0, _35clofun2920, 1, x);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), y, s2);
 } else {
 coraCall(co, 1, _35cc1260);
@@ -4955,7 +4955,7 @@ Obj x = _35reg1665;
 Obj _35reg1666 = primCdr(closureRef(co, 0));
 Obj y = _35reg1666;
 Obj s2 = closureRef(co, 1);
-pushCont(co, _35clofun2915, 3, y, s2, _35cc1254);
+pushCont(co, 0, _35clofun2915, 3, y, s2, _35cc1254);
 coraCall(co, 3, globalRef(intern("elem?")), x, s2);
 } else {
 coraCall(co, 1, _35cc1254);
@@ -4983,7 +4983,7 @@ Obj x = _35reg1660;
 Obj _35reg1661 = primCdr(closureRef(co, 0));
 Obj y = _35reg1661;
 Obj s2 = closureRef(co, 1);
-pushCont(co, _35clofun2914, 1, x);
+pushCont(co, 0, _35clofun2914, 1, x);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), y, s2);
 } else {
 coraCall(co, 1, _35cc1255);
@@ -5008,7 +5008,7 @@ Obj _35p1241 = co->args[2];
 Obj _35cc1242 = makeNative(_35clofun2881, 0, 2, _35p1240, _35p1241);
 Obj __ = _35p1240;
 Obj x = _35p1241;
-pushCont(co, _35clofun2907, 2, x, _35cc1242);
+pushCont(co, 0, _35clofun2907, 2, x, _35cc1242);
 coraCall(co, 2, globalRef(intern("number?")), x);
 }
 
@@ -5037,7 +5037,7 @@ return;
 coraCall(co, 1, _35cc1242);
 }
 } else {
-pushCont(co, _35clofun2908, 2, x, _35cc1242);
+pushCont(co, 0, _35clofun2908, 2, x, _35cc1242);
 coraCall(co, 2, globalRef(intern("boolean?")), x);
 }
 }
@@ -5057,7 +5057,7 @@ return;
 coraCall(co, 1, _35cc1242);
 }
 } else {
-pushCont(co, _35clofun2909, 2, x, _35cc1242);
+pushCont(co, 0, _35clofun2909, 2, x, _35cc1242);
 coraCall(co, 2, globalRef(intern("null?")), x);
 }
 }
@@ -5129,7 +5129,7 @@ Obj env = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 Obj _35reg1628 = primIsSymbol(x);
 if (True == _35reg1628) {
-pushCont(co, _35clofun2906, 1, x);
+pushCont(co, 0, _35clofun2906, 1, x);
 coraCall(co, 3, globalRef(intern("elem?")), x, env);
 } else {
 coraCall(co, 1, _35cc1244);
@@ -5177,7 +5177,7 @@ Obj _35reg1620 = primCdr(_35reg1619);
 Obj _35reg1621 = primCdr(_35reg1620);
 Obj _35reg1622 = primEQ(Nil, _35reg1621);
 if (True == _35reg1622) {
-pushCont(co, _35clofun2904, 2, body, args);
+pushCont(co, 0, _35clofun2904, 2, body, args);
 coraCall(co, 3, globalRef(intern("append")), args, env);
 } else {
 coraCall(co, 1, _35cc1245);
@@ -5200,7 +5200,7 @@ void _35clofun2904(struct Cora* co) {
 Obj _35val1623 = co->args[1];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun2905, 1, args);
+pushCont(co, 0, _35clofun2905, 1, args);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35val1623, body);
 }
 
@@ -5224,7 +5224,7 @@ Obj _35reg1601 = primEQ(intern("if"), _35reg1600);
 if (True == _35reg1601) {
 Obj _35reg1602 = primCdr(closureRef(co, 1));
 Obj args = _35reg1602;
-pushCont(co, _35clofun2902, 1, args);
+pushCont(co, 0, _35clofun2902, 1, args);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.parse")), env);
 } else {
 coraCall(co, 1, _35cc1246);
@@ -5237,7 +5237,7 @@ coraCall(co, 1, _35cc1246);
 void _35clofun2902(struct Cora* co) {
 Obj _35val1603 = co->args[1];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, _35clofun2903, 0);
+pushCont(co, 0, _35clofun2903, 0);
 coraCall(co, 3, globalRef(intern("map")), _35val1603, args);
 }
 
@@ -5275,7 +5275,7 @@ Obj _35reg1591 = primCdr(_35reg1590);
 Obj _35reg1592 = primCdr(_35reg1591);
 Obj _35reg1593 = primEQ(Nil, _35reg1592);
 if (True == _35reg1593) {
-pushCont(co, _35clofun2900, 2, env, y);
+pushCont(co, 0, _35clofun2900, 2, env, y);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, x);
 } else {
 coraCall(co, 1, _35cc1247);
@@ -5298,7 +5298,7 @@ void _35clofun2900(struct Cora* co) {
 Obj _35val1594 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun2901, 1, _35val1594);
+pushCont(co, 0, _35clofun2901, 1, _35val1594);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, y);
 }
 
@@ -5350,7 +5350,7 @@ Obj _35reg1567 = primCdr(_35reg1566);
 Obj _35reg1568 = primCdr(_35reg1567);
 Obj _35reg1569 = primEQ(Nil, _35reg1568);
 if (True == _35reg1569) {
-pushCont(co, _35clofun2898, 3, env, c, a);
+pushCont(co, 0, _35clofun2898, 3, env, c, a);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, b);
 } else {
 coraCall(co, 1, _35cc1248);
@@ -5378,7 +5378,7 @@ Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg1571 = primCons(a, env);
-pushCont(co, _35clofun2899, 2, _35val1570, a);
+pushCont(co, 0, _35clofun2899, 2, _35val1570, a);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35reg1571, c);
 }
 
@@ -5403,7 +5403,7 @@ Obj _35reg1525 = primCar(closureRef(co, 1));
 Obj op = _35reg1525;
 Obj _35reg1526 = primCdr(closureRef(co, 1));
 Obj args = _35reg1526;
-pushCont(co, _35clofun2891, 4, op, args, env, _35cc1249);
+pushCont(co, 0, _35clofun2891, 4, op, args, env, _35cc1249);
 coraCall(co, 2, globalRef(intern("builtin?")), op);
 } else {
 coraCall(co, 1, _35cc1249);
@@ -5417,7 +5417,7 @@ Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35cc1249 = co->ctx.stk.stack[co->ctx.stk.base + 3];
 if (True == _35val1527) {
-pushCont(co, _35clofun2892, 3, op, args, env);
+pushCont(co, 0, _35clofun2892, 3, op, args, env);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.builtin->args")), op);
 } else {
 coraCall(co, 1, _35cc1249);
@@ -5430,7 +5430,7 @@ Obj op = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj required = _35val1528;
-pushCont(co, _35clofun2893, 4, required, op, args, env);
+pushCont(co, 0, _35clofun2893, 4, required, op, args, env);
 coraCall(co, 2, globalRef(intern("length")), args);
 }
 
@@ -5445,13 +5445,13 @@ Obj _35reg1530 = primEQ(required, provided);
 if (True == _35reg1530) {
 Obj _35reg1531 = primCons(op, Nil);
 Obj _35reg1532 = primCons(intern("%builtin"), _35reg1531);
-pushCont(co, _35clofun2894, 2, args, _35reg1532);
+pushCont(co, 0, _35clofun2894, 2, args, _35reg1532);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.parse")), env);
 } else {
 Obj _35reg1536 = primGT(required, provided);
 if (True == _35reg1536) {
 Obj _35reg1537 = primSub(required, provided);
-pushCont(co, _35clofun2896, 3, op, args, env);
+pushCont(co, 0, _35clofun2896, 3, op, args, env);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.temp-list")), _35reg1537, Nil);
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("primitive call mismatch"));
@@ -5466,7 +5466,7 @@ Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj tmp = _35val1538;
 Obj _35reg1539 = primCons(op, args);
-pushCont(co, _35clofun2897, 2, tmp, env);
+pushCont(co, 0, _35clofun2897, 2, tmp, env);
 coraCall(co, 3, globalRef(intern("append")), _35reg1539, tmp);
 }
 
@@ -5484,7 +5484,7 @@ void _35clofun2894(struct Cora* co) {
 Obj _35val1533 = co->args[1];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg1532 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, _35clofun2895, 1, _35reg1532);
+pushCont(co, 0, _35clofun2895, 1, _35reg1532);
 coraCall(co, 3, globalRef(intern("map")), _35val1533, args);
 }
 
@@ -5500,7 +5500,7 @@ void _35clofun2888(struct Cora* co) {
 Obj _35cc1250 = makeNative(_35clofun2889, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ls = closureRef(co, 1);
-pushCont(co, _35clofun2890, 1, ls);
+pushCont(co, 0, _35clofun2890, 1, ls);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.parse")), env);
 }
 
@@ -5544,14 +5544,14 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 
 void _35clofun2874(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun2875, 0);
+pushCont(co, 0, _35clofun2875, 0);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), x, globalRef(intern("cora/lib/toc.*builtin-prims*")));
 }
 
 void _35clofun2875(struct Cora* co) {
 Obj _35val1515 = co->args[1];
 Obj find = _35val1515;
-pushCont(co, _35clofun2876, 1, find);
+pushCont(co, 0, _35clofun2876, 1, find);
 coraCall(co, 2, globalRef(intern("null?")), find);
 }
 
@@ -5568,14 +5568,14 @@ coraCall(co, 2, globalRef(intern("cadr")), find);
 
 void _35clofun2871(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun2872, 0);
+pushCont(co, 0, _35clofun2872, 0);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), x, globalRef(intern("cora/lib/toc.*builtin-prims*")));
 }
 
 void _35clofun2872(struct Cora* co) {
 Obj _35val1512 = co->args[1];
 Obj find = _35val1512;
-pushCont(co, _35clofun2873, 1, find);
+pushCont(co, 0, _35clofun2873, 1, find);
 coraCall(co, 2, globalRef(intern("null?")), find);
 }
 
@@ -5592,13 +5592,13 @@ coraCall(co, 2, globalRef(intern("caddr")), find);
 
 void _35clofun2868(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, _35clofun2869, 0);
+pushCont(co, 0, _35clofun2869, 0);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), x, globalRef(intern("cora/lib/toc.*builtin-prims*")));
 }
 
 void _35clofun2869(struct Cora* co) {
 Obj _35val1508 = co->args[1];
-pushCont(co, _35clofun2870, 0);
+pushCont(co, 0, _35clofun2870, 0);
 coraCall(co, 2, globalRef(intern("null?")), _35val1508);
 }
 
@@ -5632,7 +5632,7 @@ Obj _35reg1433 = primCar(closureRef(co, 1));
 Obj hd = _35reg1433;
 Obj _35reg1434 = primCdr(closureRef(co, 1));
 Obj tl = _35reg1434;
-pushCont(co, _35clofun2867, 2, x, tl);
+pushCont(co, 0, _35clofun2867, 2, x, tl);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.index")), x, hd);
 } else {
 coraCall(co, 1, _35cc1235);
@@ -5747,7 +5747,7 @@ Obj _35reg1416 = primCar(closureRef(co, 2));
 Obj x = _35reg1416;
 Obj _35reg1417 = primCdr(closureRef(co, 2));
 Obj y = _35reg1417;
-pushCont(co, _35clofun2858, 2, f, y);
+pushCont(co, 0, _35clofun2858, 2, f, y);
 coraCall(co, 3, f, acc, x);
 } else {
 coraCall(co, 1, _35cc1225);

--- a/toc.c
+++ b/toc.c
@@ -530,7 +530,7 @@ coraCall(co, 2, globalRef(intern("number?")), exp);
 
 void _35clofun3201(struct Cora* co) {
 Obj _35val2809 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[co->stk.base + 0];
 if (True == _35val2809) {
 if (True == True) {
 coraReturn(co, exp);
@@ -582,7 +582,7 @@ coraCall(co, 2, globalRef(intern("boolean?")), exp);
 
 void _35clofun3206(struct Cora* co) {
 Obj _35val2825 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[co->stk.base + 0];
 if (True == _35val2825) {
 if (True == True) {
 coraReturn(co, exp);
@@ -611,7 +611,7 @@ coraCall(co, 2, globalRef(intern("null?")), exp);
 
 void _35clofun3209(struct Cora* co) {
 Obj _35val2833 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[co->stk.base + 0];
 if (True == _35val2833) {
 if (True == True) {
 coraReturn(co, exp);
@@ -657,7 +657,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 
 void _35clofun3212(struct Cora* co) {
 Obj _35val2845 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[co->stk.base + 0];
 Obj _35reg2846 = primCdr(exp);
 pushCont(co, _35clofun3213, 1, _35val2845);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2846);
@@ -665,13 +665,13 @@ coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")
 
 void _35clofun3213(struct Cora* co) {
 Obj _35val2847 = co->args[1];
-Obj _35val2845 = co->stack[co->base + 0];
+Obj _35val2845 = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("apply")), _35val2845, _35val2847);
 }
 
 void _35clofun3210(struct Cora* co) {
 Obj _35val2838 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[co->stk.base + 0];
 Obj _35reg2839 = primCdr(exp);
 pushCont(co, _35clofun3211, 1, _35val2838);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2839);
@@ -679,13 +679,13 @@ coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")
 
 void _35clofun3211(struct Cora* co) {
 Obj _35val2840 = co->args[1];
-Obj _35val2838 = co->stack[co->base + 0];
+Obj _35val2838 = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("apply")), _35val2838, _35val2840);
 }
 
 void _35clofun3207(struct Cora* co) {
 Obj _35val2830 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[co->stk.base + 0];
 Obj _35reg2831 = primCdr(exp);
 pushCont(co, _35clofun3208, 1, _35val2830);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2831);
@@ -693,13 +693,13 @@ coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")
 
 void _35clofun3208(struct Cora* co) {
 Obj _35val2832 = co->args[1];
-Obj _35val2830 = co->stack[co->base + 0];
+Obj _35val2830 = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("apply")), _35val2830, _35val2832);
 }
 
 void _35clofun3204(struct Cora* co) {
 Obj _35val2822 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[co->stk.base + 0];
 Obj _35reg2823 = primCdr(exp);
 pushCont(co, _35clofun3205, 1, _35val2822);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2823);
@@ -707,13 +707,13 @@ coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")
 
 void _35clofun3205(struct Cora* co) {
 Obj _35val2824 = co->args[1];
-Obj _35val2822 = co->stack[co->base + 0];
+Obj _35val2822 = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("apply")), _35val2822, _35val2824);
 }
 
 void _35clofun3202(struct Cora* co) {
 Obj _35val2814 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[co->stk.base + 0];
 Obj _35reg2815 = primCdr(exp);
 pushCont(co, _35clofun3203, 1, _35val2814);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2815);
@@ -721,7 +721,7 @@ coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")
 
 void _35clofun3203(struct Cora* co) {
 Obj _35val2816 = co->args[1];
-Obj _35val2814 = co->stack[co->base + 0];
+Obj _35val2814 = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("apply")), _35val2814, _35val2816);
 }
 
@@ -857,7 +857,7 @@ coraCall(co, 3, globalRef(intern("read-file-as-sexp")), from, pkg_45str);
 
 void _35clofun3179(struct Cora* co) {
 Obj _35val2770 = co->args[1];
-Obj to = co->stack[co->base + 0];
+Obj to = co->stk.stack[co->stk.base + 0];
 Obj sexp = _35val2770;
 pushCont(co, _35clofun3180, 1, to);
 coraCall(co, 2, globalRef(intern("macroexpand")), sexp);
@@ -865,7 +865,7 @@ coraCall(co, 2, globalRef(intern("macroexpand")), sexp);
 
 void _35clofun3180(struct Cora* co) {
 Obj _35val2771 = co->args[1];
-Obj to = co->stack[co->base + 0];
+Obj to = co->stk.stack[co->stk.base + 0];
 Obj input = _35val2771;
 pushCont(co, _35clofun3181, 1, to);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.compile")), input);
@@ -873,7 +873,7 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.compile")), input);
 
 void _35clofun3181(struct Cora* co) {
 Obj _35val2772 = co->args[1];
-Obj to = co->stack[co->base + 0];
+Obj to = co->stk.stack[co->stk.base + 0];
 Obj bc = _35val2772;
 pushCont(co, _35clofun3182, 1, bc);
 coraCall(co, 2, globalRef(intern("cora/lib/io.open-output-file")), to);
@@ -881,7 +881,7 @@ coraCall(co, 2, globalRef(intern("cora/lib/io.open-output-file")), to);
 
 void _35clofun3182(struct Cora* co) {
 Obj _35val2773 = co->args[1];
-Obj bc = co->stack[co->base + 0];
+Obj bc = co->stk.stack[co->stk.base + 0];
 Obj stream = _35val2773;
 pushCont(co, _35clofun3183, 1, stream);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.generate-c")), stream, bc);
@@ -889,7 +889,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.generate-c")), stream, bc);
 
 void _35clofun3183(struct Cora* co) {
 Obj _35val2774 = co->args[1];
-Obj stream = co->stack[co->base + 0];
+Obj stream = co->stk.stack[co->stk.base + 0];
 coraCall(co, 2, globalRef(intern("cora/lib/io.close-output-file")), stream);
 }
 
@@ -902,32 +902,32 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, mak
 
 void _35clofun3171(struct Cora* co) {
 Obj _35val2763 = co->args[1];
-Obj to = co->stack[co->base + 0];
-Obj bc = co->stack[co->base + 1];
+Obj to = co->stk.stack[co->stk.base + 0];
+Obj bc = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3172, 2, to, bc);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("#include \"runtime.h\"\n\n"));
 }
 
 void _35clofun3172(struct Cora* co) {
 Obj _35val2764 = co->args[1];
-Obj to = co->stack[co->base + 0];
-Obj bc = co->stack[co->base + 1];
+Obj to = co->stk.stack[co->stk.base + 0];
+Obj bc = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3175, 2, to, bc);
 coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3173, 1, 1, to), bc);
 }
 
 void _35clofun3175(struct Cora* co) {
 Obj _35val2767 = co->args[1];
-Obj to = co->stack[co->base + 0];
-Obj bc = co->stack[co->base + 1];
+Obj to = co->stk.stack[co->stk.base + 0];
+Obj bc = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3176, 2, to, bc);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("\n"));
 }
 
 void _35clofun3176(struct Cora* co) {
 Obj _35val2768 = co->args[1];
-Obj to = co->stack[co->base + 0];
-Obj bc = co->stack[co->base + 1];
+Obj to = co->stk.stack[co->stk.base + 0];
+Obj bc = co->stk.stack[co->stk.base + 1];
 coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3177, 1, 1, to), bc);
 }
 
@@ -980,8 +980,8 @@ coraCall(co, 1, _35cc1371);
 
 void _35clofun3169(struct Cora* co) {
 Obj _35val2760 = co->args[1];
-Obj fn = co->stack[co->base + 0];
-Obj y = co->stack[co->base + 1];
+Obj fn = co->stk.stack[co->stk.base + 0];
+Obj y = co->stk.stack[co->stk.base + 1];
 coraCall(co, 3, globalRef(intern("for-each")), fn, y);
 }
 
@@ -1026,7 +1026,7 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun3158(struct Cora* co) {
 Obj _35val2749 = co->args[1];
-Obj exp = co->stack[co->base + 0];
+Obj exp = co->stk.stack[co->stk.base + 0];
 Obj obj = _35val2749;
 pushCont(co, _35clofun3159, 1, obj);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
@@ -1034,7 +1034,7 @@ coraCall(co, 2, globalRef(intern("cddr")), exp);
 
 void _35clofun3159(struct Cora* co) {
 Obj _35val2750 = co->args[1];
-Obj obj = co->stack[co->base + 0];
+Obj obj = co->stk.stack[co->stk.base + 0];
 Obj fns = _35val2750;
 coraCall(co, 3, globalRef(intern("cora/lib/toc.rewrite-->macro")), obj, fns);
 }
@@ -1215,46 +1215,46 @@ coraCall(co, 1, _35cc1363);
 
 void _35clofun3143(struct Cora* co) {
 Obj _35val2724 = co->args[1];
-Obj actives = co->stack[co->base + 0];
-Obj params = co->stack[co->base + 1];
-Obj body = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
+Obj actives = co->stk.stack[co->stk.base + 0];
+Obj params = co->stk.stack[co->stk.base + 1];
+Obj body = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
 pushCont(co, _35clofun3144, 4, actives, params, body, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" {\n"));
 }
 
 void _35clofun3144(struct Cora* co) {
 Obj _35val2725 = co->args[1];
-Obj actives = co->stack[co->base + 0];
-Obj params = co->stack[co->base + 1];
-Obj body = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
+Obj actives = co->stk.stack[co->stk.base + 0];
+Obj params = co->stk.stack[co->stk.base + 1];
+Obj body = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
 pushCont(co, _35clofun3145, 4, actives, params, body, w);
 coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->args["), makeNumber(1), params);
 }
 
 void _35clofun3145(struct Cora* co) {
 Obj _35val2726 = co->args[1];
-Obj actives = co->stack[co->base + 0];
-Obj params = co->stack[co->base + 1];
-Obj body = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
+Obj actives = co->stk.stack[co->stk.base + 0];
+Obj params = co->stk.stack[co->stk.base + 1];
+Obj body = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
 pushCont(co, _35clofun3146, 3, params, body, w);
-coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->stack[co->base + "), makeNumber(0), actives);
+coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->stk.stack[co->stk.base + "), makeNumber(0), actives);
 }
 
 void _35clofun3146(struct Cora* co) {
 Obj _35val2727 = co->args[1];
-Obj params = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj params = co->stk.stack[co->stk.base + 0];
+Obj body = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3147, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), params, w, body);
 }
 
 void _35clofun3147(struct Cora* co) {
 Obj _35val2728 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("}\n\n"));
 }
 
@@ -1303,56 +1303,56 @@ coraCall(co, 1, _35cc1360);
 
 void _35clofun3136(struct Cora* co) {
 Obj _35val2665 = co->args[1];
-Obj a = co->stack[co->base + 0];
-Obj idx = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
-Obj dest_45str = co->stack[co->base + 4];
-Obj b = co->stack[co->base + 5];
+Obj a = co->stk.stack[co->stk.base + 0];
+Obj idx = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
+Obj dest_45str = co->stk.stack[co->stk.base + 4];
+Obj b = co->stk.stack[co->stk.base + 5];
 pushCont(co, _35clofun3137, 5, idx, env, w, dest_45str, b);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
 void _35clofun3137(struct Cora* co) {
 Obj _35val2666 = co->args[1];
-Obj idx = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj dest_45str = co->stack[co->base + 3];
-Obj b = co->stack[co->base + 4];
+Obj idx = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj dest_45str = co->stk.stack[co->stk.base + 3];
+Obj b = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3138, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, dest_45str);
 }
 
 void _35clofun3138(struct Cora* co) {
 Obj _35val2667 = co->args[1];
-Obj idx = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj dest_45str = co->stack[co->base + 3];
-Obj b = co->stack[co->base + 4];
+Obj idx = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj dest_45str = co->stk.stack[co->stk.base + 3];
+Obj b = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3139, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
 void _35clofun3139(struct Cora* co) {
 Obj _35val2668 = co->args[1];
-Obj idx = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj dest_45str = co->stack[co->base + 3];
-Obj b = co->stack[co->base + 4];
+Obj idx = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj dest_45str = co->stk.stack[co->stk.base + 3];
+Obj b = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3140, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("];\n"));
 }
 
 void _35clofun3140(struct Cora* co) {
 Obj _35val2669 = co->args[1];
-Obj idx = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj dest_45str = co->stack[co->base + 3];
-Obj b = co->stack[co->base + 4];
+Obj idx = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj dest_45str = co->stk.stack[co->stk.base + 3];
+Obj b = co->stk.stack[co->stk.base + 4];
 Obj _35reg2670 = primAdd(idx, makeNumber(1));
 coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), env, w, dest_45str, _35reg2670, b);
 }
@@ -1370,22 +1370,22 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 
 void _35clofun3130(struct Cora* co) {
 Obj _35val2658 = co->args[1];
-Obj name = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj name = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3131, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, name);
 }
 
 void _35clofun3131(struct Cora* co) {
 Obj _35val2659 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 pushCont(co, _35clofun3132, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("(struct Cora* co"));
 }
 
 void _35clofun3132(struct Cora* co) {
 Obj _35val2660 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
@@ -1434,20 +1434,20 @@ coraCall(co, 1, _35cc1353);
 
 void _35clofun3125(struct Cora* co) {
 Obj _35val2651 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj fn = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj b = co->stack[co->base + 3];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj fn = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj b = co->stk.stack[co->stk.base + 3];
 pushCont(co, _35clofun3126, 4, env, fn, w, b);
 coraCall(co, 2, globalRef(intern("null?")), b);
 }
 
 void _35clofun3126(struct Cora* co) {
 Obj _35val2652 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj fn = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj b = co->stack[co->base + 3];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj fn = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj b = co->stk.stack[co->stk.base + 3];
 Obj _35reg2653 = primNot(_35val2652);
 if (True == _35reg2653) {
 pushCont(co, _35clofun3127, 4, env, fn, w, b);
@@ -1460,10 +1460,10 @@ coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-inst-list-h")), env, fn,
 
 void _35clofun3127(struct Cora* co) {
 Obj _35val2654 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj fn = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj b = co->stack[co->base + 3];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj fn = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj b = co->stk.stack[co->stk.base + 3];
 coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-inst-list-h")), env, fn, w, b);
 }
 
@@ -1505,49 +1505,49 @@ coraCall(co, 1, _35cc1347);
 
 void _35clofun3113(struct Cora* co) {
 Obj _35val2638 = co->args[1];
-Obj label = co->stack[co->base + 0];
-Obj stacks = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj label = co->stk.stack[co->stk.base + 0];
+Obj stacks = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3114, 2, stacks, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, label);
 }
 
 void _35clofun3114(struct Cora* co) {
 Obj _35val2639 = co->args[1];
-Obj stacks = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj stacks = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3115, 2, stacks, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 }
 
 void _35clofun3115(struct Cora* co) {
 Obj _35val2640 = co->args[1];
-Obj stacks = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj stacks = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3116, 2, stacks, w);
 coraCall(co, 2, globalRef(intern("length")), stacks);
 }
 
 void _35clofun3116(struct Cora* co) {
 Obj _35val2641 = co->args[1];
-Obj stacks = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj stacks = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3117, 2, stacks, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2641);
 }
 
 void _35clofun3117(struct Cora* co) {
 Obj _35val2642 = co->args[1];
-Obj stacks = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj stacks = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3118, 2, stacks, w);
 coraCall(co, 2, globalRef(intern("null?")), stacks);
 }
 
 void _35clofun3118(struct Cora* co) {
 Obj _35val2643 = co->args[1];
-Obj stacks = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj stacks = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 Obj _35reg2644 = primNot(_35val2643);
 if (True == _35reg2644) {
 pushCont(co, _35clofun3121, 1, w);
@@ -1560,7 +1560,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 
 void _35clofun3121(struct Cora* co) {
 Obj _35val2646 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
 }
 
@@ -1572,7 +1572,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closure
 
 void _35clofun3120(struct Cora* co) {
 Obj _35val2645 = co->args[1];
-Obj x = co->stack[co->base + 0];
+Obj x = co->stk.stack[co->stk.base + 0];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), Nil, closureRef(co, 0), x);
 }
 
@@ -1618,53 +1618,53 @@ coraCall(co, 1, _35cc1344);
 
 void _35clofun3106(struct Cora* co) {
 Obj _35val2621 = co->args[1];
-Obj a = co->stack[co->base + 0];
-Obj idx = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
-Obj b = co->stack[co->base + 4];
+Obj a = co->stk.stack[co->stk.base + 0];
+Obj idx = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
+Obj b = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3107, 5, a, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
 void _35clofun3107(struct Cora* co) {
 Obj _35val2622 = co->args[1];
-Obj a = co->stack[co->base + 0];
-Obj idx = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
-Obj b = co->stack[co->base + 4];
+Obj a = co->stk.stack[co->stk.base + 0];
+Obj idx = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
+Obj b = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3108, 5, a, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("] = "));
 }
 
 void _35clofun3108(struct Cora* co) {
 Obj _35val2623 = co->args[1];
-Obj a = co->stack[co->base + 0];
-Obj idx = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
-Obj b = co->stack[co->base + 4];
+Obj a = co->stk.stack[co->stk.base + 0];
+Obj idx = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
+Obj b = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3109, 4, idx, env, w, b);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
 void _35clofun3109(struct Cora* co) {
 Obj _35val2624 = co->args[1];
-Obj idx = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj b = co->stack[co->base + 3];
+Obj idx = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj b = co->stk.stack[co->stk.base + 3];
 pushCont(co, _35clofun3110, 4, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
 void _35clofun3110(struct Cora* co) {
 Obj _35val2625 = co->args[1];
-Obj idx = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj b = co->stack[co->base + 3];
+Obj idx = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj b = co->stk.stack[co->stk.base + 3];
 Obj _35reg2626 = primAdd(idx, makeNumber(1));
 coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-call-args")), env, w, _35reg2626, b);
 }
@@ -1726,22 +1726,22 @@ coraCall(co, 1, _35cc1326);
 
 void _35clofun3100(struct Cora* co) {
 Obj _35val2613 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3101, 1, w);
 coraCall(co, 2, globalRef(intern("symbol->string")), x);
 }
 
 void _35clofun3101(struct Cora* co) {
 Obj _35val2614 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 pushCont(co, _35clofun3102, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2614);
 }
 
 void _35clofun3102(struct Cora* co) {
 Obj _35val2615 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("\"))"));
 }
 
@@ -1782,15 +1782,15 @@ coraCall(co, 1, _35cc1327);
 
 void _35clofun3098(struct Cora* co) {
 Obj _35val2601 = co->args[1];
-Obj idx = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj idx = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3099, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
 void _35clofun3099(struct Cora* co) {
 Obj _35val2602 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
@@ -1831,15 +1831,15 @@ coraCall(co, 1, _35cc1328);
 
 void _35clofun3096(struct Cora* co) {
 Obj _35val2589 = co->args[1];
-Obj idx = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj idx = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3097, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
 void _35clofun3097(struct Cora* co) {
 Obj _35val2590 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
@@ -1886,8 +1886,8 @@ coraCall(co, 1, _35cc1329);
 
 void _35clofun3090(struct Cora* co) {
 Obj _35val2569 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 if (True == _35val2569) {
 pushCont(co, _35clofun3091, 2, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeNumber("));
@@ -1919,57 +1919,57 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 
 void _35clofun3093(struct Cora* co) {
 Obj _35val2573 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3094, 1, w);
 coraCall(co, 2, globalRef(intern("cora/lib/toc/internal.escape-str")), x);
 }
 
 void _35clofun3094(struct Cora* co) {
 Obj _35val2574 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 pushCont(co, _35clofun3095, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2574);
 }
 
 void _35clofun3095(struct Cora* co) {
 Obj _35val2575 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("\")"));
 }
 
 void _35clofun3091(struct Cora* co) {
 Obj _35val2570 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3092, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, x);
 }
 
 void _35clofun3092(struct Cora* co) {
 Obj _35val2571 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
 void _35clofun3087(struct Cora* co) {
 Obj _35val2566 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3088, 1, w);
 coraCall(co, 2, globalRef(intern("symbol->string")), x);
 }
 
 void _35clofun3088(struct Cora* co) {
 Obj _35val2567 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 pushCont(co, _35clofun3089, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2567);
 }
 
 void _35clofun3089(struct Cora* co) {
 Obj _35val2568 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("\")"));
 }
 
@@ -2036,11 +2036,11 @@ coraCall(co, 1, _35cc1330);
 
 void _35clofun3077(struct Cora* co) {
 Obj _35val2542 = co->args[1];
-Obj b = co->stack[co->base + 0];
-Obj a = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
-Obj c = co->stack[co->base + 4];
+Obj b = co->stk.stack[co->stk.base + 0];
+Obj a = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
+Obj c = co->stk.stack[co->stk.base + 4];
 Obj idx = _35val2542;
 Obj _35reg2543 = primLT(idx, makeNumber(0));
 if (True == _35reg2543) {
@@ -2055,95 +2055,95 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
 
 void _35clofun3083(struct Cora* co) {
 Obj _35val2550 = co->args[1];
-Obj b = co->stack[co->base + 0];
-Obj a = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
-Obj c = co->stack[co->base + 4];
+Obj b = co->stk.stack[co->stk.base + 0];
+Obj a = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
+Obj c = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3084, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
 }
 
 void _35clofun3084(struct Cora* co) {
 Obj _35val2551 = co->args[1];
-Obj b = co->stack[co->base + 0];
-Obj a = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
-Obj c = co->stack[co->base + 4];
+Obj b = co->stk.stack[co->stk.base + 0];
+Obj a = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
+Obj c = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3085, 4, a, env, w, c);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
 void _35clofun3085(struct Cora* co) {
 Obj _35val2552 = co->args[1];
-Obj a = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj c = co->stack[co->base + 3];
+Obj a = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj c = co->stk.stack[co->stk.base + 3];
 pushCont(co, _35clofun3086, 4, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
 void _35clofun3086(struct Cora* co) {
 Obj _35val2553 = co->args[1];
-Obj a = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj c = co->stack[co->base + 3];
+Obj a = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj c = co->stk.stack[co->stk.base + 3];
 Obj _35reg2554 = primCons(a, env);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2554, w, c);
 }
 
 void _35clofun3078(struct Cora* co) {
 Obj _35val2544 = co->args[1];
-Obj b = co->stack[co->base + 0];
-Obj a = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
-Obj c = co->stack[co->base + 4];
+Obj b = co->stk.stack[co->stk.base + 0];
+Obj a = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
+Obj c = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3079, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
 }
 
 void _35clofun3079(struct Cora* co) {
 Obj _35val2545 = co->args[1];
-Obj b = co->stack[co->base + 0];
-Obj a = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
-Obj c = co->stack[co->base + 4];
+Obj b = co->stk.stack[co->stk.base + 0];
+Obj a = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
+Obj c = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3080, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
 }
 
 void _35clofun3080(struct Cora* co) {
 Obj _35val2546 = co->args[1];
-Obj b = co->stack[co->base + 0];
-Obj a = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
-Obj c = co->stack[co->base + 4];
+Obj b = co->stk.stack[co->stk.base + 0];
+Obj a = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
+Obj c = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3081, 4, a, env, w, c);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
 void _35clofun3081(struct Cora* co) {
 Obj _35val2547 = co->args[1];
-Obj a = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj c = co->stack[co->base + 3];
+Obj a = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj c = co->stk.stack[co->stk.base + 3];
 pushCont(co, _35clofun3082, 4, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
 void _35clofun3082(struct Cora* co) {
 Obj _35val2548 = co->args[1];
-Obj a = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
-Obj c = co->stack[co->base + 3];
+Obj a = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
+Obj c = co->stk.stack[co->stk.base + 3];
 Obj _35reg2549 = primCons(a, env);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2549, w, c);
 }
@@ -2197,34 +2197,34 @@ coraCall(co, 1, _35cc1331);
 
 void _35clofun3073(struct Cora* co) {
 Obj _35val2512 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3074, 3, env, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, _35val2512);
 }
 
 void _35clofun3074(struct Cora* co) {
 Obj _35val2513 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3075, 3, env, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("("));
 }
 
 void _35clofun3075(struct Cora* co) {
 Obj _35val2514 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3076, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst-list")), env, w, args);
 }
 
 void _35clofun3076(struct Cora* co) {
 Obj _35val2515 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
@@ -2291,56 +2291,56 @@ coraCall(co, 1, _35cc1332);
 
 void _35clofun3067(struct Cora* co) {
 Obj _35val2489 = co->args[1];
-Obj a = co->stack[co->base + 0];
-Obj b = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj c = co->stack[co->base + 3];
-Obj w = co->stack[co->base + 4];
+Obj a = co->stk.stack[co->stk.base + 0];
+Obj b = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj c = co->stk.stack[co->stk.base + 3];
+Obj w = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3068, 4, b, env, c, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
 void _35clofun3068(struct Cora* co) {
 Obj _35val2490 = co->args[1];
-Obj b = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj c = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
+Obj b = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj c = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
 pushCont(co, _35clofun3069, 4, b, env, c, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(") {\n"));
 }
 
 void _35clofun3069(struct Cora* co) {
 Obj _35val2491 = co->args[1];
-Obj b = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj c = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
+Obj b = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj c = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
 pushCont(co, _35clofun3070, 3, env, c, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
 void _35clofun3070(struct Cora* co) {
 Obj _35val2492 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj c = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj c = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3071, 3, env, c, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("} else {\n"));
 }
 
 void _35clofun3071(struct Cora* co) {
 Obj _35val2493 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj c = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj c = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3072, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, c);
 }
 
 void _35clofun3072(struct Cora* co) {
 Obj _35val2494 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("}\n"));
 }
 
@@ -2389,76 +2389,76 @@ coraCall(co, 1, _35cc1333);
 
 void _35clofun3057(struct Cora* co) {
 Obj _35val2452 = co->args[1];
-Obj label = co->stack[co->base + 0];
-Obj nargs = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj frees = co->stack[co->base + 3];
-Obj w = co->stack[co->base + 4];
+Obj label = co->stk.stack[co->stk.base + 0];
+Obj nargs = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj frees = co->stk.stack[co->stk.base + 3];
+Obj w = co->stk.stack[co->stk.base + 4];
 pushCont(co, _35clofun3058, 4, nargs, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, label);
 }
 
 void _35clofun3058(struct Cora* co) {
 Obj _35val2453 = co->args[1];
-Obj nargs = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj frees = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
+Obj nargs = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj frees = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
 pushCont(co, _35clofun3059, 4, nargs, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 }
 
 void _35clofun3059(struct Cora* co) {
 Obj _35val2454 = co->args[1];
-Obj nargs = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
-Obj frees = co->stack[co->base + 2];
-Obj w = co->stack[co->base + 3];
+Obj nargs = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
+Obj frees = co->stk.stack[co->stk.base + 2];
+Obj w = co->stk.stack[co->stk.base + 3];
 pushCont(co, _35clofun3060, 3, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, nargs);
 }
 
 void _35clofun3060(struct Cora* co) {
 Obj _35val2455 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj frees = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj frees = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3061, 3, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 }
 
 void _35clofun3061(struct Cora* co) {
 Obj _35val2456 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj frees = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj frees = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3062, 3, env, frees, w);
 coraCall(co, 2, globalRef(intern("length")), frees);
 }
 
 void _35clofun3062(struct Cora* co) {
 Obj _35val2457 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj frees = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj frees = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3063, 3, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2457);
 }
 
 void _35clofun3063(struct Cora* co) {
 Obj _35val2458 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj frees = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj frees = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3064, 3, env, frees, w);
 coraCall(co, 2, globalRef(intern("null?")), frees);
 }
 
 void _35clofun3064(struct Cora* co) {
 Obj _35val2459 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj frees = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj frees = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 Obj _35reg2460 = primNot(_35val2459);
 if (True == _35reg2460) {
 pushCont(co, _35clofun3065, 3, env, frees, w);
@@ -2471,16 +2471,16 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 
 void _35clofun3065(struct Cora* co) {
 Obj _35val2461 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj frees = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj frees = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3066, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst-list")), env, w, frees);
 }
 
 void _35clofun3066(struct Cora* co) {
 Obj _35val2462 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
@@ -2533,18 +2533,18 @@ coraCall(co, 1, _35cc1334);
 
 void _35clofun3055(struct Cora* co) {
 Obj _35val2434 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
-Obj b = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
+Obj b = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3056, 3, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
 void _35clofun3056(struct Cora* co) {
 Obj _35val2435 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
-Obj b = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
+Obj b = co->stk.stack[co->stk.base + 2];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
@@ -2585,16 +2585,16 @@ coraCall(co, 1, _35cc1335);
 
 void _35clofun3053(struct Cora* co) {
 Obj _35val2415 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj x = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj x = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3054, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, x);
 }
 
 void _35clofun3054(struct Cora* co) {
 Obj _35val2416 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\nreturn;\n"));
 }
 
@@ -2681,9 +2681,9 @@ coraCall(co, 1, _35cc1337);
 
 void _35clofun3052(struct Cora* co) {
 Obj _35val2394 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj w = co->stack[co->base + 1];
-Obj exp = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj w = co->stk.stack[co->stk.base + 1];
+Obj exp = co->stk.stack[co->stk.base + 2];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, exp);
 }
 
@@ -2706,18 +2706,18 @@ coraCall(co, 1, _35cc1338);
 
 void _35clofun3046(struct Cora* co) {
 Obj _35val2370 = co->args[1];
-Obj f = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj f = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3047, 3, f, args, w);
 coraCall(co, 2, globalRef(intern("length")), args);
 }
 
 void _35clofun3047(struct Cora* co) {
 Obj _35val2371 = co->args[1];
-Obj f = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj f = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 Obj _35reg2372 = primAdd(makeNumber(1), _35val2371);
 pushCont(co, _35clofun3048, 3, f, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35reg2372);
@@ -2725,9 +2725,9 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35r
 
 void _35clofun3048(struct Cora* co) {
 Obj _35val2373 = co->args[1];
-Obj f = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
-Obj w = co->stack[co->base + 2];
+Obj f = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
+Obj w = co->stk.stack[co->stk.base + 2];
 Obj _35reg2375 = primCons(f, args);
 pushCont(co, _35clofun3051, 1, w);
 coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3049, 1, 1, w), _35reg2375);
@@ -2735,7 +2735,7 @@ coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3049, 1, 1, w
 
 void _35clofun3051(struct Cora* co) {
 Obj _35val2376 = co->args[1];
-Obj w = co->stack[co->base + 0];
+Obj w = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
 }
 
@@ -2747,7 +2747,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closure
 
 void _35clofun3050(struct Cora* co) {
 Obj _35val2374 = co->args[1];
-Obj x = co->stack[co->base + 0];
+Obj x = co->stk.stack[co->stk.base + 0];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), Nil, closureRef(co, 0), x);
 }
 
@@ -2766,8 +2766,8 @@ coraCall(co, 2, k, tmp);
 
 void _35clofun3030(struct Cora* co) {
 Obj _35val2361 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj tmp = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj tmp = co->stk.stack[co->stk.base + 1];
 Obj _35reg2362 = primCons(_35val2361, Nil);
 Obj _35reg2363 = primCons(x, _35reg2362);
 Obj _35reg2364 = primCons(tmp, _35reg2363);
@@ -2796,8 +2796,8 @@ coraCall(co, 1, _35cc1320);
 
 void _35clofun3028(struct Cora* co) {
 Obj _35val2358 = co->args[1];
-Obj k = co->stack[co->base + 0];
-Obj init = co->stack[co->base + 1];
+Obj k = co->stk.stack[co->stk.base + 0];
+Obj init = co->stk.stack[co->stk.base + 1];
 coraCall(co, 3, k, init, _35val2358);
 }
 
@@ -2966,7 +2966,7 @@ coraCall(co, 3, closureRef(co, 0), _35reg2349, _35reg2351);
 
 void _35clofun3023(struct Cora* co) {
 Obj _35val2339 = co->args[1];
-Obj _35reg2338 = co->stack[co->base + 0];
+Obj _35reg2338 = co->stk.stack[co->stk.base + 0];
 Obj _35reg2340 = primCons(_35val2339, closureRef(co, 4));
 Obj _35reg2341 = primCons(closureRef(co, 3), _35reg2340);
 Obj _35reg2342 = primCons(closureRef(co, 2), _35reg2341);
@@ -3003,7 +3003,7 @@ coraCall(co, 3, closureRef(co, 0), _35reg2327, _35reg2329);
 
 void _35clofun3021(struct Cora* co) {
 Obj _35val2317 = co->args[1];
-Obj _35reg2316 = co->stack[co->base + 0];
+Obj _35reg2316 = co->stk.stack[co->stk.base + 0];
 Obj _35reg2318 = primCons(_35val2317, closureRef(co, 4));
 Obj _35reg2319 = primCons(closureRef(co, 3), _35reg2318);
 Obj _35reg2320 = primCons(closureRef(co, 2), _35reg2319);
@@ -3040,7 +3040,7 @@ coraCall(co, 3, closureRef(co, 0), _35reg2304, _35reg2306);
 
 void _35clofun3019(struct Cora* co) {
 Obj _35val2294 = co->args[1];
-Obj _35reg2293 = co->stack[co->base + 0];
+Obj _35reg2293 = co->stk.stack[co->stk.base + 0];
 Obj _35reg2295 = primCons(_35val2294, closureRef(co, 4));
 Obj _35reg2296 = primCons(closureRef(co, 3), _35reg2295);
 Obj _35reg2297 = primCons(closureRef(co, 2), _35reg2296);
@@ -3084,8 +3084,8 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 
 void _35clofun3013(struct Cora* co) {
 Obj _35val2244 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj _35cc1304 = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj _35cc1304 = co->stk.stack[co->stk.base + 1];
 if (True == _35val2244) {
 coraReturn(co, x);
 return;
@@ -3155,7 +3155,7 @@ coraCall(co, 1, _35cc1306);
 
 void _35clofun3012(struct Cora* co) {
 Obj _35val2239 = co->args[1];
-Obj args = co->stack[co->base + 0];
+Obj args = co->stk.stack[co->stk.base + 0];
 Obj _35reg2240 = primCons(_35val2239, Nil);
 Obj _35reg2241 = primCons(args, _35reg2240);
 Obj _35reg2242 = primCons(intern("lambda"), _35reg2241);
@@ -3211,18 +3211,18 @@ coraCall(co, 1, _35cc1307);
 
 void _35clofun3007(struct Cora* co) {
 Obj _35val2212 = co->args[1];
-Obj fvs = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
-Obj val = co->stack[co->base + 2];
+Obj fvs = co->stk.stack[co->stk.base + 0];
+Obj body = co->stk.stack[co->stk.base + 1];
+Obj val = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3008, 3, fvs, body, val);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val2212, val);
 }
 
 void _35clofun3008(struct Cora* co) {
 Obj _35val2213 = co->args[1];
-Obj fvs = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
-Obj val = co->stack[co->base + 2];
+Obj fvs = co->stk.stack[co->stk.base + 0];
+Obj body = co->stk.stack[co->stk.base + 1];
+Obj val = co->stk.stack[co->stk.base + 2];
 Obj fvs1 = _35val2213;
 pushCont(co, _35clofun3009, 3, fvs1, body, val);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
@@ -3230,18 +3230,18 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
 
 void _35clofun3009(struct Cora* co) {
 Obj _35val2214 = co->args[1];
-Obj fvs1 = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
-Obj val = co->stack[co->base + 2];
+Obj fvs1 = co->stk.stack[co->stk.base + 0];
+Obj body = co->stk.stack[co->stk.base + 1];
+Obj val = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3010, 3, fvs1, body, val);
 coraCall(co, 3, globalRef(intern("map")), _35val2214, fvs1);
 }
 
 void _35clofun3010(struct Cora* co) {
 Obj _35val2215 = co->args[1];
-Obj fvs1 = co->stack[co->base + 0];
-Obj body = co->stack[co->base + 1];
-Obj val = co->stack[co->base + 2];
+Obj fvs1 = co->stk.stack[co->stk.base + 0];
+Obj body = co->stk.stack[co->stk.base + 1];
+Obj val = co->stk.stack[co->stk.base + 2];
 Obj fvs2 = _35val2215;
 pushCont(co, _35clofun3011, 2, val, fvs2);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs1, body);
@@ -3249,8 +3249,8 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs1, body);
 
 void _35clofun3011(struct Cora* co) {
 Obj _35val2216 = co->args[1];
-Obj val = co->stack[co->base + 0];
-Obj fvs2 = co->stack[co->base + 1];
+Obj val = co->stk.stack[co->stk.base + 0];
+Obj fvs2 = co->stk.stack[co->stk.base + 1];
 Obj _35reg2217 = primCons(_35val2216, Nil);
 Obj _35reg2218 = primCons(val, _35reg2217);
 Obj _35reg2219 = primCons(intern("lambda"), _35reg2218);
@@ -3308,24 +3308,24 @@ coraCall(co, 1, _35cc1308);
 
 void _35clofun3004(struct Cora* co) {
 Obj _35val2189 = co->args[1];
-Obj exp = co->stack[co->base + 0];
-Obj fvs = co->stack[co->base + 1];
-Obj cont = co->stack[co->base + 2];
+Obj exp = co->stk.stack[co->stk.base + 0];
+Obj fvs = co->stk.stack[co->stk.base + 1];
+Obj cont = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun3005, 2, fvs, cont);
 coraCall(co, 3, globalRef(intern("map")), _35val2189, exp);
 }
 
 void _35clofun3005(struct Cora* co) {
 Obj _35val2190 = co->args[1];
-Obj fvs = co->stack[co->base + 0];
-Obj cont = co->stack[co->base + 1];
+Obj fvs = co->stk.stack[co->stk.base + 0];
+Obj cont = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun3006, 1, _35val2190);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs, cont);
 }
 
 void _35clofun3006(struct Cora* co) {
 Obj _35val2191 = co->args[1];
-Obj _35val2190 = co->stack[co->base + 0];
+Obj _35val2190 = co->stk.stack[co->stk.base + 0];
 Obj _35reg2192 = primCons(_35val2191, Nil);
 Obj _35reg2193 = primCons(_35val2190, _35reg2192);
 Obj _35reg2194 = primCons(intern("call"), _35reg2193);
@@ -3351,8 +3351,8 @@ coraCall(co, 1, _35cc1309);
 
 void _35clofun3003(struct Cora* co) {
 Obj _35val2170 = co->args[1];
-Obj f = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
+Obj f = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
 Obj _35reg2171 = primCons(f, args);
 coraCall(co, 3, globalRef(intern("map")), _35val2170, _35reg2171);
 }
@@ -3379,7 +3379,7 @@ coraCall(co, 1, _35cc1300);
 
 void _35clofun2990(struct Cora* co) {
 Obj _35val2125 = co->args[1];
-Obj next = co->stack[co->base + 0];
+Obj next = co->stk.stack[co->stk.base + 0];
 Obj exp = _35val2125;
 Obj _35reg2126 = primCar(exp);
 pushCont(co, _35clofun2991, 2, next, exp);
@@ -3388,8 +3388,8 @@ coraCall(co, 2, globalRef(intern("pair?")), _35reg2126);
 
 void _35clofun2991(struct Cora* co) {
 Obj _35val2127 = co->args[1];
-Obj next = co->stack[co->base + 0];
-Obj exp = co->stack[co->base + 1];
+Obj next = co->stk.stack[co->stk.base + 0];
+Obj exp = co->stk.stack[co->stk.base + 1];
 if (True == _35val2127) {
 pushCont(co, _35clofun2992, 2, next, exp);
 coraCall(co, 2, globalRef(intern("caar")), exp);
@@ -3416,8 +3416,8 @@ coraCall(co, 2, next, val);
 
 void _35clofun2995(struct Cora* co) {
 Obj _35val2159 = co->args[1];
-Obj _35reg2158 = co->stack[co->base + 0];
-Obj exp = co->stack[co->base + 1];
+Obj _35reg2158 = co->stk.stack[co->stk.base + 0];
+Obj exp = co->stk.stack[co->stk.base + 1];
 Obj _35reg2160 = primCons(_35val2159, Nil);
 Obj _35reg2161 = primCons(_35reg2158, _35reg2160);
 Obj _35reg2162 = primCons(intern("continuation"), _35reg2161);
@@ -3430,8 +3430,8 @@ return;
 
 void _35clofun2992(struct Cora* co) {
 Obj _35val2128 = co->args[1];
-Obj next = co->stack[co->base + 0];
-Obj exp = co->stack[co->base + 1];
+Obj next = co->stk.stack[co->stk.base + 0];
+Obj exp = co->stk.stack[co->stk.base + 1];
 Obj _35reg2129 = primEQ(_35val2128, intern("%builtin"));
 if (True == _35reg2129) {
 if (True == True) {
@@ -3474,8 +3474,8 @@ coraCall(co, 2, next, val);
 
 void _35clofun2994(struct Cora* co) {
 Obj _35val2147 = co->args[1];
-Obj _35reg2146 = co->stack[co->base + 0];
-Obj exp = co->stack[co->base + 1];
+Obj _35reg2146 = co->stk.stack[co->stk.base + 0];
+Obj exp = co->stk.stack[co->stk.base + 1];
 Obj _35reg2148 = primCons(_35val2147, Nil);
 Obj _35reg2149 = primCons(_35reg2146, _35reg2148);
 Obj _35reg2150 = primCons(intern("continuation"), _35reg2149);
@@ -3488,8 +3488,8 @@ return;
 
 void _35clofun2993(struct Cora* co) {
 Obj _35val2135 = co->args[1];
-Obj _35reg2134 = co->stack[co->base + 0];
-Obj exp = co->stack[co->base + 1];
+Obj _35reg2134 = co->stk.stack[co->stk.base + 0];
+Obj exp = co->stk.stack[co->stk.base + 1];
 Obj _35reg2136 = primCons(_35val2135, Nil);
 Obj _35reg2137 = primCons(_35reg2134, _35reg2136);
 Obj _35reg2138 = primCons(intern("continuation"), _35reg2137);
@@ -3547,9 +3547,9 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 
 void _35clofun2985(struct Cora* co) {
 Obj _35val2118 = co->args[1];
-Obj next = co->stack[co->base + 0];
-Obj x = co->stack[co->base + 1];
-Obj _35cc1290 = co->stack[co->base + 2];
+Obj next = co->stk.stack[co->stk.base + 0];
+Obj x = co->stk.stack[co->stk.base + 1];
+Obj _35cc1290 = co->stk.stack[co->stk.base + 2];
 if (True == _35val2118) {
 if (True == True) {
 coraCall(co, 2, next, x);
@@ -3575,8 +3575,8 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 
 void _35clofun2984(struct Cora* co) {
 Obj _35val2116 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj _35cc1291 = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj _35cc1291 = co->stk.stack[co->stk.base + 1];
 if (True == _35val2116) {
 coraReturn(co, x);
 return;
@@ -3652,15 +3652,15 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), cl
 
 void _35clofun2982(struct Cora* co) {
 Obj _35val2110 = co->args[1];
-Obj ra = co->stack[co->base + 0];
+Obj ra = co->stk.stack[co->stk.base + 0];
 pushCont(co, _35clofun2983, 2, _35val2110, ra);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 1), closureRef(co, 2));
 }
 
 void _35clofun2983(struct Cora* co) {
 Obj _35val2111 = co->args[1];
-Obj _35val2110 = co->stack[co->base + 0];
-Obj ra = co->stack[co->base + 1];
+Obj _35val2110 = co->stk.stack[co->stk.base + 0];
+Obj ra = co->stk.stack[co->stk.base + 1];
 Obj _35reg2112 = primCons(_35val2111, Nil);
 Obj _35reg2113 = primCons(_35val2110, _35reg2112);
 Obj _35reg2114 = primCons(ra, _35reg2113);
@@ -3727,7 +3727,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), cl
 
 void _35clofun2980(struct Cora* co) {
 Obj _35val2080 = co->args[1];
-Obj ra = co->stack[co->base + 0];
+Obj ra = co->stk.stack[co->stk.base + 0];
 Obj _35reg2081 = primCons(_35val2080, Nil);
 Obj _35reg2082 = primCons(ra, _35reg2081);
 Obj _35reg2083 = primCons(intern("do"), _35reg2082);
@@ -3802,7 +3802,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 1), cl
 
 void _35clofun2978(struct Cora* co) {
 Obj _35val2057 = co->args[1];
-Obj rb = co->stack[co->base + 0];
+Obj rb = co->stk.stack[co->stk.base + 0];
 Obj _35reg2058 = primCons(_35val2057, Nil);
 Obj _35reg2059 = primCons(rb, _35reg2058);
 Obj _35reg2060 = primCons(closureRef(co, 0), _35reg2059);
@@ -3893,9 +3893,9 @@ coraCall(co, 1, _35cc1295);
 
 void _35clofun2976(struct Cora* co) {
 Obj _35val2025 = co->args[1];
-Obj args = co->stack[co->base + 0];
-Obj frees = co->stack[co->base + 1];
-Obj next = co->stack[co->base + 2];
+Obj args = co->stk.stack[co->stk.base + 0];
+Obj frees = co->stk.stack[co->stk.base + 1];
+Obj next = co->stk.stack[co->stk.base + 2];
 Obj _35reg2026 = primCons(_35val2025, Nil);
 Obj _35reg2027 = primCons(args, _35reg2026);
 Obj _35reg2028 = primCons(intern("lambda"), _35reg2027);
@@ -3944,8 +3944,8 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 
 void _35clofun2966(struct Cora* co) {
 Obj _35val1978 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj _35cc1283 = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj _35cc1283 = co->stk.stack[co->stk.base + 1];
 if (True == _35val1978) {
 coraReturn(co, x);
 return;
@@ -3969,7 +3969,7 @@ coraCall(co, 1, _35cc1284);
 
 void _35clofun2965(struct Cora* co) {
 Obj _35val1974 = co->args[1];
-Obj var = co->stack[co->base + 0];
+Obj var = co->stk.stack[co->stk.base + 0];
 Obj pos = _35val1974;
 Obj _35reg1975 = primEQ(makeNumber(-1), pos);
 if (True == _35reg1975) {
@@ -4034,9 +4034,9 @@ coraCall(co, 1, _35cc1285);
 
 void _35clofun2961(struct Cora* co) {
 Obj _35val1964 = co->args[1];
-Obj body = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
-Obj fvs = co->stack[co->base + 2];
+Obj body = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
+Obj fvs = co->stk.stack[co->stk.base + 2];
 Obj fvs1 = _35val1964;
 pushCont(co, _35clofun2962, 3, args, fvs, fvs1);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs1, body);
@@ -4044,9 +4044,9 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs1, body);
 
 void _35clofun2962(struct Cora* co) {
 Obj _35val1965 = co->args[1];
-Obj args = co->stack[co->base + 0];
-Obj fvs = co->stack[co->base + 1];
-Obj fvs1 = co->stack[co->base + 2];
+Obj args = co->stk.stack[co->stk.base + 0];
+Obj fvs = co->stk.stack[co->stk.base + 1];
+Obj fvs1 = co->stk.stack[co->stk.base + 2];
 Obj _35reg1966 = primCons(_35val1965, Nil);
 Obj _35reg1967 = primCons(args, _35reg1966);
 Obj _35reg1968 = primCons(intern("lambda"), _35reg1967);
@@ -4056,15 +4056,15 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert")), fvs);
 
 void _35clofun2963(struct Cora* co) {
 Obj _35val1969 = co->args[1];
-Obj fvs1 = co->stack[co->base + 0];
-Obj _35reg1968 = co->stack[co->base + 1];
+Obj fvs1 = co->stk.stack[co->stk.base + 0];
+Obj _35reg1968 = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun2964, 1, _35reg1968);
 coraCall(co, 3, globalRef(intern("map")), _35val1969, fvs1);
 }
 
 void _35clofun2964(struct Cora* co) {
 Obj _35val1970 = co->args[1];
-Obj _35reg1968 = co->stack[co->base + 0];
+Obj _35reg1968 = co->stk.stack[co->stk.base + 0];
 Obj _35reg1971 = primCons(_35reg1968, _35val1970);
 Obj _35reg1972 = primCons(intern("%closure"), _35reg1971);
 coraReturn(co, _35reg1972);
@@ -4133,17 +4133,17 @@ coraCall(co, 1, _35cc1286);
 
 void _35clofun2959(struct Cora* co) {
 Obj _35val1938 = co->args[1];
-Obj fvs = co->stack[co->base + 0];
-Obj c = co->stack[co->base + 1];
-Obj a = co->stack[co->base + 2];
+Obj fvs = co->stk.stack[co->stk.base + 0];
+Obj c = co->stk.stack[co->stk.base + 1];
+Obj a = co->stk.stack[co->stk.base + 2];
 pushCont(co, _35clofun2960, 2, _35val1938, a);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs, c);
 }
 
 void _35clofun2960(struct Cora* co) {
 Obj _35val1939 = co->args[1];
-Obj _35val1938 = co->stack[co->base + 0];
-Obj a = co->stack[co->base + 1];
+Obj _35val1938 = co->stk.stack[co->stk.base + 0];
+Obj a = co->stk.stack[co->stk.base + 1];
 Obj _35reg1940 = primCons(_35val1939, Nil);
 Obj _35reg1941 = primCons(_35val1938, _35reg1940);
 Obj _35reg1942 = primCons(a, _35reg1941);
@@ -4170,8 +4170,8 @@ coraCall(co, 1, _35cc1287);
 
 void _35clofun2958(struct Cora* co) {
 Obj _35val1910 = co->args[1];
-Obj f = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
+Obj f = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
 Obj _35reg1911 = primCons(f, args);
 coraCall(co, 3, globalRef(intern("map")), _35val1910, _35reg1911);
 }
@@ -4190,7 +4190,7 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 
 void _35clofun2951(struct Cora* co) {
 Obj _35val1905 = co->args[1];
-Obj _35cc1269 = co->stack[co->base + 0];
+Obj _35cc1269 = co->stk.stack[co->stk.base + 0];
 if (True == _35val1905) {
 coraReturn(co, Nil);
 return;
@@ -4259,7 +4259,7 @@ coraCall(co, 1, _35cc1271);
 
 void _35clofun2950(struct Cora* co) {
 Obj _35val1902 = co->args[1];
-Obj args = co->stack[co->base + 0];
+Obj args = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1902, args);
 }
 
@@ -4443,16 +4443,16 @@ coraCall(co, 1, _35cc1274);
 
 void _35clofun2945(struct Cora* co) {
 Obj _35val1831 = co->args[1];
-Obj c = co->stack[co->base + 0];
-Obj a = co->stack[co->base + 1];
+Obj c = co->stk.stack[co->stk.base + 0];
+Obj a = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun2946, 2, a, _35val1831);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), c);
 }
 
 void _35clofun2946(struct Cora* co) {
 Obj _35val1832 = co->args[1];
-Obj a = co->stack[co->base + 0];
-Obj _35val1831 = co->stack[co->base + 1];
+Obj a = co->stk.stack[co->stk.base + 0];
+Obj _35val1831 = co->stk.stack[co->stk.base + 1];
 Obj _35reg1833 = primCons(a, Nil);
 pushCont(co, _35clofun2947, 1, _35val1831);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1832, _35reg1833);
@@ -4460,7 +4460,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1832, _35reg1833);
 
 void _35clofun2947(struct Cora* co) {
 Obj _35val1834 = co->args[1];
-Obj _35val1831 = co->stack[co->base + 0];
+Obj _35val1831 = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), _35val1831, _35val1834);
 }
 
@@ -4656,7 +4656,7 @@ coraCall(co, 1, _35cc1279);
 
 void _35clofun2943(struct Cora* co) {
 Obj _35val1754 = co->args[1];
-Obj arg = co->stack[co->base + 0];
+Obj arg = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1754, arg);
 }
 
@@ -4894,9 +4894,9 @@ coraCall(co, 1, _35cc1259);
 
 void _35clofun2921(struct Cora* co) {
 Obj _35val1678 = co->args[1];
-Obj y = co->stack[co->base + 0];
-Obj s2 = co->stack[co->base + 1];
-Obj _35cc1259 = co->stack[co->base + 2];
+Obj y = co->stk.stack[co->stk.base + 0];
+Obj s2 = co->stk.stack[co->stk.base + 1];
+Obj _35cc1259 = co->stk.stack[co->stk.base + 2];
 if (True == _35val1678) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), y, s2);
 } else {
@@ -4922,7 +4922,7 @@ coraCall(co, 1, _35cc1260);
 
 void _35clofun2920(struct Cora* co) {
 Obj _35val1673 = co->args[1];
-Obj x = co->stack[co->base + 0];
+Obj x = co->stk.stack[co->stk.base + 0];
 Obj _35reg1674 = primCons(x, _35val1673);
 coraReturn(co, _35reg1674);
 return;
@@ -4964,9 +4964,9 @@ coraCall(co, 1, _35cc1254);
 
 void _35clofun2915(struct Cora* co) {
 Obj _35val1667 = co->args[1];
-Obj y = co->stack[co->base + 0];
-Obj s2 = co->stack[co->base + 1];
-Obj _35cc1254 = co->stack[co->base + 2];
+Obj y = co->stk.stack[co->stk.base + 0];
+Obj s2 = co->stk.stack[co->stk.base + 1];
+Obj _35cc1254 = co->stk.stack[co->stk.base + 2];
 if (True == _35val1667) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), y, s2);
 } else {
@@ -4992,7 +4992,7 @@ coraCall(co, 1, _35cc1255);
 
 void _35clofun2914(struct Cora* co) {
 Obj _35val1662 = co->args[1];
-Obj x = co->stack[co->base + 0];
+Obj x = co->stk.stack[co->stk.base + 0];
 Obj _35reg1663 = primCons(x, _35val1662);
 coraReturn(co, _35reg1663);
 return;
@@ -5014,8 +5014,8 @@ coraCall(co, 2, globalRef(intern("number?")), x);
 
 void _35clofun2907(struct Cora* co) {
 Obj _35val1644 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj _35cc1242 = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj _35cc1242 = co->stk.stack[co->stk.base + 1];
 if (True == _35val1644) {
 if (True == True) {
 Obj _35reg1645 = primCons(x, Nil);
@@ -5045,8 +5045,8 @@ coraCall(co, 2, globalRef(intern("boolean?")), x);
 
 void _35clofun2908(struct Cora* co) {
 Obj _35val1650 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj _35cc1242 = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj _35cc1242 = co->stk.stack[co->stk.base + 1];
 if (True == _35val1650) {
 if (True == True) {
 Obj _35reg1651 = primCons(x, Nil);
@@ -5064,8 +5064,8 @@ coraCall(co, 2, globalRef(intern("null?")), x);
 
 void _35clofun2909(struct Cora* co) {
 Obj _35val1653 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj _35cc1242 = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj _35cc1242 = co->stk.stack[co->stk.base + 1];
 if (True == _35val1653) {
 if (True == True) {
 Obj _35reg1654 = primCons(x, Nil);
@@ -5138,7 +5138,7 @@ coraCall(co, 1, _35cc1244);
 
 void _35clofun2906(struct Cora* co) {
 Obj _35val1629 = co->args[1];
-Obj x = co->stack[co->base + 0];
+Obj x = co->stk.stack[co->stk.base + 0];
 if (True == _35val1629) {
 coraReturn(co, x);
 return;
@@ -5198,15 +5198,15 @@ coraCall(co, 1, _35cc1245);
 
 void _35clofun2904(struct Cora* co) {
 Obj _35val1623 = co->args[1];
-Obj body = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
+Obj body = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun2905, 1, args);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35val1623, body);
 }
 
 void _35clofun2905(struct Cora* co) {
 Obj _35val1624 = co->args[1];
-Obj args = co->stack[co->base + 0];
+Obj args = co->stk.stack[co->stk.base + 0];
 Obj _35reg1625 = primCons(_35val1624, Nil);
 Obj _35reg1626 = primCons(args, _35reg1625);
 Obj _35reg1627 = primCons(intern("lambda"), _35reg1626);
@@ -5236,7 +5236,7 @@ coraCall(co, 1, _35cc1246);
 
 void _35clofun2902(struct Cora* co) {
 Obj _35val1603 = co->args[1];
-Obj args = co->stack[co->base + 0];
+Obj args = co->stk.stack[co->stk.base + 0];
 pushCont(co, _35clofun2903, 0);
 coraCall(co, 3, globalRef(intern("map")), _35val1603, args);
 }
@@ -5296,15 +5296,15 @@ coraCall(co, 1, _35cc1247);
 
 void _35clofun2900(struct Cora* co) {
 Obj _35val1594 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj y = co->stack[co->base + 1];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj y = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun2901, 1, _35val1594);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, y);
 }
 
 void _35clofun2901(struct Cora* co) {
 Obj _35val1595 = co->args[1];
-Obj _35val1594 = co->stack[co->base + 0];
+Obj _35val1594 = co->stk.stack[co->stk.base + 0];
 Obj _35reg1596 = primCons(_35val1595, Nil);
 Obj _35reg1597 = primCons(_35val1594, _35reg1596);
 Obj _35reg1598 = primCons(intern("do"), _35reg1597);
@@ -5374,9 +5374,9 @@ coraCall(co, 1, _35cc1248);
 
 void _35clofun2898(struct Cora* co) {
 Obj _35val1570 = co->args[1];
-Obj env = co->stack[co->base + 0];
-Obj c = co->stack[co->base + 1];
-Obj a = co->stack[co->base + 2];
+Obj env = co->stk.stack[co->stk.base + 0];
+Obj c = co->stk.stack[co->stk.base + 1];
+Obj a = co->stk.stack[co->stk.base + 2];
 Obj _35reg1571 = primCons(a, env);
 pushCont(co, _35clofun2899, 2, _35val1570, a);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35reg1571, c);
@@ -5384,8 +5384,8 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35reg1571, c);
 
 void _35clofun2899(struct Cora* co) {
 Obj _35val1572 = co->args[1];
-Obj _35val1570 = co->stack[co->base + 0];
-Obj a = co->stack[co->base + 1];
+Obj _35val1570 = co->stk.stack[co->stk.base + 0];
+Obj a = co->stk.stack[co->stk.base + 1];
 Obj _35reg1573 = primCons(_35val1572, Nil);
 Obj _35reg1574 = primCons(_35val1570, _35reg1573);
 Obj _35reg1575 = primCons(a, _35reg1574);
@@ -5412,10 +5412,10 @@ coraCall(co, 1, _35cc1249);
 
 void _35clofun2891(struct Cora* co) {
 Obj _35val1527 = co->args[1];
-Obj op = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
-Obj _35cc1249 = co->stack[co->base + 3];
+Obj op = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
+Obj _35cc1249 = co->stk.stack[co->stk.base + 3];
 if (True == _35val1527) {
 pushCont(co, _35clofun2892, 3, op, args, env);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.builtin->args")), op);
@@ -5426,9 +5426,9 @@ coraCall(co, 1, _35cc1249);
 
 void _35clofun2892(struct Cora* co) {
 Obj _35val1528 = co->args[1];
-Obj op = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
+Obj op = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
 Obj required = _35val1528;
 pushCont(co, _35clofun2893, 4, required, op, args, env);
 coraCall(co, 2, globalRef(intern("length")), args);
@@ -5436,10 +5436,10 @@ coraCall(co, 2, globalRef(intern("length")), args);
 
 void _35clofun2893(struct Cora* co) {
 Obj _35val1529 = co->args[1];
-Obj required = co->stack[co->base + 0];
-Obj op = co->stack[co->base + 1];
-Obj args = co->stack[co->base + 2];
-Obj env = co->stack[co->base + 3];
+Obj required = co->stk.stack[co->stk.base + 0];
+Obj op = co->stk.stack[co->stk.base + 1];
+Obj args = co->stk.stack[co->stk.base + 2];
+Obj env = co->stk.stack[co->stk.base + 3];
 Obj provided = _35val1529;
 Obj _35reg1530 = primEQ(required, provided);
 if (True == _35reg1530) {
@@ -5461,9 +5461,9 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("primitive call mismatch
 
 void _35clofun2896(struct Cora* co) {
 Obj _35val1538 = co->args[1];
-Obj op = co->stack[co->base + 0];
-Obj args = co->stack[co->base + 1];
-Obj env = co->stack[co->base + 2];
+Obj op = co->stk.stack[co->stk.base + 0];
+Obj args = co->stk.stack[co->stk.base + 1];
+Obj env = co->stk.stack[co->stk.base + 2];
 Obj tmp = _35val1538;
 Obj _35reg1539 = primCons(op, args);
 pushCont(co, _35clofun2897, 2, tmp, env);
@@ -5472,8 +5472,8 @@ coraCall(co, 3, globalRef(intern("append")), _35reg1539, tmp);
 
 void _35clofun2897(struct Cora* co) {
 Obj _35val1540 = co->args[1];
-Obj tmp = co->stack[co->base + 0];
-Obj env = co->stack[co->base + 1];
+Obj tmp = co->stk.stack[co->stk.base + 0];
+Obj env = co->stk.stack[co->stk.base + 1];
 Obj _35reg1541 = primCons(_35val1540, Nil);
 Obj _35reg1542 = primCons(tmp, _35reg1541);
 Obj _35reg1543 = primCons(intern("lambda"), _35reg1542);
@@ -5482,15 +5482,15 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, _35reg1543);
 
 void _35clofun2894(struct Cora* co) {
 Obj _35val1533 = co->args[1];
-Obj args = co->stack[co->base + 0];
-Obj _35reg1532 = co->stack[co->base + 1];
+Obj args = co->stk.stack[co->stk.base + 0];
+Obj _35reg1532 = co->stk.stack[co->stk.base + 1];
 pushCont(co, _35clofun2895, 1, _35reg1532);
 coraCall(co, 3, globalRef(intern("map")), _35val1533, args);
 }
 
 void _35clofun2895(struct Cora* co) {
 Obj _35val1534 = co->args[1];
-Obj _35reg1532 = co->stack[co->base + 0];
+Obj _35reg1532 = co->stk.stack[co->stk.base + 0];
 Obj _35reg1535 = primCons(_35reg1532, _35val1534);
 coraReturn(co, _35reg1535);
 return;
@@ -5506,7 +5506,7 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.parse")), env);
 
 void _35clofun2890(struct Cora* co) {
 Obj _35val1523 = co->args[1];
-Obj ls = co->stack[co->base + 0];
+Obj ls = co->stk.stack[co->stk.base + 0];
 coraCall(co, 3, globalRef(intern("map")), _35val1523, ls);
 }
 
@@ -5557,7 +5557,7 @@ coraCall(co, 2, globalRef(intern("null?")), find);
 
 void _35clofun2876(struct Cora* co) {
 Obj _35val1516 = co->args[1];
-Obj find = co->stack[co->base + 0];
+Obj find = co->stk.stack[co->stk.base + 0];
 if (True == _35val1516) {
 coraReturn(co, makeString1("ERROR"));
 return;
@@ -5581,7 +5581,7 @@ coraCall(co, 2, globalRef(intern("null?")), find);
 
 void _35clofun2873(struct Cora* co) {
 Obj _35val1513 = co->args[1];
-Obj find = co->stack[co->base + 0];
+Obj find = co->stk.stack[co->stk.base + 0];
 if (True == _35val1513) {
 coraReturn(co, makeString1("ERROR"));
 return;
@@ -5641,8 +5641,8 @@ coraCall(co, 1, _35cc1235);
 
 void _35clofun2867(struct Cora* co) {
 Obj _35val1435 = co->args[1];
-Obj x = co->stack[co->base + 0];
-Obj tl = co->stack[co->base + 1];
+Obj x = co->stk.stack[co->stk.base + 0];
+Obj tl = co->stk.stack[co->stk.base + 1];
 Obj _35reg1436 = primLT(_35val1435, makeNumber(0));
 if (True == _35reg1436) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.exist-in-env")), x, tl);
@@ -5756,8 +5756,8 @@ coraCall(co, 1, _35cc1225);
 
 void _35clofun2858(struct Cora* co) {
 Obj _35val1418 = co->args[1];
-Obj f = co->stack[co->base + 0];
-Obj y = co->stack[co->base + 1];
+Obj f = co->stk.stack[co->stk.base + 0];
+Obj y = co->stk.stack[co->stk.base + 1];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), f, _35val1418, y);
 }
 

--- a/toc.c
+++ b/toc.c
@@ -530,7 +530,7 @@ coraCall(co, 2, globalRef(intern("number?")), exp);
 
 void _35clofun3201(struct Cora* co) {
 Obj _35val2809 = co->args[1];
-Obj exp = co->stk.stack[co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val2809) {
 if (True == True) {
 coraReturn(co, exp);
@@ -582,7 +582,7 @@ coraCall(co, 2, globalRef(intern("boolean?")), exp);
 
 void _35clofun3206(struct Cora* co) {
 Obj _35val2825 = co->args[1];
-Obj exp = co->stk.stack[co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val2825) {
 if (True == True) {
 coraReturn(co, exp);
@@ -611,7 +611,7 @@ coraCall(co, 2, globalRef(intern("null?")), exp);
 
 void _35clofun3209(struct Cora* co) {
 Obj _35val2833 = co->args[1];
-Obj exp = co->stk.stack[co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val2833) {
 if (True == True) {
 coraReturn(co, exp);
@@ -657,7 +657,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 
 void _35clofun3212(struct Cora* co) {
 Obj _35val2845 = co->args[1];
-Obj exp = co->stk.stack[co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2846 = primCdr(exp);
 pushCont(co, _35clofun3213, 1, _35val2845);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2846);
@@ -665,13 +665,13 @@ coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")
 
 void _35clofun3213(struct Cora* co) {
 Obj _35val2847 = co->args[1];
-Obj _35val2845 = co->stk.stack[co->stk.base + 0];
+Obj _35val2845 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("apply")), _35val2845, _35val2847);
 }
 
 void _35clofun3210(struct Cora* co) {
 Obj _35val2838 = co->args[1];
-Obj exp = co->stk.stack[co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2839 = primCdr(exp);
 pushCont(co, _35clofun3211, 1, _35val2838);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2839);
@@ -679,13 +679,13 @@ coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")
 
 void _35clofun3211(struct Cora* co) {
 Obj _35val2840 = co->args[1];
-Obj _35val2838 = co->stk.stack[co->stk.base + 0];
+Obj _35val2838 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("apply")), _35val2838, _35val2840);
 }
 
 void _35clofun3207(struct Cora* co) {
 Obj _35val2830 = co->args[1];
-Obj exp = co->stk.stack[co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2831 = primCdr(exp);
 pushCont(co, _35clofun3208, 1, _35val2830);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2831);
@@ -693,13 +693,13 @@ coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")
 
 void _35clofun3208(struct Cora* co) {
 Obj _35val2832 = co->args[1];
-Obj _35val2830 = co->stk.stack[co->stk.base + 0];
+Obj _35val2830 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("apply")), _35val2830, _35val2832);
 }
 
 void _35clofun3204(struct Cora* co) {
 Obj _35val2822 = co->args[1];
-Obj exp = co->stk.stack[co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2823 = primCdr(exp);
 pushCont(co, _35clofun3205, 1, _35val2822);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2823);
@@ -707,13 +707,13 @@ coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")
 
 void _35clofun3205(struct Cora* co) {
 Obj _35val2824 = co->args[1];
-Obj _35val2822 = co->stk.stack[co->stk.base + 0];
+Obj _35val2822 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("apply")), _35val2822, _35val2824);
 }
 
 void _35clofun3202(struct Cora* co) {
 Obj _35val2814 = co->args[1];
-Obj exp = co->stk.stack[co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2815 = primCdr(exp);
 pushCont(co, _35clofun3203, 1, _35val2814);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2815);
@@ -721,7 +721,7 @@ coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")
 
 void _35clofun3203(struct Cora* co) {
 Obj _35val2816 = co->args[1];
-Obj _35val2814 = co->stk.stack[co->stk.base + 0];
+Obj _35val2814 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("apply")), _35val2814, _35val2816);
 }
 
@@ -857,7 +857,7 @@ coraCall(co, 3, globalRef(intern("read-file-as-sexp")), from, pkg_45str);
 
 void _35clofun3179(struct Cora* co) {
 Obj _35val2770 = co->args[1];
-Obj to = co->stk.stack[co->stk.base + 0];
+Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj sexp = _35val2770;
 pushCont(co, _35clofun3180, 1, to);
 coraCall(co, 2, globalRef(intern("macroexpand")), sexp);
@@ -865,7 +865,7 @@ coraCall(co, 2, globalRef(intern("macroexpand")), sexp);
 
 void _35clofun3180(struct Cora* co) {
 Obj _35val2771 = co->args[1];
-Obj to = co->stk.stack[co->stk.base + 0];
+Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj input = _35val2771;
 pushCont(co, _35clofun3181, 1, to);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.compile")), input);
@@ -873,7 +873,7 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.compile")), input);
 
 void _35clofun3181(struct Cora* co) {
 Obj _35val2772 = co->args[1];
-Obj to = co->stk.stack[co->stk.base + 0];
+Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = _35val2772;
 pushCont(co, _35clofun3182, 1, bc);
 coraCall(co, 2, globalRef(intern("cora/lib/io.open-output-file")), to);
@@ -881,7 +881,7 @@ coraCall(co, 2, globalRef(intern("cora/lib/io.open-output-file")), to);
 
 void _35clofun3182(struct Cora* co) {
 Obj _35val2773 = co->args[1];
-Obj bc = co->stk.stack[co->stk.base + 0];
+Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stream = _35val2773;
 pushCont(co, _35clofun3183, 1, stream);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.generate-c")), stream, bc);
@@ -889,7 +889,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.generate-c")), stream, bc);
 
 void _35clofun3183(struct Cora* co) {
 Obj _35val2774 = co->args[1];
-Obj stream = co->stk.stack[co->stk.base + 0];
+Obj stream = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 2, globalRef(intern("cora/lib/io.close-output-file")), stream);
 }
 
@@ -902,32 +902,32 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, mak
 
 void _35clofun3171(struct Cora* co) {
 Obj _35val2763 = co->args[1];
-Obj to = co->stk.stack[co->stk.base + 0];
-Obj bc = co->stk.stack[co->stk.base + 1];
+Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3172, 2, to, bc);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("#include \"runtime.h\"\n\n"));
 }
 
 void _35clofun3172(struct Cora* co) {
 Obj _35val2764 = co->args[1];
-Obj to = co->stk.stack[co->stk.base + 0];
-Obj bc = co->stk.stack[co->stk.base + 1];
+Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3175, 2, to, bc);
 coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3173, 1, 1, to), bc);
 }
 
 void _35clofun3175(struct Cora* co) {
 Obj _35val2767 = co->args[1];
-Obj to = co->stk.stack[co->stk.base + 0];
-Obj bc = co->stk.stack[co->stk.base + 1];
+Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3176, 2, to, bc);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("\n"));
 }
 
 void _35clofun3176(struct Cora* co) {
 Obj _35val2768 = co->args[1];
-Obj to = co->stk.stack[co->stk.base + 0];
-Obj bc = co->stk.stack[co->stk.base + 1];
+Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
 coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3177, 1, 1, to), bc);
 }
 
@@ -980,8 +980,8 @@ coraCall(co, 1, _35cc1371);
 
 void _35clofun3169(struct Cora* co) {
 Obj _35val2760 = co->args[1];
-Obj fn = co->stk.stack[co->stk.base + 0];
-Obj y = co->stk.stack[co->stk.base + 1];
+Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
 coraCall(co, 3, globalRef(intern("for-each")), fn, y);
 }
 
@@ -1026,7 +1026,7 @@ coraCall(co, 2, globalRef(intern("cadr")), exp);
 
 void _35clofun3158(struct Cora* co) {
 Obj _35val2749 = co->args[1];
-Obj exp = co->stk.stack[co->stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj obj = _35val2749;
 pushCont(co, _35clofun3159, 1, obj);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
@@ -1034,7 +1034,7 @@ coraCall(co, 2, globalRef(intern("cddr")), exp);
 
 void _35clofun3159(struct Cora* co) {
 Obj _35val2750 = co->args[1];
-Obj obj = co->stk.stack[co->stk.base + 0];
+Obj obj = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fns = _35val2750;
 coraCall(co, 3, globalRef(intern("cora/lib/toc.rewrite-->macro")), obj, fns);
 }
@@ -1215,46 +1215,46 @@ coraCall(co, 1, _35cc1363);
 
 void _35clofun3143(struct Cora* co) {
 Obj _35val2724 = co->args[1];
-Obj actives = co->stk.stack[co->stk.base + 0];
-Obj params = co->stk.stack[co->stk.base + 1];
-Obj body = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
+Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, _35clofun3144, 4, actives, params, body, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" {\n"));
 }
 
 void _35clofun3144(struct Cora* co) {
 Obj _35val2725 = co->args[1];
-Obj actives = co->stk.stack[co->stk.base + 0];
-Obj params = co->stk.stack[co->stk.base + 1];
-Obj body = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
+Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, _35clofun3145, 4, actives, params, body, w);
 coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->args["), makeNumber(1), params);
 }
 
 void _35clofun3145(struct Cora* co) {
 Obj _35val2726 = co->args[1];
-Obj actives = co->stk.stack[co->stk.base + 0];
-Obj params = co->stk.stack[co->stk.base + 1];
-Obj body = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
+Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, _35clofun3146, 3, params, body, w);
-coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->stk.stack[co->stk.base + "), makeNumber(0), actives);
+coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->ctx.stk.stack[co->ctx.stk.base + "), makeNumber(0), actives);
 }
 
 void _35clofun3146(struct Cora* co) {
 Obj _35val2727 = co->args[1];
-Obj params = co->stk.stack[co->stk.base + 0];
-Obj body = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj params = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3147, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), params, w, body);
 }
 
 void _35clofun3147(struct Cora* co) {
 Obj _35val2728 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("}\n\n"));
 }
 
@@ -1303,56 +1303,56 @@ coraCall(co, 1, _35cc1360);
 
 void _35clofun3136(struct Cora* co) {
 Obj _35val2665 = co->args[1];
-Obj a = co->stk.stack[co->stk.base + 0];
-Obj idx = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
-Obj dest_45str = co->stk.stack[co->stk.base + 4];
-Obj b = co->stk.stack[co->stk.base + 5];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 5];
 pushCont(co, _35clofun3137, 5, idx, env, w, dest_45str, b);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
 void _35clofun3137(struct Cora* co) {
 Obj _35val2666 = co->args[1];
-Obj idx = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj dest_45str = co->stk.stack[co->stk.base + 3];
-Obj b = co->stk.stack[co->stk.base + 4];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3138, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, dest_45str);
 }
 
 void _35clofun3138(struct Cora* co) {
 Obj _35val2667 = co->args[1];
-Obj idx = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj dest_45str = co->stk.stack[co->stk.base + 3];
-Obj b = co->stk.stack[co->stk.base + 4];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3139, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
 void _35clofun3139(struct Cora* co) {
 Obj _35val2668 = co->args[1];
-Obj idx = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj dest_45str = co->stk.stack[co->stk.base + 3];
-Obj b = co->stk.stack[co->stk.base + 4];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3140, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("];\n"));
 }
 
 void _35clofun3140(struct Cora* co) {
 Obj _35val2669 = co->args[1];
-Obj idx = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj dest_45str = co->stk.stack[co->stk.base + 3];
-Obj b = co->stk.stack[co->stk.base + 4];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj _35reg2670 = primAdd(idx, makeNumber(1));
 coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), env, w, dest_45str, _35reg2670, b);
 }
@@ -1370,22 +1370,22 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 
 void _35clofun3130(struct Cora* co) {
 Obj _35val2658 = co->args[1];
-Obj name = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj name = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3131, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, name);
 }
 
 void _35clofun3131(struct Cora* co) {
 Obj _35val2659 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 pushCont(co, _35clofun3132, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("(struct Cora* co"));
 }
 
 void _35clofun3132(struct Cora* co) {
 Obj _35val2660 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
@@ -1434,20 +1434,20 @@ coraCall(co, 1, _35cc1353);
 
 void _35clofun3125(struct Cora* co) {
 Obj _35val2651 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj fn = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj b = co->stk.stack[co->stk.base + 3];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, _35clofun3126, 4, env, fn, w, b);
 coraCall(co, 2, globalRef(intern("null?")), b);
 }
 
 void _35clofun3126(struct Cora* co) {
 Obj _35val2652 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj fn = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj b = co->stk.stack[co->stk.base + 3];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj _35reg2653 = primNot(_35val2652);
 if (True == _35reg2653) {
 pushCont(co, _35clofun3127, 4, env, fn, w, b);
@@ -1460,10 +1460,10 @@ coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-inst-list-h")), env, fn,
 
 void _35clofun3127(struct Cora* co) {
 Obj _35val2654 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj fn = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj b = co->stk.stack[co->stk.base + 3];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
 coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-inst-list-h")), env, fn, w, b);
 }
 
@@ -1505,49 +1505,49 @@ coraCall(co, 1, _35cc1347);
 
 void _35clofun3113(struct Cora* co) {
 Obj _35val2638 = co->args[1];
-Obj label = co->stk.stack[co->stk.base + 0];
-Obj stacks = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj label = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3114, 2, stacks, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, label);
 }
 
 void _35clofun3114(struct Cora* co) {
 Obj _35val2639 = co->args[1];
-Obj stacks = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3115, 2, stacks, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 }
 
 void _35clofun3115(struct Cora* co) {
 Obj _35val2640 = co->args[1];
-Obj stacks = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3116, 2, stacks, w);
 coraCall(co, 2, globalRef(intern("length")), stacks);
 }
 
 void _35clofun3116(struct Cora* co) {
 Obj _35val2641 = co->args[1];
-Obj stacks = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3117, 2, stacks, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2641);
 }
 
 void _35clofun3117(struct Cora* co) {
 Obj _35val2642 = co->args[1];
-Obj stacks = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3118, 2, stacks, w);
 coraCall(co, 2, globalRef(intern("null?")), stacks);
 }
 
 void _35clofun3118(struct Cora* co) {
 Obj _35val2643 = co->args[1];
-Obj stacks = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg2644 = primNot(_35val2643);
 if (True == _35reg2644) {
 pushCont(co, _35clofun3121, 1, w);
@@ -1560,7 +1560,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 
 void _35clofun3121(struct Cora* co) {
 Obj _35val2646 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
 }
 
@@ -1572,7 +1572,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closure
 
 void _35clofun3120(struct Cora* co) {
 Obj _35val2645 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), Nil, closureRef(co, 0), x);
 }
 
@@ -1618,53 +1618,53 @@ coraCall(co, 1, _35cc1344);
 
 void _35clofun3106(struct Cora* co) {
 Obj _35val2621 = co->args[1];
-Obj a = co->stk.stack[co->stk.base + 0];
-Obj idx = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
-Obj b = co->stk.stack[co->stk.base + 4];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3107, 5, a, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
 void _35clofun3107(struct Cora* co) {
 Obj _35val2622 = co->args[1];
-Obj a = co->stk.stack[co->stk.base + 0];
-Obj idx = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
-Obj b = co->stk.stack[co->stk.base + 4];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3108, 5, a, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("] = "));
 }
 
 void _35clofun3108(struct Cora* co) {
 Obj _35val2623 = co->args[1];
-Obj a = co->stk.stack[co->stk.base + 0];
-Obj idx = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
-Obj b = co->stk.stack[co->stk.base + 4];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3109, 4, idx, env, w, b);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
 void _35clofun3109(struct Cora* co) {
 Obj _35val2624 = co->args[1];
-Obj idx = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj b = co->stk.stack[co->stk.base + 3];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, _35clofun3110, 4, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
 void _35clofun3110(struct Cora* co) {
 Obj _35val2625 = co->args[1];
-Obj idx = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj b = co->stk.stack[co->stk.base + 3];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj _35reg2626 = primAdd(idx, makeNumber(1));
 coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-call-args")), env, w, _35reg2626, b);
 }
@@ -1726,22 +1726,22 @@ coraCall(co, 1, _35cc1326);
 
 void _35clofun3100(struct Cora* co) {
 Obj _35val2613 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3101, 1, w);
 coraCall(co, 2, globalRef(intern("symbol->string")), x);
 }
 
 void _35clofun3101(struct Cora* co) {
 Obj _35val2614 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 pushCont(co, _35clofun3102, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2614);
 }
 
 void _35clofun3102(struct Cora* co) {
 Obj _35val2615 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("\"))"));
 }
 
@@ -1782,15 +1782,15 @@ coraCall(co, 1, _35cc1327);
 
 void _35clofun3098(struct Cora* co) {
 Obj _35val2601 = co->args[1];
-Obj idx = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3099, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
 void _35clofun3099(struct Cora* co) {
 Obj _35val2602 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
@@ -1831,15 +1831,15 @@ coraCall(co, 1, _35cc1328);
 
 void _35clofun3096(struct Cora* co) {
 Obj _35val2589 = co->args[1];
-Obj idx = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3097, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
 void _35clofun3097(struct Cora* co) {
 Obj _35val2590 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
@@ -1886,8 +1886,8 @@ coraCall(co, 1, _35cc1329);
 
 void _35clofun3090(struct Cora* co) {
 Obj _35val2569 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val2569) {
 pushCont(co, _35clofun3091, 2, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeNumber("));
@@ -1919,57 +1919,57 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 
 void _35clofun3093(struct Cora* co) {
 Obj _35val2573 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3094, 1, w);
 coraCall(co, 2, globalRef(intern("cora/lib/toc/internal.escape-str")), x);
 }
 
 void _35clofun3094(struct Cora* co) {
 Obj _35val2574 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 pushCont(co, _35clofun3095, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2574);
 }
 
 void _35clofun3095(struct Cora* co) {
 Obj _35val2575 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("\")"));
 }
 
 void _35clofun3091(struct Cora* co) {
 Obj _35val2570 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3092, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, x);
 }
 
 void _35clofun3092(struct Cora* co) {
 Obj _35val2571 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
 void _35clofun3087(struct Cora* co) {
 Obj _35val2566 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3088, 1, w);
 coraCall(co, 2, globalRef(intern("symbol->string")), x);
 }
 
 void _35clofun3088(struct Cora* co) {
 Obj _35val2567 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 pushCont(co, _35clofun3089, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2567);
 }
 
 void _35clofun3089(struct Cora* co) {
 Obj _35val2568 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("\")"));
 }
 
@@ -2036,11 +2036,11 @@ coraCall(co, 1, _35cc1330);
 
 void _35clofun3077(struct Cora* co) {
 Obj _35val2542 = co->args[1];
-Obj b = co->stk.stack[co->stk.base + 0];
-Obj a = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
-Obj c = co->stk.stack[co->stk.base + 4];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj idx = _35val2542;
 Obj _35reg2543 = primLT(idx, makeNumber(0));
 if (True == _35reg2543) {
@@ -2055,95 +2055,95 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
 
 void _35clofun3083(struct Cora* co) {
 Obj _35val2550 = co->args[1];
-Obj b = co->stk.stack[co->stk.base + 0];
-Obj a = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
-Obj c = co->stk.stack[co->stk.base + 4];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3084, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
 }
 
 void _35clofun3084(struct Cora* co) {
 Obj _35val2551 = co->args[1];
-Obj b = co->stk.stack[co->stk.base + 0];
-Obj a = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
-Obj c = co->stk.stack[co->stk.base + 4];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3085, 4, a, env, w, c);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
 void _35clofun3085(struct Cora* co) {
 Obj _35val2552 = co->args[1];
-Obj a = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj c = co->stk.stack[co->stk.base + 3];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, _35clofun3086, 4, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
 void _35clofun3086(struct Cora* co) {
 Obj _35val2553 = co->args[1];
-Obj a = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj c = co->stk.stack[co->stk.base + 3];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj _35reg2554 = primCons(a, env);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2554, w, c);
 }
 
 void _35clofun3078(struct Cora* co) {
 Obj _35val2544 = co->args[1];
-Obj b = co->stk.stack[co->stk.base + 0];
-Obj a = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
-Obj c = co->stk.stack[co->stk.base + 4];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3079, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
 }
 
 void _35clofun3079(struct Cora* co) {
 Obj _35val2545 = co->args[1];
-Obj b = co->stk.stack[co->stk.base + 0];
-Obj a = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
-Obj c = co->stk.stack[co->stk.base + 4];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3080, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
 }
 
 void _35clofun3080(struct Cora* co) {
 Obj _35val2546 = co->args[1];
-Obj b = co->stk.stack[co->stk.base + 0];
-Obj a = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
-Obj c = co->stk.stack[co->stk.base + 4];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3081, 4, a, env, w, c);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
 void _35clofun3081(struct Cora* co) {
 Obj _35val2547 = co->args[1];
-Obj a = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj c = co->stk.stack[co->stk.base + 3];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, _35clofun3082, 4, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
 void _35clofun3082(struct Cora* co) {
 Obj _35val2548 = co->args[1];
-Obj a = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
-Obj c = co->stk.stack[co->stk.base + 3];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj _35reg2549 = primCons(a, env);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2549, w, c);
 }
@@ -2197,34 +2197,34 @@ coraCall(co, 1, _35cc1331);
 
 void _35clofun3073(struct Cora* co) {
 Obj _35val2512 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3074, 3, env, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, _35val2512);
 }
 
 void _35clofun3074(struct Cora* co) {
 Obj _35val2513 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3075, 3, env, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("("));
 }
 
 void _35clofun3075(struct Cora* co) {
 Obj _35val2514 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3076, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst-list")), env, w, args);
 }
 
 void _35clofun3076(struct Cora* co) {
 Obj _35val2515 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
@@ -2291,56 +2291,56 @@ coraCall(co, 1, _35cc1332);
 
 void _35clofun3067(struct Cora* co) {
 Obj _35val2489 = co->args[1];
-Obj a = co->stk.stack[co->stk.base + 0];
-Obj b = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj c = co->stk.stack[co->stk.base + 3];
-Obj w = co->stk.stack[co->stk.base + 4];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3068, 4, b, env, c, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
 void _35clofun3068(struct Cora* co) {
 Obj _35val2490 = co->args[1];
-Obj b = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj c = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, _35clofun3069, 4, b, env, c, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(") {\n"));
 }
 
 void _35clofun3069(struct Cora* co) {
 Obj _35val2491 = co->args[1];
-Obj b = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj c = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, _35clofun3070, 3, env, c, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
 void _35clofun3070(struct Cora* co) {
 Obj _35val2492 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj c = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3071, 3, env, c, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("} else {\n"));
 }
 
 void _35clofun3071(struct Cora* co) {
 Obj _35val2493 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj c = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3072, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, c);
 }
 
 void _35clofun3072(struct Cora* co) {
 Obj _35val2494 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("}\n"));
 }
 
@@ -2389,76 +2389,76 @@ coraCall(co, 1, _35cc1333);
 
 void _35clofun3057(struct Cora* co) {
 Obj _35val2452 = co->args[1];
-Obj label = co->stk.stack[co->stk.base + 0];
-Obj nargs = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj frees = co->stk.stack[co->stk.base + 3];
-Obj w = co->stk.stack[co->stk.base + 4];
+Obj label = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 4];
 pushCont(co, _35clofun3058, 4, nargs, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, label);
 }
 
 void _35clofun3058(struct Cora* co) {
 Obj _35val2453 = co->args[1];
-Obj nargs = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj frees = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
+Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, _35clofun3059, 4, nargs, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 }
 
 void _35clofun3059(struct Cora* co) {
 Obj _35val2454 = co->args[1];
-Obj nargs = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
-Obj frees = co->stk.stack[co->stk.base + 2];
-Obj w = co->stk.stack[co->stk.base + 3];
+Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 pushCont(co, _35clofun3060, 3, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, nargs);
 }
 
 void _35clofun3060(struct Cora* co) {
 Obj _35val2455 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj frees = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3061, 3, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 }
 
 void _35clofun3061(struct Cora* co) {
 Obj _35val2456 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj frees = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3062, 3, env, frees, w);
 coraCall(co, 2, globalRef(intern("length")), frees);
 }
 
 void _35clofun3062(struct Cora* co) {
 Obj _35val2457 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj frees = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3063, 3, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2457);
 }
 
 void _35clofun3063(struct Cora* co) {
 Obj _35val2458 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj frees = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3064, 3, env, frees, w);
 coraCall(co, 2, globalRef(intern("null?")), frees);
 }
 
 void _35clofun3064(struct Cora* co) {
 Obj _35val2459 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj frees = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg2460 = primNot(_35val2459);
 if (True == _35reg2460) {
 pushCont(co, _35clofun3065, 3, env, frees, w);
@@ -2471,16 +2471,16 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 
 void _35clofun3065(struct Cora* co) {
 Obj _35val2461 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj frees = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3066, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst-list")), env, w, frees);
 }
 
 void _35clofun3066(struct Cora* co) {
 Obj _35val2462 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
@@ -2533,18 +2533,18 @@ coraCall(co, 1, _35cc1334);
 
 void _35clofun3055(struct Cora* co) {
 Obj _35val2434 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
-Obj b = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3056, 3, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
 void _35clofun3056(struct Cora* co) {
 Obj _35val2435 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
-Obj b = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 2];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
@@ -2585,16 +2585,16 @@ coraCall(co, 1, _35cc1335);
 
 void _35clofun3053(struct Cora* co) {
 Obj _35val2415 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj x = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3054, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, x);
 }
 
 void _35clofun3054(struct Cora* co) {
 Obj _35val2416 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\nreturn;\n"));
 }
 
@@ -2681,9 +2681,9 @@ coraCall(co, 1, _35cc1337);
 
 void _35clofun3052(struct Cora* co) {
 Obj _35val2394 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj w = co->stk.stack[co->stk.base + 1];
-Obj exp = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 2];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, exp);
 }
 
@@ -2706,18 +2706,18 @@ coraCall(co, 1, _35cc1338);
 
 void _35clofun3046(struct Cora* co) {
 Obj _35val2370 = co->args[1];
-Obj f = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3047, 3, f, args, w);
 coraCall(co, 2, globalRef(intern("length")), args);
 }
 
 void _35clofun3047(struct Cora* co) {
 Obj _35val2371 = co->args[1];
-Obj f = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg2372 = primAdd(makeNumber(1), _35val2371);
 pushCont(co, _35clofun3048, 3, f, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35reg2372);
@@ -2725,9 +2725,9 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35r
 
 void _35clofun3048(struct Cora* co) {
 Obj _35val2373 = co->args[1];
-Obj f = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
-Obj w = co->stk.stack[co->stk.base + 2];
+Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg2375 = primCons(f, args);
 pushCont(co, _35clofun3051, 1, w);
 coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3049, 1, 1, w), _35reg2375);
@@ -2735,7 +2735,7 @@ coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3049, 1, 1, w
 
 void _35clofun3051(struct Cora* co) {
 Obj _35val2376 = co->args[1];
-Obj w = co->stk.stack[co->stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
 }
 
@@ -2747,7 +2747,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closure
 
 void _35clofun3050(struct Cora* co) {
 Obj _35val2374 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), Nil, closureRef(co, 0), x);
 }
 
@@ -2766,8 +2766,8 @@ coraCall(co, 2, k, tmp);
 
 void _35clofun3030(struct Cora* co) {
 Obj _35val2361 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj tmp = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj tmp = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg2362 = primCons(_35val2361, Nil);
 Obj _35reg2363 = primCons(x, _35reg2362);
 Obj _35reg2364 = primCons(tmp, _35reg2363);
@@ -2796,8 +2796,8 @@ coraCall(co, 1, _35cc1320);
 
 void _35clofun3028(struct Cora* co) {
 Obj _35val2358 = co->args[1];
-Obj k = co->stk.stack[co->stk.base + 0];
-Obj init = co->stk.stack[co->stk.base + 1];
+Obj k = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj init = co->ctx.stk.stack[co->ctx.stk.base + 1];
 coraCall(co, 3, k, init, _35val2358);
 }
 
@@ -2966,7 +2966,7 @@ coraCall(co, 3, closureRef(co, 0), _35reg2349, _35reg2351);
 
 void _35clofun3023(struct Cora* co) {
 Obj _35val2339 = co->args[1];
-Obj _35reg2338 = co->stk.stack[co->stk.base + 0];
+Obj _35reg2338 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2340 = primCons(_35val2339, closureRef(co, 4));
 Obj _35reg2341 = primCons(closureRef(co, 3), _35reg2340);
 Obj _35reg2342 = primCons(closureRef(co, 2), _35reg2341);
@@ -3003,7 +3003,7 @@ coraCall(co, 3, closureRef(co, 0), _35reg2327, _35reg2329);
 
 void _35clofun3021(struct Cora* co) {
 Obj _35val2317 = co->args[1];
-Obj _35reg2316 = co->stk.stack[co->stk.base + 0];
+Obj _35reg2316 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2318 = primCons(_35val2317, closureRef(co, 4));
 Obj _35reg2319 = primCons(closureRef(co, 3), _35reg2318);
 Obj _35reg2320 = primCons(closureRef(co, 2), _35reg2319);
@@ -3040,7 +3040,7 @@ coraCall(co, 3, closureRef(co, 0), _35reg2304, _35reg2306);
 
 void _35clofun3019(struct Cora* co) {
 Obj _35val2294 = co->args[1];
-Obj _35reg2293 = co->stk.stack[co->stk.base + 0];
+Obj _35reg2293 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2295 = primCons(_35val2294, closureRef(co, 4));
 Obj _35reg2296 = primCons(closureRef(co, 3), _35reg2295);
 Obj _35reg2297 = primCons(closureRef(co, 2), _35reg2296);
@@ -3084,8 +3084,8 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 
 void _35clofun3013(struct Cora* co) {
 Obj _35val2244 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj _35cc1304 = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1304 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val2244) {
 coraReturn(co, x);
 return;
@@ -3155,7 +3155,7 @@ coraCall(co, 1, _35cc1306);
 
 void _35clofun3012(struct Cora* co) {
 Obj _35val2239 = co->args[1];
-Obj args = co->stk.stack[co->stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2240 = primCons(_35val2239, Nil);
 Obj _35reg2241 = primCons(args, _35reg2240);
 Obj _35reg2242 = primCons(intern("lambda"), _35reg2241);
@@ -3211,18 +3211,18 @@ coraCall(co, 1, _35cc1307);
 
 void _35clofun3007(struct Cora* co) {
 Obj _35val2212 = co->args[1];
-Obj fvs = co->stk.stack[co->stk.base + 0];
-Obj body = co->stk.stack[co->stk.base + 1];
-Obj val = co->stk.stack[co->stk.base + 2];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3008, 3, fvs, body, val);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val2212, val);
 }
 
 void _35clofun3008(struct Cora* co) {
 Obj _35val2213 = co->args[1];
-Obj fvs = co->stk.stack[co->stk.base + 0];
-Obj body = co->stk.stack[co->stk.base + 1];
-Obj val = co->stk.stack[co->stk.base + 2];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs1 = _35val2213;
 pushCont(co, _35clofun3009, 3, fvs1, body, val);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
@@ -3230,18 +3230,18 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
 
 void _35clofun3009(struct Cora* co) {
 Obj _35val2214 = co->args[1];
-Obj fvs1 = co->stk.stack[co->stk.base + 0];
-Obj body = co->stk.stack[co->stk.base + 1];
-Obj val = co->stk.stack[co->stk.base + 2];
+Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3010, 3, fvs1, body, val);
 coraCall(co, 3, globalRef(intern("map")), _35val2214, fvs1);
 }
 
 void _35clofun3010(struct Cora* co) {
 Obj _35val2215 = co->args[1];
-Obj fvs1 = co->stk.stack[co->stk.base + 0];
-Obj body = co->stk.stack[co->stk.base + 1];
-Obj val = co->stk.stack[co->stk.base + 2];
+Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs2 = _35val2215;
 pushCont(co, _35clofun3011, 2, val, fvs2);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs1, body);
@@ -3249,8 +3249,8 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs1, body);
 
 void _35clofun3011(struct Cora* co) {
 Obj _35val2216 = co->args[1];
-Obj val = co->stk.stack[co->stk.base + 0];
-Obj fvs2 = co->stk.stack[co->stk.base + 1];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs2 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg2217 = primCons(_35val2216, Nil);
 Obj _35reg2218 = primCons(val, _35reg2217);
 Obj _35reg2219 = primCons(intern("lambda"), _35reg2218);
@@ -3308,24 +3308,24 @@ coraCall(co, 1, _35cc1308);
 
 void _35clofun3004(struct Cora* co) {
 Obj _35val2189 = co->args[1];
-Obj exp = co->stk.stack[co->stk.base + 0];
-Obj fvs = co->stk.stack[co->stk.base + 1];
-Obj cont = co->stk.stack[co->stk.base + 2];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cont = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun3005, 2, fvs, cont);
 coraCall(co, 3, globalRef(intern("map")), _35val2189, exp);
 }
 
 void _35clofun3005(struct Cora* co) {
 Obj _35val2190 = co->args[1];
-Obj fvs = co->stk.stack[co->stk.base + 0];
-Obj cont = co->stk.stack[co->stk.base + 1];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cont = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun3006, 1, _35val2190);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs, cont);
 }
 
 void _35clofun3006(struct Cora* co) {
 Obj _35val2191 = co->args[1];
-Obj _35val2190 = co->stk.stack[co->stk.base + 0];
+Obj _35val2190 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2192 = primCons(_35val2191, Nil);
 Obj _35reg2193 = primCons(_35val2190, _35reg2192);
 Obj _35reg2194 = primCons(intern("call"), _35reg2193);
@@ -3351,8 +3351,8 @@ coraCall(co, 1, _35cc1309);
 
 void _35clofun3003(struct Cora* co) {
 Obj _35val2170 = co->args[1];
-Obj f = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
+Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg2171 = primCons(f, args);
 coraCall(co, 3, globalRef(intern("map")), _35val2170, _35reg2171);
 }
@@ -3379,7 +3379,7 @@ coraCall(co, 1, _35cc1300);
 
 void _35clofun2990(struct Cora* co) {
 Obj _35val2125 = co->args[1];
-Obj next = co->stk.stack[co->stk.base + 0];
+Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = _35val2125;
 Obj _35reg2126 = primCar(exp);
 pushCont(co, _35clofun2991, 2, next, exp);
@@ -3388,8 +3388,8 @@ coraCall(co, 2, globalRef(intern("pair?")), _35reg2126);
 
 void _35clofun2991(struct Cora* co) {
 Obj _35val2127 = co->args[1];
-Obj next = co->stk.stack[co->stk.base + 0];
-Obj exp = co->stk.stack[co->stk.base + 1];
+Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val2127) {
 pushCont(co, _35clofun2992, 2, next, exp);
 coraCall(co, 2, globalRef(intern("caar")), exp);
@@ -3416,8 +3416,8 @@ coraCall(co, 2, next, val);
 
 void _35clofun2995(struct Cora* co) {
 Obj _35val2159 = co->args[1];
-Obj _35reg2158 = co->stk.stack[co->stk.base + 0];
-Obj exp = co->stk.stack[co->stk.base + 1];
+Obj _35reg2158 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg2160 = primCons(_35val2159, Nil);
 Obj _35reg2161 = primCons(_35reg2158, _35reg2160);
 Obj _35reg2162 = primCons(intern("continuation"), _35reg2161);
@@ -3430,8 +3430,8 @@ return;
 
 void _35clofun2992(struct Cora* co) {
 Obj _35val2128 = co->args[1];
-Obj next = co->stk.stack[co->stk.base + 0];
-Obj exp = co->stk.stack[co->stk.base + 1];
+Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg2129 = primEQ(_35val2128, intern("%builtin"));
 if (True == _35reg2129) {
 if (True == True) {
@@ -3474,8 +3474,8 @@ coraCall(co, 2, next, val);
 
 void _35clofun2994(struct Cora* co) {
 Obj _35val2147 = co->args[1];
-Obj _35reg2146 = co->stk.stack[co->stk.base + 0];
-Obj exp = co->stk.stack[co->stk.base + 1];
+Obj _35reg2146 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg2148 = primCons(_35val2147, Nil);
 Obj _35reg2149 = primCons(_35reg2146, _35reg2148);
 Obj _35reg2150 = primCons(intern("continuation"), _35reg2149);
@@ -3488,8 +3488,8 @@ return;
 
 void _35clofun2993(struct Cora* co) {
 Obj _35val2135 = co->args[1];
-Obj _35reg2134 = co->stk.stack[co->stk.base + 0];
-Obj exp = co->stk.stack[co->stk.base + 1];
+Obj _35reg2134 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg2136 = primCons(_35val2135, Nil);
 Obj _35reg2137 = primCons(_35reg2134, _35reg2136);
 Obj _35reg2138 = primCons(intern("continuation"), _35reg2137);
@@ -3547,9 +3547,9 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 
 void _35clofun2985(struct Cora* co) {
 Obj _35val2118 = co->args[1];
-Obj next = co->stk.stack[co->stk.base + 0];
-Obj x = co->stk.stack[co->stk.base + 1];
-Obj _35cc1290 = co->stk.stack[co->stk.base + 2];
+Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc1290 = co->ctx.stk.stack[co->ctx.stk.base + 2];
 if (True == _35val2118) {
 if (True == True) {
 coraCall(co, 2, next, x);
@@ -3575,8 +3575,8 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 
 void _35clofun2984(struct Cora* co) {
 Obj _35val2116 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj _35cc1291 = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1291 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val2116) {
 coraReturn(co, x);
 return;
@@ -3652,15 +3652,15 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), cl
 
 void _35clofun2982(struct Cora* co) {
 Obj _35val2110 = co->args[1];
-Obj ra = co->stk.stack[co->stk.base + 0];
+Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 0];
 pushCont(co, _35clofun2983, 2, _35val2110, ra);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 1), closureRef(co, 2));
 }
 
 void _35clofun2983(struct Cora* co) {
 Obj _35val2111 = co->args[1];
-Obj _35val2110 = co->stk.stack[co->stk.base + 0];
-Obj ra = co->stk.stack[co->stk.base + 1];
+Obj _35val2110 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg2112 = primCons(_35val2111, Nil);
 Obj _35reg2113 = primCons(_35val2110, _35reg2112);
 Obj _35reg2114 = primCons(ra, _35reg2113);
@@ -3727,7 +3727,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), cl
 
 void _35clofun2980(struct Cora* co) {
 Obj _35val2080 = co->args[1];
-Obj ra = co->stk.stack[co->stk.base + 0];
+Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2081 = primCons(_35val2080, Nil);
 Obj _35reg2082 = primCons(ra, _35reg2081);
 Obj _35reg2083 = primCons(intern("do"), _35reg2082);
@@ -3802,7 +3802,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 1), cl
 
 void _35clofun2978(struct Cora* co) {
 Obj _35val2057 = co->args[1];
-Obj rb = co->stk.stack[co->stk.base + 0];
+Obj rb = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg2058 = primCons(_35val2057, Nil);
 Obj _35reg2059 = primCons(rb, _35reg2058);
 Obj _35reg2060 = primCons(closureRef(co, 0), _35reg2059);
@@ -3893,9 +3893,9 @@ coraCall(co, 1, _35cc1295);
 
 void _35clofun2976(struct Cora* co) {
 Obj _35val2025 = co->args[1];
-Obj args = co->stk.stack[co->stk.base + 0];
-Obj frees = co->stk.stack[co->stk.base + 1];
-Obj next = co->stk.stack[co->stk.base + 2];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj next = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg2026 = primCons(_35val2025, Nil);
 Obj _35reg2027 = primCons(args, _35reg2026);
 Obj _35reg2028 = primCons(intern("lambda"), _35reg2027);
@@ -3944,8 +3944,8 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 
 void _35clofun2966(struct Cora* co) {
 Obj _35val1978 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj _35cc1283 = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1283 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val1978) {
 coraReturn(co, x);
 return;
@@ -3969,7 +3969,7 @@ coraCall(co, 1, _35cc1284);
 
 void _35clofun2965(struct Cora* co) {
 Obj _35val1974 = co->args[1];
-Obj var = co->stk.stack[co->stk.base + 0];
+Obj var = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj pos = _35val1974;
 Obj _35reg1975 = primEQ(makeNumber(-1), pos);
 if (True == _35reg1975) {
@@ -4034,9 +4034,9 @@ coraCall(co, 1, _35cc1285);
 
 void _35clofun2961(struct Cora* co) {
 Obj _35val1964 = co->args[1];
-Obj body = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
-Obj fvs = co->stk.stack[co->stk.base + 2];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs1 = _35val1964;
 pushCont(co, _35clofun2962, 3, args, fvs, fvs1);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs1, body);
@@ -4044,9 +4044,9 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs1, body);
 
 void _35clofun2962(struct Cora* co) {
 Obj _35val1965 = co->args[1];
-Obj args = co->stk.stack[co->stk.base + 0];
-Obj fvs = co->stk.stack[co->stk.base + 1];
-Obj fvs1 = co->stk.stack[co->stk.base + 2];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg1966 = primCons(_35val1965, Nil);
 Obj _35reg1967 = primCons(args, _35reg1966);
 Obj _35reg1968 = primCons(intern("lambda"), _35reg1967);
@@ -4056,15 +4056,15 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert")), fvs);
 
 void _35clofun2963(struct Cora* co) {
 Obj _35val1969 = co->args[1];
-Obj fvs1 = co->stk.stack[co->stk.base + 0];
-Obj _35reg1968 = co->stk.stack[co->stk.base + 1];
+Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1968 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun2964, 1, _35reg1968);
 coraCall(co, 3, globalRef(intern("map")), _35val1969, fvs1);
 }
 
 void _35clofun2964(struct Cora* co) {
 Obj _35val1970 = co->args[1];
-Obj _35reg1968 = co->stk.stack[co->stk.base + 0];
+Obj _35reg1968 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg1971 = primCons(_35reg1968, _35val1970);
 Obj _35reg1972 = primCons(intern("%closure"), _35reg1971);
 coraReturn(co, _35reg1972);
@@ -4133,17 +4133,17 @@ coraCall(co, 1, _35cc1286);
 
 void _35clofun2959(struct Cora* co) {
 Obj _35val1938 = co->args[1];
-Obj fvs = co->stk.stack[co->stk.base + 0];
-Obj c = co->stk.stack[co->stk.base + 1];
-Obj a = co->stk.stack[co->stk.base + 2];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 2];
 pushCont(co, _35clofun2960, 2, _35val1938, a);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs, c);
 }
 
 void _35clofun2960(struct Cora* co) {
 Obj _35val1939 = co->args[1];
-Obj _35val1938 = co->stk.stack[co->stk.base + 0];
-Obj a = co->stk.stack[co->stk.base + 1];
+Obj _35val1938 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg1940 = primCons(_35val1939, Nil);
 Obj _35reg1941 = primCons(_35val1938, _35reg1940);
 Obj _35reg1942 = primCons(a, _35reg1941);
@@ -4170,8 +4170,8 @@ coraCall(co, 1, _35cc1287);
 
 void _35clofun2958(struct Cora* co) {
 Obj _35val1910 = co->args[1];
-Obj f = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
+Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg1911 = primCons(f, args);
 coraCall(co, 3, globalRef(intern("map")), _35val1910, _35reg1911);
 }
@@ -4190,7 +4190,7 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 
 void _35clofun2951(struct Cora* co) {
 Obj _35val1905 = co->args[1];
-Obj _35cc1269 = co->stk.stack[co->stk.base + 0];
+Obj _35cc1269 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val1905) {
 coraReturn(co, Nil);
 return;
@@ -4259,7 +4259,7 @@ coraCall(co, 1, _35cc1271);
 
 void _35clofun2950(struct Cora* co) {
 Obj _35val1902 = co->args[1];
-Obj args = co->stk.stack[co->stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1902, args);
 }
 
@@ -4443,16 +4443,16 @@ coraCall(co, 1, _35cc1274);
 
 void _35clofun2945(struct Cora* co) {
 Obj _35val1831 = co->args[1];
-Obj c = co->stk.stack[co->stk.base + 0];
-Obj a = co->stk.stack[co->stk.base + 1];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun2946, 2, a, _35val1831);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), c);
 }
 
 void _35clofun2946(struct Cora* co) {
 Obj _35val1832 = co->args[1];
-Obj a = co->stk.stack[co->stk.base + 0];
-Obj _35val1831 = co->stk.stack[co->stk.base + 1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val1831 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg1833 = primCons(a, Nil);
 pushCont(co, _35clofun2947, 1, _35val1831);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1832, _35reg1833);
@@ -4460,7 +4460,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1832, _35reg1833);
 
 void _35clofun2947(struct Cora* co) {
 Obj _35val1834 = co->args[1];
-Obj _35val1831 = co->stk.stack[co->stk.base + 0];
+Obj _35val1831 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), _35val1831, _35val1834);
 }
 
@@ -4656,7 +4656,7 @@ coraCall(co, 1, _35cc1279);
 
 void _35clofun2943(struct Cora* co) {
 Obj _35val1754 = co->args[1];
-Obj arg = co->stk.stack[co->stk.base + 0];
+Obj arg = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1754, arg);
 }
 
@@ -4894,9 +4894,9 @@ coraCall(co, 1, _35cc1259);
 
 void _35clofun2921(struct Cora* co) {
 Obj _35val1678 = co->args[1];
-Obj y = co->stk.stack[co->stk.base + 0];
-Obj s2 = co->stk.stack[co->stk.base + 1];
-Obj _35cc1259 = co->stk.stack[co->stk.base + 2];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s2 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc1259 = co->ctx.stk.stack[co->ctx.stk.base + 2];
 if (True == _35val1678) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), y, s2);
 } else {
@@ -4922,7 +4922,7 @@ coraCall(co, 1, _35cc1260);
 
 void _35clofun2920(struct Cora* co) {
 Obj _35val1673 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg1674 = primCons(x, _35val1673);
 coraReturn(co, _35reg1674);
 return;
@@ -4964,9 +4964,9 @@ coraCall(co, 1, _35cc1254);
 
 void _35clofun2915(struct Cora* co) {
 Obj _35val1667 = co->args[1];
-Obj y = co->stk.stack[co->stk.base + 0];
-Obj s2 = co->stk.stack[co->stk.base + 1];
-Obj _35cc1254 = co->stk.stack[co->stk.base + 2];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s2 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc1254 = co->ctx.stk.stack[co->ctx.stk.base + 2];
 if (True == _35val1667) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), y, s2);
 } else {
@@ -4992,7 +4992,7 @@ coraCall(co, 1, _35cc1255);
 
 void _35clofun2914(struct Cora* co) {
 Obj _35val1662 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg1663 = primCons(x, _35val1662);
 coraReturn(co, _35reg1663);
 return;
@@ -5014,8 +5014,8 @@ coraCall(co, 2, globalRef(intern("number?")), x);
 
 void _35clofun2907(struct Cora* co) {
 Obj _35val1644 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj _35cc1242 = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1242 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val1644) {
 if (True == True) {
 Obj _35reg1645 = primCons(x, Nil);
@@ -5045,8 +5045,8 @@ coraCall(co, 2, globalRef(intern("boolean?")), x);
 
 void _35clofun2908(struct Cora* co) {
 Obj _35val1650 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj _35cc1242 = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1242 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val1650) {
 if (True == True) {
 Obj _35reg1651 = primCons(x, Nil);
@@ -5064,8 +5064,8 @@ coraCall(co, 2, globalRef(intern("null?")), x);
 
 void _35clofun2909(struct Cora* co) {
 Obj _35val1653 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj _35cc1242 = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1242 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val1653) {
 if (True == True) {
 Obj _35reg1654 = primCons(x, Nil);
@@ -5138,7 +5138,7 @@ coraCall(co, 1, _35cc1244);
 
 void _35clofun2906(struct Cora* co) {
 Obj _35val1629 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val1629) {
 coraReturn(co, x);
 return;
@@ -5198,15 +5198,15 @@ coraCall(co, 1, _35cc1245);
 
 void _35clofun2904(struct Cora* co) {
 Obj _35val1623 = co->args[1];
-Obj body = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun2905, 1, args);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35val1623, body);
 }
 
 void _35clofun2905(struct Cora* co) {
 Obj _35val1624 = co->args[1];
-Obj args = co->stk.stack[co->stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg1625 = primCons(_35val1624, Nil);
 Obj _35reg1626 = primCons(args, _35reg1625);
 Obj _35reg1627 = primCons(intern("lambda"), _35reg1626);
@@ -5236,7 +5236,7 @@ coraCall(co, 1, _35cc1246);
 
 void _35clofun2902(struct Cora* co) {
 Obj _35val1603 = co->args[1];
-Obj args = co->stk.stack[co->stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
 pushCont(co, _35clofun2903, 0);
 coraCall(co, 3, globalRef(intern("map")), _35val1603, args);
 }
@@ -5296,15 +5296,15 @@ coraCall(co, 1, _35cc1247);
 
 void _35clofun2900(struct Cora* co) {
 Obj _35val1594 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj y = co->stk.stack[co->stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun2901, 1, _35val1594);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, y);
 }
 
 void _35clofun2901(struct Cora* co) {
 Obj _35val1595 = co->args[1];
-Obj _35val1594 = co->stk.stack[co->stk.base + 0];
+Obj _35val1594 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg1596 = primCons(_35val1595, Nil);
 Obj _35reg1597 = primCons(_35val1594, _35reg1596);
 Obj _35reg1598 = primCons(intern("do"), _35reg1597);
@@ -5374,9 +5374,9 @@ coraCall(co, 1, _35cc1248);
 
 void _35clofun2898(struct Cora* co) {
 Obj _35val1570 = co->args[1];
-Obj env = co->stk.stack[co->stk.base + 0];
-Obj c = co->stk.stack[co->stk.base + 1];
-Obj a = co->stk.stack[co->stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg1571 = primCons(a, env);
 pushCont(co, _35clofun2899, 2, _35val1570, a);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35reg1571, c);
@@ -5384,8 +5384,8 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35reg1571, c);
 
 void _35clofun2899(struct Cora* co) {
 Obj _35val1572 = co->args[1];
-Obj _35val1570 = co->stk.stack[co->stk.base + 0];
-Obj a = co->stk.stack[co->stk.base + 1];
+Obj _35val1570 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg1573 = primCons(_35val1572, Nil);
 Obj _35reg1574 = primCons(_35val1570, _35reg1573);
 Obj _35reg1575 = primCons(a, _35reg1574);
@@ -5412,10 +5412,10 @@ coraCall(co, 1, _35cc1249);
 
 void _35clofun2891(struct Cora* co) {
 Obj _35val1527 = co->args[1];
-Obj op = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
-Obj _35cc1249 = co->stk.stack[co->stk.base + 3];
+Obj op = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35cc1249 = co->ctx.stk.stack[co->ctx.stk.base + 3];
 if (True == _35val1527) {
 pushCont(co, _35clofun2892, 3, op, args, env);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.builtin->args")), op);
@@ -5426,9 +5426,9 @@ coraCall(co, 1, _35cc1249);
 
 void _35clofun2892(struct Cora* co) {
 Obj _35val1528 = co->args[1];
-Obj op = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
+Obj op = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj required = _35val1528;
 pushCont(co, _35clofun2893, 4, required, op, args, env);
 coraCall(co, 2, globalRef(intern("length")), args);
@@ -5436,10 +5436,10 @@ coraCall(co, 2, globalRef(intern("length")), args);
 
 void _35clofun2893(struct Cora* co) {
 Obj _35val1529 = co->args[1];
-Obj required = co->stk.stack[co->stk.base + 0];
-Obj op = co->stk.stack[co->stk.base + 1];
-Obj args = co->stk.stack[co->stk.base + 2];
-Obj env = co->stk.stack[co->stk.base + 3];
+Obj required = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj op = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj provided = _35val1529;
 Obj _35reg1530 = primEQ(required, provided);
 if (True == _35reg1530) {
@@ -5461,9 +5461,9 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("primitive call mismatch
 
 void _35clofun2896(struct Cora* co) {
 Obj _35val1538 = co->args[1];
-Obj op = co->stk.stack[co->stk.base + 0];
-Obj args = co->stk.stack[co->stk.base + 1];
-Obj env = co->stk.stack[co->stk.base + 2];
+Obj op = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj tmp = _35val1538;
 Obj _35reg1539 = primCons(op, args);
 pushCont(co, _35clofun2897, 2, tmp, env);
@@ -5472,8 +5472,8 @@ coraCall(co, 3, globalRef(intern("append")), _35reg1539, tmp);
 
 void _35clofun2897(struct Cora* co) {
 Obj _35val1540 = co->args[1];
-Obj tmp = co->stk.stack[co->stk.base + 0];
-Obj env = co->stk.stack[co->stk.base + 1];
+Obj tmp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg1541 = primCons(_35val1540, Nil);
 Obj _35reg1542 = primCons(tmp, _35reg1541);
 Obj _35reg1543 = primCons(intern("lambda"), _35reg1542);
@@ -5482,15 +5482,15 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, _35reg1543);
 
 void _35clofun2894(struct Cora* co) {
 Obj _35val1533 = co->args[1];
-Obj args = co->stk.stack[co->stk.base + 0];
-Obj _35reg1532 = co->stk.stack[co->stk.base + 1];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1532 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, _35clofun2895, 1, _35reg1532);
 coraCall(co, 3, globalRef(intern("map")), _35val1533, args);
 }
 
 void _35clofun2895(struct Cora* co) {
 Obj _35val1534 = co->args[1];
-Obj _35reg1532 = co->stk.stack[co->stk.base + 0];
+Obj _35reg1532 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg1535 = primCons(_35reg1532, _35val1534);
 coraReturn(co, _35reg1535);
 return;
@@ -5506,7 +5506,7 @@ coraCall(co, 2, globalRef(intern("cora/lib/toc.parse")), env);
 
 void _35clofun2890(struct Cora* co) {
 Obj _35val1523 = co->args[1];
-Obj ls = co->stk.stack[co->stk.base + 0];
+Obj ls = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("map")), _35val1523, ls);
 }
 
@@ -5557,7 +5557,7 @@ coraCall(co, 2, globalRef(intern("null?")), find);
 
 void _35clofun2876(struct Cora* co) {
 Obj _35val1516 = co->args[1];
-Obj find = co->stk.stack[co->stk.base + 0];
+Obj find = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val1516) {
 coraReturn(co, makeString1("ERROR"));
 return;
@@ -5581,7 +5581,7 @@ coraCall(co, 2, globalRef(intern("null?")), find);
 
 void _35clofun2873(struct Cora* co) {
 Obj _35val1513 = co->args[1];
-Obj find = co->stk.stack[co->stk.base + 0];
+Obj find = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val1513) {
 coraReturn(co, makeString1("ERROR"));
 return;
@@ -5641,8 +5641,8 @@ coraCall(co, 1, _35cc1235);
 
 void _35clofun2867(struct Cora* co) {
 Obj _35val1435 = co->args[1];
-Obj x = co->stk.stack[co->stk.base + 0];
-Obj tl = co->stk.stack[co->stk.base + 1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj tl = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg1436 = primLT(_35val1435, makeNumber(0));
 if (True == _35reg1436) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.exist-in-env")), x, tl);
@@ -5756,8 +5756,8 @@ coraCall(co, 1, _35cc1225);
 
 void _35clofun2858(struct Cora* co) {
 Obj _35val1418 = co->args[1];
-Obj f = co->stk.stack[co->stk.base + 0];
-Obj y = co->stk.stack[co->stk.base + 1];
+Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), f, _35val1418, y);
 }
 

--- a/toc.c
+++ b/toc.c
@@ -381,11 +381,11 @@ coraCall(co, 2, globalRef(intern("import")), makeString1("cora/lib/io"));
 
 void _35clofun2850(struct Cora* co) {
 Obj _35val1399 = co->args[1];
-Obj _35reg1414 = primSet(intern("cora/lib/toc.assq"), makeNative(_35clofun2851, 2, 0));
-Obj _35reg1420 = primSet(intern("cora/lib/toc.foldl"), makeNative(_35clofun2855, 3, 0));
-Obj _35reg1430 = primSet(intern("cora/lib/toc.pos-in-list0"), makeNative(_35clofun2859, 3, 0));
-Obj _35reg1431 = primSet(intern("cora/lib/toc.index"), makeNative(_35clofun2863, 2, 0));
-Obj _35reg1438 = primSet(intern("cora/lib/toc.exist-in-env"), makeNative(_35clofun2864, 2, 0));
+Obj _35reg1414 = primSet(intern("cora/lib/toc.assq"), makeNative(0, _35clofun2851, 2, 0));
+Obj _35reg1420 = primSet(intern("cora/lib/toc.foldl"), makeNative(0, _35clofun2855, 3, 0));
+Obj _35reg1430 = primSet(intern("cora/lib/toc.pos-in-list0"), makeNative(0, _35clofun2859, 3, 0));
+Obj _35reg1431 = primSet(intern("cora/lib/toc.index"), makeNative(0, _35clofun2863, 2, 0));
+Obj _35reg1438 = primSet(intern("cora/lib/toc.exist-in-env"), makeNative(0, _35clofun2864, 2, 0));
 Obj _35reg1439 = primCons(intern("primSet"), Nil);
 Obj _35reg1440 = primCons(makeNumber(2), _35reg1439);
 Obj _35reg1441 = primCons(intern("set"), _35reg1440);
@@ -455,64 +455,64 @@ Obj _35reg1504 = primCons(_35reg1447, _35reg1503);
 Obj _35reg1505 = primCons(_35reg1444, _35reg1504);
 Obj _35reg1506 = primCons(_35reg1441, _35reg1505);
 Obj _35reg1507 = primSet(intern("cora/lib/toc.*builtin-prims*"), _35reg1506);
-Obj _35reg1511 = primSet(intern("builtin?"), makeNative(_35clofun2868, 1, 0));
-Obj _35reg1514 = primSet(intern("cora/lib/toc.builtin->name"), makeNative(_35clofun2871, 1, 0));
-Obj _35reg1517 = primSet(intern("cora/lib/toc.builtin->args"), makeNative(_35clofun2874, 1, 0));
-Obj _35reg1522 = primSet(intern("cora/lib/toc.temp-list"), makeNative(_35clofun2877, 2, 0));
-Obj _35reg1658 = primSet(intern("cora/lib/toc.parse"), makeNative(_35clofun2880, 2, 0));
-Obj _35reg1669 = primSet(intern("cora/lib/toc.union"), makeNative(_35clofun2910, 2, 0));
-Obj _35reg1680 = primSet(intern("cora/lib/toc.diff"), makeNative(_35clofun2916, 2, 0));
-Obj _35reg1731 = primSet(intern("cora/lib/toc.convert-protect?"), makeNative(_35clofun2922, 1, 0));
-Obj _35reg1906 = primSet(intern("cora/lib/toc.free-vars"), makeNative(_35clofun2929, 1, 0));
-Obj _35reg1979 = primSet(intern("cora/lib/toc.closure-convert"), makeNative(_35clofun2952, 2, 0));
-Obj _35reg1982 = primSet(intern("cora/lib/toc.id"), makeNative(_35clofun2967, 1, 0));
-Obj _35reg2119 = primSet(intern("cora/lib/toc.tailify"), makeNative(_35clofun2968, 2, 0));
-Obj _35reg2166 = primSet(intern("cora/lib/toc.tailify-list"), makeNative(_35clofun2986, 3, 0));
-Obj _35reg2245 = primSet(intern("cora/lib/toc.explicit-stack"), makeNative(_35clofun2996, 2, 0));
-Obj _35reg2352 = primSet(intern("cora/lib/toc.collect-lambda"), makeNative(_35clofun3014, 3, 0));
-Obj _35reg2359 = primSet(intern("cora/lib/toc.collect-lambda-list"), makeNative(_35clofun3024, 4, 0));
-Obj _35reg2366 = primSet(intern("cora/lib/toc.wrap-var"), makeNative(_35clofun3029, 2, 0));
-Obj _35reg2617 = primSet(intern("cora/lib/toc.generate-inst"), makeNative(_35clofun3031, 3, 0));
-Obj _35reg2628 = primSet(intern("cora/lib/toc.generate-call-args"), makeNative(_35clofun3103, 4, 0));
-Obj _35reg2647 = primSet(intern("cora/lib/toc.generate-cont"), makeNative(_35clofun3111, 2, 0));
-Obj _35reg2656 = primSet(intern("cora/lib/toc.generate-inst-list-h"), makeNative(_35clofun3122, 4, 0));
-Obj _35reg2657 = primSet(intern("cora/lib/toc.generate-inst-list"), makeNative(_35clofun3128, 3, 0));
-Obj _35reg2661 = primSet(intern("cora/lib/toc.code-gen-func-declare"), makeNative(_35clofun3129, 2, 0));
-Obj _35reg2672 = primSet(intern("cora/lib/toc.generate-call-args-reverse"), makeNative(_35clofun3133, 5, 0));
-Obj _35reg2729 = primSet(intern("cora/lib/toc.code-gen-toplevel"), makeNative(_35clofun3141, 2, 0));
-Obj _35reg2730 = primSet(intern("cora/lib/toc.parse-pass"), makeNative(_35clofun3148, 1, 0));
-Obj _35reg2731 = primSet(intern("cora/lib/toc.closure-convert-pass"), makeNative(_35clofun3149, 1, 0));
-Obj _35reg2732 = primSet(intern("cora/lib/toc.tailify-pass"), makeNative(_35clofun3150, 1, 0));
-Obj _35reg2733 = primSet(intern("cora/lib/toc.explicit-stack-pass"), makeNative(_35clofun3151, 1, 0));
-Obj _35reg2741 = primSet(intern("cora/lib/toc.collect-lambda-pass"), makeNative(_35clofun3152, 1, 0));
-Obj _35reg2748 = primSet(intern("cora/lib/toc.rewrite-->macro"), makeNative(_35clofun3154, 2, 0));
+Obj _35reg1511 = primSet(intern("builtin?"), makeNative(0, _35clofun2868, 1, 0));
+Obj _35reg1514 = primSet(intern("cora/lib/toc.builtin->name"), makeNative(0, _35clofun2871, 1, 0));
+Obj _35reg1517 = primSet(intern("cora/lib/toc.builtin->args"), makeNative(0, _35clofun2874, 1, 0));
+Obj _35reg1522 = primSet(intern("cora/lib/toc.temp-list"), makeNative(0, _35clofun2877, 2, 0));
+Obj _35reg1658 = primSet(intern("cora/lib/toc.parse"), makeNative(0, _35clofun2880, 2, 0));
+Obj _35reg1669 = primSet(intern("cora/lib/toc.union"), makeNative(0, _35clofun2910, 2, 0));
+Obj _35reg1680 = primSet(intern("cora/lib/toc.diff"), makeNative(0, _35clofun2916, 2, 0));
+Obj _35reg1731 = primSet(intern("cora/lib/toc.convert-protect?"), makeNative(0, _35clofun2922, 1, 0));
+Obj _35reg1906 = primSet(intern("cora/lib/toc.free-vars"), makeNative(0, _35clofun2929, 1, 0));
+Obj _35reg1979 = primSet(intern("cora/lib/toc.closure-convert"), makeNative(0, _35clofun2952, 2, 0));
+Obj _35reg1982 = primSet(intern("cora/lib/toc.id"), makeNative(0, _35clofun2967, 1, 0));
+Obj _35reg2119 = primSet(intern("cora/lib/toc.tailify"), makeNative(0, _35clofun2968, 2, 0));
+Obj _35reg2166 = primSet(intern("cora/lib/toc.tailify-list"), makeNative(0, _35clofun2986, 3, 0));
+Obj _35reg2245 = primSet(intern("cora/lib/toc.explicit-stack"), makeNative(0, _35clofun2996, 2, 0));
+Obj _35reg2352 = primSet(intern("cora/lib/toc.collect-lambda"), makeNative(0, _35clofun3014, 3, 0));
+Obj _35reg2359 = primSet(intern("cora/lib/toc.collect-lambda-list"), makeNative(0, _35clofun3024, 4, 0));
+Obj _35reg2366 = primSet(intern("cora/lib/toc.wrap-var"), makeNative(0, _35clofun3029, 2, 0));
+Obj _35reg2617 = primSet(intern("cora/lib/toc.generate-inst"), makeNative(0, _35clofun3031, 3, 0));
+Obj _35reg2628 = primSet(intern("cora/lib/toc.generate-call-args"), makeNative(0, _35clofun3103, 4, 0));
+Obj _35reg2647 = primSet(intern("cora/lib/toc.generate-cont"), makeNative(0, _35clofun3111, 2, 0));
+Obj _35reg2656 = primSet(intern("cora/lib/toc.generate-inst-list-h"), makeNative(0, _35clofun3122, 4, 0));
+Obj _35reg2657 = primSet(intern("cora/lib/toc.generate-inst-list"), makeNative(0, _35clofun3128, 3, 0));
+Obj _35reg2661 = primSet(intern("cora/lib/toc.code-gen-func-declare"), makeNative(0, _35clofun3129, 2, 0));
+Obj _35reg2672 = primSet(intern("cora/lib/toc.generate-call-args-reverse"), makeNative(0, _35clofun3133, 5, 0));
+Obj _35reg2729 = primSet(intern("cora/lib/toc.code-gen-toplevel"), makeNative(0, _35clofun3141, 2, 0));
+Obj _35reg2730 = primSet(intern("cora/lib/toc.parse-pass"), makeNative(0, _35clofun3148, 1, 0));
+Obj _35reg2731 = primSet(intern("cora/lib/toc.closure-convert-pass"), makeNative(0, _35clofun3149, 1, 0));
+Obj _35reg2732 = primSet(intern("cora/lib/toc.tailify-pass"), makeNative(0, _35clofun3150, 1, 0));
+Obj _35reg2733 = primSet(intern("cora/lib/toc.explicit-stack-pass"), makeNative(0, _35clofun3151, 1, 0));
+Obj _35reg2741 = primSet(intern("cora/lib/toc.collect-lambda-pass"), makeNative(0, _35clofun3152, 1, 0));
+Obj _35reg2748 = primSet(intern("cora/lib/toc.rewrite-->macro"), makeNative(0, _35clofun3154, 2, 0));
 pushCont(co, 0, _35clofun3160, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("->"), makeNative(_35clofun3157, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("->"), makeNative(0, _35clofun3157, 1, 0));
 }
 
 void _35clofun3160(struct Cora* co) {
 Obj _35val2751 = co->args[1];
-Obj _35reg2756 = primSet(intern("cora/lib/toc.compile"), makeNative(_35clofun3161, 1, 0));
-Obj _35reg2762 = primSet(intern("for-each"), makeNative(_35clofun3166, 2, 0));
-Obj _35reg2769 = primSet(intern("cora/lib/toc.generate-c"), makeNative(_35clofun3170, 2, 0));
-Obj _35reg2775 = primSet(intern("cora/lib/toc.compile-to-c"), makeNative(_35clofun3178, 3, 0));
-Obj _35reg2777 = primSet(intern("set"), makeNative(_35clofun3184, 2, 0));
-Obj _35reg2779 = primSet(intern("car"), makeNative(_35clofun3185, 1, 0));
-Obj _35reg2781 = primSet(intern("cdr"), makeNative(_35clofun3186, 1, 0));
-Obj _35reg2783 = primSet(intern("cons"), makeNative(_35clofun3187, 2, 0));
-Obj _35reg2785 = primSet(intern("cons"), makeNative(_35clofun3188, 2, 0));
-Obj _35reg2787 = primSet(intern("+"), makeNative(_35clofun3189, 2, 0));
-Obj _35reg2789 = primSet(intern("-"), makeNative(_35clofun3190, 2, 0));
-Obj _35reg2791 = primSet(intern("*"), makeNative(_35clofun3191, 2, 0));
-Obj _35reg2793 = primSet(intern("/"), makeNative(_35clofun3192, 2, 0));
-Obj _35reg2795 = primSet(intern("="), makeNative(_35clofun3193, 2, 0));
-Obj _35reg2797 = primSet(intern(">"), makeNative(_35clofun3194, 2, 0));
-Obj _35reg2799 = primSet(intern("<"), makeNative(_35clofun3195, 2, 0));
-Obj _35reg2801 = primSet(intern("gensym"), makeNative(_35clofun3196, 1, 0));
-Obj _35reg2803 = primSet(intern("symbol?"), makeNative(_35clofun3197, 1, 0));
-Obj _35reg2805 = primSet(intern("not"), makeNative(_35clofun3198, 1, 0));
-Obj _35reg2807 = primSet(intern("string?"), makeNative(_35clofun3199, 1, 0));
-Obj _35reg2848 = primSet(intern("cora/lib/toc.eval0"), makeNative(_35clofun3200, 1, 0));
+Obj _35reg2756 = primSet(intern("cora/lib/toc.compile"), makeNative(0, _35clofun3161, 1, 0));
+Obj _35reg2762 = primSet(intern("for-each"), makeNative(0, _35clofun3166, 2, 0));
+Obj _35reg2769 = primSet(intern("cora/lib/toc.generate-c"), makeNative(0, _35clofun3170, 2, 0));
+Obj _35reg2775 = primSet(intern("cora/lib/toc.compile-to-c"), makeNative(0, _35clofun3178, 3, 0));
+Obj _35reg2777 = primSet(intern("set"), makeNative(0, _35clofun3184, 2, 0));
+Obj _35reg2779 = primSet(intern("car"), makeNative(0, _35clofun3185, 1, 0));
+Obj _35reg2781 = primSet(intern("cdr"), makeNative(0, _35clofun3186, 1, 0));
+Obj _35reg2783 = primSet(intern("cons"), makeNative(0, _35clofun3187, 2, 0));
+Obj _35reg2785 = primSet(intern("cons"), makeNative(0, _35clofun3188, 2, 0));
+Obj _35reg2787 = primSet(intern("+"), makeNative(0, _35clofun3189, 2, 0));
+Obj _35reg2789 = primSet(intern("-"), makeNative(0, _35clofun3190, 2, 0));
+Obj _35reg2791 = primSet(intern("*"), makeNative(0, _35clofun3191, 2, 0));
+Obj _35reg2793 = primSet(intern("/"), makeNative(0, _35clofun3192, 2, 0));
+Obj _35reg2795 = primSet(intern("="), makeNative(0, _35clofun3193, 2, 0));
+Obj _35reg2797 = primSet(intern(">"), makeNative(0, _35clofun3194, 2, 0));
+Obj _35reg2799 = primSet(intern("<"), makeNative(0, _35clofun3195, 2, 0));
+Obj _35reg2801 = primSet(intern("gensym"), makeNative(0, _35clofun3196, 1, 0));
+Obj _35reg2803 = primSet(intern("symbol?"), makeNative(0, _35clofun3197, 1, 0));
+Obj _35reg2805 = primSet(intern("not"), makeNative(0, _35clofun3198, 1, 0));
+Obj _35reg2807 = primSet(intern("string?"), makeNative(0, _35clofun3199, 1, 0));
+Obj _35reg2848 = primSet(intern("cora/lib/toc.eval0"), makeNative(0, _35clofun3200, 1, 0));
 coraReturn(co, _35reg2848);
 return;
 }
@@ -913,7 +913,7 @@ Obj _35val2764 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
 pushCont(co, 0, _35clofun3175, 2, to, bc);
-coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3173, 1, 1, to), bc);
+coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3173, 1, 1, to), bc);
 }
 
 void _35clofun3175(struct Cora* co) {
@@ -928,7 +928,7 @@ void _35clofun3176(struct Cora* co) {
 Obj _35val2768 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3177, 1, 1, to), bc);
+coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3177, 1, 1, to), bc);
 }
 
 void _35clofun3177(struct Cora* co) {
@@ -951,7 +951,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closure
 void _35clofun3166(struct Cora* co) {
 Obj _35p1368 = co->args[1];
 Obj _35p1369 = co->args[2];
-Obj _35cc1370 = makeNative(_35clofun3167, 0, 2, _35p1368, _35p1369);
+Obj _35cc1370 = makeNative(0, _35clofun3167, 0, 2, _35p1368, _35p1369);
 Obj fn = _35p1368;
 Obj _35reg2761 = primEQ(Nil, _35p1369);
 if (True == _35reg2761) {
@@ -963,7 +963,7 @@ coraCall(co, 1, _35cc1370);
 }
 
 void _35clofun3167(struct Cora* co) {
-Obj _35cc1371 = makeNative(_35clofun3168, 0, 0);
+Obj _35cc1371 = makeNative(0, _35clofun3168, 0, 0);
 Obj fn = closureRef(co, 0);
 Obj _35reg2757 = primIsCons(closureRef(co, 1));
 if (True == _35reg2757) {
@@ -1042,7 +1042,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.rewrite-->macro")), obj, fns);
 void _35clofun3154(struct Cora* co) {
 Obj _35p1364 = co->args[1];
 Obj _35p1365 = co->args[2];
-Obj _35cc1366 = makeNative(_35clofun3155, 0, 2, _35p1364, _35p1365);
+Obj _35cc1366 = makeNative(0, _35clofun3155, 0, 2, _35p1364, _35p1365);
 Obj obj = _35p1364;
 Obj _35reg2747 = primEQ(Nil, _35p1365);
 if (True == _35reg2747) {
@@ -1054,7 +1054,7 @@ coraCall(co, 1, _35cc1366);
 }
 
 void _35clofun3155(struct Cora* co) {
-Obj _35cc1367 = makeNative(_35clofun3156, 0, 0);
+Obj _35cc1367 = makeNative(0, _35clofun3156, 0, 0);
 Obj obj = closureRef(co, 0);
 Obj _35reg2742 = primIsCons(closureRef(co, 1));
 if (True == _35reg2742) {
@@ -1076,7 +1076,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 
 void _35clofun3152(struct Cora* co) {
 Obj exp = co->args[1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), Nil, exp, makeNative(_35clofun3153, 2, 0));
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), Nil, exp, makeNative(0, _35clofun3153, 2, 0));
 }
 
 void _35clofun3153(struct Cora* co) {
@@ -1116,7 +1116,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), Nil, exp);
 void _35clofun3141(struct Cora* co) {
 Obj _35p1361 = co->args[1];
 Obj _35p1362 = co->args[2];
-Obj _35cc1363 = makeNative(_35clofun3142, 0, 0);
+Obj _35cc1363 = makeNative(0, _35clofun3142, 0, 0);
 Obj w = _35p1361;
 Obj _35reg2673 = primIsCons(_35p1362);
 if (True == _35reg2673) {
@@ -1268,7 +1268,7 @@ Obj _35p1355 = co->args[2];
 Obj _35p1356 = co->args[3];
 Obj _35p1357 = co->args[4];
 Obj _35p1358 = co->args[5];
-Obj _35cc1359 = makeNative(_35clofun3134, 0, 5, _35p1354, _35p1355, _35p1356, _35p1357, _35p1358);
+Obj _35cc1359 = makeNative(0, _35clofun3134, 0, 5, _35p1354, _35p1355, _35p1356, _35p1357, _35p1358);
 Obj env = _35p1354;
 Obj w = _35p1355;
 Obj dest_45str = _35p1356;
@@ -1283,7 +1283,7 @@ coraCall(co, 1, _35cc1359);
 }
 
 void _35clofun3134(struct Cora* co) {
-Obj _35cc1360 = makeNative(_35clofun3135, 0, 0);
+Obj _35cc1360 = makeNative(0, _35clofun3135, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj dest_45str = closureRef(co, 2);
@@ -1401,7 +1401,7 @@ Obj _35p1348 = co->args[1];
 Obj _35p1349 = co->args[2];
 Obj _35p1350 = co->args[3];
 Obj _35p1351 = co->args[4];
-Obj _35cc1352 = makeNative(_35clofun3123, 0, 4, _35p1348, _35p1349, _35p1350, _35p1351);
+Obj _35cc1352 = makeNative(0, _35clofun3123, 0, 4, _35p1348, _35p1349, _35p1350, _35p1351);
 Obj env = _35p1348;
 Obj fn = _35p1349;
 Obj w = _35p1350;
@@ -1415,7 +1415,7 @@ coraCall(co, 1, _35cc1352);
 }
 
 void _35clofun3123(struct Cora* co) {
-Obj _35cc1353 = makeNative(_35clofun3124, 0, 0);
+Obj _35cc1353 = makeNative(0, _35clofun3124, 0, 0);
 Obj env = closureRef(co, 0);
 Obj fn = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -1474,7 +1474,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 void _35clofun3111(struct Cora* co) {
 Obj _35p1345 = co->args[1];
 Obj _35p1346 = co->args[2];
-Obj _35cc1347 = makeNative(_35clofun3112, 0, 0);
+Obj _35cc1347 = makeNative(0, _35clofun3112, 0, 0);
 Obj w = _35p1345;
 Obj _35reg2629 = primIsCons(_35p1346);
 if (True == _35reg2629) {
@@ -1551,7 +1551,7 @@ Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg2644 = primNot(_35val2643);
 if (True == _35reg2644) {
 pushCont(co, 0, _35clofun3121, 1, w);
-coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3119, 1, 1, w), stacks);
+coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3119, 1, 1, w), stacks);
 } else {
 Nil;
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
@@ -1585,7 +1585,7 @@ Obj _35p1339 = co->args[1];
 Obj _35p1340 = co->args[2];
 Obj _35p1341 = co->args[3];
 Obj _35p1342 = co->args[4];
-Obj _35cc1343 = makeNative(_35clofun3104, 0, 4, _35p1339, _35p1340, _35p1341, _35p1342);
+Obj _35cc1343 = makeNative(0, _35clofun3104, 0, 4, _35p1339, _35p1340, _35p1341, _35p1342);
 Obj env = _35p1339;
 Obj w = _35p1340;
 Obj idx = _35p1341;
@@ -1599,7 +1599,7 @@ coraCall(co, 1, _35cc1343);
 }
 
 void _35clofun3104(struct Cora* co) {
-Obj _35cc1344 = makeNative(_35clofun3105, 0, 0);
+Obj _35cc1344 = makeNative(0, _35clofun3105, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj idx = closureRef(co, 2);
@@ -1677,7 +1677,7 @@ void _35clofun3031(struct Cora* co) {
 Obj _35p1322 = co->args[1];
 Obj _35p1323 = co->args[2];
 Obj _35p1324 = co->args[3];
-Obj _35cc1325 = makeNative(_35clofun3032, 0, 3, _35p1322, _35p1323, _35p1324);
+Obj _35cc1325 = makeNative(0, _35clofun3032, 0, 3, _35p1322, _35p1323, _35p1324);
 Obj env = _35p1322;
 Obj w = _35p1323;
 Obj x = _35p1324;
@@ -1690,7 +1690,7 @@ coraCall(co, 1, _35cc1325);
 }
 
 void _35clofun3032(struct Cora* co) {
-Obj _35cc1326 = makeNative(_35clofun3033, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1326 = makeNative(0, _35clofun3033, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2603 = primIsCons(closureRef(co, 2));
@@ -1746,7 +1746,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 }
 
 void _35clofun3033(struct Cora* co) {
-Obj _35cc1327 = makeNative(_35clofun3034, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1327 = makeNative(0, _35clofun3034, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2591 = primIsCons(closureRef(co, 2));
@@ -1795,7 +1795,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 }
 
 void _35clofun3034(struct Cora* co) {
-Obj _35cc1328 = makeNative(_35clofun3035, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1328 = makeNative(0, _35clofun3035, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2579 = primIsCons(closureRef(co, 2));
@@ -1844,7 +1844,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 }
 
 void _35clofun3035(struct Cora* co) {
-Obj _35cc1329 = makeNative(_35clofun3036, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1329 = makeNative(0, _35clofun3036, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2555 = primIsCons(closureRef(co, 2));
@@ -1974,7 +1974,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 }
 
 void _35clofun3036(struct Cora* co) {
-Obj _35cc1330 = makeNative(_35clofun3037, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1330 = makeNative(0, _35clofun3037, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2516 = primIsCons(closureRef(co, 2));
@@ -2149,7 +2149,7 @@ coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2549, w, 
 }
 
 void _35clofun3037(struct Cora* co) {
-Obj _35cc1331 = makeNative(_35clofun3038, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1331 = makeNative(0, _35clofun3038, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2495 = primIsCons(closureRef(co, 2));
@@ -2229,7 +2229,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 }
 
 void _35clofun3038(struct Cora* co) {
-Obj _35cc1332 = makeNative(_35clofun3039, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1332 = makeNative(0, _35clofun3039, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2463 = primIsCons(closureRef(co, 2));
@@ -2345,7 +2345,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 }
 
 void _35clofun3039(struct Cora* co) {
-Obj _35cc1333 = makeNative(_35clofun3040, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1333 = makeNative(0, _35clofun3040, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2436 = primIsCons(closureRef(co, 2));
@@ -2372,7 +2372,7 @@ Obj _35reg2450 = primCdr(_35reg2449);
 Obj _35reg2451 = primCdr(_35reg2450);
 Obj frees = _35reg2451;
 pushCont(co, 0, _35clofun3057, 5, label, nargs, env, frees, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeNative("));
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeNative(0, "));
 } else {
 coraCall(co, 1, _35cc1333);
 }
@@ -2485,7 +2485,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 }
 
 void _35clofun3040(struct Cora* co) {
-Obj _35cc1334 = makeNative(_35clofun3041, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1334 = makeNative(0, _35clofun3041, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2417 = primIsCons(closureRef(co, 2));
@@ -2549,7 +2549,7 @@ coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
 void _35clofun3041(struct Cora* co) {
-Obj _35cc1335 = makeNative(_35clofun3042, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1335 = makeNative(0, _35clofun3042, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2405 = primIsCons(closureRef(co, 2));
@@ -2599,7 +2599,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 }
 
 void _35clofun3042(struct Cora* co) {
-Obj _35cc1336 = makeNative(_35clofun3043, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1336 = makeNative(0, _35clofun3043, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2395 = primIsCons(closureRef(co, 2));
@@ -2633,7 +2633,7 @@ coraCall(co, 1, _35cc1336);
 }
 
 void _35clofun3043(struct Cora* co) {
-Obj _35cc1337 = makeNative(_35clofun3044, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1337 = makeNative(0, _35clofun3044, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2377 = primIsCons(closureRef(co, 2));
@@ -2688,7 +2688,7 @@ coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, exp);
 }
 
 void _35clofun3044(struct Cora* co) {
-Obj _35cc1338 = makeNative(_35clofun3045, 0, 0);
+Obj _35cc1338 = makeNative(0, _35clofun3045, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj _35reg2367 = primIsCons(closureRef(co, 2));
@@ -2730,7 +2730,7 @@ Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg2375 = primCons(f, args);
 pushCont(co, 0, _35clofun3051, 1, w);
-coraCall(co, 3, globalRef(intern("for-each")), makeNative(_35clofun3049, 1, 1, w), _35reg2375);
+coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3049, 1, 1, w), _35reg2375);
 }
 
 void _35clofun3051(struct Cora* co) {
@@ -2781,7 +2781,7 @@ Obj _35p1316 = co->args[1];
 Obj _35p1317 = co->args[2];
 Obj _35p1318 = co->args[3];
 Obj _35p1319 = co->args[4];
-Obj _35cc1320 = makeNative(_35clofun3025, 0, 4, _35p1316, _35p1317, _35p1318, _35p1319);
+Obj _35cc1320 = makeNative(0, _35clofun3025, 0, 4, _35p1316, _35p1317, _35p1318, _35p1319);
 Obj res = _35p1316;
 Obj init = _35p1317;
 Obj _35reg2357 = primEQ(Nil, _35p1318);
@@ -2802,7 +2802,7 @@ coraCall(co, 3, k, init, _35val2358);
 }
 
 void _35clofun3025(struct Cora* co) {
-Obj _35cc1321 = makeNative(_35clofun3026, 0, 0);
+Obj _35cc1321 = makeNative(0, _35clofun3026, 0, 0);
 Obj res = closureRef(co, 0);
 Obj init = closureRef(co, 1);
 Obj _35reg2353 = primIsCons(closureRef(co, 2));
@@ -2812,7 +2812,7 @@ Obj x = _35reg2354;
 Obj _35reg2355 = primCdr(closureRef(co, 2));
 Obj y = _35reg2355;
 Obj k = closureRef(co, 3);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), init, x, makeNative(_35clofun3027, 2, 3, res, y, k));
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), init, x, makeNative(0, _35clofun3027, 2, 3, res, y, k));
 } else {
 coraCall(co, 1, _35cc1321);
 }
@@ -2833,7 +2833,7 @@ void _35clofun3014(struct Cora* co) {
 Obj _35p1310 = co->args[1];
 Obj _35p1311 = co->args[2];
 Obj _35p1312 = co->args[3];
-Obj _35cc1313 = makeNative(_35clofun3015, 0, 3, _35p1310, _35p1311, _35p1312);
+Obj _35cc1313 = makeNative(0, _35clofun3015, 0, 3, _35p1310, _35p1311, _35p1312);
 Obj res = _35p1310;
 Obj _35reg2247 = primIsCons(_35p1311);
 if (True == _35reg2247) {
@@ -2889,7 +2889,7 @@ if (True == _35reg2284) {
 if (True == True) {
 Obj _35reg2285 = primGenSym(intern("clofun"));
 Obj name = _35reg2285;
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(_35clofun3018, 2, 5, k, params, clo_45or_45cont, name, fvs));
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3018, 2, 5, k, params, clo_45or_45cont, name, fvs));
 } else {
 coraCall(co, 1, _35cc1313);
 }
@@ -2899,7 +2899,7 @@ if (True == _35reg2307) {
 if (True == True) {
 Obj _35reg2308 = primGenSym(intern("clofun"));
 Obj name = _35reg2308;
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(_35clofun3020, 2, 5, k, params, clo_45or_45cont, name, fvs));
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3020, 2, 5, k, params, clo_45or_45cont, name, fvs));
 } else {
 coraCall(co, 1, _35cc1313);
 }
@@ -2907,7 +2907,7 @@ coraCall(co, 1, _35cc1313);
 if (True == False) {
 Obj _35reg2330 = primGenSym(intern("clofun"));
 Obj name = _35reg2330;
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(_35clofun3022, 2, 5, k, params, clo_45or_45cont, name, fvs));
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3022, 2, 5, k, params, clo_45or_45cont, name, fvs));
 } else {
 coraCall(co, 1, _35cc1313);
 }
@@ -3048,7 +3048,7 @@ coraCall(co, 3, closureRef(co, 0), _35reg2293, _35reg2297);
 }
 
 void _35clofun3015(struct Cora* co) {
-Obj _35cc1314 = makeNative(_35clofun3016, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1314 = makeNative(0, _35clofun3016, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj res = closureRef(co, 0);
 Obj f_45args = closureRef(co, 1);
 Obj k = closureRef(co, 2);
@@ -3061,7 +3061,7 @@ coraCall(co, 1, _35cc1314);
 }
 
 void _35clofun3016(struct Cora* co) {
-Obj _35cc1315 = makeNative(_35clofun3017, 0, 0);
+Obj _35cc1315 = makeNative(0, _35clofun3017, 0, 0);
 Obj res = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 Obj k = closureRef(co, 2);
@@ -3075,7 +3075,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 void _35clofun2996(struct Cora* co) {
 Obj _35p1302 = co->args[1];
 Obj _35p1303 = co->args[2];
-Obj _35cc1304 = makeNative(_35clofun2997, 0, 2, _35p1302, _35p1303);
+Obj _35cc1304 = makeNative(0, _35clofun2997, 0, 2, _35p1302, _35p1303);
 Obj __ = _35p1302;
 Obj x = _35p1303;
 pushCont(co, 0, _35clofun3013, 2, x, _35cc1304);
@@ -3095,7 +3095,7 @@ coraCall(co, 1, _35cc1304);
 }
 
 void _35clofun2997(struct Cora* co) {
-Obj _35cc1305 = makeNative(_35clofun2998, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1305 = makeNative(0, _35clofun2998, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
 Obj _35reg2243 = primIsSymbol(var);
@@ -3108,7 +3108,7 @@ coraCall(co, 1, _35cc1305);
 }
 
 void _35clofun2998(struct Cora* co) {
-Obj _35cc1306 = makeNative(_35clofun2999, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1306 = makeNative(0, _35clofun2999, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj _35reg2222 = primIsCons(closureRef(co, 1));
 if (True == _35reg2222) {
@@ -3164,7 +3164,7 @@ return;
 }
 
 void _35clofun2999(struct Cora* co) {
-Obj _35cc1307 = makeNative(_35clofun3000, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1307 = makeNative(0, _35clofun3000, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj _35reg2195 = primIsCons(closureRef(co, 1));
 if (True == _35reg2195) {
@@ -3261,7 +3261,7 @@ return;
 }
 
 void _35clofun3000(struct Cora* co) {
-Obj _35cc1308 = makeNative(_35clofun3001, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1308 = makeNative(0, _35clofun3001, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj _35reg2172 = primIsCons(closureRef(co, 1));
 if (True == _35reg2172) {
@@ -3334,7 +3334,7 @@ return;
 }
 
 void _35clofun3001(struct Cora* co) {
-Obj _35cc1309 = makeNative(_35clofun3002, 0, 0);
+Obj _35cc1309 = makeNative(0, _35clofun3002, 0, 0);
 Obj fvs = closureRef(co, 0);
 Obj _35reg2167 = primIsCons(closureRef(co, 1));
 if (True == _35reg2167) {
@@ -3365,7 +3365,7 @@ void _35clofun2986(struct Cora* co) {
 Obj _35p1297 = co->args[1];
 Obj _35p1298 = co->args[2];
 Obj _35p1299 = co->args[3];
-Obj _35cc1300 = makeNative(_35clofun2987, 0, 3, _35p1297, _35p1298, _35p1299);
+Obj _35cc1300 = makeNative(0, _35clofun2987, 0, 3, _35p1297, _35p1298, _35p1299);
 Obj _35reg2124 = primEQ(Nil, _35p1297);
 if (True == _35reg2124) {
 Obj ls = _35p1298;
@@ -3501,7 +3501,7 @@ return;
 }
 
 void _35clofun2987(struct Cora* co) {
-Obj _35cc1301 = makeNative(_35clofun2988, 0, 0);
+Obj _35cc1301 = makeNative(0, _35clofun2988, 0, 0);
 Obj _35reg2120 = primIsCons(closureRef(co, 0));
 if (True == _35reg2120) {
 Obj _35reg2121 = primCar(closureRef(co, 0));
@@ -3510,7 +3510,7 @@ Obj _35reg2122 = primCdr(closureRef(co, 0));
 Obj tl = _35reg2122;
 Obj ls = closureRef(co, 1);
 Obj next = closureRef(co, 2);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), hd, makeNative(_35clofun2989, 1, 3, tl, ls, next));
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), hd, makeNative(0, _35clofun2989, 1, 3, tl, ls, next));
 } else {
 coraCall(co, 1, _35cc1301);
 }
@@ -3529,7 +3529,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 void _35clofun2968(struct Cora* co) {
 Obj _35p1288 = co->args[1];
 Obj _35p1289 = co->args[2];
-Obj _35cc1290 = makeNative(_35clofun2969, 0, 2, _35p1288, _35p1289);
+Obj _35cc1290 = makeNative(0, _35clofun2969, 0, 2, _35p1288, _35p1289);
 Obj x = _35p1288;
 Obj next = _35p1289;
 Obj _35reg2117 = primIsSymbol(x);
@@ -3566,7 +3566,7 @@ coraCall(co, 1, _35cc1290);
 }
 
 void _35clofun2969(struct Cora* co) {
-Obj _35cc1291 = makeNative(_35clofun2970, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1291 = makeNative(0, _35clofun2970, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj x = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
 pushCont(co, 0, _35clofun2984, 2, x, _35cc1291);
@@ -3586,7 +3586,7 @@ coraCall(co, 1, _35cc1291);
 }
 
 void _35clofun2970(struct Cora* co) {
-Obj _35cc1292 = makeNative(_35clofun2971, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1292 = makeNative(0, _35clofun2971, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg2084 = primIsCons(closureRef(co, 0));
 if (True == _35reg2084) {
 Obj _35reg2085 = primCar(closureRef(co, 0));
@@ -3623,7 +3623,7 @@ Obj _35reg2108 = primCdr(_35reg2107);
 Obj _35reg2109 = primEQ(Nil, _35reg2108);
 if (True == _35reg2109) {
 Obj next = closureRef(co, 1);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), a, makeNative(_35clofun2981, 1, 3, b, c, next));
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), a, makeNative(0, _35clofun2981, 1, 3, b, c, next));
 } else {
 coraCall(co, 1, _35cc1292);
 }
@@ -3670,7 +3670,7 @@ return;
 }
 
 void _35clofun2971(struct Cora* co) {
-Obj _35cc1293 = makeNative(_35clofun2972, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1293 = makeNative(0, _35clofun2972, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg2062 = primIsCons(closureRef(co, 0));
 if (True == _35reg2062) {
 Obj _35reg2063 = primCar(closureRef(co, 0));
@@ -3696,7 +3696,7 @@ Obj _35reg2077 = primCdr(_35reg2076);
 Obj _35reg2078 = primEQ(Nil, _35reg2077);
 if (True == _35reg2078) {
 Obj next = closureRef(co, 1);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), a, makeNative(_35clofun2979, 1, 2, b, next));
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), a, makeNative(0, _35clofun2979, 1, 2, b, next));
 } else {
 coraCall(co, 1, _35cc1293);
 }
@@ -3736,7 +3736,7 @@ return;
 }
 
 void _35clofun2972(struct Cora* co) {
-Obj _35cc1294 = makeNative(_35clofun2973, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1294 = makeNative(0, _35clofun2973, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg2031 = primIsCons(closureRef(co, 0));
 if (True == _35reg2031) {
 Obj _35reg2032 = primCar(closureRef(co, 0));
@@ -3773,7 +3773,7 @@ Obj _35reg2055 = primCdr(_35reg2054);
 Obj _35reg2056 = primEQ(Nil, _35reg2055);
 if (True == _35reg2056) {
 Obj next = closureRef(co, 1);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), b, makeNative(_35clofun2977, 1, 3, a, c, next));
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), b, makeNative(0, _35clofun2977, 1, 3, a, c, next));
 } else {
 coraCall(co, 1, _35cc1294);
 }
@@ -3812,7 +3812,7 @@ return;
 }
 
 void _35clofun2973(struct Cora* co) {
-Obj _35cc1295 = makeNative(_35clofun2974, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1295 = makeNative(0, _35clofun2974, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg1987 = primIsCons(closureRef(co, 0));
 if (True == _35reg1987) {
 Obj _35reg1988 = primCar(closureRef(co, 0));
@@ -3905,7 +3905,7 @@ coraCall(co, 2, next, _35reg2030);
 }
 
 void _35clofun2974(struct Cora* co) {
-Obj _35cc1296 = makeNative(_35clofun2975, 0, 0);
+Obj _35cc1296 = makeNative(0, _35clofun2975, 0, 0);
 Obj _35reg1983 = primIsCons(closureRef(co, 0));
 if (True == _35reg1983) {
 Obj _35reg1984 = primCar(closureRef(co, 0));
@@ -3935,7 +3935,7 @@ return;
 void _35clofun2952(struct Cora* co) {
 Obj _35p1281 = co->args[1];
 Obj _35p1282 = co->args[2];
-Obj _35cc1283 = makeNative(_35clofun2953, 0, 2, _35p1281, _35p1282);
+Obj _35cc1283 = makeNative(0, _35clofun2953, 0, 2, _35p1281, _35p1282);
 Obj __ = _35p1281;
 Obj x = _35p1282;
 pushCont(co, 0, _35clofun2966, 2, x, _35cc1283);
@@ -3955,7 +3955,7 @@ coraCall(co, 1, _35cc1283);
 }
 
 void _35clofun2953(struct Cora* co) {
-Obj _35cc1284 = makeNative(_35clofun2954, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1284 = makeNative(0, _35clofun2954, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
 Obj _35reg1973 = primIsSymbol(var);
@@ -3984,7 +3984,7 @@ return;
 }
 
 void _35clofun2954(struct Cora* co) {
-Obj _35cc1285 = makeNative(_35clofun2955, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1285 = makeNative(0, _35clofun2955, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj _35reg1944 = primIsCons(closureRef(co, 1));
 if (True == _35reg1944) {
@@ -4072,7 +4072,7 @@ return;
 }
 
 void _35clofun2955(struct Cora* co) {
-Obj _35cc1286 = makeNative(_35clofun2956, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1286 = makeNative(0, _35clofun2956, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj _35reg1912 = primIsCons(closureRef(co, 1));
 if (True == _35reg1912) {
@@ -4153,7 +4153,7 @@ return;
 }
 
 void _35clofun2956(struct Cora* co) {
-Obj _35cc1287 = makeNative(_35clofun2957, 0, 0);
+Obj _35cc1287 = makeNative(0, _35clofun2957, 0, 0);
 Obj fvs = closureRef(co, 0);
 Obj _35reg1907 = primIsCons(closureRef(co, 1));
 if (True == _35reg1907) {
@@ -4182,7 +4182,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 
 void _35clofun2929(struct Cora* co) {
 Obj _35p1268 = co->args[1];
-Obj _35cc1269 = makeNative(_35clofun2930, 0, 1, _35p1268);
+Obj _35cc1269 = makeNative(0, _35clofun2930, 0, 1, _35p1268);
 Obj x = _35p1268;
 pushCont(co, 0, _35clofun2951, 1, _35cc1269);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
@@ -4200,7 +4200,7 @@ coraCall(co, 1, _35cc1269);
 }
 
 void _35clofun2930(struct Cora* co) {
-Obj _35cc1270 = makeNative(_35clofun2931, 0, 1, closureRef(co, 0));
+Obj _35cc1270 = makeNative(0, _35clofun2931, 0, 1, closureRef(co, 0));
 Obj x = closureRef(co, 0);
 Obj _35reg1903 = primIsSymbol(x);
 if (True == _35reg1903) {
@@ -4213,7 +4213,7 @@ coraCall(co, 1, _35cc1270);
 }
 
 void _35clofun2931(struct Cora* co) {
-Obj _35cc1271 = makeNative(_35clofun2932, 0, 1, closureRef(co, 0));
+Obj _35cc1271 = makeNative(0, _35clofun2932, 0, 1, closureRef(co, 0));
 Obj _35reg1885 = primIsCons(closureRef(co, 0));
 if (True == _35reg1885) {
 Obj _35reg1886 = primCar(closureRef(co, 0));
@@ -4264,7 +4264,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1902, args);
 }
 
 void _35clofun2932(struct Cora* co) {
-Obj _35cc1272 = makeNative(_35clofun2933, 0, 1, closureRef(co, 0));
+Obj _35cc1272 = makeNative(0, _35clofun2933, 0, 1, closureRef(co, 0));
 Obj _35reg1855 = primIsCons(closureRef(co, 0));
 if (True == _35reg1855) {
 Obj _35reg1856 = primCar(closureRef(co, 0));
@@ -4331,7 +4331,7 @@ coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/
 }
 
 void _35clofun2933(struct Cora* co) {
-Obj _35cc1273 = makeNative(_35clofun2934, 0, 1, closureRef(co, 0));
+Obj _35cc1273 = makeNative(0, _35clofun2934, 0, 1, closureRef(co, 0));
 Obj _35reg1835 = primIsCons(closureRef(co, 0));
 if (True == _35reg1835) {
 Obj _35reg1836 = primCar(closureRef(co, 0));
@@ -4383,7 +4383,7 @@ coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/
 }
 
 void _35clofun2934(struct Cora* co) {
-Obj _35cc1274 = makeNative(_35clofun2935, 0, 1, closureRef(co, 0));
+Obj _35cc1274 = makeNative(0, _35clofun2935, 0, 1, closureRef(co, 0));
 Obj _35reg1805 = primIsCons(closureRef(co, 0));
 if (True == _35reg1805) {
 Obj _35reg1806 = primCar(closureRef(co, 0));
@@ -4465,7 +4465,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), _35val1831, _35val1834)
 }
 
 void _35clofun2935(struct Cora* co) {
-Obj _35cc1275 = makeNative(_35clofun2936, 0, 1, closureRef(co, 0));
+Obj _35cc1275 = makeNative(0, _35clofun2936, 0, 1, closureRef(co, 0));
 Obj _35reg1795 = primIsCons(closureRef(co, 0));
 if (True == _35reg1795) {
 Obj _35reg1796 = primCar(closureRef(co, 0));
@@ -4494,7 +4494,7 @@ coraCall(co, 1, _35cc1275);
 }
 
 void _35clofun2936(struct Cora* co) {
-Obj _35cc1276 = makeNative(_35clofun2937, 0, 1, closureRef(co, 0));
+Obj _35cc1276 = makeNative(0, _35clofun2937, 0, 1, closureRef(co, 0));
 Obj _35reg1785 = primIsCons(closureRef(co, 0));
 if (True == _35reg1785) {
 Obj _35reg1786 = primCar(closureRef(co, 0));
@@ -4526,7 +4526,7 @@ coraCall(co, 1, _35cc1276);
 }
 
 void _35clofun2937(struct Cora* co) {
-Obj _35cc1277 = makeNative(_35clofun2938, 0, 1, closureRef(co, 0));
+Obj _35cc1277 = makeNative(0, _35clofun2938, 0, 1, closureRef(co, 0));
 Obj _35reg1765 = primIsCons(closureRef(co, 0));
 if (True == _35reg1765) {
 Obj _35reg1766 = primCar(closureRef(co, 0));
@@ -4578,7 +4578,7 @@ coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/
 }
 
 void _35clofun2938(struct Cora* co) {
-Obj _35cc1278 = makeNative(_35clofun2939, 0, 1, closureRef(co, 0));
+Obj _35cc1278 = makeNative(0, _35clofun2939, 0, 1, closureRef(co, 0));
 Obj _35reg1755 = primIsCons(closureRef(co, 0));
 if (True == _35reg1755) {
 Obj _35reg1756 = primCar(closureRef(co, 0));
@@ -4610,7 +4610,7 @@ coraCall(co, 1, _35cc1278);
 }
 
 void _35clofun2939(struct Cora* co) {
-Obj _35cc1279 = makeNative(_35clofun2940, 0, 1, closureRef(co, 0));
+Obj _35cc1279 = makeNative(0, _35clofun2940, 0, 1, closureRef(co, 0));
 Obj _35reg1737 = primIsCons(closureRef(co, 0));
 if (True == _35reg1737) {
 Obj _35reg1738 = primCar(closureRef(co, 0));
@@ -4661,7 +4661,7 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1754, arg);
 }
 
 void _35clofun2940(struct Cora* co) {
-Obj _35cc1280 = makeNative(_35clofun2941, 0, 0);
+Obj _35cc1280 = makeNative(0, _35clofun2941, 0, 0);
 Obj _35reg1732 = primIsCons(closureRef(co, 0));
 if (True == _35reg1732) {
 Obj _35reg1733 = primCar(closureRef(co, 0));
@@ -4687,7 +4687,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 
 void _35clofun2922(struct Cora* co) {
 Obj _35p1261 = co->args[1];
-Obj _35cc1262 = makeNative(_35clofun2923, 0, 1, _35p1261);
+Obj _35cc1262 = makeNative(0, _35clofun2923, 0, 1, _35p1261);
 Obj _35reg1721 = primIsCons(_35p1261);
 if (True == _35reg1721) {
 Obj _35reg1722 = primCar(_35p1261);
@@ -4720,7 +4720,7 @@ coraCall(co, 1, _35cc1262);
 }
 
 void _35clofun2923(struct Cora* co) {
-Obj _35cc1263 = makeNative(_35clofun2924, 0, 1, closureRef(co, 0));
+Obj _35cc1263 = makeNative(0, _35clofun2924, 0, 1, closureRef(co, 0));
 Obj _35reg1711 = primIsCons(closureRef(co, 0));
 if (True == _35reg1711) {
 Obj _35reg1712 = primCar(closureRef(co, 0));
@@ -4753,7 +4753,7 @@ coraCall(co, 1, _35cc1263);
 }
 
 void _35clofun2924(struct Cora* co) {
-Obj _35cc1264 = makeNative(_35clofun2925, 0, 1, closureRef(co, 0));
+Obj _35cc1264 = makeNative(0, _35clofun2925, 0, 1, closureRef(co, 0));
 Obj _35reg1701 = primIsCons(closureRef(co, 0));
 if (True == _35reg1701) {
 Obj _35reg1702 = primCar(closureRef(co, 0));
@@ -4786,7 +4786,7 @@ coraCall(co, 1, _35cc1264);
 }
 
 void _35clofun2925(struct Cora* co) {
-Obj _35cc1265 = makeNative(_35clofun2926, 0, 1, closureRef(co, 0));
+Obj _35cc1265 = makeNative(0, _35clofun2926, 0, 1, closureRef(co, 0));
 Obj _35reg1691 = primIsCons(closureRef(co, 0));
 if (True == _35reg1691) {
 Obj _35reg1692 = primCar(closureRef(co, 0));
@@ -4819,7 +4819,7 @@ coraCall(co, 1, _35cc1265);
 }
 
 void _35clofun2926(struct Cora* co) {
-Obj _35cc1266 = makeNative(_35clofun2927, 0, 1, closureRef(co, 0));
+Obj _35cc1266 = makeNative(0, _35clofun2927, 0, 1, closureRef(co, 0));
 Obj _35reg1681 = primIsCons(closureRef(co, 0));
 if (True == _35reg1681) {
 Obj _35reg1682 = primCar(closureRef(co, 0));
@@ -4852,7 +4852,7 @@ coraCall(co, 1, _35cc1266);
 }
 
 void _35clofun2927(struct Cora* co) {
-Obj _35cc1267 = makeNative(_35clofun2928, 0, 0);
+Obj _35cc1267 = makeNative(0, _35clofun2928, 0, 0);
 Obj x = closureRef(co, 0);
 coraReturn(co, False);
 return;
@@ -4865,7 +4865,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 void _35clofun2916(struct Cora* co) {
 Obj _35p1256 = co->args[1];
 Obj _35p1257 = co->args[2];
-Obj _35cc1258 = makeNative(_35clofun2917, 0, 2, _35p1256, _35p1257);
+Obj _35cc1258 = makeNative(0, _35clofun2917, 0, 2, _35p1256, _35p1257);
 Obj _35reg1679 = primEQ(Nil, _35p1256);
 if (True == _35reg1679) {
 Obj __ = _35p1257;
@@ -4877,7 +4877,7 @@ coraCall(co, 1, _35cc1258);
 }
 
 void _35clofun2917(struct Cora* co) {
-Obj _35cc1259 = makeNative(_35clofun2918, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1259 = makeNative(0, _35clofun2918, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg1675 = primIsCons(closureRef(co, 0));
 if (True == _35reg1675) {
 Obj _35reg1676 = primCar(closureRef(co, 0));
@@ -4905,7 +4905,7 @@ coraCall(co, 1, _35cc1259);
 }
 
 void _35clofun2918(struct Cora* co) {
-Obj _35cc1260 = makeNative(_35clofun2919, 0, 0);
+Obj _35cc1260 = makeNative(0, _35clofun2919, 0, 0);
 Obj _35reg1670 = primIsCons(closureRef(co, 0));
 if (True == _35reg1670) {
 Obj _35reg1671 = primCar(closureRef(co, 0));
@@ -4935,7 +4935,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 void _35clofun2910(struct Cora* co) {
 Obj _35p1251 = co->args[1];
 Obj _35p1252 = co->args[2];
-Obj _35cc1253 = makeNative(_35clofun2911, 0, 2, _35p1251, _35p1252);
+Obj _35cc1253 = makeNative(0, _35clofun2911, 0, 2, _35p1251, _35p1252);
 Obj _35reg1668 = primEQ(Nil, _35p1251);
 if (True == _35reg1668) {
 Obj s2 = _35p1252;
@@ -4947,7 +4947,7 @@ coraCall(co, 1, _35cc1253);
 }
 
 void _35clofun2911(struct Cora* co) {
-Obj _35cc1254 = makeNative(_35clofun2912, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1254 = makeNative(0, _35clofun2912, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg1664 = primIsCons(closureRef(co, 0));
 if (True == _35reg1664) {
 Obj _35reg1665 = primCar(closureRef(co, 0));
@@ -4975,7 +4975,7 @@ coraCall(co, 1, _35cc1254);
 }
 
 void _35clofun2912(struct Cora* co) {
-Obj _35cc1255 = makeNative(_35clofun2913, 0, 0);
+Obj _35cc1255 = makeNative(0, _35clofun2913, 0, 0);
 Obj _35reg1659 = primIsCons(closureRef(co, 0));
 if (True == _35reg1659) {
 Obj _35reg1660 = primCar(closureRef(co, 0));
@@ -5005,7 +5005,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 void _35clofun2880(struct Cora* co) {
 Obj _35p1240 = co->args[1];
 Obj _35p1241 = co->args[2];
-Obj _35cc1242 = makeNative(_35clofun2881, 0, 2, _35p1240, _35p1241);
+Obj _35cc1242 = makeNative(0, _35clofun2881, 0, 2, _35p1240, _35p1241);
 Obj __ = _35p1240;
 Obj x = _35p1241;
 pushCont(co, 0, _35clofun2907, 2, x, _35cc1242);
@@ -5088,7 +5088,7 @@ coraCall(co, 1, _35cc1242);
 }
 
 void _35clofun2881(struct Cora* co) {
-Obj _35cc1243 = makeNative(_35clofun2882, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1243 = makeNative(0, _35clofun2882, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj __ = closureRef(co, 0);
 Obj _35reg1632 = primIsCons(closureRef(co, 1));
 if (True == _35reg1632) {
@@ -5124,7 +5124,7 @@ coraCall(co, 1, _35cc1243);
 }
 
 void _35clofun2882(struct Cora* co) {
-Obj _35cc1244 = makeNative(_35clofun2883, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1244 = makeNative(0, _35clofun2883, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 Obj _35reg1628 = primIsSymbol(x);
@@ -5151,7 +5151,7 @@ return;
 }
 
 void _35clofun2883(struct Cora* co) {
-Obj _35cc1245 = makeNative(_35clofun2884, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1245 = makeNative(0, _35clofun2884, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
 Obj _35reg1606 = primIsCons(closureRef(co, 1));
 if (True == _35reg1606) {
@@ -5215,7 +5215,7 @@ return;
 }
 
 void _35clofun2884(struct Cora* co) {
-Obj _35cc1246 = makeNative(_35clofun2885, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1246 = makeNative(0, _35clofun2885, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
 Obj _35reg1599 = primIsCons(closureRef(co, 1));
 if (True == _35reg1599) {
@@ -5249,7 +5249,7 @@ return;
 }
 
 void _35clofun2885(struct Cora* co) {
-Obj _35cc1247 = makeNative(_35clofun2886, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1247 = makeNative(0, _35clofun2886, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
 Obj _35reg1577 = primIsCons(closureRef(co, 1));
 if (True == _35reg1577) {
@@ -5313,7 +5313,7 @@ return;
 }
 
 void _35clofun2886(struct Cora* co) {
-Obj _35cc1248 = makeNative(_35clofun2887, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1248 = makeNative(0, _35clofun2887, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
 Obj _35reg1544 = primIsCons(closureRef(co, 1));
 if (True == _35reg1544) {
@@ -5395,7 +5395,7 @@ return;
 }
 
 void _35clofun2887(struct Cora* co) {
-Obj _35cc1249 = makeNative(_35clofun2888, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1249 = makeNative(0, _35clofun2888, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
 Obj _35reg1524 = primIsCons(closureRef(co, 1));
 if (True == _35reg1524) {
@@ -5497,7 +5497,7 @@ return;
 }
 
 void _35clofun2888(struct Cora* co) {
-Obj _35cc1250 = makeNative(_35clofun2889, 0, 0);
+Obj _35cc1250 = makeNative(0, _35clofun2889, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ls = closureRef(co, 1);
 pushCont(co, 0, _35clofun2890, 1, ls);
@@ -5517,7 +5517,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 void _35clofun2877(struct Cora* co) {
 Obj _35p1236 = co->args[1];
 Obj _35p1237 = co->args[2];
-Obj _35cc1238 = makeNative(_35clofun2878, 0, 2, _35p1236, _35p1237);
+Obj _35cc1238 = makeNative(0, _35clofun2878, 0, 2, _35p1236, _35p1237);
 Obj _35reg1521 = primEQ(makeNumber(0), _35p1236);
 if (True == _35reg1521) {
 Obj res = _35p1237;
@@ -5529,7 +5529,7 @@ coraCall(co, 1, _35cc1238);
 }
 
 void _35clofun2878(struct Cora* co) {
-Obj _35cc1239 = makeNative(_35clofun2879, 0, 0);
+Obj _35cc1239 = makeNative(0, _35clofun2879, 0, 0);
 Obj n = closureRef(co, 0);
 Obj res = closureRef(co, 1);
 Obj _35reg1518 = primSub(n, makeNumber(1));
@@ -5612,7 +5612,7 @@ return;
 void _35clofun2864(struct Cora* co) {
 Obj _35p1232 = co->args[1];
 Obj _35p1233 = co->args[2];
-Obj _35cc1234 = makeNative(_35clofun2865, 0, 2, _35p1232, _35p1233);
+Obj _35cc1234 = makeNative(0, _35clofun2865, 0, 2, _35p1232, _35p1233);
 Obj x = _35p1232;
 Obj _35reg1437 = primEQ(Nil, _35p1233);
 if (True == _35reg1437) {
@@ -5624,7 +5624,7 @@ coraCall(co, 1, _35cc1234);
 }
 
 void _35clofun2865(struct Cora* co) {
-Obj _35cc1235 = makeNative(_35clofun2866, 0, 0);
+Obj _35cc1235 = makeNative(0, _35clofun2866, 0, 0);
 Obj x = closureRef(co, 0);
 Obj _35reg1432 = primIsCons(closureRef(co, 1));
 if (True == _35reg1432) {
@@ -5666,7 +5666,7 @@ void _35clofun2859(struct Cora* co) {
 Obj _35p1226 = co->args[1];
 Obj _35p1227 = co->args[2];
 Obj _35p1228 = co->args[3];
-Obj _35cc1229 = makeNative(_35clofun2860, 0, 3, _35p1226, _35p1227, _35p1228);
+Obj _35cc1229 = makeNative(0, _35clofun2860, 0, 3, _35p1226, _35p1227, _35p1228);
 Obj __ = _35p1226;
 Obj x = _35p1227;
 Obj _35reg1429 = primEQ(Nil, _35p1228);
@@ -5679,7 +5679,7 @@ coraCall(co, 1, _35cc1229);
 }
 
 void _35clofun2860(struct Cora* co) {
-Obj _35cc1230 = makeNative(_35clofun2861, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1230 = makeNative(0, _35clofun2861, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 Obj _35reg1425 = primIsCons(closureRef(co, 2));
@@ -5701,7 +5701,7 @@ coraCall(co, 1, _35cc1230);
 }
 
 void _35clofun2861(struct Cora* co) {
-Obj _35cc1231 = makeNative(_35clofun2862, 0, 0);
+Obj _35cc1231 = makeNative(0, _35clofun2862, 0, 0);
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 Obj _35reg1421 = primIsCons(closureRef(co, 2));
@@ -5725,7 +5725,7 @@ void _35clofun2855(struct Cora* co) {
 Obj _35p1221 = co->args[1];
 Obj _35p1222 = co->args[2];
 Obj _35p1223 = co->args[3];
-Obj _35cc1224 = makeNative(_35clofun2856, 0, 3, _35p1221, _35p1222, _35p1223);
+Obj _35cc1224 = makeNative(0, _35clofun2856, 0, 3, _35p1221, _35p1222, _35p1223);
 Obj f = _35p1221;
 Obj acc = _35p1222;
 Obj _35reg1419 = primEQ(Nil, _35p1223);
@@ -5738,7 +5738,7 @@ coraCall(co, 1, _35cc1224);
 }
 
 void _35clofun2856(struct Cora* co) {
-Obj _35cc1225 = makeNative(_35clofun2857, 0, 0);
+Obj _35cc1225 = makeNative(0, _35clofun2857, 0, 0);
 Obj f = closureRef(co, 0);
 Obj acc = closureRef(co, 1);
 Obj _35reg1415 = primIsCons(closureRef(co, 2));
@@ -5768,7 +5768,7 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"))
 void _35clofun2851(struct Cora* co) {
 Obj _35p1216 = co->args[1];
 Obj _35p1217 = co->args[2];
-Obj _35cc1218 = makeNative(_35clofun2852, 0, 2, _35p1216, _35p1217);
+Obj _35cc1218 = makeNative(0, _35clofun2852, 0, 2, _35p1216, _35p1217);
 Obj var = _35p1216;
 Obj _35reg1413 = primEQ(Nil, _35p1217);
 if (True == _35reg1413) {
@@ -5780,7 +5780,7 @@ coraCall(co, 1, _35cc1218);
 }
 
 void _35clofun2852(struct Cora* co) {
-Obj _35cc1219 = makeNative(_35clofun2853, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1219 = makeNative(0, _35clofun2853, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
 Obj _35reg1403 = primIsCons(closureRef(co, 1));
 if (True == _35reg1403) {
@@ -5812,7 +5812,7 @@ coraCall(co, 1, _35cc1219);
 }
 
 void _35clofun2853(struct Cora* co) {
-Obj _35cc1220 = makeNative(_35clofun2854, 0, 0);
+Obj _35cc1220 = makeNative(0, _35clofun2854, 0, 0);
 Obj var = closureRef(co, 0);
 Obj _35reg1400 = primIsCons(closureRef(co, 1));
 if (True == _35reg1400) {


### PR DESCRIPTION
Before

```
struct Cora {
  Obj *stack;
  int base;
  int pos;

  struct callStack callstack;

  Obj frees;
  Obj args[32];
  int nargs;
  basicBlock pc;
};
```

After

```
struct Cora {
  struct returnAddr ctx;
  struct callStack callstack;

  Obj args[32];
  int nargs;
};
```

The benefit of this change is that recover several fields together could save several lines of code.
Some fields always works together.

For example, popStack can now filled in one line:

```
co->ctx = co->callstack.data[--co->callstack.len];
```

while in the past it is:

```
static void
popStack(struct Cora *co) {
  struct callStack *cs = &co->callstack;
  cs->len--;
  struct returnAddr *addr = &cs->data[cs->len];
  co->pc = addr->pc;
  co->stack = addr->stack;
  co->base = addr->base;
  co->pos = addr->pos;
  co->frees = addr->frees;
  return;
}
```


Another change in this commit is that an extra label parameter is added to `makeNative`