### PR TITLE
toc,runtime: let compile-to-c import dependencies first before macroexpand

### DIFF
--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -400,14 +400,26 @@
    (c.generate-str to "\n")
    (for-each (lambda (x) (.code-gen-toplevel to x)) bc)))
 
+(func .handle-import-eagerly
+      ['begin . remain] => (.handle-import-eagerly remain)
+      [['import pkg] . remain] => (begin
+				   (import pkg)
+				   ;; (io.display "import ==")
+				   ;; (io.display pkg)
+				   ;; (io.display "\n\n")
+				   (.handle-import-eagerly remain))
+      _ => ())
+
 (defun .compile-to-c (from to pkg-str)
   (let sexp (read-file-as-sexp from pkg-str)
-       (let input (macroexpand sexp)
-	    (let bc (.compile input)
-		 (let stream (io.open-output-file to)
-		      (begin
-		       (.generate-c stream bc)
-		       (io.close-output-file stream)))))))
+       (begin
+	(.handle-import-eagerly sexp)
+	(let input (macroexpand sexp)
+	     (let bc (.compile input)
+		  (let stream (io.open-output-file to)
+		       (begin
+			(.generate-c stream bc)
+			(io.close-output-file stream))))))))
 
 
 ;; ============== utilities of eval0 ==========

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -569,7 +569,9 @@ builtinLoad(struct Cora *co) {
 
   const int BUFSIZE = 512;
   char buf[BUFSIZE];
-  snprintf(buf, BUFSIZE, "/tmp/cora-xxx-%d.c", unique);
+  int cfileidx = unique;
+  unique++;
+  snprintf(buf, BUFSIZE, "/tmp/cora-xxx-%d.c", cfileidx);
   str tmpCFile = cstr(buf);
   co->args[2] = makeString(tmpCFile.str, tmpCFile.len);
   co->args[3] = pkg;
@@ -577,12 +579,11 @@ builtinLoad(struct Cora *co) {
   Obj res = co->args[1];
   // TODO: check res?
 
-  snprintf(buf, BUFSIZE, "gcc -shared -Isrc -I. -g -fPIC /tmp/cora-xxx-%d.c -o /tmp/cora-xxx-%d.so -ldl -Lsrc -lcora", unique, unique);
+  snprintf(buf, BUFSIZE, "gcc -shared -Isrc -I. -g -fPIC /tmp/cora-xxx-%d.c -o /tmp/cora-xxx-%d.so -ldl -Lsrc -lcora", cfileidx, cfileidx);
   int exitCode = system(buf);
   if (exitCode == 0) {
     /* co->args[0] = globalRef(intern("load-so"));  */
-    snprintf(buf, BUFSIZE, "/tmp/cora-xxx-%d.so", unique);
-    unique++;
+    snprintf(buf, BUFSIZE, "/tmp/cora-xxx-%d.so", cfileidx);
     str tmpSoFile = cstr(buf);
     co->nargs = 3;
     co->args[1] = makeString(tmpSoFile.str, tmpSoFile.len);
@@ -591,7 +592,6 @@ builtinLoad(struct Cora *co) {
     return;
   }
 
-  unique++;
   coraReturn(co, makeNumber(exitCode));
 }
 

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -611,6 +611,9 @@ builtinImport(struct Cora *co) {
     }
   }
 
+  // Set the *imported* variable to avlid repeated load.
+  symbolSet(sym, cons(pkg, imported));
+
   // CORA PATH
   strBuf tmp = getCoraPath();
 
@@ -635,9 +638,6 @@ builtinImport(struct Cora *co) {
   co->args[2] = pkg;
   trampoline(co, 0, coraDispatch);
   strFree(tmp);
-
-  // Set the *imported* variable to avlid repeated load.
-  symbolSet(sym, cons(pkg, imported));
 
   coraReturn(co, pkg);
 }

--- a/toc.c
+++ b/toc.c
@@ -2,631 +2,638 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun2849(struct Cora* co);
-void _35clofun2850(struct Cora* co);
-void _35clofun3160(struct Cora* co);
-void _35clofun3200(struct Cora* co);
-void _35clofun3201(struct Cora* co);
-void _35clofun3206(struct Cora* co);
-void _35clofun3209(struct Cora* co);
+void _35clofun2877(struct Cora* co);
+void _35clofun2878(struct Cora* co);
+void _35clofun3188(struct Cora* co);
+void _35clofun3234(struct Cora* co);
+void _35clofun3235(struct Cora* co);
+void _35clofun3240(struct Cora* co);
+void _35clofun3243(struct Cora* co);
+void _35clofun3246(struct Cora* co);
+void _35clofun3247(struct Cora* co);
+void _35clofun3244(struct Cora* co);
+void _35clofun3245(struct Cora* co);
+void _35clofun3241(struct Cora* co);
+void _35clofun3242(struct Cora* co);
+void _35clofun3238(struct Cora* co);
+void _35clofun3239(struct Cora* co);
+void _35clofun3236(struct Cora* co);
+void _35clofun3237(struct Cora* co);
+void _35clofun3233(struct Cora* co);
+void _35clofun3232(struct Cora* co);
+void _35clofun3231(struct Cora* co);
+void _35clofun3230(struct Cora* co);
+void _35clofun3229(struct Cora* co);
+void _35clofun3228(struct Cora* co);
+void _35clofun3227(struct Cora* co);
+void _35clofun3226(struct Cora* co);
+void _35clofun3225(struct Cora* co);
+void _35clofun3224(struct Cora* co);
+void _35clofun3223(struct Cora* co);
+void _35clofun3222(struct Cora* co);
+void _35clofun3221(struct Cora* co);
+void _35clofun3220(struct Cora* co);
+void _35clofun3219(struct Cora* co);
+void _35clofun3218(struct Cora* co);
+void _35clofun3211(struct Cora* co);
 void _35clofun3212(struct Cora* co);
 void _35clofun3213(struct Cora* co);
-void _35clofun3210(struct Cora* co);
-void _35clofun3211(struct Cora* co);
+void _35clofun3214(struct Cora* co);
+void _35clofun3215(struct Cora* co);
+void _35clofun3216(struct Cora* co);
+void _35clofun3217(struct Cora* co);
+void _35clofun3206(struct Cora* co);
 void _35clofun3207(struct Cora* co);
+void _35clofun3210(struct Cora* co);
 void _35clofun3208(struct Cora* co);
+void _35clofun3209(struct Cora* co);
+void _35clofun3198(struct Cora* co);
+void _35clofun3199(struct Cora* co);
+void _35clofun3200(struct Cora* co);
+void _35clofun3203(struct Cora* co);
 void _35clofun3204(struct Cora* co);
 void _35clofun3205(struct Cora* co);
+void _35clofun3201(struct Cora* co);
 void _35clofun3202(struct Cora* co);
-void _35clofun3203(struct Cora* co);
-void _35clofun3199(struct Cora* co);
-void _35clofun3198(struct Cora* co);
+void _35clofun3194(struct Cora* co);
+void _35clofun3195(struct Cora* co);
 void _35clofun3197(struct Cora* co);
 void _35clofun3196(struct Cora* co);
-void _35clofun3195(struct Cora* co);
-void _35clofun3194(struct Cora* co);
-void _35clofun3193(struct Cora* co);
-void _35clofun3192(struct Cora* co);
-void _35clofun3191(struct Cora* co);
-void _35clofun3190(struct Cora* co);
 void _35clofun3189(struct Cora* co);
-void _35clofun3188(struct Cora* co);
-void _35clofun3187(struct Cora* co);
-void _35clofun3186(struct Cora* co);
+void _35clofun3190(struct Cora* co);
+void _35clofun3191(struct Cora* co);
+void _35clofun3192(struct Cora* co);
+void _35clofun3193(struct Cora* co);
 void _35clofun3185(struct Cora* co);
-void _35clofun3184(struct Cora* co);
-void _35clofun3178(struct Cora* co);
-void _35clofun3179(struct Cora* co);
-void _35clofun3180(struct Cora* co);
-void _35clofun3181(struct Cora* co);
+void _35clofun3186(struct Cora* co);
+void _35clofun3187(struct Cora* co);
 void _35clofun3182(struct Cora* co);
 void _35clofun3183(struct Cora* co);
-void _35clofun3170(struct Cora* co);
+void _35clofun3184(struct Cora* co);
+void _35clofun3180(struct Cora* co);
+void _35clofun3181(struct Cora* co);
+void _35clofun3179(struct Cora* co);
+void _35clofun3178(struct Cora* co);
+void _35clofun3177(struct Cora* co);
+void _35clofun3176(struct Cora* co);
+void _35clofun3169(struct Cora* co);
 void _35clofun3171(struct Cora* co);
 void _35clofun3172(struct Cora* co);
-void _35clofun3175(struct Cora* co);
-void _35clofun3176(struct Cora* co);
-void _35clofun3177(struct Cora* co);
 void _35clofun3173(struct Cora* co);
 void _35clofun3174(struct Cora* co);
-void _35clofun3166(struct Cora* co);
-void _35clofun3167(struct Cora* co);
-void _35clofun3169(struct Cora* co);
-void _35clofun3168(struct Cora* co);
+void _35clofun3175(struct Cora* co);
+void _35clofun3170(struct Cora* co);
 void _35clofun3161(struct Cora* co);
 void _35clofun3162(struct Cora* co);
-void _35clofun3163(struct Cora* co);
 void _35clofun3164(struct Cora* co);
 void _35clofun3165(struct Cora* co);
+void _35clofun3166(struct Cora* co);
+void _35clofun3167(struct Cora* co);
+void _35clofun3168(struct Cora* co);
+void _35clofun3163(struct Cora* co);
 void _35clofun3157(struct Cora* co);
 void _35clofun3158(struct Cora* co);
 void _35clofun3159(struct Cora* co);
+void _35clofun3160(struct Cora* co);
+void _35clofun3156(struct Cora* co);
+void _35clofun3150(struct Cora* co);
+void _35clofun3151(struct Cora* co);
+void _35clofun3153(struct Cora* co);
 void _35clofun3154(struct Cora* co);
 void _35clofun3155(struct Cora* co);
-void _35clofun3156(struct Cora* co);
 void _35clofun3152(struct Cora* co);
-void _35clofun3153(struct Cora* co);
-void _35clofun3151(struct Cora* co);
-void _35clofun3150(struct Cora* co);
-void _35clofun3149(struct Cora* co);
-void _35clofun3148(struct Cora* co);
+void _35clofun3139(struct Cora* co);
 void _35clofun3141(struct Cora* co);
+void _35clofun3142(struct Cora* co);
 void _35clofun3143(struct Cora* co);
 void _35clofun3144(struct Cora* co);
 void _35clofun3145(struct Cora* co);
 void _35clofun3146(struct Cora* co);
+void _35clofun3149(struct Cora* co);
 void _35clofun3147(struct Cora* co);
-void _35clofun3142(struct Cora* co);
-void _35clofun3133(struct Cora* co);
+void _35clofun3148(struct Cora* co);
+void _35clofun3140(struct Cora* co);
+void _35clofun3131(struct Cora* co);
+void _35clofun3132(struct Cora* co);
 void _35clofun3134(struct Cora* co);
+void _35clofun3135(struct Cora* co);
 void _35clofun3136(struct Cora* co);
 void _35clofun3137(struct Cora* co);
 void _35clofun3138(struct Cora* co);
-void _35clofun3139(struct Cora* co);
-void _35clofun3140(struct Cora* co);
-void _35clofun3135(struct Cora* co);
+void _35clofun3133(struct Cora* co);
+void _35clofun3059(struct Cora* co);
+void _35clofun3060(struct Cora* co);
+void _35clofun3128(struct Cora* co);
 void _35clofun3129(struct Cora* co);
 void _35clofun3130(struct Cora* co);
-void _35clofun3131(struct Cora* co);
-void _35clofun3132(struct Cora* co);
-void _35clofun3128(struct Cora* co);
-void _35clofun3122(struct Cora* co);
-void _35clofun3123(struct Cora* co);
-void _35clofun3125(struct Cora* co);
+void _35clofun3061(struct Cora* co);
 void _35clofun3126(struct Cora* co);
 void _35clofun3127(struct Cora* co);
+void _35clofun3062(struct Cora* co);
 void _35clofun3124(struct Cora* co);
-void _35clofun3111(struct Cora* co);
-void _35clofun3113(struct Cora* co);
-void _35clofun3114(struct Cora* co);
+void _35clofun3125(struct Cora* co);
+void _35clofun3063(struct Cora* co);
+void _35clofun3118(struct Cora* co);
+void _35clofun3121(struct Cora* co);
+void _35clofun3122(struct Cora* co);
+void _35clofun3123(struct Cora* co);
+void _35clofun3119(struct Cora* co);
+void _35clofun3120(struct Cora* co);
 void _35clofun3115(struct Cora* co);
 void _35clofun3116(struct Cora* co);
 void _35clofun3117(struct Cora* co);
-void _35clofun3118(struct Cora* co);
-void _35clofun3121(struct Cora* co);
-void _35clofun3119(struct Cora* co);
-void _35clofun3120(struct Cora* co);
+void _35clofun3064(struct Cora* co);
+void _35clofun3105(struct Cora* co);
+void _35clofun3111(struct Cora* co);
 void _35clofun3112(struct Cora* co);
-void _35clofun3103(struct Cora* co);
-void _35clofun3104(struct Cora* co);
+void _35clofun3113(struct Cora* co);
+void _35clofun3114(struct Cora* co);
 void _35clofun3106(struct Cora* co);
 void _35clofun3107(struct Cora* co);
 void _35clofun3108(struct Cora* co);
 void _35clofun3109(struct Cora* co);
 void _35clofun3110(struct Cora* co);
-void _35clofun3105(struct Cora* co);
-void _35clofun3031(struct Cora* co);
-void _35clofun3032(struct Cora* co);
-void _35clofun3100(struct Cora* co);
+void _35clofun3065(struct Cora* co);
 void _35clofun3101(struct Cora* co);
 void _35clofun3102(struct Cora* co);
-void _35clofun3033(struct Cora* co);
-void _35clofun3098(struct Cora* co);
-void _35clofun3099(struct Cora* co);
-void _35clofun3034(struct Cora* co);
+void _35clofun3103(struct Cora* co);
+void _35clofun3104(struct Cora* co);
+void _35clofun3066(struct Cora* co);
+void _35clofun3095(struct Cora* co);
 void _35clofun3096(struct Cora* co);
 void _35clofun3097(struct Cora* co);
-void _35clofun3035(struct Cora* co);
-void _35clofun3090(struct Cora* co);
-void _35clofun3093(struct Cora* co);
-void _35clofun3094(struct Cora* co);
-void _35clofun3095(struct Cora* co);
-void _35clofun3091(struct Cora* co);
-void _35clofun3092(struct Cora* co);
+void _35clofun3098(struct Cora* co);
+void _35clofun3099(struct Cora* co);
+void _35clofun3100(struct Cora* co);
+void _35clofun3067(struct Cora* co);
+void _35clofun3085(struct Cora* co);
+void _35clofun3086(struct Cora* co);
 void _35clofun3087(struct Cora* co);
 void _35clofun3088(struct Cora* co);
 void _35clofun3089(struct Cora* co);
-void _35clofun3036(struct Cora* co);
-void _35clofun3077(struct Cora* co);
+void _35clofun3090(struct Cora* co);
+void _35clofun3091(struct Cora* co);
+void _35clofun3092(struct Cora* co);
+void _35clofun3093(struct Cora* co);
+void _35clofun3094(struct Cora* co);
+void _35clofun3068(struct Cora* co);
 void _35clofun3083(struct Cora* co);
 void _35clofun3084(struct Cora* co);
-void _35clofun3085(struct Cora* co);
-void _35clofun3086(struct Cora* co);
-void _35clofun3078(struct Cora* co);
-void _35clofun3079(struct Cora* co);
-void _35clofun3080(struct Cora* co);
+void _35clofun3069(struct Cora* co);
 void _35clofun3081(struct Cora* co);
 void _35clofun3082(struct Cora* co);
-void _35clofun3037(struct Cora* co);
-void _35clofun3073(struct Cora* co);
+void _35clofun3070(struct Cora* co);
+void _35clofun3071(struct Cora* co);
+void _35clofun3080(struct Cora* co);
+void _35clofun3072(struct Cora* co);
 void _35clofun3074(struct Cora* co);
 void _35clofun3075(struct Cora* co);
 void _35clofun3076(struct Cora* co);
-void _35clofun3038(struct Cora* co);
-void _35clofun3067(struct Cora* co);
-void _35clofun3068(struct Cora* co);
-void _35clofun3069(struct Cora* co);
-void _35clofun3070(struct Cora* co);
-void _35clofun3071(struct Cora* co);
-void _35clofun3072(struct Cora* co);
-void _35clofun3039(struct Cora* co);
+void _35clofun3079(struct Cora* co);
+void _35clofun3077(struct Cora* co);
+void _35clofun3078(struct Cora* co);
+void _35clofun3073(struct Cora* co);
 void _35clofun3057(struct Cora* co);
 void _35clofun3058(struct Cora* co);
-void _35clofun3059(struct Cora* co);
-void _35clofun3060(struct Cora* co);
-void _35clofun3061(struct Cora* co);
-void _35clofun3062(struct Cora* co);
-void _35clofun3063(struct Cora* co);
-void _35clofun3064(struct Cora* co);
-void _35clofun3065(struct Cora* co);
-void _35clofun3066(struct Cora* co);
-void _35clofun3040(struct Cora* co);
-void _35clofun3055(struct Cora* co);
+void _35clofun3052(struct Cora* co);
 void _35clofun3056(struct Cora* co);
-void _35clofun3041(struct Cora* co);
 void _35clofun3053(struct Cora* co);
+void _35clofun3055(struct Cora* co);
 void _35clofun3054(struct Cora* co);
 void _35clofun3042(struct Cora* co);
-void _35clofun3043(struct Cora* co);
-void _35clofun3052(struct Cora* co);
-void _35clofun3044(struct Cora* co);
+void _35clofun3050(struct Cora* co);
+void _35clofun3051(struct Cora* co);
+void _35clofun3048(struct Cora* co);
+void _35clofun3049(struct Cora* co);
 void _35clofun3046(struct Cora* co);
 void _35clofun3047(struct Cora* co);
-void _35clofun3048(struct Cora* co);
-void _35clofun3051(struct Cora* co);
-void _35clofun3049(struct Cora* co);
-void _35clofun3050(struct Cora* co);
+void _35clofun3043(struct Cora* co);
+void _35clofun3044(struct Cora* co);
 void _35clofun3045(struct Cora* co);
-void _35clofun3029(struct Cora* co);
-void _35clofun3030(struct Cora* co);
 void _35clofun3024(struct Cora* co);
-void _35clofun3028(struct Cora* co);
+void _35clofun3041(struct Cora* co);
 void _35clofun3025(struct Cora* co);
-void _35clofun3027(struct Cora* co);
 void _35clofun3026(struct Cora* co);
+void _35clofun3040(struct Cora* co);
+void _35clofun3027(struct Cora* co);
+void _35clofun3035(struct Cora* co);
+void _35clofun3036(struct Cora* co);
+void _35clofun3037(struct Cora* co);
+void _35clofun3038(struct Cora* co);
+void _35clofun3039(struct Cora* co);
+void _35clofun3028(struct Cora* co);
+void _35clofun3032(struct Cora* co);
+void _35clofun3033(struct Cora* co);
+void _35clofun3034(struct Cora* co);
+void _35clofun3029(struct Cora* co);
+void _35clofun3031(struct Cora* co);
+void _35clofun3030(struct Cora* co);
 void _35clofun3014(struct Cora* co);
-void _35clofun3022(struct Cora* co);
-void _35clofun3023(struct Cora* co);
-void _35clofun3020(struct Cora* co);
-void _35clofun3021(struct Cora* co);
 void _35clofun3018(struct Cora* co);
 void _35clofun3019(struct Cora* co);
+void _35clofun3023(struct Cora* co);
+void _35clofun3020(struct Cora* co);
+void _35clofun3022(struct Cora* co);
+void _35clofun3021(struct Cora* co);
 void _35clofun3015(struct Cora* co);
-void _35clofun3016(struct Cora* co);
 void _35clofun3017(struct Cora* co);
+void _35clofun3016(struct Cora* co);
 void _35clofun2996(struct Cora* co);
 void _35clofun3013(struct Cora* co);
 void _35clofun2997(struct Cora* co);
-void _35clofun2998(struct Cora* co);
 void _35clofun3012(struct Cora* co);
-void _35clofun2999(struct Cora* co);
-void _35clofun3007(struct Cora* co);
-void _35clofun3008(struct Cora* co);
+void _35clofun2998(struct Cora* co);
 void _35clofun3009(struct Cora* co);
 void _35clofun3010(struct Cora* co);
 void _35clofun3011(struct Cora* co);
+void _35clofun2999(struct Cora* co);
+void _35clofun3007(struct Cora* co);
+void _35clofun3008(struct Cora* co);
 void _35clofun3000(struct Cora* co);
-void _35clofun3004(struct Cora* co);
 void _35clofun3005(struct Cora* co);
 void _35clofun3006(struct Cora* co);
 void _35clofun3001(struct Cora* co);
-void _35clofun3003(struct Cora* co);
+void _35clofun3004(struct Cora* co);
 void _35clofun3002(struct Cora* co);
-void _35clofun2986(struct Cora* co);
+void _35clofun3003(struct Cora* co);
+void _35clofun2995(struct Cora* co);
+void _35clofun2980(struct Cora* co);
+void _35clofun2994(struct Cora* co);
+void _35clofun2981(struct Cora* co);
+void _35clofun2993(struct Cora* co);
+void _35clofun2982(struct Cora* co);
+void _35clofun2989(struct Cora* co);
 void _35clofun2990(struct Cora* co);
 void _35clofun2991(struct Cora* co);
-void _35clofun2995(struct Cora* co);
 void _35clofun2992(struct Cora* co);
-void _35clofun2994(struct Cora* co);
-void _35clofun2993(struct Cora* co);
-void _35clofun2987(struct Cora* co);
-void _35clofun2989(struct Cora* co);
-void _35clofun2988(struct Cora* co);
-void _35clofun2968(struct Cora* co);
-void _35clofun2985(struct Cora* co);
-void _35clofun2969(struct Cora* co);
-void _35clofun2984(struct Cora* co);
-void _35clofun2970(struct Cora* co);
-void _35clofun2981(struct Cora* co);
-void _35clofun2982(struct Cora* co);
 void _35clofun2983(struct Cora* co);
-void _35clofun2971(struct Cora* co);
+void _35clofun2987(struct Cora* co);
+void _35clofun2988(struct Cora* co);
+void _35clofun2984(struct Cora* co);
+void _35clofun2986(struct Cora* co);
+void _35clofun2985(struct Cora* co);
+void _35clofun2957(struct Cora* co);
 void _35clofun2979(struct Cora* co);
-void _35clofun2980(struct Cora* co);
-void _35clofun2972(struct Cora* co);
-void _35clofun2977(struct Cora* co);
+void _35clofun2958(struct Cora* co);
+void _35clofun2959(struct Cora* co);
 void _35clofun2978(struct Cora* co);
-void _35clofun2973(struct Cora* co);
+void _35clofun2960(struct Cora* co);
+void _35clofun2977(struct Cora* co);
+void _35clofun2961(struct Cora* co);
 void _35clofun2976(struct Cora* co);
+void _35clofun2962(struct Cora* co);
+void _35clofun2973(struct Cora* co);
 void _35clofun2974(struct Cora* co);
 void _35clofun2975(struct Cora* co);
-void _35clofun2967(struct Cora* co);
-void _35clofun2952(struct Cora* co);
-void _35clofun2966(struct Cora* co);
-void _35clofun2953(struct Cora* co);
-void _35clofun2965(struct Cora* co);
-void _35clofun2954(struct Cora* co);
-void _35clofun2961(struct Cora* co);
-void _35clofun2962(struct Cora* co);
 void _35clofun2963(struct Cora* co);
 void _35clofun2964(struct Cora* co);
-void _35clofun2955(struct Cora* co);
-void _35clofun2959(struct Cora* co);
-void _35clofun2960(struct Cora* co);
-void _35clofun2956(struct Cora* co);
-void _35clofun2958(struct Cora* co);
-void _35clofun2957(struct Cora* co);
-void _35clofun2929(struct Cora* co);
-void _35clofun2951(struct Cora* co);
-void _35clofun2930(struct Cora* co);
-void _35clofun2931(struct Cora* co);
+void _35clofun2965(struct Cora* co);
+void _35clofun2972(struct Cora* co);
+void _35clofun2966(struct Cora* co);
+void _35clofun2967(struct Cora* co);
+void _35clofun2971(struct Cora* co);
+void _35clofun2968(struct Cora* co);
+void _35clofun2970(struct Cora* co);
+void _35clofun2969(struct Cora* co);
 void _35clofun2950(struct Cora* co);
-void _35clofun2932(struct Cora* co);
-void _35clofun2949(struct Cora* co);
-void _35clofun2933(struct Cora* co);
-void _35clofun2948(struct Cora* co);
-void _35clofun2934(struct Cora* co);
-void _35clofun2945(struct Cora* co);
-void _35clofun2946(struct Cora* co);
-void _35clofun2947(struct Cora* co);
-void _35clofun2935(struct Cora* co);
-void _35clofun2936(struct Cora* co);
-void _35clofun2937(struct Cora* co);
+void _35clofun2951(struct Cora* co);
+void _35clofun2952(struct Cora* co);
+void _35clofun2953(struct Cora* co);
+void _35clofun2954(struct Cora* co);
+void _35clofun2955(struct Cora* co);
+void _35clofun2956(struct Cora* co);
 void _35clofun2944(struct Cora* co);
+void _35clofun2945(struct Cora* co);
+void _35clofun2949(struct Cora* co);
+void _35clofun2946(struct Cora* co);
+void _35clofun2948(struct Cora* co);
+void _35clofun2947(struct Cora* co);
 void _35clofun2938(struct Cora* co);
 void _35clofun2939(struct Cora* co);
 void _35clofun2943(struct Cora* co);
 void _35clofun2940(struct Cora* co);
 void _35clofun2942(struct Cora* co);
 void _35clofun2941(struct Cora* co);
-void _35clofun2922(struct Cora* co);
-void _35clofun2923(struct Cora* co);
-void _35clofun2924(struct Cora* co);
-void _35clofun2925(struct Cora* co);
+void _35clofun2908(struct Cora* co);
+void _35clofun2935(struct Cora* co);
+void _35clofun2936(struct Cora* co);
+void _35clofun2937(struct Cora* co);
+void _35clofun2909(struct Cora* co);
+void _35clofun2910(struct Cora* co);
+void _35clofun2934(struct Cora* co);
+void _35clofun2911(struct Cora* co);
+void _35clofun2932(struct Cora* co);
+void _35clofun2933(struct Cora* co);
+void _35clofun2912(struct Cora* co);
+void _35clofun2930(struct Cora* co);
+void _35clofun2931(struct Cora* co);
+void _35clofun2913(struct Cora* co);
+void _35clofun2928(struct Cora* co);
+void _35clofun2929(struct Cora* co);
+void _35clofun2914(struct Cora* co);
 void _35clofun2926(struct Cora* co);
 void _35clofun2927(struct Cora* co);
-void _35clofun2928(struct Cora* co);
-void _35clofun2916(struct Cora* co);
-void _35clofun2917(struct Cora* co);
-void _35clofun2921(struct Cora* co);
-void _35clofun2918(struct Cora* co);
-void _35clofun2920(struct Cora* co);
-void _35clofun2919(struct Cora* co);
-void _35clofun2910(struct Cora* co);
-void _35clofun2911(struct Cora* co);
 void _35clofun2915(struct Cora* co);
-void _35clofun2912(struct Cora* co);
-void _35clofun2914(struct Cora* co);
-void _35clofun2913(struct Cora* co);
-void _35clofun2880(struct Cora* co);
-void _35clofun2907(struct Cora* co);
-void _35clofun2908(struct Cora* co);
-void _35clofun2909(struct Cora* co);
-void _35clofun2881(struct Cora* co);
-void _35clofun2882(struct Cora* co);
-void _35clofun2906(struct Cora* co);
-void _35clofun2883(struct Cora* co);
-void _35clofun2904(struct Cora* co);
+void _35clofun2919(struct Cora* co);
+void _35clofun2920(struct Cora* co);
+void _35clofun2921(struct Cora* co);
+void _35clofun2924(struct Cora* co);
+void _35clofun2925(struct Cora* co);
+void _35clofun2922(struct Cora* co);
+void _35clofun2923(struct Cora* co);
+void _35clofun2916(struct Cora* co);
+void _35clofun2918(struct Cora* co);
+void _35clofun2917(struct Cora* co);
 void _35clofun2905(struct Cora* co);
-void _35clofun2884(struct Cora* co);
+void _35clofun2906(struct Cora* co);
+void _35clofun2907(struct Cora* co);
 void _35clofun2902(struct Cora* co);
 void _35clofun2903(struct Cora* co);
-void _35clofun2885(struct Cora* co);
+void _35clofun2904(struct Cora* co);
+void _35clofun2899(struct Cora* co);
 void _35clofun2900(struct Cora* co);
 void _35clofun2901(struct Cora* co);
-void _35clofun2886(struct Cora* co);
-void _35clofun2898(struct Cora* co);
-void _35clofun2899(struct Cora* co);
-void _35clofun2887(struct Cora* co);
-void _35clofun2891(struct Cora* co);
-void _35clofun2892(struct Cora* co);
-void _35clofun2893(struct Cora* co);
 void _35clofun2896(struct Cora* co);
 void _35clofun2897(struct Cora* co);
-void _35clofun2894(struct Cora* co);
+void _35clofun2898(struct Cora* co);
+void _35clofun2892(struct Cora* co);
+void _35clofun2893(struct Cora* co);
 void _35clofun2895(struct Cora* co);
+void _35clofun2894(struct Cora* co);
+void _35clofun2891(struct Cora* co);
+void _35clofun2887(struct Cora* co);
 void _35clofun2888(struct Cora* co);
-void _35clofun2890(struct Cora* co);
 void _35clofun2889(struct Cora* co);
-void _35clofun2877(struct Cora* co);
-void _35clofun2878(struct Cora* co);
+void _35clofun2890(struct Cora* co);
+void _35clofun2883(struct Cora* co);
+void _35clofun2884(struct Cora* co);
+void _35clofun2886(struct Cora* co);
+void _35clofun2885(struct Cora* co);
 void _35clofun2879(struct Cora* co);
-void _35clofun2874(struct Cora* co);
-void _35clofun2875(struct Cora* co);
-void _35clofun2876(struct Cora* co);
-void _35clofun2871(struct Cora* co);
-void _35clofun2872(struct Cora* co);
-void _35clofun2873(struct Cora* co);
-void _35clofun2868(struct Cora* co);
-void _35clofun2869(struct Cora* co);
-void _35clofun2870(struct Cora* co);
-void _35clofun2864(struct Cora* co);
-void _35clofun2865(struct Cora* co);
-void _35clofun2867(struct Cora* co);
-void _35clofun2866(struct Cora* co);
-void _35clofun2863(struct Cora* co);
-void _35clofun2859(struct Cora* co);
-void _35clofun2860(struct Cora* co);
-void _35clofun2861(struct Cora* co);
-void _35clofun2862(struct Cora* co);
-void _35clofun2855(struct Cora* co);
-void _35clofun2856(struct Cora* co);
-void _35clofun2858(struct Cora* co);
-void _35clofun2857(struct Cora* co);
-void _35clofun2851(struct Cora* co);
-void _35clofun2852(struct Cora* co);
-void _35clofun2853(struct Cora* co);
-void _35clofun2854(struct Cora* co);
+void _35clofun2880(struct Cora* co);
+void _35clofun2881(struct Cora* co);
+void _35clofun2882(struct Cora* co);
 
 void entry(struct Cora* co) {
-pushCont(co, 0, _35clofun2849, 0);
+pushCont(co, 0, _35clofun2877, 0);
 coraCall(co, 2, globalRef(intern("import")), makeString1("cora/lib/toc/internal"));
 }
 
-void _35clofun2849(struct Cora* co) {
-Obj _35val1398 = co->args[1];
-pushCont(co, 0, _35clofun2850, 0);
+void _35clofun2877(struct Cora* co) {
+Obj _35val1402 = co->args[1];
+pushCont(co, 0, _35clofun2878, 0);
 coraCall(co, 2, globalRef(intern("import")), makeString1("cora/lib/io"));
 }
 
-void _35clofun2850(struct Cora* co) {
-Obj _35val1399 = co->args[1];
-Obj _35reg1414 = primSet(intern("cora/lib/toc.assq"), makeNative(0, _35clofun2851, 2, 0));
-Obj _35reg1420 = primSet(intern("cora/lib/toc.foldl"), makeNative(0, _35clofun2855, 3, 0));
-Obj _35reg1430 = primSet(intern("cora/lib/toc.pos-in-list0"), makeNative(0, _35clofun2859, 3, 0));
-Obj _35reg1431 = primSet(intern("cora/lib/toc.index"), makeNative(0, _35clofun2863, 2, 0));
-Obj _35reg1438 = primSet(intern("cora/lib/toc.exist-in-env"), makeNative(0, _35clofun2864, 2, 0));
-Obj _35reg1439 = primCons(intern("primSet"), Nil);
-Obj _35reg1440 = primCons(makeNumber(2), _35reg1439);
-Obj _35reg1441 = primCons(intern("set"), _35reg1440);
-Obj _35reg1442 = primCons(intern("primCar"), Nil);
-Obj _35reg1443 = primCons(makeNumber(1), _35reg1442);
-Obj _35reg1444 = primCons(intern("car"), _35reg1443);
-Obj _35reg1445 = primCons(intern("primCdr"), Nil);
-Obj _35reg1446 = primCons(makeNumber(1), _35reg1445);
-Obj _35reg1447 = primCons(intern("cdr"), _35reg1446);
-Obj _35reg1448 = primCons(intern("primCons"), Nil);
-Obj _35reg1449 = primCons(makeNumber(2), _35reg1448);
-Obj _35reg1450 = primCons(intern("cons"), _35reg1449);
-Obj _35reg1451 = primCons(intern("primIsCons"), Nil);
-Obj _35reg1452 = primCons(makeNumber(1), _35reg1451);
-Obj _35reg1453 = primCons(intern("cons?"), _35reg1452);
-Obj _35reg1454 = primCons(intern("primAdd"), Nil);
-Obj _35reg1455 = primCons(makeNumber(2), _35reg1454);
-Obj _35reg1456 = primCons(intern("+"), _35reg1455);
-Obj _35reg1457 = primCons(intern("primSub"), Nil);
-Obj _35reg1458 = primCons(makeNumber(2), _35reg1457);
-Obj _35reg1459 = primCons(intern("-"), _35reg1458);
-Obj _35reg1460 = primCons(intern("primMul"), Nil);
-Obj _35reg1461 = primCons(makeNumber(2), _35reg1460);
-Obj _35reg1462 = primCons(intern("*"), _35reg1461);
-Obj _35reg1463 = primCons(intern("primDiv"), Nil);
-Obj _35reg1464 = primCons(makeNumber(2), _35reg1463);
-Obj _35reg1465 = primCons(intern("/"), _35reg1464);
-Obj _35reg1466 = primCons(intern("primEQ"), Nil);
-Obj _35reg1467 = primCons(makeNumber(2), _35reg1466);
-Obj _35reg1468 = primCons(intern("="), _35reg1467);
-Obj _35reg1469 = primCons(intern("primGT"), Nil);
-Obj _35reg1470 = primCons(makeNumber(2), _35reg1469);
-Obj _35reg1471 = primCons(intern(">"), _35reg1470);
-Obj _35reg1472 = primCons(intern("primLT"), Nil);
-Obj _35reg1473 = primCons(makeNumber(2), _35reg1472);
-Obj _35reg1474 = primCons(intern("<"), _35reg1473);
-Obj _35reg1475 = primCons(intern("primGenSym"), Nil);
-Obj _35reg1476 = primCons(makeNumber(1), _35reg1475);
-Obj _35reg1477 = primCons(intern("gensym"), _35reg1476);
-Obj _35reg1478 = primCons(intern("primIsSymbol"), Nil);
-Obj _35reg1479 = primCons(makeNumber(1), _35reg1478);
-Obj _35reg1480 = primCons(intern("symbol?"), _35reg1479);
-Obj _35reg1481 = primCons(intern("primNot"), Nil);
-Obj _35reg1482 = primCons(makeNumber(1), _35reg1481);
-Obj _35reg1483 = primCons(intern("not"), _35reg1482);
-Obj _35reg1484 = primCons(intern("primIsNumber"), Nil);
-Obj _35reg1485 = primCons(makeNumber(1), _35reg1484);
-Obj _35reg1486 = primCons(intern("integer?"), _35reg1485);
-Obj _35reg1487 = primCons(intern("primIsString"), Nil);
-Obj _35reg1488 = primCons(makeNumber(1), _35reg1487);
-Obj _35reg1489 = primCons(intern("string?"), _35reg1488);
-Obj _35reg1490 = primCons(_35reg1489, Nil);
-Obj _35reg1491 = primCons(_35reg1486, _35reg1490);
-Obj _35reg1492 = primCons(_35reg1483, _35reg1491);
-Obj _35reg1493 = primCons(_35reg1480, _35reg1492);
-Obj _35reg1494 = primCons(_35reg1477, _35reg1493);
-Obj _35reg1495 = primCons(_35reg1474, _35reg1494);
-Obj _35reg1496 = primCons(_35reg1471, _35reg1495);
-Obj _35reg1497 = primCons(_35reg1468, _35reg1496);
-Obj _35reg1498 = primCons(_35reg1465, _35reg1497);
-Obj _35reg1499 = primCons(_35reg1462, _35reg1498);
-Obj _35reg1500 = primCons(_35reg1459, _35reg1499);
-Obj _35reg1501 = primCons(_35reg1456, _35reg1500);
-Obj _35reg1502 = primCons(_35reg1453, _35reg1501);
-Obj _35reg1503 = primCons(_35reg1450, _35reg1502);
-Obj _35reg1504 = primCons(_35reg1447, _35reg1503);
-Obj _35reg1505 = primCons(_35reg1444, _35reg1504);
-Obj _35reg1506 = primCons(_35reg1441, _35reg1505);
-Obj _35reg1507 = primSet(intern("cora/lib/toc.*builtin-prims*"), _35reg1506);
-Obj _35reg1511 = primSet(intern("builtin?"), makeNative(0, _35clofun2868, 1, 0));
-Obj _35reg1514 = primSet(intern("cora/lib/toc.builtin->name"), makeNative(0, _35clofun2871, 1, 0));
-Obj _35reg1517 = primSet(intern("cora/lib/toc.builtin->args"), makeNative(0, _35clofun2874, 1, 0));
-Obj _35reg1522 = primSet(intern("cora/lib/toc.temp-list"), makeNative(0, _35clofun2877, 2, 0));
-Obj _35reg1658 = primSet(intern("cora/lib/toc.parse"), makeNative(0, _35clofun2880, 2, 0));
-Obj _35reg1669 = primSet(intern("cora/lib/toc.union"), makeNative(0, _35clofun2910, 2, 0));
-Obj _35reg1680 = primSet(intern("cora/lib/toc.diff"), makeNative(0, _35clofun2916, 2, 0));
-Obj _35reg1731 = primSet(intern("cora/lib/toc.convert-protect?"), makeNative(0, _35clofun2922, 1, 0));
-Obj _35reg1906 = primSet(intern("cora/lib/toc.free-vars"), makeNative(0, _35clofun2929, 1, 0));
-Obj _35reg1979 = primSet(intern("cora/lib/toc.closure-convert"), makeNative(0, _35clofun2952, 2, 0));
-Obj _35reg1982 = primSet(intern("cora/lib/toc.id"), makeNative(0, _35clofun2967, 1, 0));
-Obj _35reg2119 = primSet(intern("cora/lib/toc.tailify"), makeNative(0, _35clofun2968, 2, 0));
-Obj _35reg2166 = primSet(intern("cora/lib/toc.tailify-list"), makeNative(0, _35clofun2986, 3, 0));
-Obj _35reg2245 = primSet(intern("cora/lib/toc.explicit-stack"), makeNative(0, _35clofun2996, 2, 0));
-Obj _35reg2352 = primSet(intern("cora/lib/toc.collect-lambda"), makeNative(0, _35clofun3014, 3, 0));
-Obj _35reg2359 = primSet(intern("cora/lib/toc.collect-lambda-list"), makeNative(0, _35clofun3024, 4, 0));
-Obj _35reg2366 = primSet(intern("cora/lib/toc.wrap-var"), makeNative(0, _35clofun3029, 2, 0));
-Obj _35reg2617 = primSet(intern("cora/lib/toc.generate-inst"), makeNative(0, _35clofun3031, 3, 0));
-Obj _35reg2628 = primSet(intern("cora/lib/toc.generate-call-args"), makeNative(0, _35clofun3103, 4, 0));
-Obj _35reg2647 = primSet(intern("cora/lib/toc.generate-cont"), makeNative(0, _35clofun3111, 2, 0));
-Obj _35reg2656 = primSet(intern("cora/lib/toc.generate-inst-list-h"), makeNative(0, _35clofun3122, 4, 0));
-Obj _35reg2657 = primSet(intern("cora/lib/toc.generate-inst-list"), makeNative(0, _35clofun3128, 3, 0));
-Obj _35reg2661 = primSet(intern("cora/lib/toc.code-gen-func-declare"), makeNative(0, _35clofun3129, 2, 0));
-Obj _35reg2672 = primSet(intern("cora/lib/toc.generate-call-args-reverse"), makeNative(0, _35clofun3133, 5, 0));
-Obj _35reg2729 = primSet(intern("cora/lib/toc.code-gen-toplevel"), makeNative(0, _35clofun3141, 2, 0));
-Obj _35reg2730 = primSet(intern("cora/lib/toc.parse-pass"), makeNative(0, _35clofun3148, 1, 0));
-Obj _35reg2731 = primSet(intern("cora/lib/toc.closure-convert-pass"), makeNative(0, _35clofun3149, 1, 0));
-Obj _35reg2732 = primSet(intern("cora/lib/toc.tailify-pass"), makeNative(0, _35clofun3150, 1, 0));
-Obj _35reg2733 = primSet(intern("cora/lib/toc.explicit-stack-pass"), makeNative(0, _35clofun3151, 1, 0));
-Obj _35reg2741 = primSet(intern("cora/lib/toc.collect-lambda-pass"), makeNative(0, _35clofun3152, 1, 0));
-Obj _35reg2748 = primSet(intern("cora/lib/toc.rewrite-->macro"), makeNative(0, _35clofun3154, 2, 0));
-pushCont(co, 0, _35clofun3160, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("->"), makeNative(0, _35clofun3157, 1, 0));
+void _35clofun2878(struct Cora* co) {
+Obj _35val1403 = co->args[1];
+Obj _35reg1418 = primSet(intern("cora/lib/toc.assq"), makeNative(0, _35clofun2879, 2, 0));
+Obj _35reg1424 = primSet(intern("cora/lib/toc.foldl"), makeNative(0, _35clofun2883, 3, 0));
+Obj _35reg1434 = primSet(intern("cora/lib/toc.pos-in-list0"), makeNative(0, _35clofun2887, 3, 0));
+Obj _35reg1435 = primSet(intern("cora/lib/toc.index"), makeNative(0, _35clofun2891, 2, 0));
+Obj _35reg1442 = primSet(intern("cora/lib/toc.exist-in-env"), makeNative(0, _35clofun2892, 2, 0));
+Obj _35reg1443 = primCons(intern("primSet"), Nil);
+Obj _35reg1444 = primCons(makeNumber(2), _35reg1443);
+Obj _35reg1445 = primCons(intern("set"), _35reg1444);
+Obj _35reg1446 = primCons(intern("primCar"), Nil);
+Obj _35reg1447 = primCons(makeNumber(1), _35reg1446);
+Obj _35reg1448 = primCons(intern("car"), _35reg1447);
+Obj _35reg1449 = primCons(intern("primCdr"), Nil);
+Obj _35reg1450 = primCons(makeNumber(1), _35reg1449);
+Obj _35reg1451 = primCons(intern("cdr"), _35reg1450);
+Obj _35reg1452 = primCons(intern("primCons"), Nil);
+Obj _35reg1453 = primCons(makeNumber(2), _35reg1452);
+Obj _35reg1454 = primCons(intern("cons"), _35reg1453);
+Obj _35reg1455 = primCons(intern("primIsCons"), Nil);
+Obj _35reg1456 = primCons(makeNumber(1), _35reg1455);
+Obj _35reg1457 = primCons(intern("cons?"), _35reg1456);
+Obj _35reg1458 = primCons(intern("primAdd"), Nil);
+Obj _35reg1459 = primCons(makeNumber(2), _35reg1458);
+Obj _35reg1460 = primCons(intern("+"), _35reg1459);
+Obj _35reg1461 = primCons(intern("primSub"), Nil);
+Obj _35reg1462 = primCons(makeNumber(2), _35reg1461);
+Obj _35reg1463 = primCons(intern("-"), _35reg1462);
+Obj _35reg1464 = primCons(intern("primMul"), Nil);
+Obj _35reg1465 = primCons(makeNumber(2), _35reg1464);
+Obj _35reg1466 = primCons(intern("*"), _35reg1465);
+Obj _35reg1467 = primCons(intern("primDiv"), Nil);
+Obj _35reg1468 = primCons(makeNumber(2), _35reg1467);
+Obj _35reg1469 = primCons(intern("/"), _35reg1468);
+Obj _35reg1470 = primCons(intern("primEQ"), Nil);
+Obj _35reg1471 = primCons(makeNumber(2), _35reg1470);
+Obj _35reg1472 = primCons(intern("="), _35reg1471);
+Obj _35reg1473 = primCons(intern("primGT"), Nil);
+Obj _35reg1474 = primCons(makeNumber(2), _35reg1473);
+Obj _35reg1475 = primCons(intern(">"), _35reg1474);
+Obj _35reg1476 = primCons(intern("primLT"), Nil);
+Obj _35reg1477 = primCons(makeNumber(2), _35reg1476);
+Obj _35reg1478 = primCons(intern("<"), _35reg1477);
+Obj _35reg1479 = primCons(intern("primGenSym"), Nil);
+Obj _35reg1480 = primCons(makeNumber(1), _35reg1479);
+Obj _35reg1481 = primCons(intern("gensym"), _35reg1480);
+Obj _35reg1482 = primCons(intern("primIsSymbol"), Nil);
+Obj _35reg1483 = primCons(makeNumber(1), _35reg1482);
+Obj _35reg1484 = primCons(intern("symbol?"), _35reg1483);
+Obj _35reg1485 = primCons(intern("primNot"), Nil);
+Obj _35reg1486 = primCons(makeNumber(1), _35reg1485);
+Obj _35reg1487 = primCons(intern("not"), _35reg1486);
+Obj _35reg1488 = primCons(intern("primIsNumber"), Nil);
+Obj _35reg1489 = primCons(makeNumber(1), _35reg1488);
+Obj _35reg1490 = primCons(intern("integer?"), _35reg1489);
+Obj _35reg1491 = primCons(intern("primIsString"), Nil);
+Obj _35reg1492 = primCons(makeNumber(1), _35reg1491);
+Obj _35reg1493 = primCons(intern("string?"), _35reg1492);
+Obj _35reg1494 = primCons(_35reg1493, Nil);
+Obj _35reg1495 = primCons(_35reg1490, _35reg1494);
+Obj _35reg1496 = primCons(_35reg1487, _35reg1495);
+Obj _35reg1497 = primCons(_35reg1484, _35reg1496);
+Obj _35reg1498 = primCons(_35reg1481, _35reg1497);
+Obj _35reg1499 = primCons(_35reg1478, _35reg1498);
+Obj _35reg1500 = primCons(_35reg1475, _35reg1499);
+Obj _35reg1501 = primCons(_35reg1472, _35reg1500);
+Obj _35reg1502 = primCons(_35reg1469, _35reg1501);
+Obj _35reg1503 = primCons(_35reg1466, _35reg1502);
+Obj _35reg1504 = primCons(_35reg1463, _35reg1503);
+Obj _35reg1505 = primCons(_35reg1460, _35reg1504);
+Obj _35reg1506 = primCons(_35reg1457, _35reg1505);
+Obj _35reg1507 = primCons(_35reg1454, _35reg1506);
+Obj _35reg1508 = primCons(_35reg1451, _35reg1507);
+Obj _35reg1509 = primCons(_35reg1448, _35reg1508);
+Obj _35reg1510 = primCons(_35reg1445, _35reg1509);
+Obj _35reg1511 = primSet(intern("cora/lib/toc.*builtin-prims*"), _35reg1510);
+Obj _35reg1515 = primSet(intern("builtin?"), makeNative(0, _35clofun2896, 1, 0));
+Obj _35reg1518 = primSet(intern("cora/lib/toc.builtin->name"), makeNative(0, _35clofun2899, 1, 0));
+Obj _35reg1521 = primSet(intern("cora/lib/toc.builtin->args"), makeNative(0, _35clofun2902, 1, 0));
+Obj _35reg1526 = primSet(intern("cora/lib/toc.temp-list"), makeNative(0, _35clofun2905, 2, 0));
+Obj _35reg1662 = primSet(intern("cora/lib/toc.parse"), makeNative(0, _35clofun2908, 2, 0));
+Obj _35reg1673 = primSet(intern("cora/lib/toc.union"), makeNative(0, _35clofun2938, 2, 0));
+Obj _35reg1684 = primSet(intern("cora/lib/toc.diff"), makeNative(0, _35clofun2944, 2, 0));
+Obj _35reg1735 = primSet(intern("cora/lib/toc.convert-protect?"), makeNative(0, _35clofun2950, 1, 0));
+Obj _35reg1910 = primSet(intern("cora/lib/toc.free-vars"), makeNative(0, _35clofun2957, 1, 0));
+Obj _35reg1983 = primSet(intern("cora/lib/toc.closure-convert"), makeNative(0, _35clofun2980, 2, 0));
+Obj _35reg1986 = primSet(intern("cora/lib/toc.id"), makeNative(0, _35clofun2995, 1, 0));
+Obj _35reg2123 = primSet(intern("cora/lib/toc.tailify"), makeNative(0, _35clofun2996, 2, 0));
+Obj _35reg2170 = primSet(intern("cora/lib/toc.tailify-list"), makeNative(0, _35clofun3014, 3, 0));
+Obj _35reg2249 = primSet(intern("cora/lib/toc.explicit-stack"), makeNative(0, _35clofun3024, 2, 0));
+Obj _35reg2356 = primSet(intern("cora/lib/toc.collect-lambda"), makeNative(0, _35clofun3042, 3, 0));
+Obj _35reg2363 = primSet(intern("cora/lib/toc.collect-lambda-list"), makeNative(0, _35clofun3052, 4, 0));
+Obj _35reg2370 = primSet(intern("cora/lib/toc.wrap-var"), makeNative(0, _35clofun3057, 2, 0));
+Obj _35reg2621 = primSet(intern("cora/lib/toc.generate-inst"), makeNative(0, _35clofun3059, 3, 0));
+Obj _35reg2632 = primSet(intern("cora/lib/toc.generate-call-args"), makeNative(0, _35clofun3131, 4, 0));
+Obj _35reg2651 = primSet(intern("cora/lib/toc.generate-cont"), makeNative(0, _35clofun3139, 2, 0));
+Obj _35reg2660 = primSet(intern("cora/lib/toc.generate-inst-list-h"), makeNative(0, _35clofun3150, 4, 0));
+Obj _35reg2661 = primSet(intern("cora/lib/toc.generate-inst-list"), makeNative(0, _35clofun3156, 3, 0));
+Obj _35reg2665 = primSet(intern("cora/lib/toc.code-gen-func-declare"), makeNative(0, _35clofun3157, 2, 0));
+Obj _35reg2676 = primSet(intern("cora/lib/toc.generate-call-args-reverse"), makeNative(0, _35clofun3161, 5, 0));
+Obj _35reg2733 = primSet(intern("cora/lib/toc.code-gen-toplevel"), makeNative(0, _35clofun3169, 2, 0));
+Obj _35reg2734 = primSet(intern("cora/lib/toc.parse-pass"), makeNative(0, _35clofun3176, 1, 0));
+Obj _35reg2735 = primSet(intern("cora/lib/toc.closure-convert-pass"), makeNative(0, _35clofun3177, 1, 0));
+Obj _35reg2736 = primSet(intern("cora/lib/toc.tailify-pass"), makeNative(0, _35clofun3178, 1, 0));
+Obj _35reg2737 = primSet(intern("cora/lib/toc.explicit-stack-pass"), makeNative(0, _35clofun3179, 1, 0));
+Obj _35reg2745 = primSet(intern("cora/lib/toc.collect-lambda-pass"), makeNative(0, _35clofun3180, 1, 0));
+Obj _35reg2752 = primSet(intern("cora/lib/toc.rewrite-->macro"), makeNative(0, _35clofun3182, 2, 0));
+pushCont(co, 0, _35clofun3188, 0);
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("->"), makeNative(0, _35clofun3185, 1, 0));
 }
 
-void _35clofun3160(struct Cora* co) {
-Obj _35val2751 = co->args[1];
-Obj _35reg2756 = primSet(intern("cora/lib/toc.compile"), makeNative(0, _35clofun3161, 1, 0));
-Obj _35reg2762 = primSet(intern("for-each"), makeNative(0, _35clofun3166, 2, 0));
-Obj _35reg2769 = primSet(intern("cora/lib/toc.generate-c"), makeNative(0, _35clofun3170, 2, 0));
-Obj _35reg2775 = primSet(intern("cora/lib/toc.compile-to-c"), makeNative(0, _35clofun3178, 3, 0));
-Obj _35reg2777 = primSet(intern("set"), makeNative(0, _35clofun3184, 2, 0));
-Obj _35reg2779 = primSet(intern("car"), makeNative(0, _35clofun3185, 1, 0));
-Obj _35reg2781 = primSet(intern("cdr"), makeNative(0, _35clofun3186, 1, 0));
-Obj _35reg2783 = primSet(intern("cons"), makeNative(0, _35clofun3187, 2, 0));
-Obj _35reg2785 = primSet(intern("cons"), makeNative(0, _35clofun3188, 2, 0));
-Obj _35reg2787 = primSet(intern("+"), makeNative(0, _35clofun3189, 2, 0));
-Obj _35reg2789 = primSet(intern("-"), makeNative(0, _35clofun3190, 2, 0));
-Obj _35reg2791 = primSet(intern("*"), makeNative(0, _35clofun3191, 2, 0));
-Obj _35reg2793 = primSet(intern("/"), makeNative(0, _35clofun3192, 2, 0));
-Obj _35reg2795 = primSet(intern("="), makeNative(0, _35clofun3193, 2, 0));
-Obj _35reg2797 = primSet(intern(">"), makeNative(0, _35clofun3194, 2, 0));
-Obj _35reg2799 = primSet(intern("<"), makeNative(0, _35clofun3195, 2, 0));
-Obj _35reg2801 = primSet(intern("gensym"), makeNative(0, _35clofun3196, 1, 0));
-Obj _35reg2803 = primSet(intern("symbol?"), makeNative(0, _35clofun3197, 1, 0));
-Obj _35reg2805 = primSet(intern("not"), makeNative(0, _35clofun3198, 1, 0));
-Obj _35reg2807 = primSet(intern("string?"), makeNative(0, _35clofun3199, 1, 0));
-Obj _35reg2848 = primSet(intern("cora/lib/toc.eval0"), makeNative(0, _35clofun3200, 1, 0));
-coraReturn(co, _35reg2848);
+void _35clofun3188(struct Cora* co) {
+Obj _35val2755 = co->args[1];
+Obj _35reg2760 = primSet(intern("cora/lib/toc.compile"), makeNative(0, _35clofun3189, 1, 0));
+Obj _35reg2766 = primSet(intern("for-each"), makeNative(0, _35clofun3194, 2, 0));
+Obj _35reg2773 = primSet(intern("cora/lib/toc.generate-c"), makeNative(0, _35clofun3198, 2, 0));
+Obj _35reg2796 = primSet(intern("cora/lib/toc.handle-import-eagerly"), makeNative(0, _35clofun3206, 1, 0));
+Obj _35reg2803 = primSet(intern("cora/lib/toc.compile-to-c"), makeNative(0, _35clofun3211, 3, 0));
+Obj _35reg2805 = primSet(intern("set"), makeNative(0, _35clofun3218, 2, 0));
+Obj _35reg2807 = primSet(intern("car"), makeNative(0, _35clofun3219, 1, 0));
+Obj _35reg2809 = primSet(intern("cdr"), makeNative(0, _35clofun3220, 1, 0));
+Obj _35reg2811 = primSet(intern("cons"), makeNative(0, _35clofun3221, 2, 0));
+Obj _35reg2813 = primSet(intern("cons"), makeNative(0, _35clofun3222, 2, 0));
+Obj _35reg2815 = primSet(intern("+"), makeNative(0, _35clofun3223, 2, 0));
+Obj _35reg2817 = primSet(intern("-"), makeNative(0, _35clofun3224, 2, 0));
+Obj _35reg2819 = primSet(intern("*"), makeNative(0, _35clofun3225, 2, 0));
+Obj _35reg2821 = primSet(intern("/"), makeNative(0, _35clofun3226, 2, 0));
+Obj _35reg2823 = primSet(intern("="), makeNative(0, _35clofun3227, 2, 0));
+Obj _35reg2825 = primSet(intern(">"), makeNative(0, _35clofun3228, 2, 0));
+Obj _35reg2827 = primSet(intern("<"), makeNative(0, _35clofun3229, 2, 0));
+Obj _35reg2829 = primSet(intern("gensym"), makeNative(0, _35clofun3230, 1, 0));
+Obj _35reg2831 = primSet(intern("symbol?"), makeNative(0, _35clofun3231, 1, 0));
+Obj _35reg2833 = primSet(intern("not"), makeNative(0, _35clofun3232, 1, 0));
+Obj _35reg2835 = primSet(intern("string?"), makeNative(0, _35clofun3233, 1, 0));
+Obj _35reg2876 = primSet(intern("cora/lib/toc.eval0"), makeNative(0, _35clofun3234, 1, 0));
+coraReturn(co, _35reg2876);
 return;
 }
 
-void _35clofun3200(struct Cora* co) {
+void _35clofun3234(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg2808 = primIsSymbol(exp);
-if (True == _35reg2808) {
+Obj _35reg2836 = primIsSymbol(exp);
+if (True == _35reg2836) {
 coraCall(co, 2, globalRef(intern("value")), exp);
 } else {
-pushCont(co, 0, _35clofun3201, 1, exp);
+pushCont(co, 0, _35clofun3235, 1, exp);
 coraCall(co, 2, globalRef(intern("number?")), exp);
 }
 }
 
-void _35clofun3201(struct Cora* co) {
-Obj _35val2809 = co->args[1];
+void _35clofun3235(struct Cora* co) {
+Obj _35val2837 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val2809) {
+if (True == _35val2837) {
 if (True == True) {
 coraReturn(co, exp);
 return;
 } else {
-Obj _35reg2810 = primIsCons(exp);
-if (True == _35reg2810) {
-Obj _35reg2811 = primCar(exp);
-Obj _35reg2812 = primEQ(_35reg2811, intern("quote"));
-if (True == _35reg2812) {
+Obj _35reg2838 = primIsCons(exp);
+if (True == _35reg2838) {
+Obj _35reg2839 = primCar(exp);
+Obj _35reg2840 = primEQ(_35reg2839, intern("quote"));
+if (True == _35reg2840) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
-Obj _35reg2813 = primCar(exp);
-pushCont(co, 0, _35clofun3202, 1, exp);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2813);
+Obj _35reg2841 = primCar(exp);
+pushCont(co, 0, _35clofun3236, 1, exp);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2841);
 }
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 } else {
-Obj _35reg2817 = primIsString(exp);
-if (True == _35reg2817) {
+Obj _35reg2845 = primIsString(exp);
+if (True == _35reg2845) {
 if (True == True) {
 coraReturn(co, exp);
 return;
 } else {
-Obj _35reg2818 = primIsCons(exp);
-if (True == _35reg2818) {
-Obj _35reg2819 = primCar(exp);
-Obj _35reg2820 = primEQ(_35reg2819, intern("quote"));
-if (True == _35reg2820) {
+Obj _35reg2846 = primIsCons(exp);
+if (True == _35reg2846) {
+Obj _35reg2847 = primCar(exp);
+Obj _35reg2848 = primEQ(_35reg2847, intern("quote"));
+if (True == _35reg2848) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
-Obj _35reg2821 = primCar(exp);
-pushCont(co, 0, _35clofun3204, 1, exp);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2821);
+Obj _35reg2849 = primCar(exp);
+pushCont(co, 0, _35clofun3238, 1, exp);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2849);
 }
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 } else {
-pushCont(co, 0, _35clofun3206, 1, exp);
+pushCont(co, 0, _35clofun3240, 1, exp);
 coraCall(co, 2, globalRef(intern("boolean?")), exp);
 }
 }
 }
 
-void _35clofun3206(struct Cora* co) {
-Obj _35val2825 = co->args[1];
+void _35clofun3240(struct Cora* co) {
+Obj _35val2853 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val2825) {
+if (True == _35val2853) {
 if (True == True) {
 coraReturn(co, exp);
 return;
 } else {
-Obj _35reg2826 = primIsCons(exp);
-if (True == _35reg2826) {
-Obj _35reg2827 = primCar(exp);
-Obj _35reg2828 = primEQ(_35reg2827, intern("quote"));
-if (True == _35reg2828) {
+Obj _35reg2854 = primIsCons(exp);
+if (True == _35reg2854) {
+Obj _35reg2855 = primCar(exp);
+Obj _35reg2856 = primEQ(_35reg2855, intern("quote"));
+if (True == _35reg2856) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
-Obj _35reg2829 = primCar(exp);
-pushCont(co, 0, _35clofun3207, 1, exp);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2829);
+Obj _35reg2857 = primCar(exp);
+pushCont(co, 0, _35clofun3241, 1, exp);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2857);
 }
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 } else {
-pushCont(co, 0, _35clofun3209, 1, exp);
+pushCont(co, 0, _35clofun3243, 1, exp);
 coraCall(co, 2, globalRef(intern("null?")), exp);
 }
 }
 
-void _35clofun3209(struct Cora* co) {
-Obj _35val2833 = co->args[1];
+void _35clofun3243(struct Cora* co) {
+Obj _35val2861 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val2833) {
+if (True == _35val2861) {
 if (True == True) {
 coraReturn(co, exp);
 return;
 } else {
-Obj _35reg2834 = primIsCons(exp);
-if (True == _35reg2834) {
-Obj _35reg2835 = primCar(exp);
-Obj _35reg2836 = primEQ(_35reg2835, intern("quote"));
-if (True == _35reg2836) {
+Obj _35reg2862 = primIsCons(exp);
+if (True == _35reg2862) {
+Obj _35reg2863 = primCar(exp);
+Obj _35reg2864 = primEQ(_35reg2863, intern("quote"));
+if (True == _35reg2864) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
-Obj _35reg2837 = primCar(exp);
-pushCont(co, 0, _35clofun3210, 1, exp);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2837);
+Obj _35reg2865 = primCar(exp);
+pushCont(co, 0, _35clofun3244, 1, exp);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2865);
 }
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
@@ -637,16 +644,16 @@ if (True == False) {
 coraReturn(co, exp);
 return;
 } else {
-Obj _35reg2841 = primIsCons(exp);
-if (True == _35reg2841) {
-Obj _35reg2842 = primCar(exp);
-Obj _35reg2843 = primEQ(_35reg2842, intern("quote"));
-if (True == _35reg2843) {
+Obj _35reg2869 = primIsCons(exp);
+if (True == _35reg2869) {
+Obj _35reg2870 = primCar(exp);
+Obj _35reg2871 = primEQ(_35reg2870, intern("quote"));
+if (True == _35reg2871) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
-Obj _35reg2844 = primCar(exp);
-pushCont(co, 0, _35clofun3212, 1, exp);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2844);
+Obj _35reg2872 = primCar(exp);
+pushCont(co, 0, _35clofun3246, 1, exp);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2872);
 }
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
@@ -655,306 +662,395 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 
-void _35clofun3212(struct Cora* co) {
-Obj _35val2845 = co->args[1];
+void _35clofun3246(struct Cora* co) {
+Obj _35val2873 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2846 = primCdr(exp);
-pushCont(co, 0, _35clofun3213, 1, _35val2845);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2846);
+Obj _35reg2874 = primCdr(exp);
+pushCont(co, 0, _35clofun3247, 1, _35val2873);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2874);
 }
 
-void _35clofun3213(struct Cora* co) {
-Obj _35val2847 = co->args[1];
-Obj _35val2845 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("apply")), _35val2845, _35val2847);
+void _35clofun3247(struct Cora* co) {
+Obj _35val2875 = co->args[1];
+Obj _35val2873 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("apply")), _35val2873, _35val2875);
 }
 
-void _35clofun3210(struct Cora* co) {
-Obj _35val2838 = co->args[1];
+void _35clofun3244(struct Cora* co) {
+Obj _35val2866 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2839 = primCdr(exp);
-pushCont(co, 0, _35clofun3211, 1, _35val2838);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2839);
+Obj _35reg2867 = primCdr(exp);
+pushCont(co, 0, _35clofun3245, 1, _35val2866);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2867);
 }
 
-void _35clofun3211(struct Cora* co) {
-Obj _35val2840 = co->args[1];
-Obj _35val2838 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("apply")), _35val2838, _35val2840);
+void _35clofun3245(struct Cora* co) {
+Obj _35val2868 = co->args[1];
+Obj _35val2866 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("apply")), _35val2866, _35val2868);
 }
 
-void _35clofun3207(struct Cora* co) {
-Obj _35val2830 = co->args[1];
+void _35clofun3241(struct Cora* co) {
+Obj _35val2858 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2831 = primCdr(exp);
-pushCont(co, 0, _35clofun3208, 1, _35val2830);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2831);
+Obj _35reg2859 = primCdr(exp);
+pushCont(co, 0, _35clofun3242, 1, _35val2858);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2859);
 }
 
-void _35clofun3208(struct Cora* co) {
-Obj _35val2832 = co->args[1];
-Obj _35val2830 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("apply")), _35val2830, _35val2832);
+void _35clofun3242(struct Cora* co) {
+Obj _35val2860 = co->args[1];
+Obj _35val2858 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("apply")), _35val2858, _35val2860);
 }
 
-void _35clofun3204(struct Cora* co) {
-Obj _35val2822 = co->args[1];
+void _35clofun3238(struct Cora* co) {
+Obj _35val2850 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2823 = primCdr(exp);
-pushCont(co, 0, _35clofun3205, 1, _35val2822);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2823);
+Obj _35reg2851 = primCdr(exp);
+pushCont(co, 0, _35clofun3239, 1, _35val2850);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2851);
 }
 
-void _35clofun3205(struct Cora* co) {
-Obj _35val2824 = co->args[1];
-Obj _35val2822 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("apply")), _35val2822, _35val2824);
+void _35clofun3239(struct Cora* co) {
+Obj _35val2852 = co->args[1];
+Obj _35val2850 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("apply")), _35val2850, _35val2852);
 }
 
-void _35clofun3202(struct Cora* co) {
-Obj _35val2814 = co->args[1];
+void _35clofun3236(struct Cora* co) {
+Obj _35val2842 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2815 = primCdr(exp);
-pushCont(co, 0, _35clofun3203, 1, _35val2814);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2815);
+Obj _35reg2843 = primCdr(exp);
+pushCont(co, 0, _35clofun3237, 1, _35val2842);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2843);
 }
 
-void _35clofun3203(struct Cora* co) {
-Obj _35val2816 = co->args[1];
-Obj _35val2814 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("apply")), _35val2814, _35val2816);
+void _35clofun3237(struct Cora* co) {
+Obj _35val2844 = co->args[1];
+Obj _35val2842 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("apply")), _35val2842, _35val2844);
 }
 
-void _35clofun3199(struct Cora* co) {
+void _35clofun3233(struct Cora* co) {
+Obj _35tmp1401 = co->args[1];
+Obj _35reg2834 = primIsString(_35tmp1401);
+coraReturn(co, _35reg2834);
+return;
+}
+
+void _35clofun3232(struct Cora* co) {
+Obj _35tmp1400 = co->args[1];
+Obj _35reg2832 = primNot(_35tmp1400);
+coraReturn(co, _35reg2832);
+return;
+}
+
+void _35clofun3231(struct Cora* co) {
+Obj _35tmp1399 = co->args[1];
+Obj _35reg2830 = primIsSymbol(_35tmp1399);
+coraReturn(co, _35reg2830);
+return;
+}
+
+void _35clofun3230(struct Cora* co) {
+Obj _35tmp1398 = co->args[1];
+Obj _35reg2828 = primGenSym(_35tmp1398);
+coraReturn(co, _35reg2828);
+return;
+}
+
+void _35clofun3229(struct Cora* co) {
 Obj _35tmp1397 = co->args[1];
-Obj _35reg2806 = primIsString(_35tmp1397);
+Obj _35tmp1396 = co->args[2];
+Obj _35reg2826 = primLT(_35tmp1397, _35tmp1396);
+coraReturn(co, _35reg2826);
+return;
+}
+
+void _35clofun3228(struct Cora* co) {
+Obj _35tmp1395 = co->args[1];
+Obj _35tmp1394 = co->args[2];
+Obj _35reg2824 = primGT(_35tmp1395, _35tmp1394);
+coraReturn(co, _35reg2824);
+return;
+}
+
+void _35clofun3227(struct Cora* co) {
+Obj _35tmp1393 = co->args[1];
+Obj _35tmp1392 = co->args[2];
+Obj _35reg2822 = primEQ(_35tmp1393, _35tmp1392);
+coraReturn(co, _35reg2822);
+return;
+}
+
+void _35clofun3226(struct Cora* co) {
+Obj _35tmp1391 = co->args[1];
+Obj _35tmp1390 = co->args[2];
+Obj _35reg2820 = primDiv(_35tmp1391, _35tmp1390);
+coraReturn(co, _35reg2820);
+return;
+}
+
+void _35clofun3225(struct Cora* co) {
+Obj _35tmp1389 = co->args[1];
+Obj _35tmp1388 = co->args[2];
+Obj _35reg2818 = primMul(_35tmp1389, _35tmp1388);
+coraReturn(co, _35reg2818);
+return;
+}
+
+void _35clofun3224(struct Cora* co) {
+Obj _35tmp1387 = co->args[1];
+Obj _35tmp1386 = co->args[2];
+Obj _35reg2816 = primSub(_35tmp1387, _35tmp1386);
+coraReturn(co, _35reg2816);
+return;
+}
+
+void _35clofun3223(struct Cora* co) {
+Obj _35tmp1385 = co->args[1];
+Obj _35tmp1384 = co->args[2];
+Obj _35reg2814 = primAdd(_35tmp1385, _35tmp1384);
+coraReturn(co, _35reg2814);
+return;
+}
+
+void _35clofun3222(struct Cora* co) {
+Obj _35tmp1383 = co->args[1];
+Obj _35tmp1382 = co->args[2];
+Obj _35reg2812 = primCons(_35tmp1383, _35tmp1382);
+coraReturn(co, _35reg2812);
+return;
+}
+
+void _35clofun3221(struct Cora* co) {
+Obj _35tmp1381 = co->args[1];
+Obj _35tmp1380 = co->args[2];
+Obj _35reg2810 = primCons(_35tmp1381, _35tmp1380);
+coraReturn(co, _35reg2810);
+return;
+}
+
+void _35clofun3220(struct Cora* co) {
+Obj _35tmp1379 = co->args[1];
+Obj _35reg2808 = primCdr(_35tmp1379);
+coraReturn(co, _35reg2808);
+return;
+}
+
+void _35clofun3219(struct Cora* co) {
+Obj _35tmp1378 = co->args[1];
+Obj _35reg2806 = primCar(_35tmp1378);
 coraReturn(co, _35reg2806);
 return;
 }
 
-void _35clofun3198(struct Cora* co) {
-Obj _35tmp1396 = co->args[1];
-Obj _35reg2804 = primNot(_35tmp1396);
+void _35clofun3218(struct Cora* co) {
+Obj _35tmp1377 = co->args[1];
+Obj _35tmp1376 = co->args[2];
+Obj _35reg2804 = primSet(_35tmp1377, _35tmp1376);
 coraReturn(co, _35reg2804);
 return;
 }
 
-void _35clofun3197(struct Cora* co) {
-Obj _35tmp1395 = co->args[1];
-Obj _35reg2802 = primIsSymbol(_35tmp1395);
-coraReturn(co, _35reg2802);
-return;
-}
-
-void _35clofun3196(struct Cora* co) {
-Obj _35tmp1394 = co->args[1];
-Obj _35reg2800 = primGenSym(_35tmp1394);
-coraReturn(co, _35reg2800);
-return;
-}
-
-void _35clofun3195(struct Cora* co) {
-Obj _35tmp1393 = co->args[1];
-Obj _35tmp1392 = co->args[2];
-Obj _35reg2798 = primLT(_35tmp1393, _35tmp1392);
-coraReturn(co, _35reg2798);
-return;
-}
-
-void _35clofun3194(struct Cora* co) {
-Obj _35tmp1391 = co->args[1];
-Obj _35tmp1390 = co->args[2];
-Obj _35reg2796 = primGT(_35tmp1391, _35tmp1390);
-coraReturn(co, _35reg2796);
-return;
-}
-
-void _35clofun3193(struct Cora* co) {
-Obj _35tmp1389 = co->args[1];
-Obj _35tmp1388 = co->args[2];
-Obj _35reg2794 = primEQ(_35tmp1389, _35tmp1388);
-coraReturn(co, _35reg2794);
-return;
-}
-
-void _35clofun3192(struct Cora* co) {
-Obj _35tmp1387 = co->args[1];
-Obj _35tmp1386 = co->args[2];
-Obj _35reg2792 = primDiv(_35tmp1387, _35tmp1386);
-coraReturn(co, _35reg2792);
-return;
-}
-
-void _35clofun3191(struct Cora* co) {
-Obj _35tmp1385 = co->args[1];
-Obj _35tmp1384 = co->args[2];
-Obj _35reg2790 = primMul(_35tmp1385, _35tmp1384);
-coraReturn(co, _35reg2790);
-return;
-}
-
-void _35clofun3190(struct Cora* co) {
-Obj _35tmp1383 = co->args[1];
-Obj _35tmp1382 = co->args[2];
-Obj _35reg2788 = primSub(_35tmp1383, _35tmp1382);
-coraReturn(co, _35reg2788);
-return;
-}
-
-void _35clofun3189(struct Cora* co) {
-Obj _35tmp1381 = co->args[1];
-Obj _35tmp1380 = co->args[2];
-Obj _35reg2786 = primAdd(_35tmp1381, _35tmp1380);
-coraReturn(co, _35reg2786);
-return;
-}
-
-void _35clofun3188(struct Cora* co) {
-Obj _35tmp1379 = co->args[1];
-Obj _35tmp1378 = co->args[2];
-Obj _35reg2784 = primCons(_35tmp1379, _35tmp1378);
-coraReturn(co, _35reg2784);
-return;
-}
-
-void _35clofun3187(struct Cora* co) {
-Obj _35tmp1377 = co->args[1];
-Obj _35tmp1376 = co->args[2];
-Obj _35reg2782 = primCons(_35tmp1377, _35tmp1376);
-coraReturn(co, _35reg2782);
-return;
-}
-
-void _35clofun3186(struct Cora* co) {
-Obj _35tmp1375 = co->args[1];
-Obj _35reg2780 = primCdr(_35tmp1375);
-coraReturn(co, _35reg2780);
-return;
-}
-
-void _35clofun3185(struct Cora* co) {
-Obj _35tmp1374 = co->args[1];
-Obj _35reg2778 = primCar(_35tmp1374);
-coraReturn(co, _35reg2778);
-return;
-}
-
-void _35clofun3184(struct Cora* co) {
-Obj _35tmp1373 = co->args[1];
-Obj _35tmp1372 = co->args[2];
-Obj _35reg2776 = primSet(_35tmp1373, _35tmp1372);
-coraReturn(co, _35reg2776);
-return;
-}
-
-void _35clofun3178(struct Cora* co) {
+void _35clofun3211(struct Cora* co) {
 Obj from = co->args[1];
 Obj to = co->args[2];
 Obj pkg_45str = co->args[3];
-pushCont(co, 0, _35clofun3179, 1, to);
+pushCont(co, 0, _35clofun3212, 1, to);
 coraCall(co, 3, globalRef(intern("read-file-as-sexp")), from, pkg_45str);
 }
 
-void _35clofun3179(struct Cora* co) {
-Obj _35val2770 = co->args[1];
+void _35clofun3212(struct Cora* co) {
+Obj _35val2797 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj sexp = _35val2770;
-pushCont(co, 0, _35clofun3180, 1, to);
+Obj sexp = _35val2797;
+pushCont(co, 0, _35clofun3213, 2, sexp, to);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.handle-import-eagerly")), sexp);
+}
+
+void _35clofun3213(struct Cora* co) {
+Obj _35val2798 = co->args[1];
+Obj sexp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj to = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun3214, 1, to);
 coraCall(co, 2, globalRef(intern("macroexpand")), sexp);
 }
 
-void _35clofun3180(struct Cora* co) {
-Obj _35val2771 = co->args[1];
+void _35clofun3214(struct Cora* co) {
+Obj _35val2799 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj input = _35val2771;
-pushCont(co, 0, _35clofun3181, 1, to);
+Obj input = _35val2799;
+pushCont(co, 0, _35clofun3215, 1, to);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.compile")), input);
 }
 
-void _35clofun3181(struct Cora* co) {
-Obj _35val2772 = co->args[1];
+void _35clofun3215(struct Cora* co) {
+Obj _35val2800 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc = _35val2772;
-pushCont(co, 0, _35clofun3182, 1, bc);
+Obj bc = _35val2800;
+pushCont(co, 0, _35clofun3216, 1, bc);
 coraCall(co, 2, globalRef(intern("cora/lib/io.open-output-file")), to);
 }
 
-void _35clofun3182(struct Cora* co) {
-Obj _35val2773 = co->args[1];
+void _35clofun3216(struct Cora* co) {
+Obj _35val2801 = co->args[1];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stream = _35val2773;
-pushCont(co, 0, _35clofun3183, 1, stream);
+Obj stream = _35val2801;
+pushCont(co, 0, _35clofun3217, 1, stream);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.generate-c")), stream, bc);
 }
 
-void _35clofun3183(struct Cora* co) {
-Obj _35val2774 = co->args[1];
+void _35clofun3217(struct Cora* co) {
+Obj _35val2802 = co->args[1];
 Obj stream = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 2, globalRef(intern("cora/lib/io.close-output-file")), stream);
 }
 
-void _35clofun3170(struct Cora* co) {
+void _35clofun3206(struct Cora* co) {
+Obj _35p1372 = co->args[1];
+Obj _35cc1373 = makeNative(0, _35clofun3207, 0, 1, _35p1372);
+Obj _35reg2792 = primIsCons(_35p1372);
+if (True == _35reg2792) {
+Obj _35reg2793 = primCar(_35p1372);
+Obj _35reg2794 = primEQ(intern("begin"), _35reg2793);
+if (True == _35reg2794) {
+Obj _35reg2795 = primCdr(_35p1372);
+Obj remain = _35reg2795;
+coraCall(co, 2, globalRef(intern("cora/lib/toc.handle-import-eagerly")), remain);
+} else {
+coraCall(co, 1, _35cc1373);
+}
+} else {
+coraCall(co, 1, _35cc1373);
+}
+}
+
+void _35clofun3207(struct Cora* co) {
+Obj _35cc1374 = makeNative(0, _35clofun3208, 0, 1, closureRef(co, 0));
+Obj _35reg2774 = primIsCons(closureRef(co, 0));
+if (True == _35reg2774) {
+Obj _35reg2775 = primCar(closureRef(co, 0));
+Obj _35reg2776 = primIsCons(_35reg2775);
+if (True == _35reg2776) {
+Obj _35reg2777 = primCar(closureRef(co, 0));
+Obj _35reg2778 = primCar(_35reg2777);
+Obj _35reg2779 = primEQ(intern("import"), _35reg2778);
+if (True == _35reg2779) {
+Obj _35reg2780 = primCar(closureRef(co, 0));
+Obj _35reg2781 = primCdr(_35reg2780);
+Obj _35reg2782 = primIsCons(_35reg2781);
+if (True == _35reg2782) {
+Obj _35reg2783 = primCar(closureRef(co, 0));
+Obj _35reg2784 = primCdr(_35reg2783);
+Obj _35reg2785 = primCar(_35reg2784);
+Obj pkg = _35reg2785;
+Obj _35reg2786 = primCar(closureRef(co, 0));
+Obj _35reg2787 = primCdr(_35reg2786);
+Obj _35reg2788 = primCdr(_35reg2787);
+Obj _35reg2789 = primEQ(Nil, _35reg2788);
+if (True == _35reg2789) {
+Obj _35reg2790 = primCdr(closureRef(co, 0));
+Obj remain = _35reg2790;
+pushCont(co, 0, _35clofun3210, 1, remain);
+coraCall(co, 2, globalRef(intern("import")), pkg);
+} else {
+coraCall(co, 1, _35cc1374);
+}
+} else {
+coraCall(co, 1, _35cc1374);
+}
+} else {
+coraCall(co, 1, _35cc1374);
+}
+} else {
+coraCall(co, 1, _35cc1374);
+}
+} else {
+coraCall(co, 1, _35cc1374);
+}
+}
+
+void _35clofun3210(struct Cora* co) {
+Obj _35val2791 = co->args[1];
+Obj remain = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 2, globalRef(intern("cora/lib/toc.handle-import-eagerly")), remain);
+}
+
+void _35clofun3208(struct Cora* co) {
+Obj _35cc1375 = makeNative(0, _35clofun3209, 0, 0);
+Obj __ = closureRef(co, 0);
+coraReturn(co, Nil);
+return;
+}
+
+void _35clofun3209(struct Cora* co) {
+coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
+}
+
+void _35clofun3198(struct Cora* co) {
 Obj to = co->args[1];
 Obj bc = co->args[2];
-pushCont(co, 0, _35clofun3171, 2, to, bc);
+pushCont(co, 0, _35clofun3199, 2, to, bc);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("#include \"types.h\"\n"));
 }
 
-void _35clofun3171(struct Cora* co) {
-Obj _35val2763 = co->args[1];
-Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3172, 2, to, bc);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("#include \"runtime.h\"\n\n"));
-}
-
-void _35clofun3172(struct Cora* co) {
-Obj _35val2764 = co->args[1];
-Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3175, 2, to, bc);
-coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3173, 1, 1, to), bc);
-}
-
-void _35clofun3175(struct Cora* co) {
+void _35clofun3199(struct Cora* co) {
 Obj _35val2767 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3176, 2, to, bc);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("\n"));
+pushCont(co, 0, _35clofun3200, 2, to, bc);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("#include \"runtime.h\"\n\n"));
 }
 
-void _35clofun3176(struct Cora* co) {
+void _35clofun3200(struct Cora* co) {
 Obj _35val2768 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3177, 1, 1, to), bc);
+pushCont(co, 0, _35clofun3203, 2, to, bc);
+coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3201, 1, 1, to), bc);
 }
 
-void _35clofun3177(struct Cora* co) {
+void _35clofun3203(struct Cora* co) {
+Obj _35val2771 = co->args[1];
+Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun3204, 2, to, bc);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("\n"));
+}
+
+void _35clofun3204(struct Cora* co) {
+Obj _35val2772 = co->args[1];
+Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
+coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3205, 1, 1, to), bc);
+}
+
+void _35clofun3205(struct Cora* co) {
 Obj x = co->args[1];
 coraCall(co, 3, globalRef(intern("cora/lib/toc.code-gen-toplevel")), closureRef(co, 0), x);
 }
 
-void _35clofun3173(struct Cora* co) {
+void _35clofun3201(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg2765 = primCar(x);
-pushCont(co, 0, _35clofun3174, 0);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.code-gen-func-declare")), closureRef(co, 0), _35reg2765);
+Obj _35reg2769 = primCar(x);
+pushCont(co, 0, _35clofun3202, 0);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.code-gen-func-declare")), closureRef(co, 0), _35reg2769);
 }
 
-void _35clofun3174(struct Cora* co) {
-Obj _35val2766 = co->args[1];
+void _35clofun3202(struct Cora* co) {
+Obj _35val2770 = co->args[1];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closureRef(co, 0), makeString1(";\n"));
 }
 
-void _35clofun3166(struct Cora* co) {
+void _35clofun3194(struct Cora* co) {
 Obj _35p1368 = co->args[1];
 Obj _35p1369 = co->args[2];
-Obj _35cc1370 = makeNative(0, _35clofun3167, 0, 2, _35p1368, _35p1369);
+Obj _35cc1370 = makeNative(0, _35clofun3195, 0, 2, _35p1368, _35p1369);
 Obj fn = _35p1368;
-Obj _35reg2761 = primEQ(Nil, _35p1369);
-if (True == _35reg2761) {
+Obj _35reg2765 = primEQ(Nil, _35p1369);
+if (True == _35reg2765) {
 coraReturn(co, Nil);
 return;
 } else {
@@ -962,90 +1058,90 @@ coraCall(co, 1, _35cc1370);
 }
 }
 
-void _35clofun3167(struct Cora* co) {
-Obj _35cc1371 = makeNative(0, _35clofun3168, 0, 0);
+void _35clofun3195(struct Cora* co) {
+Obj _35cc1371 = makeNative(0, _35clofun3196, 0, 0);
 Obj fn = closureRef(co, 0);
-Obj _35reg2757 = primIsCons(closureRef(co, 1));
-if (True == _35reg2757) {
-Obj _35reg2758 = primCar(closureRef(co, 1));
-Obj x = _35reg2758;
-Obj _35reg2759 = primCdr(closureRef(co, 1));
-Obj y = _35reg2759;
-pushCont(co, 0, _35clofun3169, 2, fn, y);
+Obj _35reg2761 = primIsCons(closureRef(co, 1));
+if (True == _35reg2761) {
+Obj _35reg2762 = primCar(closureRef(co, 1));
+Obj x = _35reg2762;
+Obj _35reg2763 = primCdr(closureRef(co, 1));
+Obj y = _35reg2763;
+pushCont(co, 0, _35clofun3197, 2, fn, y);
 coraCall(co, 2, fn, x);
 } else {
 coraCall(co, 1, _35cc1371);
 }
 }
 
-void _35clofun3169(struct Cora* co) {
-Obj _35val2760 = co->args[1];
+void _35clofun3197(struct Cora* co) {
+Obj _35val2764 = co->args[1];
 Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
 coraCall(co, 3, globalRef(intern("for-each")), fn, y);
 }
 
-void _35clofun3168(struct Cora* co) {
+void _35clofun3196(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3161(struct Cora* co) {
+void _35clofun3189(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, 0, _35clofun3162, 0);
+pushCont(co, 0, _35clofun3190, 0);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.parse-pass")), exp);
 }
 
-void _35clofun3162(struct Cora* co) {
-Obj _35val2752 = co->args[1];
-pushCont(co, 0, _35clofun3163, 0);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert-pass")), _35val2752);
+void _35clofun3190(struct Cora* co) {
+Obj _35val2756 = co->args[1];
+pushCont(co, 0, _35clofun3191, 0);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert-pass")), _35val2756);
 }
 
-void _35clofun3163(struct Cora* co) {
-Obj _35val2753 = co->args[1];
-pushCont(co, 0, _35clofun3164, 0);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.tailify-pass")), _35val2753);
+void _35clofun3191(struct Cora* co) {
+Obj _35val2757 = co->args[1];
+pushCont(co, 0, _35clofun3192, 0);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.tailify-pass")), _35val2757);
 }
 
-void _35clofun3164(struct Cora* co) {
-Obj _35val2754 = co->args[1];
-pushCont(co, 0, _35clofun3165, 0);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack-pass")), _35val2754);
+void _35clofun3192(struct Cora* co) {
+Obj _35val2758 = co->args[1];
+pushCont(co, 0, _35clofun3193, 0);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack-pass")), _35val2758);
 }
 
-void _35clofun3165(struct Cora* co) {
-Obj _35val2755 = co->args[1];
-coraCall(co, 2, globalRef(intern("cora/lib/toc.collect-lambda-pass")), _35val2755);
+void _35clofun3193(struct Cora* co) {
+Obj _35val2759 = co->args[1];
+coraCall(co, 2, globalRef(intern("cora/lib/toc.collect-lambda-pass")), _35val2759);
 }
 
-void _35clofun3157(struct Cora* co) {
+void _35clofun3185(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, 0, _35clofun3158, 1, exp);
+pushCont(co, 0, _35clofun3186, 1, exp);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
-void _35clofun3158(struct Cora* co) {
-Obj _35val2749 = co->args[1];
+void _35clofun3186(struct Cora* co) {
+Obj _35val2753 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj obj = _35val2749;
-pushCont(co, 0, _35clofun3159, 1, obj);
+Obj obj = _35val2753;
+pushCont(co, 0, _35clofun3187, 1, obj);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
-void _35clofun3159(struct Cora* co) {
-Obj _35val2750 = co->args[1];
+void _35clofun3187(struct Cora* co) {
+Obj _35val2754 = co->args[1];
 Obj obj = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fns = _35val2750;
+Obj fns = _35val2754;
 coraCall(co, 3, globalRef(intern("cora/lib/toc.rewrite-->macro")), obj, fns);
 }
 
-void _35clofun3154(struct Cora* co) {
+void _35clofun3182(struct Cora* co) {
 Obj _35p1364 = co->args[1];
 Obj _35p1365 = co->args[2];
-Obj _35cc1366 = makeNative(0, _35clofun3155, 0, 2, _35p1364, _35p1365);
+Obj _35cc1366 = makeNative(0, _35clofun3183, 0, 2, _35p1364, _35p1365);
 Obj obj = _35p1364;
-Obj _35reg2747 = primEQ(Nil, _35p1365);
-if (True == _35reg2747) {
+Obj _35reg2751 = primEQ(Nil, _35p1365);
+if (True == _35reg2751) {
 coraReturn(co, obj);
 return;
 } else {
@@ -1053,136 +1149,136 @@ coraCall(co, 1, _35cc1366);
 }
 }
 
-void _35clofun3155(struct Cora* co) {
-Obj _35cc1367 = makeNative(0, _35clofun3156, 0, 0);
+void _35clofun3183(struct Cora* co) {
+Obj _35cc1367 = makeNative(0, _35clofun3184, 0, 0);
 Obj obj = closureRef(co, 0);
-Obj _35reg2742 = primIsCons(closureRef(co, 1));
-if (True == _35reg2742) {
-Obj _35reg2743 = primCar(closureRef(co, 1));
-Obj hd = _35reg2743;
-Obj _35reg2744 = primCdr(closureRef(co, 1));
-Obj more = _35reg2744;
-Obj _35reg2745 = primCons(obj, Nil);
-Obj _35reg2746 = primCons(hd, _35reg2745);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.rewrite-->macro")), _35reg2746, more);
+Obj _35reg2746 = primIsCons(closureRef(co, 1));
+if (True == _35reg2746) {
+Obj _35reg2747 = primCar(closureRef(co, 1));
+Obj hd = _35reg2747;
+Obj _35reg2748 = primCdr(closureRef(co, 1));
+Obj more = _35reg2748;
+Obj _35reg2749 = primCons(obj, Nil);
+Obj _35reg2750 = primCons(hd, _35reg2749);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.rewrite-->macro")), _35reg2750, more);
 } else {
 coraCall(co, 1, _35cc1367);
 }
 }
 
-void _35clofun3156(struct Cora* co) {
+void _35clofun3184(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3152(struct Cora* co) {
+void _35clofun3180(struct Cora* co) {
 Obj exp = co->args[1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), Nil, exp, makeNative(0, _35clofun3153, 2, 0));
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), Nil, exp, makeNative(0, _35clofun3181, 2, 0));
 }
 
-void _35clofun3153(struct Cora* co) {
+void _35clofun3181(struct Cora* co) {
 Obj ls = co->args[1];
 Obj e1 = co->args[2];
-Obj _35reg2734 = primCons(e1, Nil);
-Obj _35reg2735 = primCons(Nil, _35reg2734);
-Obj _35reg2736 = primCons(Nil, _35reg2735);
-Obj _35reg2737 = primCons(intern("lambda"), _35reg2736);
-Obj _35reg2738 = primCons(_35reg2737, Nil);
-Obj _35reg2739 = primCons(intern("entry"), _35reg2738);
-Obj _35reg2740 = primCons(_35reg2739, ls);
-coraReturn(co, _35reg2740);
+Obj _35reg2738 = primCons(e1, Nil);
+Obj _35reg2739 = primCons(Nil, _35reg2738);
+Obj _35reg2740 = primCons(Nil, _35reg2739);
+Obj _35reg2741 = primCons(intern("lambda"), _35reg2740);
+Obj _35reg2742 = primCons(_35reg2741, Nil);
+Obj _35reg2743 = primCons(intern("entry"), _35reg2742);
+Obj _35reg2744 = primCons(_35reg2743, ls);
+coraReturn(co, _35reg2744);
 return;
 }
 
-void _35clofun3151(struct Cora* co) {
+void _35clofun3179(struct Cora* co) {
 Obj exp = co->args[1];
 coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), Nil, exp);
 }
 
-void _35clofun3150(struct Cora* co) {
+void _35clofun3178(struct Cora* co) {
 Obj exp = co->args[1];
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), exp, globalRef(intern("cora/lib/toc.id")));
 }
 
-void _35clofun3149(struct Cora* co) {
+void _35clofun3177(struct Cora* co) {
 Obj exp = co->args[1];
 coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), Nil, exp);
 }
 
-void _35clofun3148(struct Cora* co) {
+void _35clofun3176(struct Cora* co) {
 Obj exp = co->args[1];
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), Nil, exp);
 }
 
-void _35clofun3141(struct Cora* co) {
+void _35clofun3169(struct Cora* co) {
 Obj _35p1361 = co->args[1];
 Obj _35p1362 = co->args[2];
-Obj _35cc1363 = makeNative(0, _35clofun3142, 0, 0);
+Obj _35cc1363 = makeNative(0, _35clofun3170, 0, 0);
 Obj w = _35p1361;
-Obj _35reg2673 = primIsCons(_35p1362);
-if (True == _35reg2673) {
-Obj _35reg2674 = primCar(_35p1362);
-Obj name = _35reg2674;
-Obj _35reg2675 = primCdr(_35p1362);
-Obj _35reg2676 = primIsCons(_35reg2675);
-if (True == _35reg2676) {
-Obj _35reg2677 = primCdr(_35p1362);
-Obj _35reg2678 = primCar(_35reg2677);
-Obj _35reg2679 = primIsCons(_35reg2678);
-if (True == _35reg2679) {
-Obj _35reg2680 = primCdr(_35p1362);
-Obj _35reg2681 = primCar(_35reg2680);
+Obj _35reg2677 = primIsCons(_35p1362);
+if (True == _35reg2677) {
+Obj _35reg2678 = primCar(_35p1362);
+Obj name = _35reg2678;
+Obj _35reg2679 = primCdr(_35p1362);
+Obj _35reg2680 = primIsCons(_35reg2679);
+if (True == _35reg2680) {
+Obj _35reg2681 = primCdr(_35p1362);
 Obj _35reg2682 = primCar(_35reg2681);
-Obj _35reg2683 = primEQ(intern("lambda"), _35reg2682);
+Obj _35reg2683 = primIsCons(_35reg2682);
 if (True == _35reg2683) {
 Obj _35reg2684 = primCdr(_35p1362);
 Obj _35reg2685 = primCar(_35reg2684);
-Obj _35reg2686 = primCdr(_35reg2685);
-Obj _35reg2687 = primIsCons(_35reg2686);
+Obj _35reg2686 = primCar(_35reg2685);
+Obj _35reg2687 = primEQ(intern("lambda"), _35reg2686);
 if (True == _35reg2687) {
 Obj _35reg2688 = primCdr(_35p1362);
 Obj _35reg2689 = primCar(_35reg2688);
 Obj _35reg2690 = primCdr(_35reg2689);
-Obj _35reg2691 = primCar(_35reg2690);
-Obj params = _35reg2691;
+Obj _35reg2691 = primIsCons(_35reg2690);
+if (True == _35reg2691) {
 Obj _35reg2692 = primCdr(_35p1362);
 Obj _35reg2693 = primCar(_35reg2692);
 Obj _35reg2694 = primCdr(_35reg2693);
-Obj _35reg2695 = primCdr(_35reg2694);
-Obj _35reg2696 = primIsCons(_35reg2695);
-if (True == _35reg2696) {
-Obj _35reg2697 = primCdr(_35p1362);
-Obj _35reg2698 = primCar(_35reg2697);
+Obj _35reg2695 = primCar(_35reg2694);
+Obj params = _35reg2695;
+Obj _35reg2696 = primCdr(_35p1362);
+Obj _35reg2697 = primCar(_35reg2696);
+Obj _35reg2698 = primCdr(_35reg2697);
 Obj _35reg2699 = primCdr(_35reg2698);
-Obj _35reg2700 = primCdr(_35reg2699);
-Obj _35reg2701 = primCar(_35reg2700);
-Obj actives = _35reg2701;
-Obj _35reg2702 = primCdr(_35p1362);
-Obj _35reg2703 = primCar(_35reg2702);
+Obj _35reg2700 = primIsCons(_35reg2699);
+if (True == _35reg2700) {
+Obj _35reg2701 = primCdr(_35p1362);
+Obj _35reg2702 = primCar(_35reg2701);
+Obj _35reg2703 = primCdr(_35reg2702);
 Obj _35reg2704 = primCdr(_35reg2703);
-Obj _35reg2705 = primCdr(_35reg2704);
-Obj _35reg2706 = primCdr(_35reg2705);
-Obj _35reg2707 = primIsCons(_35reg2706);
-if (True == _35reg2707) {
-Obj _35reg2708 = primCdr(_35p1362);
-Obj _35reg2709 = primCar(_35reg2708);
+Obj _35reg2705 = primCar(_35reg2704);
+Obj actives = _35reg2705;
+Obj _35reg2706 = primCdr(_35p1362);
+Obj _35reg2707 = primCar(_35reg2706);
+Obj _35reg2708 = primCdr(_35reg2707);
+Obj _35reg2709 = primCdr(_35reg2708);
 Obj _35reg2710 = primCdr(_35reg2709);
-Obj _35reg2711 = primCdr(_35reg2710);
-Obj _35reg2712 = primCdr(_35reg2711);
+Obj _35reg2711 = primIsCons(_35reg2710);
+if (True == _35reg2711) {
+Obj _35reg2712 = primCdr(_35p1362);
 Obj _35reg2713 = primCar(_35reg2712);
-Obj body = _35reg2713;
-Obj _35reg2714 = primCdr(_35p1362);
-Obj _35reg2715 = primCar(_35reg2714);
+Obj _35reg2714 = primCdr(_35reg2713);
+Obj _35reg2715 = primCdr(_35reg2714);
 Obj _35reg2716 = primCdr(_35reg2715);
-Obj _35reg2717 = primCdr(_35reg2716);
-Obj _35reg2718 = primCdr(_35reg2717);
-Obj _35reg2719 = primCdr(_35reg2718);
-Obj _35reg2720 = primEQ(Nil, _35reg2719);
-if (True == _35reg2720) {
-Obj _35reg2721 = primCdr(_35p1362);
+Obj _35reg2717 = primCar(_35reg2716);
+Obj body = _35reg2717;
+Obj _35reg2718 = primCdr(_35p1362);
+Obj _35reg2719 = primCar(_35reg2718);
+Obj _35reg2720 = primCdr(_35reg2719);
+Obj _35reg2721 = primCdr(_35reg2720);
 Obj _35reg2722 = primCdr(_35reg2721);
-Obj _35reg2723 = primEQ(Nil, _35reg2722);
-if (True == _35reg2723) {
-pushCont(co, 0, _35clofun3143, 4, actives, params, body, w);
+Obj _35reg2723 = primCdr(_35reg2722);
+Obj _35reg2724 = primEQ(Nil, _35reg2723);
+if (True == _35reg2724) {
+Obj _35reg2725 = primCdr(_35p1362);
+Obj _35reg2726 = primCdr(_35reg2725);
+Obj _35reg2727 = primEQ(Nil, _35reg2726);
+if (True == _35reg2727) {
+pushCont(co, 0, _35clofun3171, 4, actives, params, body, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.code-gen-func-declare")), w, name);
 } else {
 coraCall(co, 1, _35cc1363);
@@ -1213,68 +1309,68 @@ coraCall(co, 1, _35cc1363);
 }
 }
 
-void _35clofun3143(struct Cora* co) {
-Obj _35val2724 = co->args[1];
+void _35clofun3171(struct Cora* co) {
+Obj _35val2728 = co->args[1];
 Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3144, 4, actives, params, body, w);
+pushCont(co, 0, _35clofun3172, 4, actives, params, body, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" {\n"));
 }
 
-void _35clofun3144(struct Cora* co) {
-Obj _35val2725 = co->args[1];
+void _35clofun3172(struct Cora* co) {
+Obj _35val2729 = co->args[1];
 Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3145, 4, actives, params, body, w);
+pushCont(co, 0, _35clofun3173, 4, actives, params, body, w);
 coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->args["), makeNumber(1), params);
 }
 
-void _35clofun3145(struct Cora* co) {
-Obj _35val2726 = co->args[1];
+void _35clofun3173(struct Cora* co) {
+Obj _35val2730 = co->args[1];
 Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3146, 3, params, body, w);
+pushCont(co, 0, _35clofun3174, 3, params, body, w);
 coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->ctx.stk.stack[co->ctx.stk.base + "), makeNumber(0), actives);
 }
 
-void _35clofun3146(struct Cora* co) {
-Obj _35val2727 = co->args[1];
+void _35clofun3174(struct Cora* co) {
+Obj _35val2731 = co->args[1];
 Obj params = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3147, 1, w);
+pushCont(co, 0, _35clofun3175, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), params, w, body);
 }
 
-void _35clofun3147(struct Cora* co) {
-Obj _35val2728 = co->args[1];
+void _35clofun3175(struct Cora* co) {
+Obj _35val2732 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("}\n\n"));
 }
 
-void _35clofun3142(struct Cora* co) {
+void _35clofun3170(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3133(struct Cora* co) {
+void _35clofun3161(struct Cora* co) {
 Obj _35p1354 = co->args[1];
 Obj _35p1355 = co->args[2];
 Obj _35p1356 = co->args[3];
 Obj _35p1357 = co->args[4];
 Obj _35p1358 = co->args[5];
-Obj _35cc1359 = makeNative(0, _35clofun3134, 0, 5, _35p1354, _35p1355, _35p1356, _35p1357, _35p1358);
+Obj _35cc1359 = makeNative(0, _35clofun3162, 0, 5, _35p1354, _35p1355, _35p1356, _35p1357, _35p1358);
 Obj env = _35p1354;
 Obj w = _35p1355;
 Obj dest_45str = _35p1356;
 Obj idx = _35p1357;
-Obj _35reg2671 = primEQ(Nil, _35p1358);
-if (True == _35reg2671) {
+Obj _35reg2675 = primEQ(Nil, _35p1358);
+if (True == _35reg2675) {
 coraReturn(co, Nil);
 return;
 } else {
@@ -1282,131 +1378,131 @@ coraCall(co, 1, _35cc1359);
 }
 }
 
-void _35clofun3134(struct Cora* co) {
-Obj _35cc1360 = makeNative(0, _35clofun3135, 0, 0);
+void _35clofun3162(struct Cora* co) {
+Obj _35cc1360 = makeNative(0, _35clofun3163, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj dest_45str = closureRef(co, 2);
 Obj idx = closureRef(co, 3);
-Obj _35reg2662 = primIsCons(closureRef(co, 4));
-if (True == _35reg2662) {
-Obj _35reg2663 = primCar(closureRef(co, 4));
-Obj a = _35reg2663;
-Obj _35reg2664 = primCdr(closureRef(co, 4));
-Obj b = _35reg2664;
-pushCont(co, 0, _35clofun3136, 6, a, idx, env, w, dest_45str, b);
+Obj _35reg2666 = primIsCons(closureRef(co, 4));
+if (True == _35reg2666) {
+Obj _35reg2667 = primCar(closureRef(co, 4));
+Obj a = _35reg2667;
+Obj _35reg2668 = primCdr(closureRef(co, 4));
+Obj b = _35reg2668;
+pushCont(co, 0, _35clofun3164, 6, a, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("Obj "));
 } else {
 coraCall(co, 1, _35cc1360);
 }
 }
 
-void _35clofun3136(struct Cora* co) {
-Obj _35val2665 = co->args[1];
+void _35clofun3164(struct Cora* co) {
+Obj _35val2669 = co->args[1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 0, _35clofun3137, 5, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3165, 5, idx, env, w, dest_45str, b);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
-void _35clofun3137(struct Cora* co) {
-Obj _35val2666 = co->args[1];
+void _35clofun3165(struct Cora* co) {
+Obj _35val2670 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3138, 5, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3166, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, dest_45str);
 }
 
-void _35clofun3138(struct Cora* co) {
-Obj _35val2667 = co->args[1];
+void _35clofun3166(struct Cora* co) {
+Obj _35val2671 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3139, 5, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3167, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
-void _35clofun3139(struct Cora* co) {
-Obj _35val2668 = co->args[1];
+void _35clofun3167(struct Cora* co) {
+Obj _35val2672 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3140, 5, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3168, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("];\n"));
 }
 
-void _35clofun3140(struct Cora* co) {
-Obj _35val2669 = co->args[1];
+void _35clofun3168(struct Cora* co) {
+Obj _35val2673 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2670 = primAdd(idx, makeNumber(1));
-coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), env, w, dest_45str, _35reg2670, b);
+Obj _35reg2674 = primAdd(idx, makeNumber(1));
+coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), env, w, dest_45str, _35reg2674, b);
 }
 
-void _35clofun3135(struct Cora* co) {
+void _35clofun3163(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3129(struct Cora* co) {
+void _35clofun3157(struct Cora* co) {
 Obj w = co->args[1];
 Obj name = co->args[2];
-pushCont(co, 0, _35clofun3130, 2, name, w);
+pushCont(co, 0, _35clofun3158, 2, name, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("void "));
 }
 
-void _35clofun3130(struct Cora* co) {
-Obj _35val2658 = co->args[1];
+void _35clofun3158(struct Cora* co) {
+Obj _35val2662 = co->args[1];
 Obj name = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3131, 1, w);
+pushCont(co, 0, _35clofun3159, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, name);
 }
 
-void _35clofun3131(struct Cora* co) {
-Obj _35val2659 = co->args[1];
+void _35clofun3159(struct Cora* co) {
+Obj _35val2663 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun3132, 1, w);
+pushCont(co, 0, _35clofun3160, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("(struct Cora* co"));
 }
 
-void _35clofun3132(struct Cora* co) {
-Obj _35val2660 = co->args[1];
+void _35clofun3160(struct Cora* co) {
+Obj _35val2664 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
-void _35clofun3128(struct Cora* co) {
+void _35clofun3156(struct Cora* co) {
 Obj env = co->args[1];
 Obj w = co->args[2];
 Obj l = co->args[3];
 coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-inst-list-h")), env, globalRef(intern("cora/lib/toc.generate-inst")), w, l);
 }
 
-void _35clofun3122(struct Cora* co) {
+void _35clofun3150(struct Cora* co) {
 Obj _35p1348 = co->args[1];
 Obj _35p1349 = co->args[2];
 Obj _35p1350 = co->args[3];
 Obj _35p1351 = co->args[4];
-Obj _35cc1352 = makeNative(0, _35clofun3123, 0, 4, _35p1348, _35p1349, _35p1350, _35p1351);
+Obj _35cc1352 = makeNative(0, _35clofun3151, 0, 4, _35p1348, _35p1349, _35p1350, _35p1351);
 Obj env = _35p1348;
 Obj fn = _35p1349;
 Obj w = _35p1350;
-Obj _35reg2655 = primEQ(Nil, _35p1351);
-if (True == _35reg2655) {
+Obj _35reg2659 = primEQ(Nil, _35p1351);
+if (True == _35reg2659) {
 coraReturn(co, Nil);
 return;
 } else {
@@ -1414,43 +1510,43 @@ coraCall(co, 1, _35cc1352);
 }
 }
 
-void _35clofun3123(struct Cora* co) {
-Obj _35cc1353 = makeNative(0, _35clofun3124, 0, 0);
+void _35clofun3151(struct Cora* co) {
+Obj _35cc1353 = makeNative(0, _35clofun3152, 0, 0);
 Obj env = closureRef(co, 0);
 Obj fn = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2648 = primIsCons(closureRef(co, 3));
-if (True == _35reg2648) {
-Obj _35reg2649 = primCar(closureRef(co, 3));
-Obj a = _35reg2649;
-Obj _35reg2650 = primCdr(closureRef(co, 3));
-Obj b = _35reg2650;
-pushCont(co, 0, _35clofun3125, 4, env, fn, w, b);
+Obj _35reg2652 = primIsCons(closureRef(co, 3));
+if (True == _35reg2652) {
+Obj _35reg2653 = primCar(closureRef(co, 3));
+Obj a = _35reg2653;
+Obj _35reg2654 = primCdr(closureRef(co, 3));
+Obj b = _35reg2654;
+pushCont(co, 0, _35clofun3153, 4, env, fn, w, b);
 coraCall(co, 4, fn, env, w, a);
 } else {
 coraCall(co, 1, _35cc1353);
 }
 }
 
-void _35clofun3125(struct Cora* co) {
-Obj _35val2651 = co->args[1];
+void _35clofun3153(struct Cora* co) {
+Obj _35val2655 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3126, 4, env, fn, w, b);
+pushCont(co, 0, _35clofun3154, 4, env, fn, w, b);
 coraCall(co, 2, globalRef(intern("null?")), b);
 }
 
-void _35clofun3126(struct Cora* co) {
-Obj _35val2652 = co->args[1];
+void _35clofun3154(struct Cora* co) {
+Obj _35val2656 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2653 = primNot(_35val2652);
-if (True == _35reg2653) {
-pushCont(co, 0, _35clofun3127, 4, env, fn, w, b);
+Obj _35reg2657 = primNot(_35val2656);
+if (True == _35reg2657) {
+pushCont(co, 0, _35clofun3155, 4, env, fn, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 } else {
 Nil;
@@ -1458,8 +1554,8 @@ coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-inst-list-h")), env, fn,
 }
 }
 
-void _35clofun3127(struct Cora* co) {
-Obj _35val2654 = co->args[1];
+void _35clofun3155(struct Cora* co) {
+Obj _35val2658 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -1467,30 +1563,30 @@ Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
 coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-inst-list-h")), env, fn, w, b);
 }
 
-void _35clofun3124(struct Cora* co) {
+void _35clofun3152(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3111(struct Cora* co) {
+void _35clofun3139(struct Cora* co) {
 Obj _35p1345 = co->args[1];
 Obj _35p1346 = co->args[2];
-Obj _35cc1347 = makeNative(0, _35clofun3112, 0, 0);
+Obj _35cc1347 = makeNative(0, _35clofun3140, 0, 0);
 Obj w = _35p1345;
-Obj _35reg2629 = primIsCons(_35p1346);
-if (True == _35reg2629) {
-Obj _35reg2630 = primCar(_35p1346);
-Obj _35reg2631 = primEQ(intern("%continuation"), _35reg2630);
-if (True == _35reg2631) {
-Obj _35reg2632 = primCdr(_35p1346);
-Obj _35reg2633 = primIsCons(_35reg2632);
+Obj _35reg2633 = primIsCons(_35p1346);
 if (True == _35reg2633) {
-Obj _35reg2634 = primCdr(_35p1346);
-Obj _35reg2635 = primCar(_35reg2634);
-Obj label = _35reg2635;
+Obj _35reg2634 = primCar(_35p1346);
+Obj _35reg2635 = primEQ(intern("%continuation"), _35reg2634);
+if (True == _35reg2635) {
 Obj _35reg2636 = primCdr(_35p1346);
-Obj _35reg2637 = primCdr(_35reg2636);
-Obj stacks = _35reg2637;
-pushCont(co, 0, _35clofun3113, 3, label, stacks, w);
+Obj _35reg2637 = primIsCons(_35reg2636);
+if (True == _35reg2637) {
+Obj _35reg2638 = primCdr(_35p1346);
+Obj _35reg2639 = primCar(_35reg2638);
+Obj label = _35reg2639;
+Obj _35reg2640 = primCdr(_35p1346);
+Obj _35reg2641 = primCdr(_35reg2640);
+Obj stacks = _35reg2641;
+pushCont(co, 0, _35clofun3141, 3, label, stacks, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("pushCont(co, 0, "));
 } else {
 coraCall(co, 1, _35cc1347);
@@ -1503,94 +1599,94 @@ coraCall(co, 1, _35cc1347);
 }
 }
 
-void _35clofun3113(struct Cora* co) {
-Obj _35val2638 = co->args[1];
+void _35clofun3141(struct Cora* co) {
+Obj _35val2642 = co->args[1];
 Obj label = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3114, 2, stacks, w);
+pushCont(co, 0, _35clofun3142, 2, stacks, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, label);
 }
 
-void _35clofun3114(struct Cora* co) {
-Obj _35val2639 = co->args[1];
-Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3115, 2, stacks, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
-}
-
-void _35clofun3115(struct Cora* co) {
-Obj _35val2640 = co->args[1];
-Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3116, 2, stacks, w);
-coraCall(co, 2, globalRef(intern("length")), stacks);
-}
-
-void _35clofun3116(struct Cora* co) {
-Obj _35val2641 = co->args[1];
-Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3117, 2, stacks, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2641);
-}
-
-void _35clofun3117(struct Cora* co) {
-Obj _35val2642 = co->args[1];
-Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3118, 2, stacks, w);
-coraCall(co, 2, globalRef(intern("null?")), stacks);
-}
-
-void _35clofun3118(struct Cora* co) {
+void _35clofun3142(struct Cora* co) {
 Obj _35val2643 = co->args[1];
 Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2644 = primNot(_35val2643);
-if (True == _35reg2644) {
-pushCont(co, 0, _35clofun3121, 1, w);
-coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3119, 1, 1, w), stacks);
+pushCont(co, 0, _35clofun3143, 2, stacks, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
+}
+
+void _35clofun3143(struct Cora* co) {
+Obj _35val2644 = co->args[1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun3144, 2, stacks, w);
+coraCall(co, 2, globalRef(intern("length")), stacks);
+}
+
+void _35clofun3144(struct Cora* co) {
+Obj _35val2645 = co->args[1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun3145, 2, stacks, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2645);
+}
+
+void _35clofun3145(struct Cora* co) {
+Obj _35val2646 = co->args[1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun3146, 2, stacks, w);
+coraCall(co, 2, globalRef(intern("null?")), stacks);
+}
+
+void _35clofun3146(struct Cora* co) {
+Obj _35val2647 = co->args[1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2648 = primNot(_35val2647);
+if (True == _35reg2648) {
+pushCont(co, 0, _35clofun3149, 1, w);
+coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3147, 1, 1, w), stacks);
 } else {
 Nil;
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
 }
 }
 
-void _35clofun3121(struct Cora* co) {
-Obj _35val2646 = co->args[1];
+void _35clofun3149(struct Cora* co) {
+Obj _35val2650 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
 }
 
-void _35clofun3119(struct Cora* co) {
+void _35clofun3147(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, 0, _35clofun3120, 1, x);
+pushCont(co, 0, _35clofun3148, 1, x);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closureRef(co, 0), makeString1(", "));
 }
 
-void _35clofun3120(struct Cora* co) {
-Obj _35val2645 = co->args[1];
+void _35clofun3148(struct Cora* co) {
+Obj _35val2649 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), Nil, closureRef(co, 0), x);
 }
 
-void _35clofun3112(struct Cora* co) {
+void _35clofun3140(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3103(struct Cora* co) {
+void _35clofun3131(struct Cora* co) {
 Obj _35p1339 = co->args[1];
 Obj _35p1340 = co->args[2];
 Obj _35p1341 = co->args[3];
 Obj _35p1342 = co->args[4];
-Obj _35cc1343 = makeNative(0, _35clofun3104, 0, 4, _35p1339, _35p1340, _35p1341, _35p1342);
+Obj _35cc1343 = makeNative(0, _35clofun3132, 0, 4, _35p1339, _35p1340, _35p1341, _35p1342);
 Obj env = _35p1339;
 Obj w = _35p1340;
 Obj idx = _35p1341;
-Obj _35reg2627 = primEQ(Nil, _35p1342);
-if (True == _35reg2627) {
+Obj _35reg2631 = primEQ(Nil, _35p1342);
+if (True == _35reg2631) {
 coraReturn(co, Nil);
 return;
 } else {
@@ -1598,117 +1694,117 @@ coraCall(co, 1, _35cc1343);
 }
 }
 
-void _35clofun3104(struct Cora* co) {
-Obj _35cc1344 = makeNative(0, _35clofun3105, 0, 0);
+void _35clofun3132(struct Cora* co) {
+Obj _35cc1344 = makeNative(0, _35clofun3133, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj idx = closureRef(co, 2);
-Obj _35reg2618 = primIsCons(closureRef(co, 3));
-if (True == _35reg2618) {
-Obj _35reg2619 = primCar(closureRef(co, 3));
-Obj a = _35reg2619;
-Obj _35reg2620 = primCdr(closureRef(co, 3));
-Obj b = _35reg2620;
-pushCont(co, 0, _35clofun3106, 5, a, idx, env, w, b);
+Obj _35reg2622 = primIsCons(closureRef(co, 3));
+if (True == _35reg2622) {
+Obj _35reg2623 = primCar(closureRef(co, 3));
+Obj a = _35reg2623;
+Obj _35reg2624 = primCdr(closureRef(co, 3));
+Obj b = _35reg2624;
+pushCont(co, 0, _35clofun3134, 5, a, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("co->args["));
 } else {
 coraCall(co, 1, _35cc1344);
 }
 }
 
-void _35clofun3106(struct Cora* co) {
-Obj _35val2621 = co->args[1];
+void _35clofun3134(struct Cora* co) {
+Obj _35val2625 = co->args[1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3107, 5, a, idx, env, w, b);
+pushCont(co, 0, _35clofun3135, 5, a, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
-void _35clofun3107(struct Cora* co) {
-Obj _35val2622 = co->args[1];
+void _35clofun3135(struct Cora* co) {
+Obj _35val2626 = co->args[1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3108, 5, a, idx, env, w, b);
+pushCont(co, 0, _35clofun3136, 5, a, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("] = "));
 }
 
-void _35clofun3108(struct Cora* co) {
-Obj _35val2623 = co->args[1];
+void _35clofun3136(struct Cora* co) {
+Obj _35val2627 = co->args[1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3109, 4, idx, env, w, b);
+pushCont(co, 0, _35clofun3137, 4, idx, env, w, b);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
-void _35clofun3109(struct Cora* co) {
-Obj _35val2624 = co->args[1];
+void _35clofun3137(struct Cora* co) {
+Obj _35val2628 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3110, 4, idx, env, w, b);
+pushCont(co, 0, _35clofun3138, 4, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
-void _35clofun3110(struct Cora* co) {
-Obj _35val2625 = co->args[1];
+void _35clofun3138(struct Cora* co) {
+Obj _35val2629 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2626 = primAdd(idx, makeNumber(1));
-coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-call-args")), env, w, _35reg2626, b);
+Obj _35reg2630 = primAdd(idx, makeNumber(1));
+coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-call-args")), env, w, _35reg2630, b);
 }
 
-void _35clofun3105(struct Cora* co) {
+void _35clofun3133(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3031(struct Cora* co) {
+void _35clofun3059(struct Cora* co) {
 Obj _35p1322 = co->args[1];
 Obj _35p1323 = co->args[2];
 Obj _35p1324 = co->args[3];
-Obj _35cc1325 = makeNative(0, _35clofun3032, 0, 3, _35p1322, _35p1323, _35p1324);
+Obj _35cc1325 = makeNative(0, _35clofun3060, 0, 3, _35p1322, _35p1323, _35p1324);
 Obj env = _35p1322;
 Obj w = _35p1323;
 Obj x = _35p1324;
-Obj _35reg2616 = primIsSymbol(x);
-if (True == _35reg2616) {
+Obj _35reg2620 = primIsSymbol(x);
+if (True == _35reg2620) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, x);
 } else {
 coraCall(co, 1, _35cc1325);
 }
 }
 
-void _35clofun3032(struct Cora* co) {
-Obj _35cc1326 = makeNative(0, _35clofun3033, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3060(struct Cora* co) {
+Obj _35cc1326 = makeNative(0, _35clofun3061, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2603 = primIsCons(closureRef(co, 2));
-if (True == _35reg2603) {
-Obj _35reg2604 = primCar(closureRef(co, 2));
-Obj _35reg2605 = primEQ(intern("%global"), _35reg2604);
-if (True == _35reg2605) {
-Obj _35reg2606 = primCdr(closureRef(co, 2));
-Obj _35reg2607 = primIsCons(_35reg2606);
+Obj _35reg2607 = primIsCons(closureRef(co, 2));
 if (True == _35reg2607) {
-Obj _35reg2608 = primCdr(closureRef(co, 2));
-Obj _35reg2609 = primCar(_35reg2608);
-Obj x = _35reg2609;
+Obj _35reg2608 = primCar(closureRef(co, 2));
+Obj _35reg2609 = primEQ(intern("%global"), _35reg2608);
+if (True == _35reg2609) {
 Obj _35reg2610 = primCdr(closureRef(co, 2));
-Obj _35reg2611 = primCdr(_35reg2610);
-Obj _35reg2612 = primEQ(Nil, _35reg2611);
-if (True == _35reg2612) {
-pushCont(co, 0, _35clofun3100, 2, x, w);
+Obj _35reg2611 = primIsCons(_35reg2610);
+if (True == _35reg2611) {
+Obj _35reg2612 = primCdr(closureRef(co, 2));
+Obj _35reg2613 = primCar(_35reg2612);
+Obj x = _35reg2613;
+Obj _35reg2614 = primCdr(closureRef(co, 2));
+Obj _35reg2615 = primCdr(_35reg2614);
+Obj _35reg2616 = primEQ(Nil, _35reg2615);
+if (True == _35reg2616) {
+pushCont(co, 0, _35clofun3128, 2, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("globalRef(intern(\""));
 } else {
 coraCall(co, 1, _35cc1326);
@@ -1724,47 +1820,47 @@ coraCall(co, 1, _35cc1326);
 }
 }
 
-void _35clofun3100(struct Cora* co) {
-Obj _35val2613 = co->args[1];
+void _35clofun3128(struct Cora* co) {
+Obj _35val2617 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3101, 1, w);
+pushCont(co, 0, _35clofun3129, 1, w);
 coraCall(co, 2, globalRef(intern("symbol->string")), x);
 }
 
-void _35clofun3101(struct Cora* co) {
-Obj _35val2614 = co->args[1];
+void _35clofun3129(struct Cora* co) {
+Obj _35val2618 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun3102, 1, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2614);
+pushCont(co, 0, _35clofun3130, 1, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2618);
 }
 
-void _35clofun3102(struct Cora* co) {
-Obj _35val2615 = co->args[1];
+void _35clofun3130(struct Cora* co) {
+Obj _35val2619 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("\"))"));
 }
 
-void _35clofun3033(struct Cora* co) {
-Obj _35cc1327 = makeNative(0, _35clofun3034, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3061(struct Cora* co) {
+Obj _35cc1327 = makeNative(0, _35clofun3062, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2591 = primIsCons(closureRef(co, 2));
-if (True == _35reg2591) {
-Obj _35reg2592 = primCar(closureRef(co, 2));
-Obj _35reg2593 = primEQ(intern("%closure-ref"), _35reg2592);
-if (True == _35reg2593) {
-Obj _35reg2594 = primCdr(closureRef(co, 2));
-Obj _35reg2595 = primIsCons(_35reg2594);
+Obj _35reg2595 = primIsCons(closureRef(co, 2));
 if (True == _35reg2595) {
-Obj _35reg2596 = primCdr(closureRef(co, 2));
-Obj _35reg2597 = primCar(_35reg2596);
-Obj idx = _35reg2597;
+Obj _35reg2596 = primCar(closureRef(co, 2));
+Obj _35reg2597 = primEQ(intern("%closure-ref"), _35reg2596);
+if (True == _35reg2597) {
 Obj _35reg2598 = primCdr(closureRef(co, 2));
-Obj _35reg2599 = primCdr(_35reg2598);
-Obj _35reg2600 = primEQ(Nil, _35reg2599);
-if (True == _35reg2600) {
-pushCont(co, 0, _35clofun3098, 2, idx, w);
+Obj _35reg2599 = primIsCons(_35reg2598);
+if (True == _35reg2599) {
+Obj _35reg2600 = primCdr(closureRef(co, 2));
+Obj _35reg2601 = primCar(_35reg2600);
+Obj idx = _35reg2601;
+Obj _35reg2602 = primCdr(closureRef(co, 2));
+Obj _35reg2603 = primCdr(_35reg2602);
+Obj _35reg2604 = primEQ(Nil, _35reg2603);
+if (True == _35reg2604) {
+pushCont(co, 0, _35clofun3126, 2, idx, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("closureRef(co, "));
 } else {
 coraCall(co, 1, _35cc1327);
@@ -1780,40 +1876,40 @@ coraCall(co, 1, _35cc1327);
 }
 }
 
-void _35clofun3098(struct Cora* co) {
-Obj _35val2601 = co->args[1];
+void _35clofun3126(struct Cora* co) {
+Obj _35val2605 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3099, 1, w);
+pushCont(co, 0, _35clofun3127, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
-void _35clofun3099(struct Cora* co) {
-Obj _35val2602 = co->args[1];
+void _35clofun3127(struct Cora* co) {
+Obj _35val2606 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
-void _35clofun3034(struct Cora* co) {
-Obj _35cc1328 = makeNative(0, _35clofun3035, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3062(struct Cora* co) {
+Obj _35cc1328 = makeNative(0, _35clofun3063, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2579 = primIsCons(closureRef(co, 2));
-if (True == _35reg2579) {
-Obj _35reg2580 = primCar(closureRef(co, 2));
-Obj _35reg2581 = primEQ(intern("%stack-ref"), _35reg2580);
-if (True == _35reg2581) {
-Obj _35reg2582 = primCdr(closureRef(co, 2));
-Obj _35reg2583 = primIsCons(_35reg2582);
+Obj _35reg2583 = primIsCons(closureRef(co, 2));
 if (True == _35reg2583) {
-Obj _35reg2584 = primCdr(closureRef(co, 2));
-Obj _35reg2585 = primCar(_35reg2584);
-Obj idx = _35reg2585;
+Obj _35reg2584 = primCar(closureRef(co, 2));
+Obj _35reg2585 = primEQ(intern("%stack-ref"), _35reg2584);
+if (True == _35reg2585) {
 Obj _35reg2586 = primCdr(closureRef(co, 2));
-Obj _35reg2587 = primCdr(_35reg2586);
-Obj _35reg2588 = primEQ(Nil, _35reg2587);
-if (True == _35reg2588) {
-pushCont(co, 0, _35clofun3096, 2, idx, w);
+Obj _35reg2587 = primIsCons(_35reg2586);
+if (True == _35reg2587) {
+Obj _35reg2588 = primCdr(closureRef(co, 2));
+Obj _35reg2589 = primCar(_35reg2588);
+Obj idx = _35reg2589;
+Obj _35reg2590 = primCdr(closureRef(co, 2));
+Obj _35reg2591 = primCdr(_35reg2590);
+Obj _35reg2592 = primEQ(Nil, _35reg2591);
+if (True == _35reg2592) {
+pushCont(co, 0, _35clofun3124, 2, idx, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("stackRef(co, "));
 } else {
 coraCall(co, 1, _35cc1328);
@@ -1829,45 +1925,45 @@ coraCall(co, 1, _35cc1328);
 }
 }
 
-void _35clofun3096(struct Cora* co) {
-Obj _35val2589 = co->args[1];
+void _35clofun3124(struct Cora* co) {
+Obj _35val2593 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3097, 1, w);
+pushCont(co, 0, _35clofun3125, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
-void _35clofun3097(struct Cora* co) {
-Obj _35val2590 = co->args[1];
+void _35clofun3125(struct Cora* co) {
+Obj _35val2594 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
-void _35clofun3035(struct Cora* co) {
-Obj _35cc1329 = makeNative(0, _35clofun3036, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3063(struct Cora* co) {
+Obj _35cc1329 = makeNative(0, _35clofun3064, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2555 = primIsCons(closureRef(co, 2));
-if (True == _35reg2555) {
-Obj _35reg2556 = primCar(closureRef(co, 2));
-Obj _35reg2557 = primEQ(intern("%const"), _35reg2556);
-if (True == _35reg2557) {
-Obj _35reg2558 = primCdr(closureRef(co, 2));
-Obj _35reg2559 = primIsCons(_35reg2558);
+Obj _35reg2559 = primIsCons(closureRef(co, 2));
 if (True == _35reg2559) {
-Obj _35reg2560 = primCdr(closureRef(co, 2));
-Obj _35reg2561 = primCar(_35reg2560);
-Obj x = _35reg2561;
+Obj _35reg2560 = primCar(closureRef(co, 2));
+Obj _35reg2561 = primEQ(intern("%const"), _35reg2560);
+if (True == _35reg2561) {
 Obj _35reg2562 = primCdr(closureRef(co, 2));
-Obj _35reg2563 = primCdr(_35reg2562);
-Obj _35reg2564 = primEQ(Nil, _35reg2563);
-if (True == _35reg2564) {
-Obj _35reg2565 = primIsSymbol(x);
-if (True == _35reg2565) {
-pushCont(co, 0, _35clofun3087, 2, x, w);
+Obj _35reg2563 = primIsCons(_35reg2562);
+if (True == _35reg2563) {
+Obj _35reg2564 = primCdr(closureRef(co, 2));
+Obj _35reg2565 = primCar(_35reg2564);
+Obj x = _35reg2565;
+Obj _35reg2566 = primCdr(closureRef(co, 2));
+Obj _35reg2567 = primCdr(_35reg2566);
+Obj _35reg2568 = primEQ(Nil, _35reg2567);
+if (True == _35reg2568) {
+Obj _35reg2569 = primIsSymbol(x);
+if (True == _35reg2569) {
+pushCont(co, 0, _35clofun3115, 2, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("intern(\""));
 } else {
-pushCont(co, 0, _35clofun3090, 2, x, w);
+pushCont(co, 0, _35clofun3118, 2, x, w);
 coraCall(co, 2, globalRef(intern("number?")), x);
 }
 } else {
@@ -1884,29 +1980,29 @@ coraCall(co, 1, _35cc1329);
 }
 }
 
-void _35clofun3090(struct Cora* co) {
-Obj _35val2569 = co->args[1];
+void _35clofun3118(struct Cora* co) {
+Obj _35val2573 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2569) {
-pushCont(co, 0, _35clofun3091, 2, x, w);
+if (True == _35val2573) {
+pushCont(co, 0, _35clofun3119, 2, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeNumber("));
 } else {
-Obj _35reg2572 = primIsString(x);
-if (True == _35reg2572) {
-pushCont(co, 0, _35clofun3093, 2, x, w);
+Obj _35reg2576 = primIsString(x);
+if (True == _35reg2576) {
+pushCont(co, 0, _35clofun3121, 2, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeString1(\""));
 } else {
-Obj _35reg2576 = primEQ(x, Nil);
-if (True == _35reg2576) {
+Obj _35reg2580 = primEQ(x, Nil);
+if (True == _35reg2580) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("Nil"));
 } else {
-Obj _35reg2577 = primEQ(x, True);
-if (True == _35reg2577) {
+Obj _35reg2581 = primEQ(x, True);
+if (True == _35reg2581) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("True"));
 } else {
-Obj _35reg2578 = primEQ(x, False);
-if (True == _35reg2578) {
+Obj _35reg2582 = primEQ(x, False);
+if (True == _35reg2582) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("False"));
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
@@ -1917,102 +2013,102 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 
-void _35clofun3093(struct Cora* co) {
-Obj _35val2573 = co->args[1];
+void _35clofun3121(struct Cora* co) {
+Obj _35val2577 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3094, 1, w);
+pushCont(co, 0, _35clofun3122, 1, w);
 coraCall(co, 2, globalRef(intern("cora/lib/toc/internal.escape-str")), x);
 }
 
-void _35clofun3094(struct Cora* co) {
-Obj _35val2574 = co->args[1];
+void _35clofun3122(struct Cora* co) {
+Obj _35val2578 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun3095, 1, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2574);
+pushCont(co, 0, _35clofun3123, 1, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2578);
 }
 
-void _35clofun3095(struct Cora* co) {
-Obj _35val2575 = co->args[1];
+void _35clofun3123(struct Cora* co) {
+Obj _35val2579 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("\")"));
 }
 
-void _35clofun3091(struct Cora* co) {
-Obj _35val2570 = co->args[1];
+void _35clofun3119(struct Cora* co) {
+Obj _35val2574 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3092, 1, w);
+pushCont(co, 0, _35clofun3120, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, x);
 }
 
-void _35clofun3092(struct Cora* co) {
-Obj _35val2571 = co->args[1];
+void _35clofun3120(struct Cora* co) {
+Obj _35val2575 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
-void _35clofun3087(struct Cora* co) {
-Obj _35val2566 = co->args[1];
+void _35clofun3115(struct Cora* co) {
+Obj _35val2570 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3088, 1, w);
+pushCont(co, 0, _35clofun3116, 1, w);
 coraCall(co, 2, globalRef(intern("symbol->string")), x);
 }
 
-void _35clofun3088(struct Cora* co) {
-Obj _35val2567 = co->args[1];
+void _35clofun3116(struct Cora* co) {
+Obj _35val2571 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun3089, 1, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2567);
+pushCont(co, 0, _35clofun3117, 1, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2571);
 }
 
-void _35clofun3089(struct Cora* co) {
-Obj _35val2568 = co->args[1];
+void _35clofun3117(struct Cora* co) {
+Obj _35val2572 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("\")"));
 }
 
-void _35clofun3036(struct Cora* co) {
-Obj _35cc1330 = makeNative(0, _35clofun3037, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3064(struct Cora* co) {
+Obj _35cc1330 = makeNative(0, _35clofun3065, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2516 = primIsCons(closureRef(co, 2));
-if (True == _35reg2516) {
-Obj _35reg2517 = primCar(closureRef(co, 2));
-Obj _35reg2518 = primEQ(intern("let"), _35reg2517);
-if (True == _35reg2518) {
-Obj _35reg2519 = primCdr(closureRef(co, 2));
-Obj _35reg2520 = primIsCons(_35reg2519);
+Obj _35reg2520 = primIsCons(closureRef(co, 2));
 if (True == _35reg2520) {
-Obj _35reg2521 = primCdr(closureRef(co, 2));
-Obj _35reg2522 = primCar(_35reg2521);
-Obj a = _35reg2522;
+Obj _35reg2521 = primCar(closureRef(co, 2));
+Obj _35reg2522 = primEQ(intern("let"), _35reg2521);
+if (True == _35reg2522) {
 Obj _35reg2523 = primCdr(closureRef(co, 2));
-Obj _35reg2524 = primCdr(_35reg2523);
-Obj _35reg2525 = primIsCons(_35reg2524);
-if (True == _35reg2525) {
-Obj _35reg2526 = primCdr(closureRef(co, 2));
-Obj _35reg2527 = primCdr(_35reg2526);
-Obj _35reg2528 = primCar(_35reg2527);
-Obj b = _35reg2528;
-Obj _35reg2529 = primCdr(closureRef(co, 2));
-Obj _35reg2530 = primCdr(_35reg2529);
+Obj _35reg2524 = primIsCons(_35reg2523);
+if (True == _35reg2524) {
+Obj _35reg2525 = primCdr(closureRef(co, 2));
+Obj _35reg2526 = primCar(_35reg2525);
+Obj a = _35reg2526;
+Obj _35reg2527 = primCdr(closureRef(co, 2));
+Obj _35reg2528 = primCdr(_35reg2527);
+Obj _35reg2529 = primIsCons(_35reg2528);
+if (True == _35reg2529) {
+Obj _35reg2530 = primCdr(closureRef(co, 2));
 Obj _35reg2531 = primCdr(_35reg2530);
-Obj _35reg2532 = primIsCons(_35reg2531);
-if (True == _35reg2532) {
+Obj _35reg2532 = primCar(_35reg2531);
+Obj b = _35reg2532;
 Obj _35reg2533 = primCdr(closureRef(co, 2));
 Obj _35reg2534 = primCdr(_35reg2533);
 Obj _35reg2535 = primCdr(_35reg2534);
-Obj _35reg2536 = primCar(_35reg2535);
-Obj c = _35reg2536;
+Obj _35reg2536 = primIsCons(_35reg2535);
+if (True == _35reg2536) {
 Obj _35reg2537 = primCdr(closureRef(co, 2));
 Obj _35reg2538 = primCdr(_35reg2537);
 Obj _35reg2539 = primCdr(_35reg2538);
-Obj _35reg2540 = primCdr(_35reg2539);
-Obj _35reg2541 = primEQ(Nil, _35reg2540);
-if (True == _35reg2541) {
-pushCont(co, 0, _35clofun3077, 5, b, a, env, w, c);
+Obj _35reg2540 = primCar(_35reg2539);
+Obj c = _35reg2540;
+Obj _35reg2541 = primCdr(closureRef(co, 2));
+Obj _35reg2542 = primCdr(_35reg2541);
+Obj _35reg2543 = primCdr(_35reg2542);
+Obj _35reg2544 = primCdr(_35reg2543);
+Obj _35reg2545 = primEQ(Nil, _35reg2544);
+if (True == _35reg2545) {
+pushCont(co, 0, _35clofun3105, 5, b, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.index")), a, env);
 } else {
 coraCall(co, 1, _35cc1330);
@@ -2034,149 +2130,149 @@ coraCall(co, 1, _35cc1330);
 }
 }
 
-void _35clofun3077(struct Cora* co) {
-Obj _35val2542 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val2542;
-Obj _35reg2543 = primLT(idx, makeNumber(0));
-if (True == _35reg2543) {
-pushCont(co, 0, _35clofun3078, 5, b, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("Obj "));
-} else {
-Nil;
-pushCont(co, 0, _35clofun3083, 5, b, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
-}
-}
-
-void _35clofun3083(struct Cora* co) {
-Obj _35val2550 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3084, 5, b, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
-}
-
-void _35clofun3084(struct Cora* co) {
-Obj _35val2551 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3085, 4, a, env, w, c);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
-}
-
-void _35clofun3085(struct Cora* co) {
-Obj _35val2552 = co->args[1];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3086, 4, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
-}
-
-void _35clofun3086(struct Cora* co) {
-Obj _35val2553 = co->args[1];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2554 = primCons(a, env);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2554, w, c);
-}
-
-void _35clofun3078(struct Cora* co) {
-Obj _35val2544 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3079, 5, b, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
-}
-
-void _35clofun3079(struct Cora* co) {
-Obj _35val2545 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3080, 5, b, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
-}
-
-void _35clofun3080(struct Cora* co) {
+void _35clofun3105(struct Cora* co) {
 Obj _35val2546 = co->args[1];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3081, 4, a, env, w, c);
+Obj idx = _35val2546;
+Obj _35reg2547 = primLT(idx, makeNumber(0));
+if (True == _35reg2547) {
+pushCont(co, 0, _35clofun3106, 5, b, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("Obj "));
+} else {
+Nil;
+pushCont(co, 0, _35clofun3111, 5, b, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
+}
+}
+
+void _35clofun3111(struct Cora* co) {
+Obj _35val2554 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3112, 5, b, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
+}
+
+void _35clofun3112(struct Cora* co) {
+Obj _35val2555 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3113, 4, a, env, w, c);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
-void _35clofun3081(struct Cora* co) {
-Obj _35val2547 = co->args[1];
+void _35clofun3113(struct Cora* co) {
+Obj _35val2556 = co->args[1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3082, 4, a, env, w, c);
+pushCont(co, 0, _35clofun3114, 4, a, env, w, c);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
-void _35clofun3082(struct Cora* co) {
-Obj _35val2548 = co->args[1];
+void _35clofun3114(struct Cora* co) {
+Obj _35val2557 = co->args[1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2549 = primCons(a, env);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2549, w, c);
+Obj _35reg2558 = primCons(a, env);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2558, w, c);
 }
 
-void _35clofun3037(struct Cora* co) {
-Obj _35cc1331 = makeNative(0, _35clofun3038, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3106(struct Cora* co) {
+Obj _35val2548 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3107, 5, b, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
+}
+
+void _35clofun3107(struct Cora* co) {
+Obj _35val2549 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3108, 5, b, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
+}
+
+void _35clofun3108(struct Cora* co) {
+Obj _35val2550 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3109, 4, a, env, w, c);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
+}
+
+void _35clofun3109(struct Cora* co) {
+Obj _35val2551 = co->args[1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, _35clofun3110, 4, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
+}
+
+void _35clofun3110(struct Cora* co) {
+Obj _35val2552 = co->args[1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg2553 = primCons(a, env);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2553, w, c);
+}
+
+void _35clofun3065(struct Cora* co) {
+Obj _35cc1331 = makeNative(0, _35clofun3066, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2495 = primIsCons(closureRef(co, 2));
-if (True == _35reg2495) {
-Obj _35reg2496 = primCar(closureRef(co, 2));
-Obj _35reg2497 = primIsCons(_35reg2496);
-if (True == _35reg2497) {
-Obj _35reg2498 = primCar(closureRef(co, 2));
-Obj _35reg2499 = primCar(_35reg2498);
-Obj _35reg2500 = primEQ(intern("%builtin"), _35reg2499);
-if (True == _35reg2500) {
-Obj _35reg2501 = primCar(closureRef(co, 2));
-Obj _35reg2502 = primCdr(_35reg2501);
-Obj _35reg2503 = primIsCons(_35reg2502);
-if (True == _35reg2503) {
-Obj _35reg2504 = primCar(closureRef(co, 2));
-Obj _35reg2505 = primCdr(_35reg2504);
-Obj _35reg2506 = primCar(_35reg2505);
-Obj f = _35reg2506;
-Obj _35reg2507 = primCar(closureRef(co, 2));
-Obj _35reg2508 = primCdr(_35reg2507);
+Obj _35reg2499 = primIsCons(closureRef(co, 2));
+if (True == _35reg2499) {
+Obj _35reg2500 = primCar(closureRef(co, 2));
+Obj _35reg2501 = primIsCons(_35reg2500);
+if (True == _35reg2501) {
+Obj _35reg2502 = primCar(closureRef(co, 2));
+Obj _35reg2503 = primCar(_35reg2502);
+Obj _35reg2504 = primEQ(intern("%builtin"), _35reg2503);
+if (True == _35reg2504) {
+Obj _35reg2505 = primCar(closureRef(co, 2));
+Obj _35reg2506 = primCdr(_35reg2505);
+Obj _35reg2507 = primIsCons(_35reg2506);
+if (True == _35reg2507) {
+Obj _35reg2508 = primCar(closureRef(co, 2));
 Obj _35reg2509 = primCdr(_35reg2508);
-Obj _35reg2510 = primEQ(Nil, _35reg2509);
-if (True == _35reg2510) {
-Obj _35reg2511 = primCdr(closureRef(co, 2));
-Obj args = _35reg2511;
-pushCont(co, 0, _35clofun3073, 3, env, args, w);
+Obj _35reg2510 = primCar(_35reg2509);
+Obj f = _35reg2510;
+Obj _35reg2511 = primCar(closureRef(co, 2));
+Obj _35reg2512 = primCdr(_35reg2511);
+Obj _35reg2513 = primCdr(_35reg2512);
+Obj _35reg2514 = primEQ(Nil, _35reg2513);
+if (True == _35reg2514) {
+Obj _35reg2515 = primCdr(closureRef(co, 2));
+Obj args = _35reg2515;
+pushCont(co, 0, _35clofun3101, 3, env, args, w);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.builtin->name")), f);
 } else {
 coraCall(co, 1, _35cc1331);
@@ -2195,79 +2291,79 @@ coraCall(co, 1, _35cc1331);
 }
 }
 
-void _35clofun3073(struct Cora* co) {
-Obj _35val2512 = co->args[1];
+void _35clofun3101(struct Cora* co) {
+Obj _35val2516 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3074, 3, env, args, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, _35val2512);
+pushCont(co, 0, _35clofun3102, 3, env, args, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, _35val2516);
 }
 
-void _35clofun3074(struct Cora* co) {
-Obj _35val2513 = co->args[1];
+void _35clofun3102(struct Cora* co) {
+Obj _35val2517 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3075, 3, env, args, w);
+pushCont(co, 0, _35clofun3103, 3, env, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("("));
 }
 
-void _35clofun3075(struct Cora* co) {
-Obj _35val2514 = co->args[1];
+void _35clofun3103(struct Cora* co) {
+Obj _35val2518 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3076, 1, w);
+pushCont(co, 0, _35clofun3104, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst-list")), env, w, args);
 }
 
-void _35clofun3076(struct Cora* co) {
-Obj _35val2515 = co->args[1];
+void _35clofun3104(struct Cora* co) {
+Obj _35val2519 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
-void _35clofun3038(struct Cora* co) {
-Obj _35cc1332 = makeNative(0, _35clofun3039, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3066(struct Cora* co) {
+Obj _35cc1332 = makeNative(0, _35clofun3067, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2463 = primIsCons(closureRef(co, 2));
-if (True == _35reg2463) {
-Obj _35reg2464 = primCar(closureRef(co, 2));
-Obj _35reg2465 = primEQ(intern("if"), _35reg2464);
-if (True == _35reg2465) {
-Obj _35reg2466 = primCdr(closureRef(co, 2));
-Obj _35reg2467 = primIsCons(_35reg2466);
+Obj _35reg2467 = primIsCons(closureRef(co, 2));
 if (True == _35reg2467) {
-Obj _35reg2468 = primCdr(closureRef(co, 2));
-Obj _35reg2469 = primCar(_35reg2468);
-Obj a = _35reg2469;
+Obj _35reg2468 = primCar(closureRef(co, 2));
+Obj _35reg2469 = primEQ(intern("if"), _35reg2468);
+if (True == _35reg2469) {
 Obj _35reg2470 = primCdr(closureRef(co, 2));
-Obj _35reg2471 = primCdr(_35reg2470);
-Obj _35reg2472 = primIsCons(_35reg2471);
-if (True == _35reg2472) {
-Obj _35reg2473 = primCdr(closureRef(co, 2));
-Obj _35reg2474 = primCdr(_35reg2473);
-Obj _35reg2475 = primCar(_35reg2474);
-Obj b = _35reg2475;
-Obj _35reg2476 = primCdr(closureRef(co, 2));
-Obj _35reg2477 = primCdr(_35reg2476);
+Obj _35reg2471 = primIsCons(_35reg2470);
+if (True == _35reg2471) {
+Obj _35reg2472 = primCdr(closureRef(co, 2));
+Obj _35reg2473 = primCar(_35reg2472);
+Obj a = _35reg2473;
+Obj _35reg2474 = primCdr(closureRef(co, 2));
+Obj _35reg2475 = primCdr(_35reg2474);
+Obj _35reg2476 = primIsCons(_35reg2475);
+if (True == _35reg2476) {
+Obj _35reg2477 = primCdr(closureRef(co, 2));
 Obj _35reg2478 = primCdr(_35reg2477);
-Obj _35reg2479 = primIsCons(_35reg2478);
-if (True == _35reg2479) {
+Obj _35reg2479 = primCar(_35reg2478);
+Obj b = _35reg2479;
 Obj _35reg2480 = primCdr(closureRef(co, 2));
 Obj _35reg2481 = primCdr(_35reg2480);
 Obj _35reg2482 = primCdr(_35reg2481);
-Obj _35reg2483 = primCar(_35reg2482);
-Obj c = _35reg2483;
+Obj _35reg2483 = primIsCons(_35reg2482);
+if (True == _35reg2483) {
 Obj _35reg2484 = primCdr(closureRef(co, 2));
 Obj _35reg2485 = primCdr(_35reg2484);
 Obj _35reg2486 = primCdr(_35reg2485);
-Obj _35reg2487 = primCdr(_35reg2486);
-Obj _35reg2488 = primEQ(Nil, _35reg2487);
-if (True == _35reg2488) {
-pushCont(co, 0, _35clofun3067, 5, a, b, env, c, w);
+Obj _35reg2487 = primCar(_35reg2486);
+Obj c = _35reg2487;
+Obj _35reg2488 = primCdr(closureRef(co, 2));
+Obj _35reg2489 = primCdr(_35reg2488);
+Obj _35reg2490 = primCdr(_35reg2489);
+Obj _35reg2491 = primCdr(_35reg2490);
+Obj _35reg2492 = primEQ(Nil, _35reg2491);
+if (True == _35reg2492) {
+pushCont(co, 0, _35clofun3095, 5, a, b, env, c, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("if (True == "));
 } else {
 coraCall(co, 1, _35cc1332);
@@ -2289,89 +2385,89 @@ coraCall(co, 1, _35cc1332);
 }
 }
 
-void _35clofun3067(struct Cora* co) {
-Obj _35val2489 = co->args[1];
+void _35clofun3095(struct Cora* co) {
+Obj _35val2493 = co->args[1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3068, 4, b, env, c, w);
+pushCont(co, 0, _35clofun3096, 4, b, env, c, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
-void _35clofun3068(struct Cora* co) {
-Obj _35val2490 = co->args[1];
+void _35clofun3096(struct Cora* co) {
+Obj _35val2494 = co->args[1];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3069, 4, b, env, c, w);
+pushCont(co, 0, _35clofun3097, 4, b, env, c, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(") {\n"));
 }
 
-void _35clofun3069(struct Cora* co) {
-Obj _35val2491 = co->args[1];
+void _35clofun3097(struct Cora* co) {
+Obj _35val2495 = co->args[1];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3070, 3, env, c, w);
+pushCont(co, 0, _35clofun3098, 3, env, c, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
-void _35clofun3070(struct Cora* co) {
-Obj _35val2492 = co->args[1];
+void _35clofun3098(struct Cora* co) {
+Obj _35val2496 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3071, 3, env, c, w);
+pushCont(co, 0, _35clofun3099, 3, env, c, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("} else {\n"));
 }
 
-void _35clofun3071(struct Cora* co) {
-Obj _35val2493 = co->args[1];
+void _35clofun3099(struct Cora* co) {
+Obj _35val2497 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3072, 1, w);
+pushCont(co, 0, _35clofun3100, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, c);
 }
 
-void _35clofun3072(struct Cora* co) {
-Obj _35val2494 = co->args[1];
+void _35clofun3100(struct Cora* co) {
+Obj _35val2498 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("}\n"));
 }
 
-void _35clofun3039(struct Cora* co) {
-Obj _35cc1333 = makeNative(0, _35clofun3040, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3067(struct Cora* co) {
+Obj _35cc1333 = makeNative(0, _35clofun3068, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2436 = primIsCons(closureRef(co, 2));
-if (True == _35reg2436) {
-Obj _35reg2437 = primCar(closureRef(co, 2));
-Obj _35reg2438 = primEQ(intern("%closure"), _35reg2437);
-if (True == _35reg2438) {
-Obj _35reg2439 = primCdr(closureRef(co, 2));
-Obj _35reg2440 = primIsCons(_35reg2439);
+Obj _35reg2440 = primIsCons(closureRef(co, 2));
 if (True == _35reg2440) {
-Obj _35reg2441 = primCdr(closureRef(co, 2));
-Obj _35reg2442 = primCar(_35reg2441);
-Obj label = _35reg2442;
+Obj _35reg2441 = primCar(closureRef(co, 2));
+Obj _35reg2442 = primEQ(intern("%closure"), _35reg2441);
+if (True == _35reg2442) {
 Obj _35reg2443 = primCdr(closureRef(co, 2));
-Obj _35reg2444 = primCdr(_35reg2443);
-Obj _35reg2445 = primIsCons(_35reg2444);
-if (True == _35reg2445) {
-Obj _35reg2446 = primCdr(closureRef(co, 2));
-Obj _35reg2447 = primCdr(_35reg2446);
-Obj _35reg2448 = primCar(_35reg2447);
-Obj nargs = _35reg2448;
-Obj _35reg2449 = primCdr(closureRef(co, 2));
-Obj _35reg2450 = primCdr(_35reg2449);
+Obj _35reg2444 = primIsCons(_35reg2443);
+if (True == _35reg2444) {
+Obj _35reg2445 = primCdr(closureRef(co, 2));
+Obj _35reg2446 = primCar(_35reg2445);
+Obj label = _35reg2446;
+Obj _35reg2447 = primCdr(closureRef(co, 2));
+Obj _35reg2448 = primCdr(_35reg2447);
+Obj _35reg2449 = primIsCons(_35reg2448);
+if (True == _35reg2449) {
+Obj _35reg2450 = primCdr(closureRef(co, 2));
 Obj _35reg2451 = primCdr(_35reg2450);
-Obj frees = _35reg2451;
-pushCont(co, 0, _35clofun3057, 5, label, nargs, env, frees, w);
+Obj _35reg2452 = primCar(_35reg2451);
+Obj nargs = _35reg2452;
+Obj _35reg2453 = primCdr(closureRef(co, 2));
+Obj _35reg2454 = primCdr(_35reg2453);
+Obj _35reg2455 = primCdr(_35reg2454);
+Obj frees = _35reg2455;
+pushCont(co, 0, _35clofun3085, 5, label, nargs, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeNative(0, "));
 } else {
 coraCall(co, 1, _35cc1333);
@@ -2387,81 +2483,81 @@ coraCall(co, 1, _35cc1333);
 }
 }
 
-void _35clofun3057(struct Cora* co) {
-Obj _35val2452 = co->args[1];
+void _35clofun3085(struct Cora* co) {
+Obj _35val2456 = co->args[1];
 Obj label = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3058, 4, nargs, env, frees, w);
+pushCont(co, 0, _35clofun3086, 4, nargs, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, label);
 }
 
-void _35clofun3058(struct Cora* co) {
-Obj _35val2453 = co->args[1];
+void _35clofun3086(struct Cora* co) {
+Obj _35val2457 = co->args[1];
 Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3059, 4, nargs, env, frees, w);
+pushCont(co, 0, _35clofun3087, 4, nargs, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 }
 
-void _35clofun3059(struct Cora* co) {
-Obj _35val2454 = co->args[1];
+void _35clofun3087(struct Cora* co) {
+Obj _35val2458 = co->args[1];
 Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3060, 3, env, frees, w);
+pushCont(co, 0, _35clofun3088, 3, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, nargs);
 }
 
-void _35clofun3060(struct Cora* co) {
-Obj _35val2455 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3061, 3, env, frees, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
-}
-
-void _35clofun3061(struct Cora* co) {
-Obj _35val2456 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3062, 3, env, frees, w);
-coraCall(co, 2, globalRef(intern("length")), frees);
-}
-
-void _35clofun3062(struct Cora* co) {
-Obj _35val2457 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3063, 3, env, frees, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2457);
-}
-
-void _35clofun3063(struct Cora* co) {
-Obj _35val2458 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3064, 3, env, frees, w);
-coraCall(co, 2, globalRef(intern("null?")), frees);
-}
-
-void _35clofun3064(struct Cora* co) {
+void _35clofun3088(struct Cora* co) {
 Obj _35val2459 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2460 = primNot(_35val2459);
-if (True == _35reg2460) {
-pushCont(co, 0, _35clofun3065, 3, env, frees, w);
+pushCont(co, 0, _35clofun3089, 3, env, frees, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
+}
+
+void _35clofun3089(struct Cora* co) {
+Obj _35val2460 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3090, 3, env, frees, w);
+coraCall(co, 2, globalRef(intern("length")), frees);
+}
+
+void _35clofun3090(struct Cora* co) {
+Obj _35val2461 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3091, 3, env, frees, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2461);
+}
+
+void _35clofun3091(struct Cora* co) {
+Obj _35val2462 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3092, 3, env, frees, w);
+coraCall(co, 2, globalRef(intern("null?")), frees);
+}
+
+void _35clofun3092(struct Cora* co) {
+Obj _35val2463 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg2464 = primNot(_35val2463);
+if (True == _35reg2464) {
+pushCont(co, 0, _35clofun3093, 3, env, frees, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
 } else {
 Nil;
@@ -2469,50 +2565,50 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, make
 }
 }
 
-void _35clofun3065(struct Cora* co) {
-Obj _35val2461 = co->args[1];
+void _35clofun3093(struct Cora* co) {
+Obj _35val2465 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3066, 1, w);
+pushCont(co, 0, _35clofun3094, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst-list")), env, w, frees);
 }
 
-void _35clofun3066(struct Cora* co) {
-Obj _35val2462 = co->args[1];
+void _35clofun3094(struct Cora* co) {
+Obj _35val2466 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
-void _35clofun3040(struct Cora* co) {
-Obj _35cc1334 = makeNative(0, _35clofun3041, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3068(struct Cora* co) {
+Obj _35cc1334 = makeNative(0, _35clofun3069, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2417 = primIsCons(closureRef(co, 2));
-if (True == _35reg2417) {
-Obj _35reg2418 = primCar(closureRef(co, 2));
-Obj _35reg2419 = primEQ(intern("do"), _35reg2418);
-if (True == _35reg2419) {
-Obj _35reg2420 = primCdr(closureRef(co, 2));
-Obj _35reg2421 = primIsCons(_35reg2420);
+Obj _35reg2421 = primIsCons(closureRef(co, 2));
 if (True == _35reg2421) {
-Obj _35reg2422 = primCdr(closureRef(co, 2));
-Obj _35reg2423 = primCar(_35reg2422);
-Obj a = _35reg2423;
+Obj _35reg2422 = primCar(closureRef(co, 2));
+Obj _35reg2423 = primEQ(intern("do"), _35reg2422);
+if (True == _35reg2423) {
 Obj _35reg2424 = primCdr(closureRef(co, 2));
-Obj _35reg2425 = primCdr(_35reg2424);
-Obj _35reg2426 = primIsCons(_35reg2425);
-if (True == _35reg2426) {
-Obj _35reg2427 = primCdr(closureRef(co, 2));
-Obj _35reg2428 = primCdr(_35reg2427);
-Obj _35reg2429 = primCar(_35reg2428);
-Obj b = _35reg2429;
-Obj _35reg2430 = primCdr(closureRef(co, 2));
-Obj _35reg2431 = primCdr(_35reg2430);
+Obj _35reg2425 = primIsCons(_35reg2424);
+if (True == _35reg2425) {
+Obj _35reg2426 = primCdr(closureRef(co, 2));
+Obj _35reg2427 = primCar(_35reg2426);
+Obj a = _35reg2427;
+Obj _35reg2428 = primCdr(closureRef(co, 2));
+Obj _35reg2429 = primCdr(_35reg2428);
+Obj _35reg2430 = primIsCons(_35reg2429);
+if (True == _35reg2430) {
+Obj _35reg2431 = primCdr(closureRef(co, 2));
 Obj _35reg2432 = primCdr(_35reg2431);
-Obj _35reg2433 = primEQ(Nil, _35reg2432);
-if (True == _35reg2433) {
-pushCont(co, 0, _35clofun3055, 3, env, w, b);
+Obj _35reg2433 = primCar(_35reg2432);
+Obj b = _35reg2433;
+Obj _35reg2434 = primCdr(closureRef(co, 2));
+Obj _35reg2435 = primCdr(_35reg2434);
+Obj _35reg2436 = primCdr(_35reg2435);
+Obj _35reg2437 = primEQ(Nil, _35reg2436);
+if (True == _35reg2437) {
+pushCont(co, 0, _35clofun3083, 3, env, w, b);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 } else {
 coraCall(co, 1, _35cc1334);
@@ -2531,43 +2627,43 @@ coraCall(co, 1, _35cc1334);
 }
 }
 
-void _35clofun3055(struct Cora* co) {
-Obj _35val2434 = co->args[1];
+void _35clofun3083(struct Cora* co) {
+Obj _35val2438 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3056, 3, env, w, b);
+pushCont(co, 0, _35clofun3084, 3, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
 }
 
-void _35clofun3056(struct Cora* co) {
-Obj _35val2435 = co->args[1];
+void _35clofun3084(struct Cora* co) {
+Obj _35val2439 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 2];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
 }
 
-void _35clofun3041(struct Cora* co) {
-Obj _35cc1335 = makeNative(0, _35clofun3042, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3069(struct Cora* co) {
+Obj _35cc1335 = makeNative(0, _35clofun3070, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2405 = primIsCons(closureRef(co, 2));
-if (True == _35reg2405) {
-Obj _35reg2406 = primCar(closureRef(co, 2));
-Obj _35reg2407 = primEQ(intern("return"), _35reg2406);
-if (True == _35reg2407) {
-Obj _35reg2408 = primCdr(closureRef(co, 2));
-Obj _35reg2409 = primIsCons(_35reg2408);
+Obj _35reg2409 = primIsCons(closureRef(co, 2));
 if (True == _35reg2409) {
-Obj _35reg2410 = primCdr(closureRef(co, 2));
-Obj _35reg2411 = primCar(_35reg2410);
-Obj x = _35reg2411;
+Obj _35reg2410 = primCar(closureRef(co, 2));
+Obj _35reg2411 = primEQ(intern("return"), _35reg2410);
+if (True == _35reg2411) {
 Obj _35reg2412 = primCdr(closureRef(co, 2));
-Obj _35reg2413 = primCdr(_35reg2412);
-Obj _35reg2414 = primEQ(Nil, _35reg2413);
-if (True == _35reg2414) {
-pushCont(co, 0, _35clofun3053, 3, env, x, w);
+Obj _35reg2413 = primIsCons(_35reg2412);
+if (True == _35reg2413) {
+Obj _35reg2414 = primCdr(closureRef(co, 2));
+Obj _35reg2415 = primCar(_35reg2414);
+Obj x = _35reg2415;
+Obj _35reg2416 = primCdr(closureRef(co, 2));
+Obj _35reg2417 = primCdr(_35reg2416);
+Obj _35reg2418 = primEQ(Nil, _35reg2417);
+if (True == _35reg2418) {
+pushCont(co, 0, _35clofun3081, 3, env, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("coraReturn(co, "));
 } else {
 coraCall(co, 1, _35cc1335);
@@ -2583,40 +2679,40 @@ coraCall(co, 1, _35cc1335);
 }
 }
 
-void _35clofun3053(struct Cora* co) {
-Obj _35val2415 = co->args[1];
+void _35clofun3081(struct Cora* co) {
+Obj _35val2419 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3054, 1, w);
+pushCont(co, 0, _35clofun3082, 1, w);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, x);
 }
 
-void _35clofun3054(struct Cora* co) {
-Obj _35val2416 = co->args[1];
+void _35clofun3082(struct Cora* co) {
+Obj _35val2420 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\nreturn;\n"));
 }
 
-void _35clofun3042(struct Cora* co) {
-Obj _35cc1336 = makeNative(0, _35clofun3043, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3070(struct Cora* co) {
+Obj _35cc1336 = makeNative(0, _35clofun3071, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2395 = primIsCons(closureRef(co, 2));
-if (True == _35reg2395) {
-Obj _35reg2396 = primCar(closureRef(co, 2));
-Obj _35reg2397 = primEQ(intern("tailcall"), _35reg2396);
-if (True == _35reg2397) {
-Obj _35reg2398 = primCdr(closureRef(co, 2));
-Obj _35reg2399 = primIsCons(_35reg2398);
+Obj _35reg2399 = primIsCons(closureRef(co, 2));
 if (True == _35reg2399) {
-Obj _35reg2400 = primCdr(closureRef(co, 2));
-Obj _35reg2401 = primCar(_35reg2400);
-Obj exp = _35reg2401;
+Obj _35reg2400 = primCar(closureRef(co, 2));
+Obj _35reg2401 = primEQ(intern("tailcall"), _35reg2400);
+if (True == _35reg2401) {
 Obj _35reg2402 = primCdr(closureRef(co, 2));
-Obj _35reg2403 = primCdr(_35reg2402);
-Obj _35reg2404 = primEQ(Nil, _35reg2403);
-if (True == _35reg2404) {
+Obj _35reg2403 = primIsCons(_35reg2402);
+if (True == _35reg2403) {
+Obj _35reg2404 = primCdr(closureRef(co, 2));
+Obj _35reg2405 = primCar(_35reg2404);
+Obj exp = _35reg2405;
+Obj _35reg2406 = primCdr(closureRef(co, 2));
+Obj _35reg2407 = primCdr(_35reg2406);
+Obj _35reg2408 = primEQ(Nil, _35reg2407);
+if (True == _35reg2408) {
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, exp);
 } else {
 coraCall(co, 1, _35cc1336);
@@ -2632,35 +2728,35 @@ coraCall(co, 1, _35cc1336);
 }
 }
 
-void _35clofun3043(struct Cora* co) {
-Obj _35cc1337 = makeNative(0, _35clofun3044, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3071(struct Cora* co) {
+Obj _35cc1337 = makeNative(0, _35clofun3072, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2377 = primIsCons(closureRef(co, 2));
-if (True == _35reg2377) {
-Obj _35reg2378 = primCar(closureRef(co, 2));
-Obj _35reg2379 = primEQ(intern("call"), _35reg2378);
-if (True == _35reg2379) {
-Obj _35reg2380 = primCdr(closureRef(co, 2));
-Obj _35reg2381 = primIsCons(_35reg2380);
+Obj _35reg2381 = primIsCons(closureRef(co, 2));
 if (True == _35reg2381) {
-Obj _35reg2382 = primCdr(closureRef(co, 2));
-Obj _35reg2383 = primCar(_35reg2382);
-Obj exp = _35reg2383;
+Obj _35reg2382 = primCar(closureRef(co, 2));
+Obj _35reg2383 = primEQ(intern("call"), _35reg2382);
+if (True == _35reg2383) {
 Obj _35reg2384 = primCdr(closureRef(co, 2));
-Obj _35reg2385 = primCdr(_35reg2384);
-Obj _35reg2386 = primIsCons(_35reg2385);
-if (True == _35reg2386) {
-Obj _35reg2387 = primCdr(closureRef(co, 2));
-Obj _35reg2388 = primCdr(_35reg2387);
-Obj _35reg2389 = primCar(_35reg2388);
-Obj cont = _35reg2389;
-Obj _35reg2390 = primCdr(closureRef(co, 2));
-Obj _35reg2391 = primCdr(_35reg2390);
+Obj _35reg2385 = primIsCons(_35reg2384);
+if (True == _35reg2385) {
+Obj _35reg2386 = primCdr(closureRef(co, 2));
+Obj _35reg2387 = primCar(_35reg2386);
+Obj exp = _35reg2387;
+Obj _35reg2388 = primCdr(closureRef(co, 2));
+Obj _35reg2389 = primCdr(_35reg2388);
+Obj _35reg2390 = primIsCons(_35reg2389);
+if (True == _35reg2390) {
+Obj _35reg2391 = primCdr(closureRef(co, 2));
 Obj _35reg2392 = primCdr(_35reg2391);
-Obj _35reg2393 = primEQ(Nil, _35reg2392);
-if (True == _35reg2393) {
-pushCont(co, 0, _35clofun3052, 3, env, w, exp);
+Obj _35reg2393 = primCar(_35reg2392);
+Obj cont = _35reg2393;
+Obj _35reg2394 = primCdr(closureRef(co, 2));
+Obj _35reg2395 = primCdr(_35reg2394);
+Obj _35reg2396 = primCdr(_35reg2395);
+Obj _35reg2397 = primEQ(Nil, _35reg2396);
+if (True == _35reg2397) {
+pushCont(co, 0, _35clofun3080, 3, env, w, exp);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.generate-cont")), w, cont);
 } else {
 coraCall(co, 1, _35cc1337);
@@ -2679,235 +2775,235 @@ coraCall(co, 1, _35cc1337);
 }
 }
 
-void _35clofun3052(struct Cora* co) {
-Obj _35val2394 = co->args[1];
+void _35clofun3080(struct Cora* co) {
+Obj _35val2398 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 2];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, exp);
 }
 
-void _35clofun3044(struct Cora* co) {
-Obj _35cc1338 = makeNative(0, _35clofun3045, 0, 0);
+void _35clofun3072(struct Cora* co) {
+Obj _35cc1338 = makeNative(0, _35clofun3073, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2367 = primIsCons(closureRef(co, 2));
-if (True == _35reg2367) {
-Obj _35reg2368 = primCar(closureRef(co, 2));
-Obj f = _35reg2368;
-Obj _35reg2369 = primCdr(closureRef(co, 2));
-Obj args = _35reg2369;
-pushCont(co, 0, _35clofun3046, 3, f, args, w);
+Obj _35reg2371 = primIsCons(closureRef(co, 2));
+if (True == _35reg2371) {
+Obj _35reg2372 = primCar(closureRef(co, 2));
+Obj f = _35reg2372;
+Obj _35reg2373 = primCdr(closureRef(co, 2));
+Obj args = _35reg2373;
+pushCont(co, 0, _35clofun3074, 3, f, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("coraCall(co, "));
 } else {
 coraCall(co, 1, _35cc1338);
 }
 }
 
-void _35clofun3046(struct Cora* co) {
-Obj _35val2370 = co->args[1];
+void _35clofun3074(struct Cora* co) {
+Obj _35val2374 = co->args[1];
 Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3047, 3, f, args, w);
+pushCont(co, 0, _35clofun3075, 3, f, args, w);
 coraCall(co, 2, globalRef(intern("length")), args);
 }
 
-void _35clofun3047(struct Cora* co) {
-Obj _35val2371 = co->args[1];
+void _35clofun3075(struct Cora* co) {
+Obj _35val2375 = co->args[1];
 Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2372 = primAdd(makeNumber(1), _35val2371);
-pushCont(co, 0, _35clofun3048, 3, f, args, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35reg2372);
+Obj _35reg2376 = primAdd(makeNumber(1), _35val2375);
+pushCont(co, 0, _35clofun3076, 3, f, args, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35reg2376);
 }
 
-void _35clofun3048(struct Cora* co) {
-Obj _35val2373 = co->args[1];
+void _35clofun3076(struct Cora* co) {
+Obj _35val2377 = co->args[1];
 Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2375 = primCons(f, args);
-pushCont(co, 0, _35clofun3051, 1, w);
-coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3049, 1, 1, w), _35reg2375);
+Obj _35reg2379 = primCons(f, args);
+pushCont(co, 0, _35clofun3079, 1, w);
+coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3077, 1, 1, w), _35reg2379);
 }
 
-void _35clofun3051(struct Cora* co) {
-Obj _35val2376 = co->args[1];
+void _35clofun3079(struct Cora* co) {
+Obj _35val2380 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
 }
 
-void _35clofun3049(struct Cora* co) {
+void _35clofun3077(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, 0, _35clofun3050, 1, x);
+pushCont(co, 0, _35clofun3078, 1, x);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closureRef(co, 0), makeString1(", "));
 }
 
-void _35clofun3050(struct Cora* co) {
-Obj _35val2374 = co->args[1];
+void _35clofun3078(struct Cora* co) {
+Obj _35val2378 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), Nil, closureRef(co, 0), x);
 }
 
-void _35clofun3045(struct Cora* co) {
+void _35clofun3073(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3029(struct Cora* co) {
+void _35clofun3057(struct Cora* co) {
 Obj x = co->args[1];
 Obj k = co->args[2];
-Obj _35reg2360 = primGenSym(intern("reg"));
-Obj tmp = _35reg2360;
-pushCont(co, 0, _35clofun3030, 2, x, tmp);
+Obj _35reg2364 = primGenSym(intern("reg"));
+Obj tmp = _35reg2364;
+pushCont(co, 0, _35clofun3058, 2, x, tmp);
 coraCall(co, 2, k, tmp);
 }
 
-void _35clofun3030(struct Cora* co) {
-Obj _35val2361 = co->args[1];
+void _35clofun3058(struct Cora* co) {
+Obj _35val2365 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj tmp = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2362 = primCons(_35val2361, Nil);
-Obj _35reg2363 = primCons(x, _35reg2362);
-Obj _35reg2364 = primCons(tmp, _35reg2363);
-Obj _35reg2365 = primCons(intern("let"), _35reg2364);
-coraReturn(co, _35reg2365);
+Obj _35reg2366 = primCons(_35val2365, Nil);
+Obj _35reg2367 = primCons(x, _35reg2366);
+Obj _35reg2368 = primCons(tmp, _35reg2367);
+Obj _35reg2369 = primCons(intern("let"), _35reg2368);
+coraReturn(co, _35reg2369);
 return;
 }
 
-void _35clofun3024(struct Cora* co) {
+void _35clofun3052(struct Cora* co) {
 Obj _35p1316 = co->args[1];
 Obj _35p1317 = co->args[2];
 Obj _35p1318 = co->args[3];
 Obj _35p1319 = co->args[4];
-Obj _35cc1320 = makeNative(0, _35clofun3025, 0, 4, _35p1316, _35p1317, _35p1318, _35p1319);
+Obj _35cc1320 = makeNative(0, _35clofun3053, 0, 4, _35p1316, _35p1317, _35p1318, _35p1319);
 Obj res = _35p1316;
 Obj init = _35p1317;
-Obj _35reg2357 = primEQ(Nil, _35p1318);
-if (True == _35reg2357) {
+Obj _35reg2361 = primEQ(Nil, _35p1318);
+if (True == _35reg2361) {
 Obj k = _35p1319;
-pushCont(co, 0, _35clofun3028, 2, k, init);
+pushCont(co, 0, _35clofun3056, 2, k, init);
 coraCall(co, 2, globalRef(intern("reverse")), res);
 } else {
 coraCall(co, 1, _35cc1320);
 }
 }
 
-void _35clofun3028(struct Cora* co) {
-Obj _35val2358 = co->args[1];
+void _35clofun3056(struct Cora* co) {
+Obj _35val2362 = co->args[1];
 Obj k = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj init = co->ctx.stk.stack[co->ctx.stk.base + 1];
-coraCall(co, 3, k, init, _35val2358);
+coraCall(co, 3, k, init, _35val2362);
 }
 
-void _35clofun3025(struct Cora* co) {
-Obj _35cc1321 = makeNative(0, _35clofun3026, 0, 0);
+void _35clofun3053(struct Cora* co) {
+Obj _35cc1321 = makeNative(0, _35clofun3054, 0, 0);
 Obj res = closureRef(co, 0);
 Obj init = closureRef(co, 1);
-Obj _35reg2353 = primIsCons(closureRef(co, 2));
-if (True == _35reg2353) {
-Obj _35reg2354 = primCar(closureRef(co, 2));
-Obj x = _35reg2354;
-Obj _35reg2355 = primCdr(closureRef(co, 2));
-Obj y = _35reg2355;
+Obj _35reg2357 = primIsCons(closureRef(co, 2));
+if (True == _35reg2357) {
+Obj _35reg2358 = primCar(closureRef(co, 2));
+Obj x = _35reg2358;
+Obj _35reg2359 = primCdr(closureRef(co, 2));
+Obj y = _35reg2359;
 Obj k = closureRef(co, 3);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), init, x, makeNative(0, _35clofun3027, 2, 3, res, y, k));
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), init, x, makeNative(0, _35clofun3055, 2, 3, res, y, k));
 } else {
 coraCall(co, 1, _35cc1321);
 }
 }
 
-void _35clofun3027(struct Cora* co) {
+void _35clofun3055(struct Cora* co) {
 Obj init1 = co->args[1];
 Obj x1 = co->args[2];
-Obj _35reg2356 = primCons(x1, closureRef(co, 0));
-coraCall(co, 5, globalRef(intern("cora/lib/toc.collect-lambda-list")), _35reg2356, init1, closureRef(co, 1), closureRef(co, 2));
+Obj _35reg2360 = primCons(x1, closureRef(co, 0));
+coraCall(co, 5, globalRef(intern("cora/lib/toc.collect-lambda-list")), _35reg2360, init1, closureRef(co, 1), closureRef(co, 2));
 }
 
-void _35clofun3026(struct Cora* co) {
+void _35clofun3054(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3014(struct Cora* co) {
+void _35clofun3042(struct Cora* co) {
 Obj _35p1310 = co->args[1];
 Obj _35p1311 = co->args[2];
 Obj _35p1312 = co->args[3];
-Obj _35cc1313 = makeNative(0, _35clofun3015, 0, 3, _35p1310, _35p1311, _35p1312);
+Obj _35cc1313 = makeNative(0, _35clofun3043, 0, 3, _35p1310, _35p1311, _35p1312);
 Obj res = _35p1310;
-Obj _35reg2247 = primIsCons(_35p1311);
-if (True == _35reg2247) {
-Obj _35reg2248 = primCar(_35p1311);
-Obj clo_45or_45cont = _35reg2248;
-Obj _35reg2249 = primCdr(_35p1311);
-Obj _35reg2250 = primIsCons(_35reg2249);
-if (True == _35reg2250) {
-Obj _35reg2251 = primCdr(_35p1311);
-Obj _35reg2252 = primCar(_35reg2251);
-Obj _35reg2253 = primIsCons(_35reg2252);
-if (True == _35reg2253) {
-Obj _35reg2254 = primCdr(_35p1311);
-Obj _35reg2255 = primCar(_35reg2254);
+Obj _35reg2251 = primIsCons(_35p1311);
+if (True == _35reg2251) {
+Obj _35reg2252 = primCar(_35p1311);
+Obj clo_45or_45cont = _35reg2252;
+Obj _35reg2253 = primCdr(_35p1311);
+Obj _35reg2254 = primIsCons(_35reg2253);
+if (True == _35reg2254) {
+Obj _35reg2255 = primCdr(_35p1311);
 Obj _35reg2256 = primCar(_35reg2255);
-Obj _35reg2257 = primEQ(intern("lambda"), _35reg2256);
+Obj _35reg2257 = primIsCons(_35reg2256);
 if (True == _35reg2257) {
 Obj _35reg2258 = primCdr(_35p1311);
 Obj _35reg2259 = primCar(_35reg2258);
-Obj _35reg2260 = primCdr(_35reg2259);
-Obj _35reg2261 = primIsCons(_35reg2260);
+Obj _35reg2260 = primCar(_35reg2259);
+Obj _35reg2261 = primEQ(intern("lambda"), _35reg2260);
 if (True == _35reg2261) {
 Obj _35reg2262 = primCdr(_35p1311);
 Obj _35reg2263 = primCar(_35reg2262);
 Obj _35reg2264 = primCdr(_35reg2263);
-Obj _35reg2265 = primCar(_35reg2264);
-Obj params = _35reg2265;
+Obj _35reg2265 = primIsCons(_35reg2264);
+if (True == _35reg2265) {
 Obj _35reg2266 = primCdr(_35p1311);
 Obj _35reg2267 = primCar(_35reg2266);
 Obj _35reg2268 = primCdr(_35reg2267);
-Obj _35reg2269 = primCdr(_35reg2268);
-Obj _35reg2270 = primIsCons(_35reg2269);
-if (True == _35reg2270) {
-Obj _35reg2271 = primCdr(_35p1311);
-Obj _35reg2272 = primCar(_35reg2271);
+Obj _35reg2269 = primCar(_35reg2268);
+Obj params = _35reg2269;
+Obj _35reg2270 = primCdr(_35p1311);
+Obj _35reg2271 = primCar(_35reg2270);
+Obj _35reg2272 = primCdr(_35reg2271);
 Obj _35reg2273 = primCdr(_35reg2272);
-Obj _35reg2274 = primCdr(_35reg2273);
-Obj _35reg2275 = primCar(_35reg2274);
-Obj body = _35reg2275;
-Obj _35reg2276 = primCdr(_35p1311);
-Obj _35reg2277 = primCar(_35reg2276);
+Obj _35reg2274 = primIsCons(_35reg2273);
+if (True == _35reg2274) {
+Obj _35reg2275 = primCdr(_35p1311);
+Obj _35reg2276 = primCar(_35reg2275);
+Obj _35reg2277 = primCdr(_35reg2276);
 Obj _35reg2278 = primCdr(_35reg2277);
-Obj _35reg2279 = primCdr(_35reg2278);
-Obj _35reg2280 = primCdr(_35reg2279);
-Obj _35reg2281 = primEQ(Nil, _35reg2280);
-if (True == _35reg2281) {
-Obj _35reg2282 = primCdr(_35p1311);
+Obj _35reg2279 = primCar(_35reg2278);
+Obj body = _35reg2279;
+Obj _35reg2280 = primCdr(_35p1311);
+Obj _35reg2281 = primCar(_35reg2280);
+Obj _35reg2282 = primCdr(_35reg2281);
 Obj _35reg2283 = primCdr(_35reg2282);
-Obj fvs = _35reg2283;
+Obj _35reg2284 = primCdr(_35reg2283);
+Obj _35reg2285 = primEQ(Nil, _35reg2284);
+if (True == _35reg2285) {
+Obj _35reg2286 = primCdr(_35p1311);
+Obj _35reg2287 = primCdr(_35reg2286);
+Obj fvs = _35reg2287;
 Obj k = _35p1312;
-Obj _35reg2284 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2284) {
+Obj _35reg2288 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2288) {
 if (True == True) {
-Obj _35reg2285 = primGenSym(intern("clofun"));
-Obj name = _35reg2285;
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3018, 2, 5, k, params, clo_45or_45cont, name, fvs));
+Obj _35reg2289 = primGenSym(intern("clofun"));
+Obj name = _35reg2289;
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3046, 2, 5, k, params, clo_45or_45cont, name, fvs));
 } else {
 coraCall(co, 1, _35cc1313);
 }
 } else {
-Obj _35reg2307 = primEQ(clo_45or_45cont, intern("%continuation"));
-if (True == _35reg2307) {
+Obj _35reg2311 = primEQ(clo_45or_45cont, intern("%continuation"));
+if (True == _35reg2311) {
 if (True == True) {
-Obj _35reg2308 = primGenSym(intern("clofun"));
-Obj name = _35reg2308;
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3020, 2, 5, k, params, clo_45or_45cont, name, fvs));
+Obj _35reg2312 = primGenSym(intern("clofun"));
+Obj name = _35reg2312;
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3048, 2, 5, k, params, clo_45or_45cont, name, fvs));
 } else {
 coraCall(co, 1, _35cc1313);
 }
 } else {
 if (True == False) {
-Obj _35reg2330 = primGenSym(intern("clofun"));
-Obj name = _35reg2330;
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3022, 2, 5, k, params, clo_45or_45cont, name, fvs));
+Obj _35reg2334 = primGenSym(intern("clofun"));
+Obj name = _35reg2334;
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3050, 2, 5, k, params, clo_45or_45cont, name, fvs));
 } else {
 coraCall(co, 1, _35cc1313);
 }
@@ -2936,157 +3032,157 @@ coraCall(co, 1, _35cc1313);
 }
 }
 
-void _35clofun3022(struct Cora* co) {
+void _35clofun3050(struct Cora* co) {
 Obj res1 = co->args[1];
 Obj body1 = co->args[2];
-Obj _35reg2331 = primEQ(closureRef(co, 2), intern("%closure"));
-if (True == _35reg2331) {
-Obj _35reg2332 = primCons(body1, Nil);
-Obj _35reg2333 = primCons(Nil, _35reg2332);
-Obj _35reg2334 = primCons(closureRef(co, 1), _35reg2333);
-Obj _35reg2335 = primCons(intern("lambda"), _35reg2334);
-Obj _35reg2336 = primCons(_35reg2335, Nil);
-Obj _35reg2337 = primCons(closureRef(co, 3), _35reg2336);
-Obj _35reg2338 = primCons(_35reg2337, res1);
-pushCont(co, 0, _35clofun3023, 1, _35reg2338);
-coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
-} else {
-Obj _35reg2343 = primCons(body1, Nil);
-Obj _35reg2344 = primCons(closureRef(co, 4), _35reg2343);
-Obj _35reg2345 = primCons(closureRef(co, 1), _35reg2344);
-Obj _35reg2346 = primCons(intern("lambda"), _35reg2345);
-Obj _35reg2347 = primCons(_35reg2346, Nil);
-Obj _35reg2348 = primCons(closureRef(co, 3), _35reg2347);
-Obj _35reg2349 = primCons(_35reg2348, res1);
-Obj _35reg2350 = primCons(closureRef(co, 3), closureRef(co, 4));
-Obj _35reg2351 = primCons(closureRef(co, 2), _35reg2350);
-coraCall(co, 3, closureRef(co, 0), _35reg2349, _35reg2351);
-}
-}
-
-void _35clofun3023(struct Cora* co) {
-Obj _35val2339 = co->args[1];
-Obj _35reg2338 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2340 = primCons(_35val2339, closureRef(co, 4));
+Obj _35reg2335 = primEQ(closureRef(co, 2), intern("%closure"));
+if (True == _35reg2335) {
+Obj _35reg2336 = primCons(body1, Nil);
+Obj _35reg2337 = primCons(Nil, _35reg2336);
+Obj _35reg2338 = primCons(closureRef(co, 1), _35reg2337);
+Obj _35reg2339 = primCons(intern("lambda"), _35reg2338);
+Obj _35reg2340 = primCons(_35reg2339, Nil);
 Obj _35reg2341 = primCons(closureRef(co, 3), _35reg2340);
-Obj _35reg2342 = primCons(closureRef(co, 2), _35reg2341);
-coraCall(co, 3, closureRef(co, 0), _35reg2338, _35reg2342);
-}
-
-void _35clofun3020(struct Cora* co) {
-Obj res1 = co->args[1];
-Obj body1 = co->args[2];
-Obj _35reg2309 = primEQ(closureRef(co, 2), intern("%closure"));
-if (True == _35reg2309) {
-Obj _35reg2310 = primCons(body1, Nil);
-Obj _35reg2311 = primCons(Nil, _35reg2310);
-Obj _35reg2312 = primCons(closureRef(co, 1), _35reg2311);
-Obj _35reg2313 = primCons(intern("lambda"), _35reg2312);
-Obj _35reg2314 = primCons(_35reg2313, Nil);
-Obj _35reg2315 = primCons(closureRef(co, 3), _35reg2314);
-Obj _35reg2316 = primCons(_35reg2315, res1);
-pushCont(co, 0, _35clofun3021, 1, _35reg2316);
+Obj _35reg2342 = primCons(_35reg2341, res1);
+pushCont(co, 0, _35clofun3051, 1, _35reg2342);
 coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
 } else {
-Obj _35reg2321 = primCons(body1, Nil);
-Obj _35reg2322 = primCons(closureRef(co, 4), _35reg2321);
-Obj _35reg2323 = primCons(closureRef(co, 1), _35reg2322);
-Obj _35reg2324 = primCons(intern("lambda"), _35reg2323);
-Obj _35reg2325 = primCons(_35reg2324, Nil);
-Obj _35reg2326 = primCons(closureRef(co, 3), _35reg2325);
-Obj _35reg2327 = primCons(_35reg2326, res1);
-Obj _35reg2328 = primCons(closureRef(co, 3), closureRef(co, 4));
-Obj _35reg2329 = primCons(closureRef(co, 2), _35reg2328);
-coraCall(co, 3, closureRef(co, 0), _35reg2327, _35reg2329);
+Obj _35reg2347 = primCons(body1, Nil);
+Obj _35reg2348 = primCons(closureRef(co, 4), _35reg2347);
+Obj _35reg2349 = primCons(closureRef(co, 1), _35reg2348);
+Obj _35reg2350 = primCons(intern("lambda"), _35reg2349);
+Obj _35reg2351 = primCons(_35reg2350, Nil);
+Obj _35reg2352 = primCons(closureRef(co, 3), _35reg2351);
+Obj _35reg2353 = primCons(_35reg2352, res1);
+Obj _35reg2354 = primCons(closureRef(co, 3), closureRef(co, 4));
+Obj _35reg2355 = primCons(closureRef(co, 2), _35reg2354);
+coraCall(co, 3, closureRef(co, 0), _35reg2353, _35reg2355);
 }
 }
 
-void _35clofun3021(struct Cora* co) {
-Obj _35val2317 = co->args[1];
-Obj _35reg2316 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2318 = primCons(_35val2317, closureRef(co, 4));
+void _35clofun3051(struct Cora* co) {
+Obj _35val2343 = co->args[1];
+Obj _35reg2342 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2344 = primCons(_35val2343, closureRef(co, 4));
+Obj _35reg2345 = primCons(closureRef(co, 3), _35reg2344);
+Obj _35reg2346 = primCons(closureRef(co, 2), _35reg2345);
+coraCall(co, 3, closureRef(co, 0), _35reg2342, _35reg2346);
+}
+
+void _35clofun3048(struct Cora* co) {
+Obj res1 = co->args[1];
+Obj body1 = co->args[2];
+Obj _35reg2313 = primEQ(closureRef(co, 2), intern("%closure"));
+if (True == _35reg2313) {
+Obj _35reg2314 = primCons(body1, Nil);
+Obj _35reg2315 = primCons(Nil, _35reg2314);
+Obj _35reg2316 = primCons(closureRef(co, 1), _35reg2315);
+Obj _35reg2317 = primCons(intern("lambda"), _35reg2316);
+Obj _35reg2318 = primCons(_35reg2317, Nil);
 Obj _35reg2319 = primCons(closureRef(co, 3), _35reg2318);
-Obj _35reg2320 = primCons(closureRef(co, 2), _35reg2319);
-coraCall(co, 3, closureRef(co, 0), _35reg2316, _35reg2320);
-}
-
-void _35clofun3018(struct Cora* co) {
-Obj res1 = co->args[1];
-Obj body1 = co->args[2];
-Obj _35reg2286 = primEQ(closureRef(co, 2), intern("%closure"));
-if (True == _35reg2286) {
-Obj _35reg2287 = primCons(body1, Nil);
-Obj _35reg2288 = primCons(Nil, _35reg2287);
-Obj _35reg2289 = primCons(closureRef(co, 1), _35reg2288);
-Obj _35reg2290 = primCons(intern("lambda"), _35reg2289);
-Obj _35reg2291 = primCons(_35reg2290, Nil);
-Obj _35reg2292 = primCons(closureRef(co, 3), _35reg2291);
-Obj _35reg2293 = primCons(_35reg2292, res1);
-pushCont(co, 0, _35clofun3019, 1, _35reg2293);
+Obj _35reg2320 = primCons(_35reg2319, res1);
+pushCont(co, 0, _35clofun3049, 1, _35reg2320);
 coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
 } else {
-Obj _35reg2298 = primCons(body1, Nil);
-Obj _35reg2299 = primCons(closureRef(co, 4), _35reg2298);
-Obj _35reg2300 = primCons(closureRef(co, 1), _35reg2299);
-Obj _35reg2301 = primCons(intern("lambda"), _35reg2300);
-Obj _35reg2302 = primCons(_35reg2301, Nil);
-Obj _35reg2303 = primCons(closureRef(co, 3), _35reg2302);
-Obj _35reg2304 = primCons(_35reg2303, res1);
-Obj _35reg2305 = primCons(closureRef(co, 3), closureRef(co, 4));
-Obj _35reg2306 = primCons(closureRef(co, 2), _35reg2305);
-coraCall(co, 3, closureRef(co, 0), _35reg2304, _35reg2306);
+Obj _35reg2325 = primCons(body1, Nil);
+Obj _35reg2326 = primCons(closureRef(co, 4), _35reg2325);
+Obj _35reg2327 = primCons(closureRef(co, 1), _35reg2326);
+Obj _35reg2328 = primCons(intern("lambda"), _35reg2327);
+Obj _35reg2329 = primCons(_35reg2328, Nil);
+Obj _35reg2330 = primCons(closureRef(co, 3), _35reg2329);
+Obj _35reg2331 = primCons(_35reg2330, res1);
+Obj _35reg2332 = primCons(closureRef(co, 3), closureRef(co, 4));
+Obj _35reg2333 = primCons(closureRef(co, 2), _35reg2332);
+coraCall(co, 3, closureRef(co, 0), _35reg2331, _35reg2333);
 }
 }
 
-void _35clofun3019(struct Cora* co) {
-Obj _35val2294 = co->args[1];
-Obj _35reg2293 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2295 = primCons(_35val2294, closureRef(co, 4));
+void _35clofun3049(struct Cora* co) {
+Obj _35val2321 = co->args[1];
+Obj _35reg2320 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2322 = primCons(_35val2321, closureRef(co, 4));
+Obj _35reg2323 = primCons(closureRef(co, 3), _35reg2322);
+Obj _35reg2324 = primCons(closureRef(co, 2), _35reg2323);
+coraCall(co, 3, closureRef(co, 0), _35reg2320, _35reg2324);
+}
+
+void _35clofun3046(struct Cora* co) {
+Obj res1 = co->args[1];
+Obj body1 = co->args[2];
+Obj _35reg2290 = primEQ(closureRef(co, 2), intern("%closure"));
+if (True == _35reg2290) {
+Obj _35reg2291 = primCons(body1, Nil);
+Obj _35reg2292 = primCons(Nil, _35reg2291);
+Obj _35reg2293 = primCons(closureRef(co, 1), _35reg2292);
+Obj _35reg2294 = primCons(intern("lambda"), _35reg2293);
+Obj _35reg2295 = primCons(_35reg2294, Nil);
 Obj _35reg2296 = primCons(closureRef(co, 3), _35reg2295);
-Obj _35reg2297 = primCons(closureRef(co, 2), _35reg2296);
-coraCall(co, 3, closureRef(co, 0), _35reg2293, _35reg2297);
+Obj _35reg2297 = primCons(_35reg2296, res1);
+pushCont(co, 0, _35clofun3047, 1, _35reg2297);
+coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
+} else {
+Obj _35reg2302 = primCons(body1, Nil);
+Obj _35reg2303 = primCons(closureRef(co, 4), _35reg2302);
+Obj _35reg2304 = primCons(closureRef(co, 1), _35reg2303);
+Obj _35reg2305 = primCons(intern("lambda"), _35reg2304);
+Obj _35reg2306 = primCons(_35reg2305, Nil);
+Obj _35reg2307 = primCons(closureRef(co, 3), _35reg2306);
+Obj _35reg2308 = primCons(_35reg2307, res1);
+Obj _35reg2309 = primCons(closureRef(co, 3), closureRef(co, 4));
+Obj _35reg2310 = primCons(closureRef(co, 2), _35reg2309);
+coraCall(co, 3, closureRef(co, 0), _35reg2308, _35reg2310);
+}
 }
 
-void _35clofun3015(struct Cora* co) {
-Obj _35cc1314 = makeNative(0, _35clofun3016, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3047(struct Cora* co) {
+Obj _35val2298 = co->args[1];
+Obj _35reg2297 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2299 = primCons(_35val2298, closureRef(co, 4));
+Obj _35reg2300 = primCons(closureRef(co, 3), _35reg2299);
+Obj _35reg2301 = primCons(closureRef(co, 2), _35reg2300);
+coraCall(co, 3, closureRef(co, 0), _35reg2297, _35reg2301);
+}
+
+void _35clofun3043(struct Cora* co) {
+Obj _35cc1314 = makeNative(0, _35clofun3044, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj res = closureRef(co, 0);
 Obj f_45args = closureRef(co, 1);
 Obj k = closureRef(co, 2);
-Obj _35reg2246 = primIsCons(f_45args);
-if (True == _35reg2246) {
+Obj _35reg2250 = primIsCons(f_45args);
+if (True == _35reg2250) {
 coraCall(co, 5, globalRef(intern("cora/lib/toc.collect-lambda-list")), Nil, res, f_45args, k);
 } else {
 coraCall(co, 1, _35cc1314);
 }
 }
 
-void _35clofun3016(struct Cora* co) {
-Obj _35cc1315 = makeNative(0, _35clofun3017, 0, 0);
+void _35clofun3044(struct Cora* co) {
+Obj _35cc1315 = makeNative(0, _35clofun3045, 0, 0);
 Obj res = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 Obj k = closureRef(co, 2);
 coraCall(co, 3, k, res, x);
 }
 
-void _35clofun3017(struct Cora* co) {
+void _35clofun3045(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2996(struct Cora* co) {
+void _35clofun3024(struct Cora* co) {
 Obj _35p1302 = co->args[1];
 Obj _35p1303 = co->args[2];
-Obj _35cc1304 = makeNative(0, _35clofun2997, 0, 2, _35p1302, _35p1303);
+Obj _35cc1304 = makeNative(0, _35clofun3025, 0, 2, _35p1302, _35p1303);
 Obj __ = _35p1302;
 Obj x = _35p1303;
-pushCont(co, 0, _35clofun3013, 2, x, _35cc1304);
+pushCont(co, 0, _35clofun3041, 2, x, _35cc1304);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 
-void _35clofun3013(struct Cora* co) {
-Obj _35val2244 = co->args[1];
+void _35clofun3041(struct Cora* co) {
+Obj _35val2248 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35cc1304 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2244) {
+if (True == _35val2248) {
 coraReturn(co, x);
 return;
 } else {
@@ -3094,12 +3190,12 @@ coraCall(co, 1, _35cc1304);
 }
 }
 
-void _35clofun2997(struct Cora* co) {
-Obj _35cc1305 = makeNative(0, _35clofun2998, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3025(struct Cora* co) {
+Obj _35cc1305 = makeNative(0, _35clofun3026, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj _35reg2243 = primIsSymbol(var);
-if (True == _35reg2243) {
+Obj _35reg2247 = primIsSymbol(var);
+if (True == _35reg2247) {
 coraReturn(co, var);
 return;
 } else {
@@ -3107,34 +3203,34 @@ coraCall(co, 1, _35cc1305);
 }
 }
 
-void _35clofun2998(struct Cora* co) {
-Obj _35cc1306 = makeNative(0, _35clofun2999, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3026(struct Cora* co) {
+Obj _35cc1306 = makeNative(0, _35clofun3027, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2222 = primIsCons(closureRef(co, 1));
-if (True == _35reg2222) {
-Obj _35reg2223 = primCar(closureRef(co, 1));
-Obj _35reg2224 = primEQ(intern("lambda"), _35reg2223);
-if (True == _35reg2224) {
-Obj _35reg2225 = primCdr(closureRef(co, 1));
-Obj _35reg2226 = primIsCons(_35reg2225);
+Obj _35reg2226 = primIsCons(closureRef(co, 1));
 if (True == _35reg2226) {
-Obj _35reg2227 = primCdr(closureRef(co, 1));
-Obj _35reg2228 = primCar(_35reg2227);
-Obj args = _35reg2228;
+Obj _35reg2227 = primCar(closureRef(co, 1));
+Obj _35reg2228 = primEQ(intern("lambda"), _35reg2227);
+if (True == _35reg2228) {
 Obj _35reg2229 = primCdr(closureRef(co, 1));
-Obj _35reg2230 = primCdr(_35reg2229);
-Obj _35reg2231 = primIsCons(_35reg2230);
-if (True == _35reg2231) {
-Obj _35reg2232 = primCdr(closureRef(co, 1));
-Obj _35reg2233 = primCdr(_35reg2232);
-Obj _35reg2234 = primCar(_35reg2233);
-Obj body = _35reg2234;
-Obj _35reg2235 = primCdr(closureRef(co, 1));
-Obj _35reg2236 = primCdr(_35reg2235);
+Obj _35reg2230 = primIsCons(_35reg2229);
+if (True == _35reg2230) {
+Obj _35reg2231 = primCdr(closureRef(co, 1));
+Obj _35reg2232 = primCar(_35reg2231);
+Obj args = _35reg2232;
+Obj _35reg2233 = primCdr(closureRef(co, 1));
+Obj _35reg2234 = primCdr(_35reg2233);
+Obj _35reg2235 = primIsCons(_35reg2234);
+if (True == _35reg2235) {
+Obj _35reg2236 = primCdr(closureRef(co, 1));
 Obj _35reg2237 = primCdr(_35reg2236);
-Obj _35reg2238 = primEQ(Nil, _35reg2237);
-if (True == _35reg2238) {
-pushCont(co, 0, _35clofun3012, 1, args);
+Obj _35reg2238 = primCar(_35reg2237);
+Obj body = _35reg2238;
+Obj _35reg2239 = primCdr(closureRef(co, 1));
+Obj _35reg2240 = primCdr(_35reg2239);
+Obj _35reg2241 = primCdr(_35reg2240);
+Obj _35reg2242 = primEQ(Nil, _35reg2241);
+if (True == _35reg2242) {
+pushCont(co, 0, _35clofun3040, 1, args);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs, body);
 } else {
 coraCall(co, 1, _35cc1306);
@@ -3153,44 +3249,44 @@ coraCall(co, 1, _35cc1306);
 }
 }
 
-void _35clofun3012(struct Cora* co) {
-Obj _35val2239 = co->args[1];
+void _35clofun3040(struct Cora* co) {
+Obj _35val2243 = co->args[1];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2240 = primCons(_35val2239, Nil);
-Obj _35reg2241 = primCons(args, _35reg2240);
-Obj _35reg2242 = primCons(intern("lambda"), _35reg2241);
-coraReturn(co, _35reg2242);
+Obj _35reg2244 = primCons(_35val2243, Nil);
+Obj _35reg2245 = primCons(args, _35reg2244);
+Obj _35reg2246 = primCons(intern("lambda"), _35reg2245);
+coraReturn(co, _35reg2246);
 return;
 }
 
-void _35clofun2999(struct Cora* co) {
-Obj _35cc1307 = makeNative(0, _35clofun3000, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3027(struct Cora* co) {
+Obj _35cc1307 = makeNative(0, _35clofun3028, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2195 = primIsCons(closureRef(co, 1));
-if (True == _35reg2195) {
-Obj _35reg2196 = primCar(closureRef(co, 1));
-Obj _35reg2197 = primEQ(intern("continuation"), _35reg2196);
-if (True == _35reg2197) {
-Obj _35reg2198 = primCdr(closureRef(co, 1));
-Obj _35reg2199 = primIsCons(_35reg2198);
+Obj _35reg2199 = primIsCons(closureRef(co, 1));
 if (True == _35reg2199) {
-Obj _35reg2200 = primCdr(closureRef(co, 1));
-Obj _35reg2201 = primCar(_35reg2200);
-Obj val = _35reg2201;
+Obj _35reg2200 = primCar(closureRef(co, 1));
+Obj _35reg2201 = primEQ(intern("continuation"), _35reg2200);
+if (True == _35reg2201) {
 Obj _35reg2202 = primCdr(closureRef(co, 1));
-Obj _35reg2203 = primCdr(_35reg2202);
-Obj _35reg2204 = primIsCons(_35reg2203);
-if (True == _35reg2204) {
-Obj _35reg2205 = primCdr(closureRef(co, 1));
-Obj _35reg2206 = primCdr(_35reg2205);
-Obj _35reg2207 = primCar(_35reg2206);
-Obj body = _35reg2207;
-Obj _35reg2208 = primCdr(closureRef(co, 1));
-Obj _35reg2209 = primCdr(_35reg2208);
+Obj _35reg2203 = primIsCons(_35reg2202);
+if (True == _35reg2203) {
+Obj _35reg2204 = primCdr(closureRef(co, 1));
+Obj _35reg2205 = primCar(_35reg2204);
+Obj val = _35reg2205;
+Obj _35reg2206 = primCdr(closureRef(co, 1));
+Obj _35reg2207 = primCdr(_35reg2206);
+Obj _35reg2208 = primIsCons(_35reg2207);
+if (True == _35reg2208) {
+Obj _35reg2209 = primCdr(closureRef(co, 1));
 Obj _35reg2210 = primCdr(_35reg2209);
-Obj _35reg2211 = primEQ(Nil, _35reg2210);
-if (True == _35reg2211) {
-pushCont(co, 0, _35clofun3007, 3, fvs, body, val);
+Obj _35reg2211 = primCar(_35reg2210);
+Obj body = _35reg2211;
+Obj _35reg2212 = primCdr(closureRef(co, 1));
+Obj _35reg2213 = primCdr(_35reg2212);
+Obj _35reg2214 = primCdr(_35reg2213);
+Obj _35reg2215 = primEQ(Nil, _35reg2214);
+if (True == _35reg2215) {
+pushCont(co, 0, _35clofun3035, 3, fvs, body, val);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), body);
 } else {
 coraCall(co, 1, _35cc1307);
@@ -3209,85 +3305,85 @@ coraCall(co, 1, _35cc1307);
 }
 }
 
-void _35clofun3007(struct Cora* co) {
-Obj _35val2212 = co->args[1];
+void _35clofun3035(struct Cora* co) {
+Obj _35val2216 = co->args[1];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3008, 3, fvs, body, val);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val2212, val);
+pushCont(co, 0, _35clofun3036, 3, fvs, body, val);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val2216, val);
 }
 
-void _35clofun3008(struct Cora* co) {
-Obj _35val2213 = co->args[1];
+void _35clofun3036(struct Cora* co) {
+Obj _35val2217 = co->args[1];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs1 = _35val2213;
-pushCont(co, 0, _35clofun3009, 3, fvs1, body, val);
+Obj fvs1 = _35val2217;
+pushCont(co, 0, _35clofun3037, 3, fvs1, body, val);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
 }
 
-void _35clofun3009(struct Cora* co) {
-Obj _35val2214 = co->args[1];
+void _35clofun3037(struct Cora* co) {
+Obj _35val2218 = co->args[1];
 Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3010, 3, fvs1, body, val);
-coraCall(co, 3, globalRef(intern("map")), _35val2214, fvs1);
+pushCont(co, 0, _35clofun3038, 3, fvs1, body, val);
+coraCall(co, 3, globalRef(intern("map")), _35val2218, fvs1);
 }
 
-void _35clofun3010(struct Cora* co) {
-Obj _35val2215 = co->args[1];
+void _35clofun3038(struct Cora* co) {
+Obj _35val2219 = co->args[1];
 Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs2 = _35val2215;
-pushCont(co, 0, _35clofun3011, 2, val, fvs2);
+Obj fvs2 = _35val2219;
+pushCont(co, 0, _35clofun3039, 2, val, fvs2);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs1, body);
 }
 
-void _35clofun3011(struct Cora* co) {
-Obj _35val2216 = co->args[1];
+void _35clofun3039(struct Cora* co) {
+Obj _35val2220 = co->args[1];
 Obj val = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fvs2 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2217 = primCons(_35val2216, Nil);
-Obj _35reg2218 = primCons(val, _35reg2217);
-Obj _35reg2219 = primCons(intern("lambda"), _35reg2218);
-Obj _35reg2220 = primCons(_35reg2219, fvs2);
-Obj _35reg2221 = primCons(intern("%continuation"), _35reg2220);
-coraReturn(co, _35reg2221);
+Obj _35reg2221 = primCons(_35val2220, Nil);
+Obj _35reg2222 = primCons(val, _35reg2221);
+Obj _35reg2223 = primCons(intern("lambda"), _35reg2222);
+Obj _35reg2224 = primCons(_35reg2223, fvs2);
+Obj _35reg2225 = primCons(intern("%continuation"), _35reg2224);
+coraReturn(co, _35reg2225);
 return;
 }
 
-void _35clofun3000(struct Cora* co) {
-Obj _35cc1308 = makeNative(0, _35clofun3001, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun3028(struct Cora* co) {
+Obj _35cc1308 = makeNative(0, _35clofun3029, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2172 = primIsCons(closureRef(co, 1));
-if (True == _35reg2172) {
-Obj _35reg2173 = primCar(closureRef(co, 1));
-Obj _35reg2174 = primEQ(intern("call"), _35reg2173);
-if (True == _35reg2174) {
-Obj _35reg2175 = primCdr(closureRef(co, 1));
-Obj _35reg2176 = primIsCons(_35reg2175);
+Obj _35reg2176 = primIsCons(closureRef(co, 1));
 if (True == _35reg2176) {
-Obj _35reg2177 = primCdr(closureRef(co, 1));
-Obj _35reg2178 = primCar(_35reg2177);
-Obj exp = _35reg2178;
+Obj _35reg2177 = primCar(closureRef(co, 1));
+Obj _35reg2178 = primEQ(intern("call"), _35reg2177);
+if (True == _35reg2178) {
 Obj _35reg2179 = primCdr(closureRef(co, 1));
-Obj _35reg2180 = primCdr(_35reg2179);
-Obj _35reg2181 = primIsCons(_35reg2180);
-if (True == _35reg2181) {
-Obj _35reg2182 = primCdr(closureRef(co, 1));
-Obj _35reg2183 = primCdr(_35reg2182);
-Obj _35reg2184 = primCar(_35reg2183);
-Obj cont = _35reg2184;
-Obj _35reg2185 = primCdr(closureRef(co, 1));
-Obj _35reg2186 = primCdr(_35reg2185);
+Obj _35reg2180 = primIsCons(_35reg2179);
+if (True == _35reg2180) {
+Obj _35reg2181 = primCdr(closureRef(co, 1));
+Obj _35reg2182 = primCar(_35reg2181);
+Obj exp = _35reg2182;
+Obj _35reg2183 = primCdr(closureRef(co, 1));
+Obj _35reg2184 = primCdr(_35reg2183);
+Obj _35reg2185 = primIsCons(_35reg2184);
+if (True == _35reg2185) {
+Obj _35reg2186 = primCdr(closureRef(co, 1));
 Obj _35reg2187 = primCdr(_35reg2186);
-Obj _35reg2188 = primEQ(Nil, _35reg2187);
-if (True == _35reg2188) {
-pushCont(co, 0, _35clofun3004, 3, exp, fvs, cont);
+Obj _35reg2188 = primCar(_35reg2187);
+Obj cont = _35reg2188;
+Obj _35reg2189 = primCdr(closureRef(co, 1));
+Obj _35reg2190 = primCdr(_35reg2189);
+Obj _35reg2191 = primCdr(_35reg2190);
+Obj _35reg2192 = primEQ(Nil, _35reg2191);
+if (True == _35reg2192) {
+pushCont(co, 0, _35clofun3032, 3, exp, fvs, cont);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
 } else {
 coraCall(co, 1, _35cc1308);
@@ -3306,148 +3402,148 @@ coraCall(co, 1, _35cc1308);
 }
 }
 
-void _35clofun3004(struct Cora* co) {
-Obj _35val2189 = co->args[1];
+void _35clofun3032(struct Cora* co) {
+Obj _35val2193 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cont = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3005, 2, fvs, cont);
-coraCall(co, 3, globalRef(intern("map")), _35val2189, exp);
+pushCont(co, 0, _35clofun3033, 2, fvs, cont);
+coraCall(co, 3, globalRef(intern("map")), _35val2193, exp);
 }
 
-void _35clofun3005(struct Cora* co) {
-Obj _35val2190 = co->args[1];
+void _35clofun3033(struct Cora* co) {
+Obj _35val2194 = co->args[1];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cont = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3006, 1, _35val2190);
+pushCont(co, 0, _35clofun3034, 1, _35val2194);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs, cont);
 }
 
-void _35clofun3006(struct Cora* co) {
-Obj _35val2191 = co->args[1];
-Obj _35val2190 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2192 = primCons(_35val2191, Nil);
-Obj _35reg2193 = primCons(_35val2190, _35reg2192);
-Obj _35reg2194 = primCons(intern("call"), _35reg2193);
-coraReturn(co, _35reg2194);
+void _35clofun3034(struct Cora* co) {
+Obj _35val2195 = co->args[1];
+Obj _35val2194 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2196 = primCons(_35val2195, Nil);
+Obj _35reg2197 = primCons(_35val2194, _35reg2196);
+Obj _35reg2198 = primCons(intern("call"), _35reg2197);
+coraReturn(co, _35reg2198);
 return;
 }
 
-void _35clofun3001(struct Cora* co) {
-Obj _35cc1309 = makeNative(0, _35clofun3002, 0, 0);
+void _35clofun3029(struct Cora* co) {
+Obj _35cc1309 = makeNative(0, _35clofun3030, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj _35reg2167 = primIsCons(closureRef(co, 1));
-if (True == _35reg2167) {
-Obj _35reg2168 = primCar(closureRef(co, 1));
-Obj f = _35reg2168;
-Obj _35reg2169 = primCdr(closureRef(co, 1));
-Obj args = _35reg2169;
-pushCont(co, 0, _35clofun3003, 2, f, args);
+Obj _35reg2171 = primIsCons(closureRef(co, 1));
+if (True == _35reg2171) {
+Obj _35reg2172 = primCar(closureRef(co, 1));
+Obj f = _35reg2172;
+Obj _35reg2173 = primCdr(closureRef(co, 1));
+Obj args = _35reg2173;
+pushCont(co, 0, _35clofun3031, 2, f, args);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
 } else {
 coraCall(co, 1, _35cc1309);
 }
 }
 
-void _35clofun3003(struct Cora* co) {
-Obj _35val2170 = co->args[1];
+void _35clofun3031(struct Cora* co) {
+Obj _35val2174 = co->args[1];
 Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2171 = primCons(f, args);
-coraCall(co, 3, globalRef(intern("map")), _35val2170, _35reg2171);
+Obj _35reg2175 = primCons(f, args);
+coraCall(co, 3, globalRef(intern("map")), _35val2174, _35reg2175);
 }
 
-void _35clofun3002(struct Cora* co) {
+void _35clofun3030(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2986(struct Cora* co) {
+void _35clofun3014(struct Cora* co) {
 Obj _35p1297 = co->args[1];
 Obj _35p1298 = co->args[2];
 Obj _35p1299 = co->args[3];
-Obj _35cc1300 = makeNative(0, _35clofun2987, 0, 3, _35p1297, _35p1298, _35p1299);
-Obj _35reg2124 = primEQ(Nil, _35p1297);
-if (True == _35reg2124) {
+Obj _35cc1300 = makeNative(0, _35clofun3015, 0, 3, _35p1297, _35p1298, _35p1299);
+Obj _35reg2128 = primEQ(Nil, _35p1297);
+if (True == _35reg2128) {
 Obj ls = _35p1298;
 Obj next = _35p1299;
-pushCont(co, 0, _35clofun2990, 1, next);
+pushCont(co, 0, _35clofun3018, 1, next);
 coraCall(co, 2, globalRef(intern("reverse")), ls);
 } else {
 coraCall(co, 1, _35cc1300);
 }
 }
 
-void _35clofun2990(struct Cora* co) {
-Obj _35val2125 = co->args[1];
+void _35clofun3018(struct Cora* co) {
+Obj _35val2129 = co->args[1];
 Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp = _35val2125;
-Obj _35reg2126 = primCar(exp);
-pushCont(co, 0, _35clofun2991, 2, next, exp);
-coraCall(co, 2, globalRef(intern("pair?")), _35reg2126);
+Obj exp = _35val2129;
+Obj _35reg2130 = primCar(exp);
+pushCont(co, 0, _35clofun3019, 2, next, exp);
+coraCall(co, 2, globalRef(intern("pair?")), _35reg2130);
 }
 
-void _35clofun2991(struct Cora* co) {
-Obj _35val2127 = co->args[1];
+void _35clofun3019(struct Cora* co) {
+Obj _35val2131 = co->args[1];
 Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2127) {
-pushCont(co, 0, _35clofun2992, 2, next, exp);
+if (True == _35val2131) {
+pushCont(co, 0, _35clofun3020, 2, next, exp);
 coraCall(co, 2, globalRef(intern("caar")), exp);
 } else {
 if (True == False) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.wrap-var")), exp, next);
 } else {
-Obj _35reg2154 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
-if (True == _35reg2154) {
-Obj _35reg2155 = primCons(exp, Nil);
-Obj _35reg2156 = primCons(intern("tailcall"), _35reg2155);
-coraReturn(co, _35reg2156);
+Obj _35reg2158 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
+if (True == _35reg2158) {
+Obj _35reg2159 = primCons(exp, Nil);
+Obj _35reg2160 = primCons(intern("tailcall"), _35reg2159);
+coraReturn(co, _35reg2160);
 return;
 } else {
-Obj _35reg2157 = primGenSym(intern("val"));
-Obj val = _35reg2157;
-Obj _35reg2158 = primCons(val, Nil);
-pushCont(co, 0, _35clofun2995, 2, _35reg2158, exp);
+Obj _35reg2161 = primGenSym(intern("val"));
+Obj val = _35reg2161;
+Obj _35reg2162 = primCons(val, Nil);
+pushCont(co, 0, _35clofun3023, 2, _35reg2162, exp);
 coraCall(co, 2, next, val);
 }
 }
 }
 }
 
-void _35clofun2995(struct Cora* co) {
-Obj _35val2159 = co->args[1];
-Obj _35reg2158 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+void _35clofun3023(struct Cora* co) {
+Obj _35val2163 = co->args[1];
+Obj _35reg2162 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2160 = primCons(_35val2159, Nil);
-Obj _35reg2161 = primCons(_35reg2158, _35reg2160);
-Obj _35reg2162 = primCons(intern("continuation"), _35reg2161);
-Obj _35reg2163 = primCons(_35reg2162, Nil);
-Obj _35reg2164 = primCons(exp, _35reg2163);
-Obj _35reg2165 = primCons(intern("call"), _35reg2164);
-coraReturn(co, _35reg2165);
+Obj _35reg2164 = primCons(_35val2163, Nil);
+Obj _35reg2165 = primCons(_35reg2162, _35reg2164);
+Obj _35reg2166 = primCons(intern("continuation"), _35reg2165);
+Obj _35reg2167 = primCons(_35reg2166, Nil);
+Obj _35reg2168 = primCons(exp, _35reg2167);
+Obj _35reg2169 = primCons(intern("call"), _35reg2168);
+coraReturn(co, _35reg2169);
 return;
 }
 
-void _35clofun2992(struct Cora* co) {
-Obj _35val2128 = co->args[1];
+void _35clofun3020(struct Cora* co) {
+Obj _35val2132 = co->args[1];
 Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2129 = primEQ(_35val2128, intern("%builtin"));
-if (True == _35reg2129) {
+Obj _35reg2133 = primEQ(_35val2132, intern("%builtin"));
+if (True == _35reg2133) {
 if (True == True) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.wrap-var")), exp, next);
 } else {
-Obj _35reg2130 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
-if (True == _35reg2130) {
-Obj _35reg2131 = primCons(exp, Nil);
-Obj _35reg2132 = primCons(intern("tailcall"), _35reg2131);
-coraReturn(co, _35reg2132);
+Obj _35reg2134 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
+if (True == _35reg2134) {
+Obj _35reg2135 = primCons(exp, Nil);
+Obj _35reg2136 = primCons(intern("tailcall"), _35reg2135);
+coraReturn(co, _35reg2136);
 return;
 } else {
-Obj _35reg2133 = primGenSym(intern("val"));
-Obj val = _35reg2133;
-Obj _35reg2134 = primCons(val, Nil);
-pushCont(co, 0, _35clofun2993, 2, _35reg2134, exp);
+Obj _35reg2137 = primGenSym(intern("val"));
+Obj val = _35reg2137;
+Obj _35reg2138 = primCons(val, Nil);
+pushCont(co, 0, _35clofun3021, 2, _35reg2138, exp);
 coraCall(co, 2, next, val);
 }
 }
@@ -3455,102 +3551,102 @@ coraCall(co, 2, next, val);
 if (True == False) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.wrap-var")), exp, next);
 } else {
-Obj _35reg2142 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
-if (True == _35reg2142) {
-Obj _35reg2143 = primCons(exp, Nil);
-Obj _35reg2144 = primCons(intern("tailcall"), _35reg2143);
-coraReturn(co, _35reg2144);
+Obj _35reg2146 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
+if (True == _35reg2146) {
+Obj _35reg2147 = primCons(exp, Nil);
+Obj _35reg2148 = primCons(intern("tailcall"), _35reg2147);
+coraReturn(co, _35reg2148);
 return;
 } else {
-Obj _35reg2145 = primGenSym(intern("val"));
-Obj val = _35reg2145;
-Obj _35reg2146 = primCons(val, Nil);
-pushCont(co, 0, _35clofun2994, 2, _35reg2146, exp);
+Obj _35reg2149 = primGenSym(intern("val"));
+Obj val = _35reg2149;
+Obj _35reg2150 = primCons(val, Nil);
+pushCont(co, 0, _35clofun3022, 2, _35reg2150, exp);
 coraCall(co, 2, next, val);
 }
 }
 }
 }
 
-void _35clofun2994(struct Cora* co) {
-Obj _35val2147 = co->args[1];
-Obj _35reg2146 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+void _35clofun3022(struct Cora* co) {
+Obj _35val2151 = co->args[1];
+Obj _35reg2150 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2148 = primCons(_35val2147, Nil);
-Obj _35reg2149 = primCons(_35reg2146, _35reg2148);
-Obj _35reg2150 = primCons(intern("continuation"), _35reg2149);
-Obj _35reg2151 = primCons(_35reg2150, Nil);
-Obj _35reg2152 = primCons(exp, _35reg2151);
-Obj _35reg2153 = primCons(intern("call"), _35reg2152);
-coraReturn(co, _35reg2153);
+Obj _35reg2152 = primCons(_35val2151, Nil);
+Obj _35reg2153 = primCons(_35reg2150, _35reg2152);
+Obj _35reg2154 = primCons(intern("continuation"), _35reg2153);
+Obj _35reg2155 = primCons(_35reg2154, Nil);
+Obj _35reg2156 = primCons(exp, _35reg2155);
+Obj _35reg2157 = primCons(intern("call"), _35reg2156);
+coraReturn(co, _35reg2157);
 return;
 }
 
-void _35clofun2993(struct Cora* co) {
-Obj _35val2135 = co->args[1];
-Obj _35reg2134 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+void _35clofun3021(struct Cora* co) {
+Obj _35val2139 = co->args[1];
+Obj _35reg2138 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2136 = primCons(_35val2135, Nil);
-Obj _35reg2137 = primCons(_35reg2134, _35reg2136);
-Obj _35reg2138 = primCons(intern("continuation"), _35reg2137);
-Obj _35reg2139 = primCons(_35reg2138, Nil);
-Obj _35reg2140 = primCons(exp, _35reg2139);
-Obj _35reg2141 = primCons(intern("call"), _35reg2140);
-coraReturn(co, _35reg2141);
+Obj _35reg2140 = primCons(_35val2139, Nil);
+Obj _35reg2141 = primCons(_35reg2138, _35reg2140);
+Obj _35reg2142 = primCons(intern("continuation"), _35reg2141);
+Obj _35reg2143 = primCons(_35reg2142, Nil);
+Obj _35reg2144 = primCons(exp, _35reg2143);
+Obj _35reg2145 = primCons(intern("call"), _35reg2144);
+coraReturn(co, _35reg2145);
 return;
 }
 
-void _35clofun2987(struct Cora* co) {
-Obj _35cc1301 = makeNative(0, _35clofun2988, 0, 0);
-Obj _35reg2120 = primIsCons(closureRef(co, 0));
-if (True == _35reg2120) {
-Obj _35reg2121 = primCar(closureRef(co, 0));
-Obj hd = _35reg2121;
-Obj _35reg2122 = primCdr(closureRef(co, 0));
-Obj tl = _35reg2122;
+void _35clofun3015(struct Cora* co) {
+Obj _35cc1301 = makeNative(0, _35clofun3016, 0, 0);
+Obj _35reg2124 = primIsCons(closureRef(co, 0));
+if (True == _35reg2124) {
+Obj _35reg2125 = primCar(closureRef(co, 0));
+Obj hd = _35reg2125;
+Obj _35reg2126 = primCdr(closureRef(co, 0));
+Obj tl = _35reg2126;
 Obj ls = closureRef(co, 1);
 Obj next = closureRef(co, 2);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), hd, makeNative(0, _35clofun2989, 1, 3, tl, ls, next));
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), hd, makeNative(0, _35clofun3017, 1, 3, tl, ls, next));
 } else {
 coraCall(co, 1, _35cc1301);
 }
 }
 
-void _35clofun2989(struct Cora* co) {
+void _35clofun3017(struct Cora* co) {
 Obj hd1 = co->args[1];
-Obj _35reg2123 = primCons(hd1, closureRef(co, 1));
-coraCall(co, 4, globalRef(intern("cora/lib/toc.tailify-list")), closureRef(co, 0), _35reg2123, closureRef(co, 2));
+Obj _35reg2127 = primCons(hd1, closureRef(co, 1));
+coraCall(co, 4, globalRef(intern("cora/lib/toc.tailify-list")), closureRef(co, 0), _35reg2127, closureRef(co, 2));
 }
 
-void _35clofun2988(struct Cora* co) {
+void _35clofun3016(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2968(struct Cora* co) {
+void _35clofun2996(struct Cora* co) {
 Obj _35p1288 = co->args[1];
 Obj _35p1289 = co->args[2];
-Obj _35cc1290 = makeNative(0, _35clofun2969, 0, 2, _35p1288, _35p1289);
+Obj _35cc1290 = makeNative(0, _35clofun2997, 0, 2, _35p1288, _35p1289);
 Obj x = _35p1288;
 Obj next = _35p1289;
-Obj _35reg2117 = primIsSymbol(x);
-if (True == _35reg2117) {
+Obj _35reg2121 = primIsSymbol(x);
+if (True == _35reg2121) {
 if (True == True) {
 coraCall(co, 2, next, x);
 } else {
 coraCall(co, 1, _35cc1290);
 }
 } else {
-pushCont(co, 0, _35clofun2985, 3, next, x, _35cc1290);
+pushCont(co, 0, _35clofun3013, 3, next, x, _35cc1290);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 }
 
-void _35clofun2985(struct Cora* co) {
-Obj _35val2118 = co->args[1];
+void _35clofun3013(struct Cora* co) {
+Obj _35val2122 = co->args[1];
 Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35cc1290 = co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val2118) {
+if (True == _35val2122) {
 if (True == True) {
 coraCall(co, 2, next, x);
 } else {
@@ -3565,19 +3661,19 @@ coraCall(co, 1, _35cc1290);
 }
 }
 
-void _35clofun2969(struct Cora* co) {
-Obj _35cc1291 = makeNative(0, _35clofun2970, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2997(struct Cora* co) {
+Obj _35cc1291 = makeNative(0, _35clofun2998, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj x = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
-pushCont(co, 0, _35clofun2984, 2, x, _35cc1291);
+pushCont(co, 0, _35clofun3012, 2, x, _35cc1291);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 
-void _35clofun2984(struct Cora* co) {
-Obj _35val2116 = co->args[1];
+void _35clofun3012(struct Cora* co) {
+Obj _35val2120 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35cc1291 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2116) {
+if (True == _35val2120) {
 coraReturn(co, x);
 return;
 } else {
@@ -3585,45 +3681,45 @@ coraCall(co, 1, _35cc1291);
 }
 }
 
-void _35clofun2970(struct Cora* co) {
-Obj _35cc1292 = makeNative(0, _35clofun2971, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2084 = primIsCons(closureRef(co, 0));
-if (True == _35reg2084) {
-Obj _35reg2085 = primCar(closureRef(co, 0));
-Obj _35reg2086 = primEQ(intern("if"), _35reg2085);
-if (True == _35reg2086) {
-Obj _35reg2087 = primCdr(closureRef(co, 0));
-Obj _35reg2088 = primIsCons(_35reg2087);
+void _35clofun2998(struct Cora* co) {
+Obj _35cc1292 = makeNative(0, _35clofun2999, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2088 = primIsCons(closureRef(co, 0));
 if (True == _35reg2088) {
-Obj _35reg2089 = primCdr(closureRef(co, 0));
-Obj _35reg2090 = primCar(_35reg2089);
-Obj a = _35reg2090;
+Obj _35reg2089 = primCar(closureRef(co, 0));
+Obj _35reg2090 = primEQ(intern("if"), _35reg2089);
+if (True == _35reg2090) {
 Obj _35reg2091 = primCdr(closureRef(co, 0));
-Obj _35reg2092 = primCdr(_35reg2091);
-Obj _35reg2093 = primIsCons(_35reg2092);
-if (True == _35reg2093) {
-Obj _35reg2094 = primCdr(closureRef(co, 0));
-Obj _35reg2095 = primCdr(_35reg2094);
-Obj _35reg2096 = primCar(_35reg2095);
-Obj b = _35reg2096;
-Obj _35reg2097 = primCdr(closureRef(co, 0));
-Obj _35reg2098 = primCdr(_35reg2097);
+Obj _35reg2092 = primIsCons(_35reg2091);
+if (True == _35reg2092) {
+Obj _35reg2093 = primCdr(closureRef(co, 0));
+Obj _35reg2094 = primCar(_35reg2093);
+Obj a = _35reg2094;
+Obj _35reg2095 = primCdr(closureRef(co, 0));
+Obj _35reg2096 = primCdr(_35reg2095);
+Obj _35reg2097 = primIsCons(_35reg2096);
+if (True == _35reg2097) {
+Obj _35reg2098 = primCdr(closureRef(co, 0));
 Obj _35reg2099 = primCdr(_35reg2098);
-Obj _35reg2100 = primIsCons(_35reg2099);
-if (True == _35reg2100) {
+Obj _35reg2100 = primCar(_35reg2099);
+Obj b = _35reg2100;
 Obj _35reg2101 = primCdr(closureRef(co, 0));
 Obj _35reg2102 = primCdr(_35reg2101);
 Obj _35reg2103 = primCdr(_35reg2102);
-Obj _35reg2104 = primCar(_35reg2103);
-Obj c = _35reg2104;
+Obj _35reg2104 = primIsCons(_35reg2103);
+if (True == _35reg2104) {
 Obj _35reg2105 = primCdr(closureRef(co, 0));
 Obj _35reg2106 = primCdr(_35reg2105);
 Obj _35reg2107 = primCdr(_35reg2106);
-Obj _35reg2108 = primCdr(_35reg2107);
-Obj _35reg2109 = primEQ(Nil, _35reg2108);
-if (True == _35reg2109) {
+Obj _35reg2108 = primCar(_35reg2107);
+Obj c = _35reg2108;
+Obj _35reg2109 = primCdr(closureRef(co, 0));
+Obj _35reg2110 = primCdr(_35reg2109);
+Obj _35reg2111 = primCdr(_35reg2110);
+Obj _35reg2112 = primCdr(_35reg2111);
+Obj _35reg2113 = primEQ(Nil, _35reg2112);
+if (True == _35reg2113) {
 Obj next = closureRef(co, 1);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), a, makeNative(0, _35clofun2981, 1, 3, b, c, next));
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), a, makeNative(0, _35clofun3009, 1, 3, b, c, next));
 } else {
 coraCall(co, 1, _35cc1292);
 }
@@ -3644,59 +3740,59 @@ coraCall(co, 1, _35cc1292);
 }
 }
 
-void _35clofun2981(struct Cora* co) {
+void _35clofun3009(struct Cora* co) {
 Obj ra = co->args[1];
-pushCont(co, 0, _35clofun2982, 1, ra);
+pushCont(co, 0, _35clofun3010, 1, ra);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), closureRef(co, 2));
 }
 
-void _35clofun2982(struct Cora* co) {
-Obj _35val2110 = co->args[1];
+void _35clofun3010(struct Cora* co) {
+Obj _35val2114 = co->args[1];
 Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun2983, 2, _35val2110, ra);
+pushCont(co, 0, _35clofun3011, 2, _35val2114, ra);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 1), closureRef(co, 2));
 }
 
-void _35clofun2983(struct Cora* co) {
-Obj _35val2111 = co->args[1];
-Obj _35val2110 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+void _35clofun3011(struct Cora* co) {
+Obj _35val2115 = co->args[1];
+Obj _35val2114 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2112 = primCons(_35val2111, Nil);
-Obj _35reg2113 = primCons(_35val2110, _35reg2112);
-Obj _35reg2114 = primCons(ra, _35reg2113);
-Obj _35reg2115 = primCons(intern("if"), _35reg2114);
-coraReturn(co, _35reg2115);
+Obj _35reg2116 = primCons(_35val2115, Nil);
+Obj _35reg2117 = primCons(_35val2114, _35reg2116);
+Obj _35reg2118 = primCons(ra, _35reg2117);
+Obj _35reg2119 = primCons(intern("if"), _35reg2118);
+coraReturn(co, _35reg2119);
 return;
 }
 
-void _35clofun2971(struct Cora* co) {
-Obj _35cc1293 = makeNative(0, _35clofun2972, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2062 = primIsCons(closureRef(co, 0));
-if (True == _35reg2062) {
-Obj _35reg2063 = primCar(closureRef(co, 0));
-Obj _35reg2064 = primEQ(intern("do"), _35reg2063);
-if (True == _35reg2064) {
-Obj _35reg2065 = primCdr(closureRef(co, 0));
-Obj _35reg2066 = primIsCons(_35reg2065);
+void _35clofun2999(struct Cora* co) {
+Obj _35cc1293 = makeNative(0, _35clofun3000, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2066 = primIsCons(closureRef(co, 0));
 if (True == _35reg2066) {
-Obj _35reg2067 = primCdr(closureRef(co, 0));
-Obj _35reg2068 = primCar(_35reg2067);
-Obj a = _35reg2068;
+Obj _35reg2067 = primCar(closureRef(co, 0));
+Obj _35reg2068 = primEQ(intern("do"), _35reg2067);
+if (True == _35reg2068) {
 Obj _35reg2069 = primCdr(closureRef(co, 0));
-Obj _35reg2070 = primCdr(_35reg2069);
-Obj _35reg2071 = primIsCons(_35reg2070);
-if (True == _35reg2071) {
-Obj _35reg2072 = primCdr(closureRef(co, 0));
-Obj _35reg2073 = primCdr(_35reg2072);
-Obj _35reg2074 = primCar(_35reg2073);
-Obj b = _35reg2074;
-Obj _35reg2075 = primCdr(closureRef(co, 0));
-Obj _35reg2076 = primCdr(_35reg2075);
+Obj _35reg2070 = primIsCons(_35reg2069);
+if (True == _35reg2070) {
+Obj _35reg2071 = primCdr(closureRef(co, 0));
+Obj _35reg2072 = primCar(_35reg2071);
+Obj a = _35reg2072;
+Obj _35reg2073 = primCdr(closureRef(co, 0));
+Obj _35reg2074 = primCdr(_35reg2073);
+Obj _35reg2075 = primIsCons(_35reg2074);
+if (True == _35reg2075) {
+Obj _35reg2076 = primCdr(closureRef(co, 0));
 Obj _35reg2077 = primCdr(_35reg2076);
-Obj _35reg2078 = primEQ(Nil, _35reg2077);
-if (True == _35reg2078) {
+Obj _35reg2078 = primCar(_35reg2077);
+Obj b = _35reg2078;
+Obj _35reg2079 = primCdr(closureRef(co, 0));
+Obj _35reg2080 = primCdr(_35reg2079);
+Obj _35reg2081 = primCdr(_35reg2080);
+Obj _35reg2082 = primEQ(Nil, _35reg2081);
+if (True == _35reg2082) {
 Obj next = closureRef(co, 1);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), a, makeNative(0, _35clofun2979, 1, 2, b, next));
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), a, makeNative(0, _35clofun3007, 1, 2, b, next));
 } else {
 coraCall(co, 1, _35cc1293);
 }
@@ -3714,66 +3810,66 @@ coraCall(co, 1, _35cc1293);
 }
 }
 
-void _35clofun2979(struct Cora* co) {
+void _35clofun3007(struct Cora* co) {
 Obj ra = co->args[1];
-Obj _35reg2079 = primIsSymbol(ra);
-if (True == _35reg2079) {
+Obj _35reg2083 = primIsSymbol(ra);
+if (True == _35reg2083) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), closureRef(co, 1));
 } else {
-pushCont(co, 0, _35clofun2980, 1, ra);
+pushCont(co, 0, _35clofun3008, 1, ra);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), closureRef(co, 1));
 }
 }
 
-void _35clofun2980(struct Cora* co) {
-Obj _35val2080 = co->args[1];
+void _35clofun3008(struct Cora* co) {
+Obj _35val2084 = co->args[1];
 Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2081 = primCons(_35val2080, Nil);
-Obj _35reg2082 = primCons(ra, _35reg2081);
-Obj _35reg2083 = primCons(intern("do"), _35reg2082);
-coraReturn(co, _35reg2083);
+Obj _35reg2085 = primCons(_35val2084, Nil);
+Obj _35reg2086 = primCons(ra, _35reg2085);
+Obj _35reg2087 = primCons(intern("do"), _35reg2086);
+coraReturn(co, _35reg2087);
 return;
 }
 
-void _35clofun2972(struct Cora* co) {
-Obj _35cc1294 = makeNative(0, _35clofun2973, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2031 = primIsCons(closureRef(co, 0));
-if (True == _35reg2031) {
-Obj _35reg2032 = primCar(closureRef(co, 0));
-Obj _35reg2033 = primEQ(intern("let"), _35reg2032);
-if (True == _35reg2033) {
-Obj _35reg2034 = primCdr(closureRef(co, 0));
-Obj _35reg2035 = primIsCons(_35reg2034);
+void _35clofun3000(struct Cora* co) {
+Obj _35cc1294 = makeNative(0, _35clofun3001, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2035 = primIsCons(closureRef(co, 0));
 if (True == _35reg2035) {
-Obj _35reg2036 = primCdr(closureRef(co, 0));
-Obj _35reg2037 = primCar(_35reg2036);
-Obj a = _35reg2037;
+Obj _35reg2036 = primCar(closureRef(co, 0));
+Obj _35reg2037 = primEQ(intern("let"), _35reg2036);
+if (True == _35reg2037) {
 Obj _35reg2038 = primCdr(closureRef(co, 0));
-Obj _35reg2039 = primCdr(_35reg2038);
-Obj _35reg2040 = primIsCons(_35reg2039);
-if (True == _35reg2040) {
-Obj _35reg2041 = primCdr(closureRef(co, 0));
-Obj _35reg2042 = primCdr(_35reg2041);
-Obj _35reg2043 = primCar(_35reg2042);
-Obj b = _35reg2043;
-Obj _35reg2044 = primCdr(closureRef(co, 0));
-Obj _35reg2045 = primCdr(_35reg2044);
+Obj _35reg2039 = primIsCons(_35reg2038);
+if (True == _35reg2039) {
+Obj _35reg2040 = primCdr(closureRef(co, 0));
+Obj _35reg2041 = primCar(_35reg2040);
+Obj a = _35reg2041;
+Obj _35reg2042 = primCdr(closureRef(co, 0));
+Obj _35reg2043 = primCdr(_35reg2042);
+Obj _35reg2044 = primIsCons(_35reg2043);
+if (True == _35reg2044) {
+Obj _35reg2045 = primCdr(closureRef(co, 0));
 Obj _35reg2046 = primCdr(_35reg2045);
-Obj _35reg2047 = primIsCons(_35reg2046);
-if (True == _35reg2047) {
+Obj _35reg2047 = primCar(_35reg2046);
+Obj b = _35reg2047;
 Obj _35reg2048 = primCdr(closureRef(co, 0));
 Obj _35reg2049 = primCdr(_35reg2048);
 Obj _35reg2050 = primCdr(_35reg2049);
-Obj _35reg2051 = primCar(_35reg2050);
-Obj c = _35reg2051;
+Obj _35reg2051 = primIsCons(_35reg2050);
+if (True == _35reg2051) {
 Obj _35reg2052 = primCdr(closureRef(co, 0));
 Obj _35reg2053 = primCdr(_35reg2052);
 Obj _35reg2054 = primCdr(_35reg2053);
-Obj _35reg2055 = primCdr(_35reg2054);
-Obj _35reg2056 = primEQ(Nil, _35reg2055);
-if (True == _35reg2056) {
+Obj _35reg2055 = primCar(_35reg2054);
+Obj c = _35reg2055;
+Obj _35reg2056 = primCdr(closureRef(co, 0));
+Obj _35reg2057 = primCdr(_35reg2056);
+Obj _35reg2058 = primCdr(_35reg2057);
+Obj _35reg2059 = primCdr(_35reg2058);
+Obj _35reg2060 = primEQ(Nil, _35reg2059);
+if (True == _35reg2060) {
 Obj next = closureRef(co, 1);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), b, makeNative(0, _35clofun2977, 1, 3, a, c, next));
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), b, makeNative(0, _35clofun3005, 1, 3, a, c, next));
 } else {
 coraCall(co, 1, _35cc1294);
 }
@@ -3794,76 +3890,76 @@ coraCall(co, 1, _35cc1294);
 }
 }
 
-void _35clofun2977(struct Cora* co) {
+void _35clofun3005(struct Cora* co) {
 Obj rb = co->args[1];
-pushCont(co, 0, _35clofun2978, 1, rb);
+pushCont(co, 0, _35clofun3006, 1, rb);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 1), closureRef(co, 2));
 }
 
-void _35clofun2978(struct Cora* co) {
-Obj _35val2057 = co->args[1];
+void _35clofun3006(struct Cora* co) {
+Obj _35val2061 = co->args[1];
 Obj rb = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2058 = primCons(_35val2057, Nil);
-Obj _35reg2059 = primCons(rb, _35reg2058);
-Obj _35reg2060 = primCons(closureRef(co, 0), _35reg2059);
-Obj _35reg2061 = primCons(intern("let"), _35reg2060);
-coraReturn(co, _35reg2061);
+Obj _35reg2062 = primCons(_35val2061, Nil);
+Obj _35reg2063 = primCons(rb, _35reg2062);
+Obj _35reg2064 = primCons(closureRef(co, 0), _35reg2063);
+Obj _35reg2065 = primCons(intern("let"), _35reg2064);
+coraReturn(co, _35reg2065);
 return;
 }
 
-void _35clofun2973(struct Cora* co) {
-Obj _35cc1295 = makeNative(0, _35clofun2974, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1987 = primIsCons(closureRef(co, 0));
-if (True == _35reg1987) {
-Obj _35reg1988 = primCar(closureRef(co, 0));
-Obj _35reg1989 = primEQ(intern("%closure"), _35reg1988);
-if (True == _35reg1989) {
-Obj _35reg1990 = primCdr(closureRef(co, 0));
-Obj _35reg1991 = primIsCons(_35reg1990);
+void _35clofun3001(struct Cora* co) {
+Obj _35cc1295 = makeNative(0, _35clofun3002, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1991 = primIsCons(closureRef(co, 0));
 if (True == _35reg1991) {
-Obj _35reg1992 = primCdr(closureRef(co, 0));
-Obj _35reg1993 = primCar(_35reg1992);
-Obj _35reg1994 = primIsCons(_35reg1993);
-if (True == _35reg1994) {
-Obj _35reg1995 = primCdr(closureRef(co, 0));
-Obj _35reg1996 = primCar(_35reg1995);
+Obj _35reg1992 = primCar(closureRef(co, 0));
+Obj _35reg1993 = primEQ(intern("%closure"), _35reg1992);
+if (True == _35reg1993) {
+Obj _35reg1994 = primCdr(closureRef(co, 0));
+Obj _35reg1995 = primIsCons(_35reg1994);
+if (True == _35reg1995) {
+Obj _35reg1996 = primCdr(closureRef(co, 0));
 Obj _35reg1997 = primCar(_35reg1996);
-Obj _35reg1998 = primEQ(intern("lambda"), _35reg1997);
+Obj _35reg1998 = primIsCons(_35reg1997);
 if (True == _35reg1998) {
 Obj _35reg1999 = primCdr(closureRef(co, 0));
 Obj _35reg2000 = primCar(_35reg1999);
-Obj _35reg2001 = primCdr(_35reg2000);
-Obj _35reg2002 = primIsCons(_35reg2001);
+Obj _35reg2001 = primCar(_35reg2000);
+Obj _35reg2002 = primEQ(intern("lambda"), _35reg2001);
 if (True == _35reg2002) {
 Obj _35reg2003 = primCdr(closureRef(co, 0));
 Obj _35reg2004 = primCar(_35reg2003);
 Obj _35reg2005 = primCdr(_35reg2004);
-Obj _35reg2006 = primCar(_35reg2005);
-Obj args = _35reg2006;
+Obj _35reg2006 = primIsCons(_35reg2005);
+if (True == _35reg2006) {
 Obj _35reg2007 = primCdr(closureRef(co, 0));
 Obj _35reg2008 = primCar(_35reg2007);
 Obj _35reg2009 = primCdr(_35reg2008);
-Obj _35reg2010 = primCdr(_35reg2009);
-Obj _35reg2011 = primIsCons(_35reg2010);
-if (True == _35reg2011) {
-Obj _35reg2012 = primCdr(closureRef(co, 0));
-Obj _35reg2013 = primCar(_35reg2012);
+Obj _35reg2010 = primCar(_35reg2009);
+Obj args = _35reg2010;
+Obj _35reg2011 = primCdr(closureRef(co, 0));
+Obj _35reg2012 = primCar(_35reg2011);
+Obj _35reg2013 = primCdr(_35reg2012);
 Obj _35reg2014 = primCdr(_35reg2013);
-Obj _35reg2015 = primCdr(_35reg2014);
-Obj _35reg2016 = primCar(_35reg2015);
-Obj body = _35reg2016;
-Obj _35reg2017 = primCdr(closureRef(co, 0));
-Obj _35reg2018 = primCar(_35reg2017);
+Obj _35reg2015 = primIsCons(_35reg2014);
+if (True == _35reg2015) {
+Obj _35reg2016 = primCdr(closureRef(co, 0));
+Obj _35reg2017 = primCar(_35reg2016);
+Obj _35reg2018 = primCdr(_35reg2017);
 Obj _35reg2019 = primCdr(_35reg2018);
-Obj _35reg2020 = primCdr(_35reg2019);
-Obj _35reg2021 = primCdr(_35reg2020);
-Obj _35reg2022 = primEQ(Nil, _35reg2021);
-if (True == _35reg2022) {
-Obj _35reg2023 = primCdr(closureRef(co, 0));
+Obj _35reg2020 = primCar(_35reg2019);
+Obj body = _35reg2020;
+Obj _35reg2021 = primCdr(closureRef(co, 0));
+Obj _35reg2022 = primCar(_35reg2021);
+Obj _35reg2023 = primCdr(_35reg2022);
 Obj _35reg2024 = primCdr(_35reg2023);
-Obj frees = _35reg2024;
+Obj _35reg2025 = primCdr(_35reg2024);
+Obj _35reg2026 = primEQ(Nil, _35reg2025);
+if (True == _35reg2026) {
+Obj _35reg2027 = primCdr(closureRef(co, 0));
+Obj _35reg2028 = primCdr(_35reg2027);
+Obj frees = _35reg2028;
 Obj next = closureRef(co, 1);
-pushCont(co, 0, _35clofun2976, 3, args, frees, next);
+pushCont(co, 0, _35clofun3004, 3, args, frees, next);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), body, globalRef(intern("cora/lib/toc.id")));
 } else {
 coraCall(co, 1, _35cc1295);
@@ -3891,62 +3987,62 @@ coraCall(co, 1, _35cc1295);
 }
 }
 
-void _35clofun2976(struct Cora* co) {
-Obj _35val2025 = co->args[1];
+void _35clofun3004(struct Cora* co) {
+Obj _35val2029 = co->args[1];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj next = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2026 = primCons(_35val2025, Nil);
-Obj _35reg2027 = primCons(args, _35reg2026);
-Obj _35reg2028 = primCons(intern("lambda"), _35reg2027);
-Obj _35reg2029 = primCons(_35reg2028, frees);
-Obj _35reg2030 = primCons(intern("%closure"), _35reg2029);
-coraCall(co, 2, next, _35reg2030);
+Obj _35reg2030 = primCons(_35val2029, Nil);
+Obj _35reg2031 = primCons(args, _35reg2030);
+Obj _35reg2032 = primCons(intern("lambda"), _35reg2031);
+Obj _35reg2033 = primCons(_35reg2032, frees);
+Obj _35reg2034 = primCons(intern("%closure"), _35reg2033);
+coraCall(co, 2, next, _35reg2034);
 }
 
-void _35clofun2974(struct Cora* co) {
-Obj _35cc1296 = makeNative(0, _35clofun2975, 0, 0);
-Obj _35reg1983 = primIsCons(closureRef(co, 0));
-if (True == _35reg1983) {
-Obj _35reg1984 = primCar(closureRef(co, 0));
-Obj f = _35reg1984;
-Obj _35reg1985 = primCdr(closureRef(co, 0));
-Obj args = _35reg1985;
+void _35clofun3002(struct Cora* co) {
+Obj _35cc1296 = makeNative(0, _35clofun3003, 0, 0);
+Obj _35reg1987 = primIsCons(closureRef(co, 0));
+if (True == _35reg1987) {
+Obj _35reg1988 = primCar(closureRef(co, 0));
+Obj f = _35reg1988;
+Obj _35reg1989 = primCdr(closureRef(co, 0));
+Obj args = _35reg1989;
 Obj next = closureRef(co, 1);
-Obj _35reg1986 = primCons(f, args);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.tailify-list")), _35reg1986, Nil, next);
+Obj _35reg1990 = primCons(f, args);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.tailify-list")), _35reg1990, Nil, next);
 } else {
 coraCall(co, 1, _35cc1296);
 }
 }
 
-void _35clofun2975(struct Cora* co) {
+void _35clofun3003(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2967(struct Cora* co) {
+void _35clofun2995(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg1980 = primCons(x, Nil);
-Obj _35reg1981 = primCons(intern("return"), _35reg1980);
-coraReturn(co, _35reg1981);
+Obj _35reg1984 = primCons(x, Nil);
+Obj _35reg1985 = primCons(intern("return"), _35reg1984);
+coraReturn(co, _35reg1985);
 return;
 }
 
-void _35clofun2952(struct Cora* co) {
+void _35clofun2980(struct Cora* co) {
 Obj _35p1281 = co->args[1];
 Obj _35p1282 = co->args[2];
-Obj _35cc1283 = makeNative(0, _35clofun2953, 0, 2, _35p1281, _35p1282);
+Obj _35cc1283 = makeNative(0, _35clofun2981, 0, 2, _35p1281, _35p1282);
 Obj __ = _35p1281;
 Obj x = _35p1282;
-pushCont(co, 0, _35clofun2966, 2, x, _35cc1283);
+pushCont(co, 0, _35clofun2994, 2, x, _35cc1283);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 
-void _35clofun2966(struct Cora* co) {
-Obj _35val1978 = co->args[1];
+void _35clofun2994(struct Cora* co) {
+Obj _35val1982 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35cc1283 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1978) {
+if (True == _35val1982) {
 coraReturn(co, x);
 return;
 } else {
@@ -3954,67 +4050,67 @@ coraCall(co, 1, _35cc1283);
 }
 }
 
-void _35clofun2953(struct Cora* co) {
-Obj _35cc1284 = makeNative(0, _35clofun2954, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2981(struct Cora* co) {
+Obj _35cc1284 = makeNative(0, _35clofun2982, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj _35reg1973 = primIsSymbol(var);
-if (True == _35reg1973) {
-pushCont(co, 0, _35clofun2965, 1, var);
+Obj _35reg1977 = primIsSymbol(var);
+if (True == _35reg1977) {
+pushCont(co, 0, _35clofun2993, 1, var);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.index")), var, fvs);
 } else {
 coraCall(co, 1, _35cc1284);
 }
 }
 
-void _35clofun2965(struct Cora* co) {
-Obj _35val1974 = co->args[1];
+void _35clofun2993(struct Cora* co) {
+Obj _35val1978 = co->args[1];
 Obj var = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj pos = _35val1974;
-Obj _35reg1975 = primEQ(makeNumber(-1), pos);
-if (True == _35reg1975) {
+Obj pos = _35val1978;
+Obj _35reg1979 = primEQ(makeNumber(-1), pos);
+if (True == _35reg1979) {
 coraReturn(co, var);
 return;
 } else {
-Obj _35reg1976 = primCons(pos, Nil);
-Obj _35reg1977 = primCons(intern("%closure-ref"), _35reg1976);
-coraReturn(co, _35reg1977);
+Obj _35reg1980 = primCons(pos, Nil);
+Obj _35reg1981 = primCons(intern("%closure-ref"), _35reg1980);
+coraReturn(co, _35reg1981);
 return;
 }
 }
 
-void _35clofun2954(struct Cora* co) {
-Obj _35cc1285 = makeNative(0, _35clofun2955, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2982(struct Cora* co) {
+Obj _35cc1285 = makeNative(0, _35clofun2983, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg1944 = primIsCons(closureRef(co, 1));
-if (True == _35reg1944) {
-Obj _35reg1945 = primCar(closureRef(co, 1));
-Obj _35reg1946 = primEQ(intern("lambda"), _35reg1945);
-if (True == _35reg1946) {
-Obj _35reg1947 = primCdr(closureRef(co, 1));
-Obj _35reg1948 = primIsCons(_35reg1947);
+Obj _35reg1948 = primIsCons(closureRef(co, 1));
 if (True == _35reg1948) {
-Obj _35reg1949 = primCdr(closureRef(co, 1));
-Obj _35reg1950 = primCar(_35reg1949);
-Obj args = _35reg1950;
+Obj _35reg1949 = primCar(closureRef(co, 1));
+Obj _35reg1950 = primEQ(intern("lambda"), _35reg1949);
+if (True == _35reg1950) {
 Obj _35reg1951 = primCdr(closureRef(co, 1));
-Obj _35reg1952 = primCdr(_35reg1951);
-Obj _35reg1953 = primIsCons(_35reg1952);
-if (True == _35reg1953) {
-Obj _35reg1954 = primCdr(closureRef(co, 1));
-Obj _35reg1955 = primCdr(_35reg1954);
-Obj _35reg1956 = primCar(_35reg1955);
-Obj body = _35reg1956;
-Obj _35reg1957 = primCdr(closureRef(co, 1));
-Obj _35reg1958 = primCdr(_35reg1957);
+Obj _35reg1952 = primIsCons(_35reg1951);
+if (True == _35reg1952) {
+Obj _35reg1953 = primCdr(closureRef(co, 1));
+Obj _35reg1954 = primCar(_35reg1953);
+Obj args = _35reg1954;
+Obj _35reg1955 = primCdr(closureRef(co, 1));
+Obj _35reg1956 = primCdr(_35reg1955);
+Obj _35reg1957 = primIsCons(_35reg1956);
+if (True == _35reg1957) {
+Obj _35reg1958 = primCdr(closureRef(co, 1));
 Obj _35reg1959 = primCdr(_35reg1958);
-Obj _35reg1960 = primEQ(Nil, _35reg1959);
-if (True == _35reg1960) {
-Obj _35reg1961 = primCons(body, Nil);
-Obj _35reg1962 = primCons(args, _35reg1961);
-Obj _35reg1963 = primCons(intern("lambda"), _35reg1962);
-pushCont(co, 0, _35clofun2961, 3, body, args, fvs);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), _35reg1963);
+Obj _35reg1960 = primCar(_35reg1959);
+Obj body = _35reg1960;
+Obj _35reg1961 = primCdr(closureRef(co, 1));
+Obj _35reg1962 = primCdr(_35reg1961);
+Obj _35reg1963 = primCdr(_35reg1962);
+Obj _35reg1964 = primEQ(Nil, _35reg1963);
+if (True == _35reg1964) {
+Obj _35reg1965 = primCons(body, Nil);
+Obj _35reg1966 = primCons(args, _35reg1965);
+Obj _35reg1967 = primCons(intern("lambda"), _35reg1966);
+pushCont(co, 0, _35clofun2989, 3, body, args, fvs);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), _35reg1967);
 } else {
 coraCall(co, 1, _35cc1285);
 }
@@ -4032,84 +4128,84 @@ coraCall(co, 1, _35cc1285);
 }
 }
 
-void _35clofun2961(struct Cora* co) {
-Obj _35val1964 = co->args[1];
+void _35clofun2989(struct Cora* co) {
+Obj _35val1968 = co->args[1];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs1 = _35val1964;
-pushCont(co, 0, _35clofun2962, 3, args, fvs, fvs1);
+Obj fvs1 = _35val1968;
+pushCont(co, 0, _35clofun2990, 3, args, fvs, fvs1);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs1, body);
 }
 
-void _35clofun2962(struct Cora* co) {
-Obj _35val1965 = co->args[1];
+void _35clofun2990(struct Cora* co) {
+Obj _35val1969 = co->args[1];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1966 = primCons(_35val1965, Nil);
-Obj _35reg1967 = primCons(args, _35reg1966);
-Obj _35reg1968 = primCons(intern("lambda"), _35reg1967);
-pushCont(co, 0, _35clofun2963, 2, fvs1, _35reg1968);
+Obj _35reg1970 = primCons(_35val1969, Nil);
+Obj _35reg1971 = primCons(args, _35reg1970);
+Obj _35reg1972 = primCons(intern("lambda"), _35reg1971);
+pushCont(co, 0, _35clofun2991, 2, fvs1, _35reg1972);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert")), fvs);
 }
 
-void _35clofun2963(struct Cora* co) {
-Obj _35val1969 = co->args[1];
+void _35clofun2991(struct Cora* co) {
+Obj _35val1973 = co->args[1];
 Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1968 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2964, 1, _35reg1968);
-coraCall(co, 3, globalRef(intern("map")), _35val1969, fvs1);
+Obj _35reg1972 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun2992, 1, _35reg1972);
+coraCall(co, 3, globalRef(intern("map")), _35val1973, fvs1);
 }
 
-void _35clofun2964(struct Cora* co) {
-Obj _35val1970 = co->args[1];
-Obj _35reg1968 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1971 = primCons(_35reg1968, _35val1970);
-Obj _35reg1972 = primCons(intern("%closure"), _35reg1971);
-coraReturn(co, _35reg1972);
+void _35clofun2992(struct Cora* co) {
+Obj _35val1974 = co->args[1];
+Obj _35reg1972 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1975 = primCons(_35reg1972, _35val1974);
+Obj _35reg1976 = primCons(intern("%closure"), _35reg1975);
+coraReturn(co, _35reg1976);
 return;
 }
 
-void _35clofun2955(struct Cora* co) {
-Obj _35cc1286 = makeNative(0, _35clofun2956, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2983(struct Cora* co) {
+Obj _35cc1286 = makeNative(0, _35clofun2984, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg1912 = primIsCons(closureRef(co, 1));
-if (True == _35reg1912) {
-Obj _35reg1913 = primCar(closureRef(co, 1));
-Obj _35reg1914 = primEQ(intern("let"), _35reg1913);
-if (True == _35reg1914) {
-Obj _35reg1915 = primCdr(closureRef(co, 1));
-Obj _35reg1916 = primIsCons(_35reg1915);
+Obj _35reg1916 = primIsCons(closureRef(co, 1));
 if (True == _35reg1916) {
-Obj _35reg1917 = primCdr(closureRef(co, 1));
-Obj _35reg1918 = primCar(_35reg1917);
-Obj a = _35reg1918;
+Obj _35reg1917 = primCar(closureRef(co, 1));
+Obj _35reg1918 = primEQ(intern("let"), _35reg1917);
+if (True == _35reg1918) {
 Obj _35reg1919 = primCdr(closureRef(co, 1));
-Obj _35reg1920 = primCdr(_35reg1919);
-Obj _35reg1921 = primIsCons(_35reg1920);
-if (True == _35reg1921) {
-Obj _35reg1922 = primCdr(closureRef(co, 1));
-Obj _35reg1923 = primCdr(_35reg1922);
-Obj _35reg1924 = primCar(_35reg1923);
-Obj b = _35reg1924;
-Obj _35reg1925 = primCdr(closureRef(co, 1));
-Obj _35reg1926 = primCdr(_35reg1925);
+Obj _35reg1920 = primIsCons(_35reg1919);
+if (True == _35reg1920) {
+Obj _35reg1921 = primCdr(closureRef(co, 1));
+Obj _35reg1922 = primCar(_35reg1921);
+Obj a = _35reg1922;
+Obj _35reg1923 = primCdr(closureRef(co, 1));
+Obj _35reg1924 = primCdr(_35reg1923);
+Obj _35reg1925 = primIsCons(_35reg1924);
+if (True == _35reg1925) {
+Obj _35reg1926 = primCdr(closureRef(co, 1));
 Obj _35reg1927 = primCdr(_35reg1926);
-Obj _35reg1928 = primIsCons(_35reg1927);
-if (True == _35reg1928) {
+Obj _35reg1928 = primCar(_35reg1927);
+Obj b = _35reg1928;
 Obj _35reg1929 = primCdr(closureRef(co, 1));
 Obj _35reg1930 = primCdr(_35reg1929);
 Obj _35reg1931 = primCdr(_35reg1930);
-Obj _35reg1932 = primCar(_35reg1931);
-Obj c = _35reg1932;
+Obj _35reg1932 = primIsCons(_35reg1931);
+if (True == _35reg1932) {
 Obj _35reg1933 = primCdr(closureRef(co, 1));
 Obj _35reg1934 = primCdr(_35reg1933);
 Obj _35reg1935 = primCdr(_35reg1934);
-Obj _35reg1936 = primCdr(_35reg1935);
-Obj _35reg1937 = primEQ(Nil, _35reg1936);
-if (True == _35reg1937) {
-pushCont(co, 0, _35clofun2959, 3, fvs, c, a);
+Obj _35reg1936 = primCar(_35reg1935);
+Obj c = _35reg1936;
+Obj _35reg1937 = primCdr(closureRef(co, 1));
+Obj _35reg1938 = primCdr(_35reg1937);
+Obj _35reg1939 = primCdr(_35reg1938);
+Obj _35reg1940 = primCdr(_35reg1939);
+Obj _35reg1941 = primEQ(Nil, _35reg1940);
+if (True == _35reg1941) {
+pushCont(co, 0, _35clofun2987, 3, fvs, c, a);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs, b);
 } else {
 coraCall(co, 1, _35cc1286);
@@ -4131,67 +4227,67 @@ coraCall(co, 1, _35cc1286);
 }
 }
 
-void _35clofun2959(struct Cora* co) {
-Obj _35val1938 = co->args[1];
+void _35clofun2987(struct Cora* co) {
+Obj _35val1942 = co->args[1];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun2960, 2, _35val1938, a);
+pushCont(co, 0, _35clofun2988, 2, _35val1942, a);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs, c);
 }
 
-void _35clofun2960(struct Cora* co) {
-Obj _35val1939 = co->args[1];
-Obj _35val1938 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+void _35clofun2988(struct Cora* co) {
+Obj _35val1943 = co->args[1];
+Obj _35val1942 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1940 = primCons(_35val1939, Nil);
-Obj _35reg1941 = primCons(_35val1938, _35reg1940);
-Obj _35reg1942 = primCons(a, _35reg1941);
-Obj _35reg1943 = primCons(intern("let"), _35reg1942);
-coraReturn(co, _35reg1943);
+Obj _35reg1944 = primCons(_35val1943, Nil);
+Obj _35reg1945 = primCons(_35val1942, _35reg1944);
+Obj _35reg1946 = primCons(a, _35reg1945);
+Obj _35reg1947 = primCons(intern("let"), _35reg1946);
+coraReturn(co, _35reg1947);
 return;
 }
 
-void _35clofun2956(struct Cora* co) {
-Obj _35cc1287 = makeNative(0, _35clofun2957, 0, 0);
+void _35clofun2984(struct Cora* co) {
+Obj _35cc1287 = makeNative(0, _35clofun2985, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj _35reg1907 = primIsCons(closureRef(co, 1));
-if (True == _35reg1907) {
-Obj _35reg1908 = primCar(closureRef(co, 1));
-Obj f = _35reg1908;
-Obj _35reg1909 = primCdr(closureRef(co, 1));
-Obj args = _35reg1909;
-pushCont(co, 0, _35clofun2958, 2, f, args);
+Obj _35reg1911 = primIsCons(closureRef(co, 1));
+if (True == _35reg1911) {
+Obj _35reg1912 = primCar(closureRef(co, 1));
+Obj f = _35reg1912;
+Obj _35reg1913 = primCdr(closureRef(co, 1));
+Obj args = _35reg1913;
+pushCont(co, 0, _35clofun2986, 2, f, args);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert")), fvs);
 } else {
 coraCall(co, 1, _35cc1287);
 }
 }
 
-void _35clofun2958(struct Cora* co) {
-Obj _35val1910 = co->args[1];
+void _35clofun2986(struct Cora* co) {
+Obj _35val1914 = co->args[1];
 Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1911 = primCons(f, args);
-coraCall(co, 3, globalRef(intern("map")), _35val1910, _35reg1911);
+Obj _35reg1915 = primCons(f, args);
+coraCall(co, 3, globalRef(intern("map")), _35val1914, _35reg1915);
 }
 
-void _35clofun2957(struct Cora* co) {
+void _35clofun2985(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2929(struct Cora* co) {
+void _35clofun2957(struct Cora* co) {
 Obj _35p1268 = co->args[1];
-Obj _35cc1269 = makeNative(0, _35clofun2930, 0, 1, _35p1268);
+Obj _35cc1269 = makeNative(0, _35clofun2958, 0, 1, _35p1268);
 Obj x = _35p1268;
-pushCont(co, 0, _35clofun2951, 1, _35cc1269);
+pushCont(co, 0, _35clofun2979, 1, _35cc1269);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 
-void _35clofun2951(struct Cora* co) {
-Obj _35val1905 = co->args[1];
+void _35clofun2979(struct Cora* co) {
+Obj _35val1909 = co->args[1];
 Obj _35cc1269 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1905) {
+if (True == _35val1909) {
 coraReturn(co, Nil);
 return;
 } else {
@@ -4199,46 +4295,46 @@ coraCall(co, 1, _35cc1269);
 }
 }
 
-void _35clofun2930(struct Cora* co) {
-Obj _35cc1270 = makeNative(0, _35clofun2931, 0, 1, closureRef(co, 0));
+void _35clofun2958(struct Cora* co) {
+Obj _35cc1270 = makeNative(0, _35clofun2959, 0, 1, closureRef(co, 0));
 Obj x = closureRef(co, 0);
-Obj _35reg1903 = primIsSymbol(x);
-if (True == _35reg1903) {
-Obj _35reg1904 = primCons(x, Nil);
-coraReturn(co, _35reg1904);
+Obj _35reg1907 = primIsSymbol(x);
+if (True == _35reg1907) {
+Obj _35reg1908 = primCons(x, Nil);
+coraReturn(co, _35reg1908);
 return;
 } else {
 coraCall(co, 1, _35cc1270);
 }
 }
 
-void _35clofun2931(struct Cora* co) {
-Obj _35cc1271 = makeNative(0, _35clofun2932, 0, 1, closureRef(co, 0));
-Obj _35reg1885 = primIsCons(closureRef(co, 0));
-if (True == _35reg1885) {
-Obj _35reg1886 = primCar(closureRef(co, 0));
-Obj _35reg1887 = primEQ(intern("lambda"), _35reg1886);
-if (True == _35reg1887) {
-Obj _35reg1888 = primCdr(closureRef(co, 0));
-Obj _35reg1889 = primIsCons(_35reg1888);
+void _35clofun2959(struct Cora* co) {
+Obj _35cc1271 = makeNative(0, _35clofun2960, 0, 1, closureRef(co, 0));
+Obj _35reg1889 = primIsCons(closureRef(co, 0));
 if (True == _35reg1889) {
-Obj _35reg1890 = primCdr(closureRef(co, 0));
-Obj _35reg1891 = primCar(_35reg1890);
-Obj args = _35reg1891;
+Obj _35reg1890 = primCar(closureRef(co, 0));
+Obj _35reg1891 = primEQ(intern("lambda"), _35reg1890);
+if (True == _35reg1891) {
 Obj _35reg1892 = primCdr(closureRef(co, 0));
-Obj _35reg1893 = primCdr(_35reg1892);
-Obj _35reg1894 = primIsCons(_35reg1893);
-if (True == _35reg1894) {
-Obj _35reg1895 = primCdr(closureRef(co, 0));
-Obj _35reg1896 = primCdr(_35reg1895);
-Obj _35reg1897 = primCar(_35reg1896);
-Obj body = _35reg1897;
-Obj _35reg1898 = primCdr(closureRef(co, 0));
-Obj _35reg1899 = primCdr(_35reg1898);
+Obj _35reg1893 = primIsCons(_35reg1892);
+if (True == _35reg1893) {
+Obj _35reg1894 = primCdr(closureRef(co, 0));
+Obj _35reg1895 = primCar(_35reg1894);
+Obj args = _35reg1895;
+Obj _35reg1896 = primCdr(closureRef(co, 0));
+Obj _35reg1897 = primCdr(_35reg1896);
+Obj _35reg1898 = primIsCons(_35reg1897);
+if (True == _35reg1898) {
+Obj _35reg1899 = primCdr(closureRef(co, 0));
 Obj _35reg1900 = primCdr(_35reg1899);
-Obj _35reg1901 = primEQ(Nil, _35reg1900);
-if (True == _35reg1901) {
-pushCont(co, 0, _35clofun2950, 1, args);
+Obj _35reg1901 = primCar(_35reg1900);
+Obj body = _35reg1901;
+Obj _35reg1902 = primCdr(closureRef(co, 0));
+Obj _35reg1903 = primCdr(_35reg1902);
+Obj _35reg1904 = primCdr(_35reg1903);
+Obj _35reg1905 = primEQ(Nil, _35reg1904);
+if (True == _35reg1905) {
+pushCont(co, 0, _35clofun2978, 1, args);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), body);
 } else {
 coraCall(co, 1, _35cc1271);
@@ -4257,54 +4353,54 @@ coraCall(co, 1, _35cc1271);
 }
 }
 
-void _35clofun2950(struct Cora* co) {
-Obj _35val1902 = co->args[1];
+void _35clofun2978(struct Cora* co) {
+Obj _35val1906 = co->args[1];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1902, args);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1906, args);
 }
 
-void _35clofun2932(struct Cora* co) {
-Obj _35cc1272 = makeNative(0, _35clofun2933, 0, 1, closureRef(co, 0));
-Obj _35reg1855 = primIsCons(closureRef(co, 0));
-if (True == _35reg1855) {
-Obj _35reg1856 = primCar(closureRef(co, 0));
-Obj _35reg1857 = primEQ(intern("if"), _35reg1856);
-if (True == _35reg1857) {
-Obj _35reg1858 = primCdr(closureRef(co, 0));
-Obj _35reg1859 = primIsCons(_35reg1858);
+void _35clofun2960(struct Cora* co) {
+Obj _35cc1272 = makeNative(0, _35clofun2961, 0, 1, closureRef(co, 0));
+Obj _35reg1859 = primIsCons(closureRef(co, 0));
 if (True == _35reg1859) {
-Obj _35reg1860 = primCdr(closureRef(co, 0));
-Obj _35reg1861 = primCar(_35reg1860);
-Obj x = _35reg1861;
+Obj _35reg1860 = primCar(closureRef(co, 0));
+Obj _35reg1861 = primEQ(intern("if"), _35reg1860);
+if (True == _35reg1861) {
 Obj _35reg1862 = primCdr(closureRef(co, 0));
-Obj _35reg1863 = primCdr(_35reg1862);
-Obj _35reg1864 = primIsCons(_35reg1863);
-if (True == _35reg1864) {
-Obj _35reg1865 = primCdr(closureRef(co, 0));
-Obj _35reg1866 = primCdr(_35reg1865);
-Obj _35reg1867 = primCar(_35reg1866);
-Obj y = _35reg1867;
-Obj _35reg1868 = primCdr(closureRef(co, 0));
-Obj _35reg1869 = primCdr(_35reg1868);
+Obj _35reg1863 = primIsCons(_35reg1862);
+if (True == _35reg1863) {
+Obj _35reg1864 = primCdr(closureRef(co, 0));
+Obj _35reg1865 = primCar(_35reg1864);
+Obj x = _35reg1865;
+Obj _35reg1866 = primCdr(closureRef(co, 0));
+Obj _35reg1867 = primCdr(_35reg1866);
+Obj _35reg1868 = primIsCons(_35reg1867);
+if (True == _35reg1868) {
+Obj _35reg1869 = primCdr(closureRef(co, 0));
 Obj _35reg1870 = primCdr(_35reg1869);
-Obj _35reg1871 = primIsCons(_35reg1870);
-if (True == _35reg1871) {
+Obj _35reg1871 = primCar(_35reg1870);
+Obj y = _35reg1871;
 Obj _35reg1872 = primCdr(closureRef(co, 0));
 Obj _35reg1873 = primCdr(_35reg1872);
 Obj _35reg1874 = primCdr(_35reg1873);
-Obj _35reg1875 = primCar(_35reg1874);
-Obj z = _35reg1875;
+Obj _35reg1875 = primIsCons(_35reg1874);
+if (True == _35reg1875) {
 Obj _35reg1876 = primCdr(closureRef(co, 0));
 Obj _35reg1877 = primCdr(_35reg1876);
 Obj _35reg1878 = primCdr(_35reg1877);
-Obj _35reg1879 = primCdr(_35reg1878);
-Obj _35reg1880 = primEQ(Nil, _35reg1879);
-if (True == _35reg1880) {
-Obj _35reg1881 = primCons(z, Nil);
-Obj _35reg1882 = primCons(y, _35reg1881);
-Obj _35reg1883 = primCons(x, _35reg1882);
-pushCont(co, 0, _35clofun2949, 0);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1883);
+Obj _35reg1879 = primCar(_35reg1878);
+Obj z = _35reg1879;
+Obj _35reg1880 = primCdr(closureRef(co, 0));
+Obj _35reg1881 = primCdr(_35reg1880);
+Obj _35reg1882 = primCdr(_35reg1881);
+Obj _35reg1883 = primCdr(_35reg1882);
+Obj _35reg1884 = primEQ(Nil, _35reg1883);
+if (True == _35reg1884) {
+Obj _35reg1885 = primCons(z, Nil);
+Obj _35reg1886 = primCons(y, _35reg1885);
+Obj _35reg1887 = primCons(x, _35reg1886);
+pushCont(co, 0, _35clofun2977, 0);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1887);
 } else {
 coraCall(co, 1, _35cc1272);
 }
@@ -4325,41 +4421,41 @@ coraCall(co, 1, _35cc1272);
 }
 }
 
-void _35clofun2949(struct Cora* co) {
-Obj _35val1884 = co->args[1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1884);
+void _35clofun2977(struct Cora* co) {
+Obj _35val1888 = co->args[1];
+coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1888);
 }
 
-void _35clofun2933(struct Cora* co) {
-Obj _35cc1273 = makeNative(0, _35clofun2934, 0, 1, closureRef(co, 0));
-Obj _35reg1835 = primIsCons(closureRef(co, 0));
-if (True == _35reg1835) {
-Obj _35reg1836 = primCar(closureRef(co, 0));
-Obj _35reg1837 = primEQ(intern("do"), _35reg1836);
-if (True == _35reg1837) {
-Obj _35reg1838 = primCdr(closureRef(co, 0));
-Obj _35reg1839 = primIsCons(_35reg1838);
+void _35clofun2961(struct Cora* co) {
+Obj _35cc1273 = makeNative(0, _35clofun2962, 0, 1, closureRef(co, 0));
+Obj _35reg1839 = primIsCons(closureRef(co, 0));
 if (True == _35reg1839) {
-Obj _35reg1840 = primCdr(closureRef(co, 0));
-Obj _35reg1841 = primCar(_35reg1840);
-Obj x = _35reg1841;
+Obj _35reg1840 = primCar(closureRef(co, 0));
+Obj _35reg1841 = primEQ(intern("do"), _35reg1840);
+if (True == _35reg1841) {
 Obj _35reg1842 = primCdr(closureRef(co, 0));
-Obj _35reg1843 = primCdr(_35reg1842);
-Obj _35reg1844 = primIsCons(_35reg1843);
-if (True == _35reg1844) {
-Obj _35reg1845 = primCdr(closureRef(co, 0));
-Obj _35reg1846 = primCdr(_35reg1845);
-Obj _35reg1847 = primCar(_35reg1846);
-Obj y = _35reg1847;
-Obj _35reg1848 = primCdr(closureRef(co, 0));
-Obj _35reg1849 = primCdr(_35reg1848);
+Obj _35reg1843 = primIsCons(_35reg1842);
+if (True == _35reg1843) {
+Obj _35reg1844 = primCdr(closureRef(co, 0));
+Obj _35reg1845 = primCar(_35reg1844);
+Obj x = _35reg1845;
+Obj _35reg1846 = primCdr(closureRef(co, 0));
+Obj _35reg1847 = primCdr(_35reg1846);
+Obj _35reg1848 = primIsCons(_35reg1847);
+if (True == _35reg1848) {
+Obj _35reg1849 = primCdr(closureRef(co, 0));
 Obj _35reg1850 = primCdr(_35reg1849);
-Obj _35reg1851 = primEQ(Nil, _35reg1850);
-if (True == _35reg1851) {
-Obj _35reg1852 = primCons(y, Nil);
-Obj _35reg1853 = primCons(x, _35reg1852);
-pushCont(co, 0, _35clofun2948, 0);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1853);
+Obj _35reg1851 = primCar(_35reg1850);
+Obj y = _35reg1851;
+Obj _35reg1852 = primCdr(closureRef(co, 0));
+Obj _35reg1853 = primCdr(_35reg1852);
+Obj _35reg1854 = primCdr(_35reg1853);
+Obj _35reg1855 = primEQ(Nil, _35reg1854);
+if (True == _35reg1855) {
+Obj _35reg1856 = primCons(y, Nil);
+Obj _35reg1857 = primCons(x, _35reg1856);
+pushCont(co, 0, _35clofun2976, 0);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1857);
 } else {
 coraCall(co, 1, _35cc1273);
 }
@@ -4377,49 +4473,49 @@ coraCall(co, 1, _35cc1273);
 }
 }
 
-void _35clofun2948(struct Cora* co) {
-Obj _35val1854 = co->args[1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1854);
+void _35clofun2976(struct Cora* co) {
+Obj _35val1858 = co->args[1];
+coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1858);
 }
 
-void _35clofun2934(struct Cora* co) {
-Obj _35cc1274 = makeNative(0, _35clofun2935, 0, 1, closureRef(co, 0));
-Obj _35reg1805 = primIsCons(closureRef(co, 0));
-if (True == _35reg1805) {
-Obj _35reg1806 = primCar(closureRef(co, 0));
-Obj _35reg1807 = primEQ(intern("let"), _35reg1806);
-if (True == _35reg1807) {
-Obj _35reg1808 = primCdr(closureRef(co, 0));
-Obj _35reg1809 = primIsCons(_35reg1808);
+void _35clofun2962(struct Cora* co) {
+Obj _35cc1274 = makeNative(0, _35clofun2963, 0, 1, closureRef(co, 0));
+Obj _35reg1809 = primIsCons(closureRef(co, 0));
 if (True == _35reg1809) {
-Obj _35reg1810 = primCdr(closureRef(co, 0));
-Obj _35reg1811 = primCar(_35reg1810);
-Obj a = _35reg1811;
+Obj _35reg1810 = primCar(closureRef(co, 0));
+Obj _35reg1811 = primEQ(intern("let"), _35reg1810);
+if (True == _35reg1811) {
 Obj _35reg1812 = primCdr(closureRef(co, 0));
-Obj _35reg1813 = primCdr(_35reg1812);
-Obj _35reg1814 = primIsCons(_35reg1813);
-if (True == _35reg1814) {
-Obj _35reg1815 = primCdr(closureRef(co, 0));
-Obj _35reg1816 = primCdr(_35reg1815);
-Obj _35reg1817 = primCar(_35reg1816);
-Obj b = _35reg1817;
-Obj _35reg1818 = primCdr(closureRef(co, 0));
-Obj _35reg1819 = primCdr(_35reg1818);
+Obj _35reg1813 = primIsCons(_35reg1812);
+if (True == _35reg1813) {
+Obj _35reg1814 = primCdr(closureRef(co, 0));
+Obj _35reg1815 = primCar(_35reg1814);
+Obj a = _35reg1815;
+Obj _35reg1816 = primCdr(closureRef(co, 0));
+Obj _35reg1817 = primCdr(_35reg1816);
+Obj _35reg1818 = primIsCons(_35reg1817);
+if (True == _35reg1818) {
+Obj _35reg1819 = primCdr(closureRef(co, 0));
 Obj _35reg1820 = primCdr(_35reg1819);
-Obj _35reg1821 = primIsCons(_35reg1820);
-if (True == _35reg1821) {
+Obj _35reg1821 = primCar(_35reg1820);
+Obj b = _35reg1821;
 Obj _35reg1822 = primCdr(closureRef(co, 0));
 Obj _35reg1823 = primCdr(_35reg1822);
 Obj _35reg1824 = primCdr(_35reg1823);
-Obj _35reg1825 = primCar(_35reg1824);
-Obj c = _35reg1825;
+Obj _35reg1825 = primIsCons(_35reg1824);
+if (True == _35reg1825) {
 Obj _35reg1826 = primCdr(closureRef(co, 0));
 Obj _35reg1827 = primCdr(_35reg1826);
 Obj _35reg1828 = primCdr(_35reg1827);
-Obj _35reg1829 = primCdr(_35reg1828);
-Obj _35reg1830 = primEQ(Nil, _35reg1829);
-if (True == _35reg1830) {
-pushCont(co, 0, _35clofun2945, 2, c, a);
+Obj _35reg1829 = primCar(_35reg1828);
+Obj c = _35reg1829;
+Obj _35reg1830 = primCdr(closureRef(co, 0));
+Obj _35reg1831 = primCdr(_35reg1830);
+Obj _35reg1832 = primCdr(_35reg1831);
+Obj _35reg1833 = primCdr(_35reg1832);
+Obj _35reg1834 = primEQ(Nil, _35reg1833);
+if (True == _35reg1834) {
+pushCont(co, 0, _35clofun2973, 2, c, a);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), b);
 } else {
 coraCall(co, 1, _35cc1274);
@@ -4441,47 +4537,47 @@ coraCall(co, 1, _35cc1274);
 }
 }
 
-void _35clofun2945(struct Cora* co) {
-Obj _35val1831 = co->args[1];
+void _35clofun2973(struct Cora* co) {
+Obj _35val1835 = co->args[1];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2946, 2, a, _35val1831);
+pushCont(co, 0, _35clofun2974, 2, a, _35val1835);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), c);
 }
 
-void _35clofun2946(struct Cora* co) {
-Obj _35val1832 = co->args[1];
+void _35clofun2974(struct Cora* co) {
+Obj _35val1836 = co->args[1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val1831 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1833 = primCons(a, Nil);
-pushCont(co, 0, _35clofun2947, 1, _35val1831);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1832, _35reg1833);
+Obj _35val1835 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1837 = primCons(a, Nil);
+pushCont(co, 0, _35clofun2975, 1, _35val1835);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1836, _35reg1837);
 }
 
-void _35clofun2947(struct Cora* co) {
-Obj _35val1834 = co->args[1];
-Obj _35val1831 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), _35val1831, _35val1834);
+void _35clofun2975(struct Cora* co) {
+Obj _35val1838 = co->args[1];
+Obj _35val1835 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), _35val1835, _35val1838);
 }
 
-void _35clofun2935(struct Cora* co) {
-Obj _35cc1275 = makeNative(0, _35clofun2936, 0, 1, closureRef(co, 0));
-Obj _35reg1795 = primIsCons(closureRef(co, 0));
-if (True == _35reg1795) {
-Obj _35reg1796 = primCar(closureRef(co, 0));
-Obj _35reg1797 = primEQ(intern("%closure"), _35reg1796);
-if (True == _35reg1797) {
-Obj _35reg1798 = primCdr(closureRef(co, 0));
-Obj _35reg1799 = primIsCons(_35reg1798);
+void _35clofun2963(struct Cora* co) {
+Obj _35cc1275 = makeNative(0, _35clofun2964, 0, 1, closureRef(co, 0));
+Obj _35reg1799 = primIsCons(closureRef(co, 0));
 if (True == _35reg1799) {
-Obj _35reg1800 = primCdr(closureRef(co, 0));
-Obj _35reg1801 = primCar(_35reg1800);
-Obj lam = _35reg1801;
+Obj _35reg1800 = primCar(closureRef(co, 0));
+Obj _35reg1801 = primEQ(intern("%closure"), _35reg1800);
+if (True == _35reg1801) {
 Obj _35reg1802 = primCdr(closureRef(co, 0));
-Obj _35reg1803 = primCdr(_35reg1802);
-Obj more = _35reg1803;
-Obj _35reg1804 = primCons(lam, more);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), _35reg1804);
+Obj _35reg1803 = primIsCons(_35reg1802);
+if (True == _35reg1803) {
+Obj _35reg1804 = primCdr(closureRef(co, 0));
+Obj _35reg1805 = primCar(_35reg1804);
+Obj lam = _35reg1805;
+Obj _35reg1806 = primCdr(closureRef(co, 0));
+Obj _35reg1807 = primCdr(_35reg1806);
+Obj more = _35reg1807;
+Obj _35reg1808 = primCons(lam, more);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), _35reg1808);
 } else {
 coraCall(co, 1, _35cc1275);
 }
@@ -4493,23 +4589,23 @@ coraCall(co, 1, _35cc1275);
 }
 }
 
-void _35clofun2936(struct Cora* co) {
-Obj _35cc1276 = makeNative(0, _35clofun2937, 0, 1, closureRef(co, 0));
-Obj _35reg1785 = primIsCons(closureRef(co, 0));
-if (True == _35reg1785) {
-Obj _35reg1786 = primCar(closureRef(co, 0));
-Obj _35reg1787 = primEQ(intern("return"), _35reg1786);
-if (True == _35reg1787) {
-Obj _35reg1788 = primCdr(closureRef(co, 0));
-Obj _35reg1789 = primIsCons(_35reg1788);
+void _35clofun2964(struct Cora* co) {
+Obj _35cc1276 = makeNative(0, _35clofun2965, 0, 1, closureRef(co, 0));
+Obj _35reg1789 = primIsCons(closureRef(co, 0));
 if (True == _35reg1789) {
-Obj _35reg1790 = primCdr(closureRef(co, 0));
-Obj _35reg1791 = primCar(_35reg1790);
-Obj x = _35reg1791;
+Obj _35reg1790 = primCar(closureRef(co, 0));
+Obj _35reg1791 = primEQ(intern("return"), _35reg1790);
+if (True == _35reg1791) {
 Obj _35reg1792 = primCdr(closureRef(co, 0));
-Obj _35reg1793 = primCdr(_35reg1792);
-Obj _35reg1794 = primEQ(Nil, _35reg1793);
-if (True == _35reg1794) {
+Obj _35reg1793 = primIsCons(_35reg1792);
+if (True == _35reg1793) {
+Obj _35reg1794 = primCdr(closureRef(co, 0));
+Obj _35reg1795 = primCar(_35reg1794);
+Obj x = _35reg1795;
+Obj _35reg1796 = primCdr(closureRef(co, 0));
+Obj _35reg1797 = primCdr(_35reg1796);
+Obj _35reg1798 = primEQ(Nil, _35reg1797);
+if (True == _35reg1798) {
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), x);
 } else {
 coraCall(co, 1, _35cc1276);
@@ -4525,36 +4621,36 @@ coraCall(co, 1, _35cc1276);
 }
 }
 
-void _35clofun2937(struct Cora* co) {
-Obj _35cc1277 = makeNative(0, _35clofun2938, 0, 1, closureRef(co, 0));
-Obj _35reg1765 = primIsCons(closureRef(co, 0));
-if (True == _35reg1765) {
-Obj _35reg1766 = primCar(closureRef(co, 0));
-Obj _35reg1767 = primEQ(intern("call"), _35reg1766);
-if (True == _35reg1767) {
-Obj _35reg1768 = primCdr(closureRef(co, 0));
-Obj _35reg1769 = primIsCons(_35reg1768);
+void _35clofun2965(struct Cora* co) {
+Obj _35cc1277 = makeNative(0, _35clofun2966, 0, 1, closureRef(co, 0));
+Obj _35reg1769 = primIsCons(closureRef(co, 0));
 if (True == _35reg1769) {
-Obj _35reg1770 = primCdr(closureRef(co, 0));
-Obj _35reg1771 = primCar(_35reg1770);
-Obj exp = _35reg1771;
+Obj _35reg1770 = primCar(closureRef(co, 0));
+Obj _35reg1771 = primEQ(intern("call"), _35reg1770);
+if (True == _35reg1771) {
 Obj _35reg1772 = primCdr(closureRef(co, 0));
-Obj _35reg1773 = primCdr(_35reg1772);
-Obj _35reg1774 = primIsCons(_35reg1773);
-if (True == _35reg1774) {
-Obj _35reg1775 = primCdr(closureRef(co, 0));
-Obj _35reg1776 = primCdr(_35reg1775);
-Obj _35reg1777 = primCar(_35reg1776);
-Obj cont = _35reg1777;
-Obj _35reg1778 = primCdr(closureRef(co, 0));
-Obj _35reg1779 = primCdr(_35reg1778);
+Obj _35reg1773 = primIsCons(_35reg1772);
+if (True == _35reg1773) {
+Obj _35reg1774 = primCdr(closureRef(co, 0));
+Obj _35reg1775 = primCar(_35reg1774);
+Obj exp = _35reg1775;
+Obj _35reg1776 = primCdr(closureRef(co, 0));
+Obj _35reg1777 = primCdr(_35reg1776);
+Obj _35reg1778 = primIsCons(_35reg1777);
+if (True == _35reg1778) {
+Obj _35reg1779 = primCdr(closureRef(co, 0));
 Obj _35reg1780 = primCdr(_35reg1779);
-Obj _35reg1781 = primEQ(Nil, _35reg1780);
-if (True == _35reg1781) {
-Obj _35reg1782 = primCons(cont, Nil);
-Obj _35reg1783 = primCons(exp, _35reg1782);
-pushCont(co, 0, _35clofun2944, 0);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1783);
+Obj _35reg1781 = primCar(_35reg1780);
+Obj cont = _35reg1781;
+Obj _35reg1782 = primCdr(closureRef(co, 0));
+Obj _35reg1783 = primCdr(_35reg1782);
+Obj _35reg1784 = primCdr(_35reg1783);
+Obj _35reg1785 = primEQ(Nil, _35reg1784);
+if (True == _35reg1785) {
+Obj _35reg1786 = primCons(cont, Nil);
+Obj _35reg1787 = primCons(exp, _35reg1786);
+pushCont(co, 0, _35clofun2972, 0);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1787);
 } else {
 coraCall(co, 1, _35cc1277);
 }
@@ -4572,28 +4668,28 @@ coraCall(co, 1, _35cc1277);
 }
 }
 
-void _35clofun2944(struct Cora* co) {
-Obj _35val1784 = co->args[1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1784);
+void _35clofun2972(struct Cora* co) {
+Obj _35val1788 = co->args[1];
+coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1788);
 }
 
-void _35clofun2938(struct Cora* co) {
-Obj _35cc1278 = makeNative(0, _35clofun2939, 0, 1, closureRef(co, 0));
-Obj _35reg1755 = primIsCons(closureRef(co, 0));
-if (True == _35reg1755) {
-Obj _35reg1756 = primCar(closureRef(co, 0));
-Obj _35reg1757 = primEQ(intern("tailcall"), _35reg1756);
-if (True == _35reg1757) {
-Obj _35reg1758 = primCdr(closureRef(co, 0));
-Obj _35reg1759 = primIsCons(_35reg1758);
+void _35clofun2966(struct Cora* co) {
+Obj _35cc1278 = makeNative(0, _35clofun2967, 0, 1, closureRef(co, 0));
+Obj _35reg1759 = primIsCons(closureRef(co, 0));
 if (True == _35reg1759) {
-Obj _35reg1760 = primCdr(closureRef(co, 0));
-Obj _35reg1761 = primCar(_35reg1760);
-Obj exp = _35reg1761;
+Obj _35reg1760 = primCar(closureRef(co, 0));
+Obj _35reg1761 = primEQ(intern("tailcall"), _35reg1760);
+if (True == _35reg1761) {
 Obj _35reg1762 = primCdr(closureRef(co, 0));
-Obj _35reg1763 = primCdr(_35reg1762);
-Obj _35reg1764 = primEQ(Nil, _35reg1763);
-if (True == _35reg1764) {
+Obj _35reg1763 = primIsCons(_35reg1762);
+if (True == _35reg1763) {
+Obj _35reg1764 = primCdr(closureRef(co, 0));
+Obj _35reg1765 = primCar(_35reg1764);
+Obj exp = _35reg1765;
+Obj _35reg1766 = primCdr(closureRef(co, 0));
+Obj _35reg1767 = primCdr(_35reg1766);
+Obj _35reg1768 = primEQ(Nil, _35reg1767);
+if (True == _35reg1768) {
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), exp);
 } else {
 coraCall(co, 1, _35cc1278);
@@ -4609,33 +4705,33 @@ coraCall(co, 1, _35cc1278);
 }
 }
 
-void _35clofun2939(struct Cora* co) {
-Obj _35cc1279 = makeNative(0, _35clofun2940, 0, 1, closureRef(co, 0));
-Obj _35reg1737 = primIsCons(closureRef(co, 0));
-if (True == _35reg1737) {
-Obj _35reg1738 = primCar(closureRef(co, 0));
-Obj _35reg1739 = primEQ(intern("continuation"), _35reg1738);
-if (True == _35reg1739) {
-Obj _35reg1740 = primCdr(closureRef(co, 0));
-Obj _35reg1741 = primIsCons(_35reg1740);
+void _35clofun2967(struct Cora* co) {
+Obj _35cc1279 = makeNative(0, _35clofun2968, 0, 1, closureRef(co, 0));
+Obj _35reg1741 = primIsCons(closureRef(co, 0));
 if (True == _35reg1741) {
-Obj _35reg1742 = primCdr(closureRef(co, 0));
-Obj _35reg1743 = primCar(_35reg1742);
-Obj arg = _35reg1743;
+Obj _35reg1742 = primCar(closureRef(co, 0));
+Obj _35reg1743 = primEQ(intern("continuation"), _35reg1742);
+if (True == _35reg1743) {
 Obj _35reg1744 = primCdr(closureRef(co, 0));
-Obj _35reg1745 = primCdr(_35reg1744);
-Obj _35reg1746 = primIsCons(_35reg1745);
-if (True == _35reg1746) {
-Obj _35reg1747 = primCdr(closureRef(co, 0));
-Obj _35reg1748 = primCdr(_35reg1747);
-Obj _35reg1749 = primCar(_35reg1748);
-Obj body = _35reg1749;
-Obj _35reg1750 = primCdr(closureRef(co, 0));
-Obj _35reg1751 = primCdr(_35reg1750);
+Obj _35reg1745 = primIsCons(_35reg1744);
+if (True == _35reg1745) {
+Obj _35reg1746 = primCdr(closureRef(co, 0));
+Obj _35reg1747 = primCar(_35reg1746);
+Obj arg = _35reg1747;
+Obj _35reg1748 = primCdr(closureRef(co, 0));
+Obj _35reg1749 = primCdr(_35reg1748);
+Obj _35reg1750 = primIsCons(_35reg1749);
+if (True == _35reg1750) {
+Obj _35reg1751 = primCdr(closureRef(co, 0));
 Obj _35reg1752 = primCdr(_35reg1751);
-Obj _35reg1753 = primEQ(Nil, _35reg1752);
-if (True == _35reg1753) {
-pushCont(co, 0, _35clofun2943, 1, arg);
+Obj _35reg1753 = primCar(_35reg1752);
+Obj body = _35reg1753;
+Obj _35reg1754 = primCdr(closureRef(co, 0));
+Obj _35reg1755 = primCdr(_35reg1754);
+Obj _35reg1756 = primCdr(_35reg1755);
+Obj _35reg1757 = primEQ(Nil, _35reg1756);
+if (True == _35reg1757) {
+pushCont(co, 0, _35clofun2971, 1, arg);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), body);
 } else {
 coraCall(co, 1, _35cc1279);
@@ -4654,55 +4750,55 @@ coraCall(co, 1, _35cc1279);
 }
 }
 
-void _35clofun2943(struct Cora* co) {
-Obj _35val1754 = co->args[1];
+void _35clofun2971(struct Cora* co) {
+Obj _35val1758 = co->args[1];
 Obj arg = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1754, arg);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1758, arg);
 }
 
-void _35clofun2940(struct Cora* co) {
-Obj _35cc1280 = makeNative(0, _35clofun2941, 0, 0);
-Obj _35reg1732 = primIsCons(closureRef(co, 0));
-if (True == _35reg1732) {
-Obj _35reg1733 = primCar(closureRef(co, 0));
-Obj f = _35reg1733;
-Obj _35reg1734 = primCdr(closureRef(co, 0));
-Obj args = _35reg1734;
-Obj _35reg1735 = primCons(f, args);
-pushCont(co, 0, _35clofun2942, 0);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1735);
+void _35clofun2968(struct Cora* co) {
+Obj _35cc1280 = makeNative(0, _35clofun2969, 0, 0);
+Obj _35reg1736 = primIsCons(closureRef(co, 0));
+if (True == _35reg1736) {
+Obj _35reg1737 = primCar(closureRef(co, 0));
+Obj f = _35reg1737;
+Obj _35reg1738 = primCdr(closureRef(co, 0));
+Obj args = _35reg1738;
+Obj _35reg1739 = primCons(f, args);
+pushCont(co, 0, _35clofun2970, 0);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1739);
 } else {
 coraCall(co, 1, _35cc1280);
 }
 }
 
-void _35clofun2942(struct Cora* co) {
-Obj _35val1736 = co->args[1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1736);
+void _35clofun2970(struct Cora* co) {
+Obj _35val1740 = co->args[1];
+coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1740);
 }
 
-void _35clofun2941(struct Cora* co) {
+void _35clofun2969(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2922(struct Cora* co) {
+void _35clofun2950(struct Cora* co) {
 Obj _35p1261 = co->args[1];
-Obj _35cc1262 = makeNative(0, _35clofun2923, 0, 1, _35p1261);
-Obj _35reg1721 = primIsCons(_35p1261);
-if (True == _35reg1721) {
-Obj _35reg1722 = primCar(_35p1261);
-Obj _35reg1723 = primEQ(intern("%const"), _35reg1722);
-if (True == _35reg1723) {
-Obj _35reg1724 = primCdr(_35p1261);
-Obj _35reg1725 = primIsCons(_35reg1724);
+Obj _35cc1262 = makeNative(0, _35clofun2951, 0, 1, _35p1261);
+Obj _35reg1725 = primIsCons(_35p1261);
 if (True == _35reg1725) {
-Obj _35reg1726 = primCdr(_35p1261);
-Obj _35reg1727 = primCar(_35reg1726);
-Obj x = _35reg1727;
+Obj _35reg1726 = primCar(_35p1261);
+Obj _35reg1727 = primEQ(intern("%const"), _35reg1726);
+if (True == _35reg1727) {
 Obj _35reg1728 = primCdr(_35p1261);
-Obj _35reg1729 = primCdr(_35reg1728);
-Obj _35reg1730 = primEQ(Nil, _35reg1729);
-if (True == _35reg1730) {
+Obj _35reg1729 = primIsCons(_35reg1728);
+if (True == _35reg1729) {
+Obj _35reg1730 = primCdr(_35p1261);
+Obj _35reg1731 = primCar(_35reg1730);
+Obj x = _35reg1731;
+Obj _35reg1732 = primCdr(_35p1261);
+Obj _35reg1733 = primCdr(_35reg1732);
+Obj _35reg1734 = primEQ(Nil, _35reg1733);
+if (True == _35reg1734) {
 coraReturn(co, True);
 return;
 } else {
@@ -4719,23 +4815,23 @@ coraCall(co, 1, _35cc1262);
 }
 }
 
-void _35clofun2923(struct Cora* co) {
-Obj _35cc1263 = makeNative(0, _35clofun2924, 0, 1, closureRef(co, 0));
-Obj _35reg1711 = primIsCons(closureRef(co, 0));
-if (True == _35reg1711) {
-Obj _35reg1712 = primCar(closureRef(co, 0));
-Obj _35reg1713 = primEQ(intern("%global"), _35reg1712);
-if (True == _35reg1713) {
-Obj _35reg1714 = primCdr(closureRef(co, 0));
-Obj _35reg1715 = primIsCons(_35reg1714);
+void _35clofun2951(struct Cora* co) {
+Obj _35cc1263 = makeNative(0, _35clofun2952, 0, 1, closureRef(co, 0));
+Obj _35reg1715 = primIsCons(closureRef(co, 0));
 if (True == _35reg1715) {
-Obj _35reg1716 = primCdr(closureRef(co, 0));
-Obj _35reg1717 = primCar(_35reg1716);
-Obj x = _35reg1717;
+Obj _35reg1716 = primCar(closureRef(co, 0));
+Obj _35reg1717 = primEQ(intern("%global"), _35reg1716);
+if (True == _35reg1717) {
 Obj _35reg1718 = primCdr(closureRef(co, 0));
-Obj _35reg1719 = primCdr(_35reg1718);
-Obj _35reg1720 = primEQ(Nil, _35reg1719);
-if (True == _35reg1720) {
+Obj _35reg1719 = primIsCons(_35reg1718);
+if (True == _35reg1719) {
+Obj _35reg1720 = primCdr(closureRef(co, 0));
+Obj _35reg1721 = primCar(_35reg1720);
+Obj x = _35reg1721;
+Obj _35reg1722 = primCdr(closureRef(co, 0));
+Obj _35reg1723 = primCdr(_35reg1722);
+Obj _35reg1724 = primEQ(Nil, _35reg1723);
+if (True == _35reg1724) {
 coraReturn(co, True);
 return;
 } else {
@@ -4752,23 +4848,23 @@ coraCall(co, 1, _35cc1263);
 }
 }
 
-void _35clofun2924(struct Cora* co) {
-Obj _35cc1264 = makeNative(0, _35clofun2925, 0, 1, closureRef(co, 0));
-Obj _35reg1701 = primIsCons(closureRef(co, 0));
-if (True == _35reg1701) {
-Obj _35reg1702 = primCar(closureRef(co, 0));
-Obj _35reg1703 = primEQ(intern("%builtin"), _35reg1702);
-if (True == _35reg1703) {
-Obj _35reg1704 = primCdr(closureRef(co, 0));
-Obj _35reg1705 = primIsCons(_35reg1704);
+void _35clofun2952(struct Cora* co) {
+Obj _35cc1264 = makeNative(0, _35clofun2953, 0, 1, closureRef(co, 0));
+Obj _35reg1705 = primIsCons(closureRef(co, 0));
 if (True == _35reg1705) {
-Obj _35reg1706 = primCdr(closureRef(co, 0));
-Obj _35reg1707 = primCar(_35reg1706);
-Obj op = _35reg1707;
+Obj _35reg1706 = primCar(closureRef(co, 0));
+Obj _35reg1707 = primEQ(intern("%builtin"), _35reg1706);
+if (True == _35reg1707) {
 Obj _35reg1708 = primCdr(closureRef(co, 0));
-Obj _35reg1709 = primCdr(_35reg1708);
-Obj _35reg1710 = primEQ(Nil, _35reg1709);
-if (True == _35reg1710) {
+Obj _35reg1709 = primIsCons(_35reg1708);
+if (True == _35reg1709) {
+Obj _35reg1710 = primCdr(closureRef(co, 0));
+Obj _35reg1711 = primCar(_35reg1710);
+Obj op = _35reg1711;
+Obj _35reg1712 = primCdr(closureRef(co, 0));
+Obj _35reg1713 = primCdr(_35reg1712);
+Obj _35reg1714 = primEQ(Nil, _35reg1713);
+if (True == _35reg1714) {
 coraReturn(co, True);
 return;
 } else {
@@ -4785,23 +4881,23 @@ coraCall(co, 1, _35cc1264);
 }
 }
 
-void _35clofun2925(struct Cora* co) {
-Obj _35cc1265 = makeNative(0, _35clofun2926, 0, 1, closureRef(co, 0));
-Obj _35reg1691 = primIsCons(closureRef(co, 0));
-if (True == _35reg1691) {
-Obj _35reg1692 = primCar(closureRef(co, 0));
-Obj _35reg1693 = primEQ(intern("quote"), _35reg1692);
-if (True == _35reg1693) {
-Obj _35reg1694 = primCdr(closureRef(co, 0));
-Obj _35reg1695 = primIsCons(_35reg1694);
+void _35clofun2953(struct Cora* co) {
+Obj _35cc1265 = makeNative(0, _35clofun2954, 0, 1, closureRef(co, 0));
+Obj _35reg1695 = primIsCons(closureRef(co, 0));
 if (True == _35reg1695) {
-Obj _35reg1696 = primCdr(closureRef(co, 0));
-Obj _35reg1697 = primCar(_35reg1696);
-Obj x = _35reg1697;
+Obj _35reg1696 = primCar(closureRef(co, 0));
+Obj _35reg1697 = primEQ(intern("quote"), _35reg1696);
+if (True == _35reg1697) {
 Obj _35reg1698 = primCdr(closureRef(co, 0));
-Obj _35reg1699 = primCdr(_35reg1698);
-Obj _35reg1700 = primEQ(Nil, _35reg1699);
-if (True == _35reg1700) {
+Obj _35reg1699 = primIsCons(_35reg1698);
+if (True == _35reg1699) {
+Obj _35reg1700 = primCdr(closureRef(co, 0));
+Obj _35reg1701 = primCar(_35reg1700);
+Obj x = _35reg1701;
+Obj _35reg1702 = primCdr(closureRef(co, 0));
+Obj _35reg1703 = primCdr(_35reg1702);
+Obj _35reg1704 = primEQ(Nil, _35reg1703);
+if (True == _35reg1704) {
 coraReturn(co, True);
 return;
 } else {
@@ -4818,23 +4914,23 @@ coraCall(co, 1, _35cc1265);
 }
 }
 
-void _35clofun2926(struct Cora* co) {
-Obj _35cc1266 = makeNative(0, _35clofun2927, 0, 1, closureRef(co, 0));
-Obj _35reg1681 = primIsCons(closureRef(co, 0));
-if (True == _35reg1681) {
-Obj _35reg1682 = primCar(closureRef(co, 0));
-Obj _35reg1683 = primEQ(intern("%closure-ref"), _35reg1682);
-if (True == _35reg1683) {
-Obj _35reg1684 = primCdr(closureRef(co, 0));
-Obj _35reg1685 = primIsCons(_35reg1684);
+void _35clofun2954(struct Cora* co) {
+Obj _35cc1266 = makeNative(0, _35clofun2955, 0, 1, closureRef(co, 0));
+Obj _35reg1685 = primIsCons(closureRef(co, 0));
 if (True == _35reg1685) {
-Obj _35reg1686 = primCdr(closureRef(co, 0));
-Obj _35reg1687 = primCar(_35reg1686);
-Obj __ = _35reg1687;
+Obj _35reg1686 = primCar(closureRef(co, 0));
+Obj _35reg1687 = primEQ(intern("%closure-ref"), _35reg1686);
+if (True == _35reg1687) {
 Obj _35reg1688 = primCdr(closureRef(co, 0));
-Obj _35reg1689 = primCdr(_35reg1688);
-Obj _35reg1690 = primEQ(Nil, _35reg1689);
-if (True == _35reg1690) {
+Obj _35reg1689 = primIsCons(_35reg1688);
+if (True == _35reg1689) {
+Obj _35reg1690 = primCdr(closureRef(co, 0));
+Obj _35reg1691 = primCar(_35reg1690);
+Obj __ = _35reg1691;
+Obj _35reg1692 = primCdr(closureRef(co, 0));
+Obj _35reg1693 = primCdr(_35reg1692);
+Obj _35reg1694 = primEQ(Nil, _35reg1693);
+if (True == _35reg1694) {
 coraReturn(co, True);
 return;
 } else {
@@ -4851,23 +4947,23 @@ coraCall(co, 1, _35cc1266);
 }
 }
 
-void _35clofun2927(struct Cora* co) {
-Obj _35cc1267 = makeNative(0, _35clofun2928, 0, 0);
+void _35clofun2955(struct Cora* co) {
+Obj _35cc1267 = makeNative(0, _35clofun2956, 0, 0);
 Obj x = closureRef(co, 0);
 coraReturn(co, False);
 return;
 }
 
-void _35clofun2928(struct Cora* co) {
+void _35clofun2956(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2916(struct Cora* co) {
+void _35clofun2944(struct Cora* co) {
 Obj _35p1256 = co->args[1];
 Obj _35p1257 = co->args[2];
-Obj _35cc1258 = makeNative(0, _35clofun2917, 0, 2, _35p1256, _35p1257);
-Obj _35reg1679 = primEQ(Nil, _35p1256);
-if (True == _35reg1679) {
+Obj _35cc1258 = makeNative(0, _35clofun2945, 0, 2, _35p1256, _35p1257);
+Obj _35reg1683 = primEQ(Nil, _35p1256);
+if (True == _35reg1683) {
 Obj __ = _35p1257;
 coraReturn(co, Nil);
 return;
@@ -4876,68 +4972,68 @@ coraCall(co, 1, _35cc1258);
 }
 }
 
-void _35clofun2917(struct Cora* co) {
-Obj _35cc1259 = makeNative(0, _35clofun2918, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1675 = primIsCons(closureRef(co, 0));
-if (True == _35reg1675) {
-Obj _35reg1676 = primCar(closureRef(co, 0));
-Obj x = _35reg1676;
-Obj _35reg1677 = primCdr(closureRef(co, 0));
-Obj y = _35reg1677;
+void _35clofun2945(struct Cora* co) {
+Obj _35cc1259 = makeNative(0, _35clofun2946, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1679 = primIsCons(closureRef(co, 0));
+if (True == _35reg1679) {
+Obj _35reg1680 = primCar(closureRef(co, 0));
+Obj x = _35reg1680;
+Obj _35reg1681 = primCdr(closureRef(co, 0));
+Obj y = _35reg1681;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 0, _35clofun2921, 3, y, s2, _35cc1259);
+pushCont(co, 0, _35clofun2949, 3, y, s2, _35cc1259);
 coraCall(co, 3, globalRef(intern("elem?")), x, s2);
 } else {
 coraCall(co, 1, _35cc1259);
 }
 }
 
-void _35clofun2921(struct Cora* co) {
-Obj _35val1678 = co->args[1];
+void _35clofun2949(struct Cora* co) {
+Obj _35val1682 = co->args[1];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s2 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35cc1259 = co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1678) {
+if (True == _35val1682) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), y, s2);
 } else {
 coraCall(co, 1, _35cc1259);
 }
 }
 
-void _35clofun2918(struct Cora* co) {
-Obj _35cc1260 = makeNative(0, _35clofun2919, 0, 0);
-Obj _35reg1670 = primIsCons(closureRef(co, 0));
-if (True == _35reg1670) {
-Obj _35reg1671 = primCar(closureRef(co, 0));
-Obj x = _35reg1671;
-Obj _35reg1672 = primCdr(closureRef(co, 0));
-Obj y = _35reg1672;
+void _35clofun2946(struct Cora* co) {
+Obj _35cc1260 = makeNative(0, _35clofun2947, 0, 0);
+Obj _35reg1674 = primIsCons(closureRef(co, 0));
+if (True == _35reg1674) {
+Obj _35reg1675 = primCar(closureRef(co, 0));
+Obj x = _35reg1675;
+Obj _35reg1676 = primCdr(closureRef(co, 0));
+Obj y = _35reg1676;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 0, _35clofun2920, 1, x);
+pushCont(co, 0, _35clofun2948, 1, x);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), y, s2);
 } else {
 coraCall(co, 1, _35cc1260);
 }
 }
 
-void _35clofun2920(struct Cora* co) {
-Obj _35val1673 = co->args[1];
+void _35clofun2948(struct Cora* co) {
+Obj _35val1677 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1674 = primCons(x, _35val1673);
-coraReturn(co, _35reg1674);
+Obj _35reg1678 = primCons(x, _35val1677);
+coraReturn(co, _35reg1678);
 return;
 }
 
-void _35clofun2919(struct Cora* co) {
+void _35clofun2947(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2910(struct Cora* co) {
+void _35clofun2938(struct Cora* co) {
 Obj _35p1251 = co->args[1];
 Obj _35p1252 = co->args[2];
-Obj _35cc1253 = makeNative(0, _35clofun2911, 0, 2, _35p1251, _35p1252);
-Obj _35reg1668 = primEQ(Nil, _35p1251);
-if (True == _35reg1668) {
+Obj _35cc1253 = makeNative(0, _35clofun2939, 0, 2, _35p1251, _35p1252);
+Obj _35reg1672 = primEQ(Nil, _35p1251);
+if (True == _35reg1672) {
 Obj s2 = _35p1252;
 coraReturn(co, s2);
 return;
@@ -4946,140 +5042,140 @@ coraCall(co, 1, _35cc1253);
 }
 }
 
-void _35clofun2911(struct Cora* co) {
-Obj _35cc1254 = makeNative(0, _35clofun2912, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1664 = primIsCons(closureRef(co, 0));
-if (True == _35reg1664) {
-Obj _35reg1665 = primCar(closureRef(co, 0));
-Obj x = _35reg1665;
-Obj _35reg1666 = primCdr(closureRef(co, 0));
-Obj y = _35reg1666;
+void _35clofun2939(struct Cora* co) {
+Obj _35cc1254 = makeNative(0, _35clofun2940, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1668 = primIsCons(closureRef(co, 0));
+if (True == _35reg1668) {
+Obj _35reg1669 = primCar(closureRef(co, 0));
+Obj x = _35reg1669;
+Obj _35reg1670 = primCdr(closureRef(co, 0));
+Obj y = _35reg1670;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 0, _35clofun2915, 3, y, s2, _35cc1254);
+pushCont(co, 0, _35clofun2943, 3, y, s2, _35cc1254);
 coraCall(co, 3, globalRef(intern("elem?")), x, s2);
 } else {
 coraCall(co, 1, _35cc1254);
 }
 }
 
-void _35clofun2915(struct Cora* co) {
-Obj _35val1667 = co->args[1];
+void _35clofun2943(struct Cora* co) {
+Obj _35val1671 = co->args[1];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s2 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35cc1254 = co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1667) {
+if (True == _35val1671) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), y, s2);
 } else {
 coraCall(co, 1, _35cc1254);
 }
 }
 
-void _35clofun2912(struct Cora* co) {
-Obj _35cc1255 = makeNative(0, _35clofun2913, 0, 0);
-Obj _35reg1659 = primIsCons(closureRef(co, 0));
-if (True == _35reg1659) {
-Obj _35reg1660 = primCar(closureRef(co, 0));
-Obj x = _35reg1660;
-Obj _35reg1661 = primCdr(closureRef(co, 0));
-Obj y = _35reg1661;
+void _35clofun2940(struct Cora* co) {
+Obj _35cc1255 = makeNative(0, _35clofun2941, 0, 0);
+Obj _35reg1663 = primIsCons(closureRef(co, 0));
+if (True == _35reg1663) {
+Obj _35reg1664 = primCar(closureRef(co, 0));
+Obj x = _35reg1664;
+Obj _35reg1665 = primCdr(closureRef(co, 0));
+Obj y = _35reg1665;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 0, _35clofun2914, 1, x);
+pushCont(co, 0, _35clofun2942, 1, x);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), y, s2);
 } else {
 coraCall(co, 1, _35cc1255);
 }
 }
 
-void _35clofun2914(struct Cora* co) {
-Obj _35val1662 = co->args[1];
+void _35clofun2942(struct Cora* co) {
+Obj _35val1666 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1663 = primCons(x, _35val1662);
-coraReturn(co, _35reg1663);
+Obj _35reg1667 = primCons(x, _35val1666);
+coraReturn(co, _35reg1667);
 return;
 }
 
-void _35clofun2913(struct Cora* co) {
+void _35clofun2941(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2880(struct Cora* co) {
+void _35clofun2908(struct Cora* co) {
 Obj _35p1240 = co->args[1];
 Obj _35p1241 = co->args[2];
-Obj _35cc1242 = makeNative(0, _35clofun2881, 0, 2, _35p1240, _35p1241);
+Obj _35cc1242 = makeNative(0, _35clofun2909, 0, 2, _35p1240, _35p1241);
 Obj __ = _35p1240;
 Obj x = _35p1241;
-pushCont(co, 0, _35clofun2907, 2, x, _35cc1242);
+pushCont(co, 0, _35clofun2935, 2, x, _35cc1242);
 coraCall(co, 2, globalRef(intern("number?")), x);
 }
 
-void _35clofun2907(struct Cora* co) {
-Obj _35val1644 = co->args[1];
+void _35clofun2935(struct Cora* co) {
+Obj _35val1648 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35cc1242 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1644) {
+if (True == _35val1648) {
 if (True == True) {
-Obj _35reg1645 = primCons(x, Nil);
-Obj _35reg1646 = primCons(intern("%const"), _35reg1645);
-coraReturn(co, _35reg1646);
+Obj _35reg1649 = primCons(x, Nil);
+Obj _35reg1650 = primCons(intern("%const"), _35reg1649);
+coraReturn(co, _35reg1650);
 return;
 } else {
 coraCall(co, 1, _35cc1242);
 }
 } else {
-Obj _35reg1647 = primIsString(x);
-if (True == _35reg1647) {
+Obj _35reg1651 = primIsString(x);
+if (True == _35reg1651) {
 if (True == True) {
-Obj _35reg1648 = primCons(x, Nil);
-Obj _35reg1649 = primCons(intern("%const"), _35reg1648);
-coraReturn(co, _35reg1649);
+Obj _35reg1652 = primCons(x, Nil);
+Obj _35reg1653 = primCons(intern("%const"), _35reg1652);
+coraReturn(co, _35reg1653);
 return;
 } else {
 coraCall(co, 1, _35cc1242);
 }
 } else {
-pushCont(co, 0, _35clofun2908, 2, x, _35cc1242);
+pushCont(co, 0, _35clofun2936, 2, x, _35cc1242);
 coraCall(co, 2, globalRef(intern("boolean?")), x);
 }
 }
 }
 
-void _35clofun2908(struct Cora* co) {
-Obj _35val1650 = co->args[1];
+void _35clofun2936(struct Cora* co) {
+Obj _35val1654 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35cc1242 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1650) {
+if (True == _35val1654) {
 if (True == True) {
-Obj _35reg1651 = primCons(x, Nil);
-Obj _35reg1652 = primCons(intern("%const"), _35reg1651);
-coraReturn(co, _35reg1652);
+Obj _35reg1655 = primCons(x, Nil);
+Obj _35reg1656 = primCons(intern("%const"), _35reg1655);
+coraReturn(co, _35reg1656);
 return;
 } else {
 coraCall(co, 1, _35cc1242);
 }
 } else {
-pushCont(co, 0, _35clofun2909, 2, x, _35cc1242);
+pushCont(co, 0, _35clofun2937, 2, x, _35cc1242);
 coraCall(co, 2, globalRef(intern("null?")), x);
 }
 }
 
-void _35clofun2909(struct Cora* co) {
-Obj _35val1653 = co->args[1];
+void _35clofun2937(struct Cora* co) {
+Obj _35val1657 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35cc1242 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1653) {
+if (True == _35val1657) {
 if (True == True) {
-Obj _35reg1654 = primCons(x, Nil);
-Obj _35reg1655 = primCons(intern("%const"), _35reg1654);
-coraReturn(co, _35reg1655);
+Obj _35reg1658 = primCons(x, Nil);
+Obj _35reg1659 = primCons(intern("%const"), _35reg1658);
+coraReturn(co, _35reg1659);
 return;
 } else {
 coraCall(co, 1, _35cc1242);
 }
 } else {
 if (True == False) {
-Obj _35reg1656 = primCons(x, Nil);
-Obj _35reg1657 = primCons(intern("%const"), _35reg1656);
-coraReturn(co, _35reg1657);
+Obj _35reg1660 = primCons(x, Nil);
+Obj _35reg1661 = primCons(intern("%const"), _35reg1660);
+coraReturn(co, _35reg1661);
 return;
 } else {
 coraCall(co, 1, _35cc1242);
@@ -5087,27 +5183,27 @@ coraCall(co, 1, _35cc1242);
 }
 }
 
-void _35clofun2881(struct Cora* co) {
-Obj _35cc1243 = makeNative(0, _35clofun2882, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2909(struct Cora* co) {
+Obj _35cc1243 = makeNative(0, _35clofun2910, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj __ = closureRef(co, 0);
-Obj _35reg1632 = primIsCons(closureRef(co, 1));
-if (True == _35reg1632) {
-Obj _35reg1633 = primCar(closureRef(co, 1));
-Obj _35reg1634 = primEQ(intern("quote"), _35reg1633);
-if (True == _35reg1634) {
-Obj _35reg1635 = primCdr(closureRef(co, 1));
-Obj _35reg1636 = primIsCons(_35reg1635);
+Obj _35reg1636 = primIsCons(closureRef(co, 1));
 if (True == _35reg1636) {
-Obj _35reg1637 = primCdr(closureRef(co, 1));
-Obj _35reg1638 = primCar(_35reg1637);
-Obj x = _35reg1638;
+Obj _35reg1637 = primCar(closureRef(co, 1));
+Obj _35reg1638 = primEQ(intern("quote"), _35reg1637);
+if (True == _35reg1638) {
 Obj _35reg1639 = primCdr(closureRef(co, 1));
-Obj _35reg1640 = primCdr(_35reg1639);
-Obj _35reg1641 = primEQ(Nil, _35reg1640);
-if (True == _35reg1641) {
-Obj _35reg1642 = primCons(x, Nil);
-Obj _35reg1643 = primCons(intern("%const"), _35reg1642);
-coraReturn(co, _35reg1643);
+Obj _35reg1640 = primIsCons(_35reg1639);
+if (True == _35reg1640) {
+Obj _35reg1641 = primCdr(closureRef(co, 1));
+Obj _35reg1642 = primCar(_35reg1641);
+Obj x = _35reg1642;
+Obj _35reg1643 = primCdr(closureRef(co, 1));
+Obj _35reg1644 = primCdr(_35reg1643);
+Obj _35reg1645 = primEQ(Nil, _35reg1644);
+if (True == _35reg1645) {
+Obj _35reg1646 = primCons(x, Nil);
+Obj _35reg1647 = primCons(intern("%const"), _35reg1646);
+coraReturn(co, _35reg1647);
 return;
 } else {
 coraCall(co, 1, _35cc1243);
@@ -5123,61 +5219,61 @@ coraCall(co, 1, _35cc1243);
 }
 }
 
-void _35clofun2882(struct Cora* co) {
-Obj _35cc1244 = makeNative(0, _35clofun2883, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2910(struct Cora* co) {
+Obj _35cc1244 = makeNative(0, _35clofun2911, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1628 = primIsSymbol(x);
-if (True == _35reg1628) {
-pushCont(co, 0, _35clofun2906, 1, x);
+Obj _35reg1632 = primIsSymbol(x);
+if (True == _35reg1632) {
+pushCont(co, 0, _35clofun2934, 1, x);
 coraCall(co, 3, globalRef(intern("elem?")), x, env);
 } else {
 coraCall(co, 1, _35cc1244);
 }
 }
 
-void _35clofun2906(struct Cora* co) {
-Obj _35val1629 = co->args[1];
+void _35clofun2934(struct Cora* co) {
+Obj _35val1633 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1629) {
+if (True == _35val1633) {
 coraReturn(co, x);
 return;
 } else {
-Obj _35reg1630 = primCons(x, Nil);
-Obj _35reg1631 = primCons(intern("%global"), _35reg1630);
-coraReturn(co, _35reg1631);
+Obj _35reg1634 = primCons(x, Nil);
+Obj _35reg1635 = primCons(intern("%global"), _35reg1634);
+coraReturn(co, _35reg1635);
 return;
 }
 }
 
-void _35clofun2883(struct Cora* co) {
-Obj _35cc1245 = makeNative(0, _35clofun2884, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2911(struct Cora* co) {
+Obj _35cc1245 = makeNative(0, _35clofun2912, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg1606 = primIsCons(closureRef(co, 1));
-if (True == _35reg1606) {
-Obj _35reg1607 = primCar(closureRef(co, 1));
-Obj _35reg1608 = primEQ(intern("lambda"), _35reg1607);
-if (True == _35reg1608) {
-Obj _35reg1609 = primCdr(closureRef(co, 1));
-Obj _35reg1610 = primIsCons(_35reg1609);
+Obj _35reg1610 = primIsCons(closureRef(co, 1));
 if (True == _35reg1610) {
-Obj _35reg1611 = primCdr(closureRef(co, 1));
-Obj _35reg1612 = primCar(_35reg1611);
-Obj args = _35reg1612;
+Obj _35reg1611 = primCar(closureRef(co, 1));
+Obj _35reg1612 = primEQ(intern("lambda"), _35reg1611);
+if (True == _35reg1612) {
 Obj _35reg1613 = primCdr(closureRef(co, 1));
-Obj _35reg1614 = primCdr(_35reg1613);
-Obj _35reg1615 = primIsCons(_35reg1614);
-if (True == _35reg1615) {
-Obj _35reg1616 = primCdr(closureRef(co, 1));
-Obj _35reg1617 = primCdr(_35reg1616);
-Obj _35reg1618 = primCar(_35reg1617);
-Obj body = _35reg1618;
-Obj _35reg1619 = primCdr(closureRef(co, 1));
-Obj _35reg1620 = primCdr(_35reg1619);
+Obj _35reg1614 = primIsCons(_35reg1613);
+if (True == _35reg1614) {
+Obj _35reg1615 = primCdr(closureRef(co, 1));
+Obj _35reg1616 = primCar(_35reg1615);
+Obj args = _35reg1616;
+Obj _35reg1617 = primCdr(closureRef(co, 1));
+Obj _35reg1618 = primCdr(_35reg1617);
+Obj _35reg1619 = primIsCons(_35reg1618);
+if (True == _35reg1619) {
+Obj _35reg1620 = primCdr(closureRef(co, 1));
 Obj _35reg1621 = primCdr(_35reg1620);
-Obj _35reg1622 = primEQ(Nil, _35reg1621);
-if (True == _35reg1622) {
-pushCont(co, 0, _35clofun2904, 2, body, args);
+Obj _35reg1622 = primCar(_35reg1621);
+Obj body = _35reg1622;
+Obj _35reg1623 = primCdr(closureRef(co, 1));
+Obj _35reg1624 = primCdr(_35reg1623);
+Obj _35reg1625 = primCdr(_35reg1624);
+Obj _35reg1626 = primEQ(Nil, _35reg1625);
+if (True == _35reg1626) {
+pushCont(co, 0, _35clofun2932, 2, body, args);
 coraCall(co, 3, globalRef(intern("append")), args, env);
 } else {
 coraCall(co, 1, _35cc1245);
@@ -5196,35 +5292,35 @@ coraCall(co, 1, _35cc1245);
 }
 }
 
-void _35clofun2904(struct Cora* co) {
-Obj _35val1623 = co->args[1];
+void _35clofun2932(struct Cora* co) {
+Obj _35val1627 = co->args[1];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2905, 1, args);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35val1623, body);
+pushCont(co, 0, _35clofun2933, 1, args);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35val1627, body);
 }
 
-void _35clofun2905(struct Cora* co) {
-Obj _35val1624 = co->args[1];
+void _35clofun2933(struct Cora* co) {
+Obj _35val1628 = co->args[1];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1625 = primCons(_35val1624, Nil);
-Obj _35reg1626 = primCons(args, _35reg1625);
-Obj _35reg1627 = primCons(intern("lambda"), _35reg1626);
-coraReturn(co, _35reg1627);
+Obj _35reg1629 = primCons(_35val1628, Nil);
+Obj _35reg1630 = primCons(args, _35reg1629);
+Obj _35reg1631 = primCons(intern("lambda"), _35reg1630);
+coraReturn(co, _35reg1631);
 return;
 }
 
-void _35clofun2884(struct Cora* co) {
-Obj _35cc1246 = makeNative(0, _35clofun2885, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2912(struct Cora* co) {
+Obj _35cc1246 = makeNative(0, _35clofun2913, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg1599 = primIsCons(closureRef(co, 1));
-if (True == _35reg1599) {
-Obj _35reg1600 = primCar(closureRef(co, 1));
-Obj _35reg1601 = primEQ(intern("if"), _35reg1600);
-if (True == _35reg1601) {
-Obj _35reg1602 = primCdr(closureRef(co, 1));
-Obj args = _35reg1602;
-pushCont(co, 0, _35clofun2902, 1, args);
+Obj _35reg1603 = primIsCons(closureRef(co, 1));
+if (True == _35reg1603) {
+Obj _35reg1604 = primCar(closureRef(co, 1));
+Obj _35reg1605 = primEQ(intern("if"), _35reg1604);
+if (True == _35reg1605) {
+Obj _35reg1606 = primCdr(closureRef(co, 1));
+Obj args = _35reg1606;
+pushCont(co, 0, _35clofun2930, 1, args);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.parse")), env);
 } else {
 coraCall(co, 1, _35cc1246);
@@ -5234,48 +5330,48 @@ coraCall(co, 1, _35cc1246);
 }
 }
 
-void _35clofun2902(struct Cora* co) {
-Obj _35val1603 = co->args[1];
+void _35clofun2930(struct Cora* co) {
+Obj _35val1607 = co->args[1];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun2903, 0);
-coraCall(co, 3, globalRef(intern("map")), _35val1603, args);
+pushCont(co, 0, _35clofun2931, 0);
+coraCall(co, 3, globalRef(intern("map")), _35val1607, args);
 }
 
-void _35clofun2903(struct Cora* co) {
-Obj _35val1604 = co->args[1];
-Obj _35reg1605 = primCons(intern("if"), _35val1604);
-coraReturn(co, _35reg1605);
+void _35clofun2931(struct Cora* co) {
+Obj _35val1608 = co->args[1];
+Obj _35reg1609 = primCons(intern("if"), _35val1608);
+coraReturn(co, _35reg1609);
 return;
 }
 
-void _35clofun2885(struct Cora* co) {
-Obj _35cc1247 = makeNative(0, _35clofun2886, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2913(struct Cora* co) {
+Obj _35cc1247 = makeNative(0, _35clofun2914, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg1577 = primIsCons(closureRef(co, 1));
-if (True == _35reg1577) {
-Obj _35reg1578 = primCar(closureRef(co, 1));
-Obj _35reg1579 = primEQ(intern("do"), _35reg1578);
-if (True == _35reg1579) {
-Obj _35reg1580 = primCdr(closureRef(co, 1));
-Obj _35reg1581 = primIsCons(_35reg1580);
+Obj _35reg1581 = primIsCons(closureRef(co, 1));
 if (True == _35reg1581) {
-Obj _35reg1582 = primCdr(closureRef(co, 1));
-Obj _35reg1583 = primCar(_35reg1582);
-Obj x = _35reg1583;
+Obj _35reg1582 = primCar(closureRef(co, 1));
+Obj _35reg1583 = primEQ(intern("do"), _35reg1582);
+if (True == _35reg1583) {
 Obj _35reg1584 = primCdr(closureRef(co, 1));
-Obj _35reg1585 = primCdr(_35reg1584);
-Obj _35reg1586 = primIsCons(_35reg1585);
-if (True == _35reg1586) {
-Obj _35reg1587 = primCdr(closureRef(co, 1));
-Obj _35reg1588 = primCdr(_35reg1587);
-Obj _35reg1589 = primCar(_35reg1588);
-Obj y = _35reg1589;
-Obj _35reg1590 = primCdr(closureRef(co, 1));
-Obj _35reg1591 = primCdr(_35reg1590);
+Obj _35reg1585 = primIsCons(_35reg1584);
+if (True == _35reg1585) {
+Obj _35reg1586 = primCdr(closureRef(co, 1));
+Obj _35reg1587 = primCar(_35reg1586);
+Obj x = _35reg1587;
+Obj _35reg1588 = primCdr(closureRef(co, 1));
+Obj _35reg1589 = primCdr(_35reg1588);
+Obj _35reg1590 = primIsCons(_35reg1589);
+if (True == _35reg1590) {
+Obj _35reg1591 = primCdr(closureRef(co, 1));
 Obj _35reg1592 = primCdr(_35reg1591);
-Obj _35reg1593 = primEQ(Nil, _35reg1592);
-if (True == _35reg1593) {
-pushCont(co, 0, _35clofun2900, 2, env, y);
+Obj _35reg1593 = primCar(_35reg1592);
+Obj y = _35reg1593;
+Obj _35reg1594 = primCdr(closureRef(co, 1));
+Obj _35reg1595 = primCdr(_35reg1594);
+Obj _35reg1596 = primCdr(_35reg1595);
+Obj _35reg1597 = primEQ(Nil, _35reg1596);
+if (True == _35reg1597) {
+pushCont(co, 0, _35clofun2928, 2, env, y);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, x);
 } else {
 coraCall(co, 1, _35cc1247);
@@ -5294,63 +5390,63 @@ coraCall(co, 1, _35cc1247);
 }
 }
 
-void _35clofun2900(struct Cora* co) {
-Obj _35val1594 = co->args[1];
+void _35clofun2928(struct Cora* co) {
+Obj _35val1598 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2901, 1, _35val1594);
+pushCont(co, 0, _35clofun2929, 1, _35val1598);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, y);
 }
 
-void _35clofun2901(struct Cora* co) {
-Obj _35val1595 = co->args[1];
-Obj _35val1594 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1596 = primCons(_35val1595, Nil);
-Obj _35reg1597 = primCons(_35val1594, _35reg1596);
-Obj _35reg1598 = primCons(intern("do"), _35reg1597);
-coraReturn(co, _35reg1598);
+void _35clofun2929(struct Cora* co) {
+Obj _35val1599 = co->args[1];
+Obj _35val1598 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1600 = primCons(_35val1599, Nil);
+Obj _35reg1601 = primCons(_35val1598, _35reg1600);
+Obj _35reg1602 = primCons(intern("do"), _35reg1601);
+coraReturn(co, _35reg1602);
 return;
 }
 
-void _35clofun2886(struct Cora* co) {
-Obj _35cc1248 = makeNative(0, _35clofun2887, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2914(struct Cora* co) {
+Obj _35cc1248 = makeNative(0, _35clofun2915, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg1544 = primIsCons(closureRef(co, 1));
-if (True == _35reg1544) {
-Obj _35reg1545 = primCar(closureRef(co, 1));
-Obj _35reg1546 = primEQ(intern("let"), _35reg1545);
-if (True == _35reg1546) {
-Obj _35reg1547 = primCdr(closureRef(co, 1));
-Obj _35reg1548 = primIsCons(_35reg1547);
+Obj _35reg1548 = primIsCons(closureRef(co, 1));
 if (True == _35reg1548) {
-Obj _35reg1549 = primCdr(closureRef(co, 1));
-Obj _35reg1550 = primCar(_35reg1549);
-Obj a = _35reg1550;
+Obj _35reg1549 = primCar(closureRef(co, 1));
+Obj _35reg1550 = primEQ(intern("let"), _35reg1549);
+if (True == _35reg1550) {
 Obj _35reg1551 = primCdr(closureRef(co, 1));
-Obj _35reg1552 = primCdr(_35reg1551);
-Obj _35reg1553 = primIsCons(_35reg1552);
-if (True == _35reg1553) {
-Obj _35reg1554 = primCdr(closureRef(co, 1));
-Obj _35reg1555 = primCdr(_35reg1554);
-Obj _35reg1556 = primCar(_35reg1555);
-Obj b = _35reg1556;
-Obj _35reg1557 = primCdr(closureRef(co, 1));
-Obj _35reg1558 = primCdr(_35reg1557);
+Obj _35reg1552 = primIsCons(_35reg1551);
+if (True == _35reg1552) {
+Obj _35reg1553 = primCdr(closureRef(co, 1));
+Obj _35reg1554 = primCar(_35reg1553);
+Obj a = _35reg1554;
+Obj _35reg1555 = primCdr(closureRef(co, 1));
+Obj _35reg1556 = primCdr(_35reg1555);
+Obj _35reg1557 = primIsCons(_35reg1556);
+if (True == _35reg1557) {
+Obj _35reg1558 = primCdr(closureRef(co, 1));
 Obj _35reg1559 = primCdr(_35reg1558);
-Obj _35reg1560 = primIsCons(_35reg1559);
-if (True == _35reg1560) {
+Obj _35reg1560 = primCar(_35reg1559);
+Obj b = _35reg1560;
 Obj _35reg1561 = primCdr(closureRef(co, 1));
 Obj _35reg1562 = primCdr(_35reg1561);
 Obj _35reg1563 = primCdr(_35reg1562);
-Obj _35reg1564 = primCar(_35reg1563);
-Obj c = _35reg1564;
+Obj _35reg1564 = primIsCons(_35reg1563);
+if (True == _35reg1564) {
 Obj _35reg1565 = primCdr(closureRef(co, 1));
 Obj _35reg1566 = primCdr(_35reg1565);
 Obj _35reg1567 = primCdr(_35reg1566);
-Obj _35reg1568 = primCdr(_35reg1567);
-Obj _35reg1569 = primEQ(Nil, _35reg1568);
-if (True == _35reg1569) {
-pushCont(co, 0, _35clofun2898, 3, env, c, a);
+Obj _35reg1568 = primCar(_35reg1567);
+Obj c = _35reg1568;
+Obj _35reg1569 = primCdr(closureRef(co, 1));
+Obj _35reg1570 = primCdr(_35reg1569);
+Obj _35reg1571 = primCdr(_35reg1570);
+Obj _35reg1572 = primCdr(_35reg1571);
+Obj _35reg1573 = primEQ(Nil, _35reg1572);
+if (True == _35reg1573) {
+pushCont(co, 0, _35clofun2926, 3, env, c, a);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, b);
 } else {
 coraCall(co, 1, _35cc1248);
@@ -5372,154 +5468,154 @@ coraCall(co, 1, _35cc1248);
 }
 }
 
-void _35clofun2898(struct Cora* co) {
-Obj _35val1570 = co->args[1];
+void _35clofun2926(struct Cora* co) {
+Obj _35val1574 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1571 = primCons(a, env);
-pushCont(co, 0, _35clofun2899, 2, _35val1570, a);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35reg1571, c);
+Obj _35reg1575 = primCons(a, env);
+pushCont(co, 0, _35clofun2927, 2, _35val1574, a);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35reg1575, c);
 }
 
-void _35clofun2899(struct Cora* co) {
-Obj _35val1572 = co->args[1];
-Obj _35val1570 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+void _35clofun2927(struct Cora* co) {
+Obj _35val1576 = co->args[1];
+Obj _35val1574 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1573 = primCons(_35val1572, Nil);
-Obj _35reg1574 = primCons(_35val1570, _35reg1573);
-Obj _35reg1575 = primCons(a, _35reg1574);
-Obj _35reg1576 = primCons(intern("let"), _35reg1575);
-coraReturn(co, _35reg1576);
+Obj _35reg1577 = primCons(_35val1576, Nil);
+Obj _35reg1578 = primCons(_35val1574, _35reg1577);
+Obj _35reg1579 = primCons(a, _35reg1578);
+Obj _35reg1580 = primCons(intern("let"), _35reg1579);
+coraReturn(co, _35reg1580);
 return;
 }
 
-void _35clofun2887(struct Cora* co) {
-Obj _35cc1249 = makeNative(0, _35clofun2888, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2915(struct Cora* co) {
+Obj _35cc1249 = makeNative(0, _35clofun2916, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg1524 = primIsCons(closureRef(co, 1));
-if (True == _35reg1524) {
-Obj _35reg1525 = primCar(closureRef(co, 1));
-Obj op = _35reg1525;
-Obj _35reg1526 = primCdr(closureRef(co, 1));
-Obj args = _35reg1526;
-pushCont(co, 0, _35clofun2891, 4, op, args, env, _35cc1249);
+Obj _35reg1528 = primIsCons(closureRef(co, 1));
+if (True == _35reg1528) {
+Obj _35reg1529 = primCar(closureRef(co, 1));
+Obj op = _35reg1529;
+Obj _35reg1530 = primCdr(closureRef(co, 1));
+Obj args = _35reg1530;
+pushCont(co, 0, _35clofun2919, 4, op, args, env, _35cc1249);
 coraCall(co, 2, globalRef(intern("builtin?")), op);
 } else {
 coraCall(co, 1, _35cc1249);
 }
 }
 
-void _35clofun2891(struct Cora* co) {
-Obj _35val1527 = co->args[1];
+void _35clofun2919(struct Cora* co) {
+Obj _35val1531 = co->args[1];
 Obj op = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35cc1249 = co->ctx.stk.stack[co->ctx.stk.base + 3];
-if (True == _35val1527) {
-pushCont(co, 0, _35clofun2892, 3, op, args, env);
+if (True == _35val1531) {
+pushCont(co, 0, _35clofun2920, 3, op, args, env);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.builtin->args")), op);
 } else {
 coraCall(co, 1, _35cc1249);
 }
 }
 
-void _35clofun2892(struct Cora* co) {
-Obj _35val1528 = co->args[1];
+void _35clofun2920(struct Cora* co) {
+Obj _35val1532 = co->args[1];
 Obj op = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj required = _35val1528;
-pushCont(co, 0, _35clofun2893, 4, required, op, args, env);
+Obj required = _35val1532;
+pushCont(co, 0, _35clofun2921, 4, required, op, args, env);
 coraCall(co, 2, globalRef(intern("length")), args);
 }
 
-void _35clofun2893(struct Cora* co) {
-Obj _35val1529 = co->args[1];
+void _35clofun2921(struct Cora* co) {
+Obj _35val1533 = co->args[1];
 Obj required = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj op = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj provided = _35val1529;
-Obj _35reg1530 = primEQ(required, provided);
-if (True == _35reg1530) {
-Obj _35reg1531 = primCons(op, Nil);
-Obj _35reg1532 = primCons(intern("%builtin"), _35reg1531);
-pushCont(co, 0, _35clofun2894, 2, args, _35reg1532);
+Obj provided = _35val1533;
+Obj _35reg1534 = primEQ(required, provided);
+if (True == _35reg1534) {
+Obj _35reg1535 = primCons(op, Nil);
+Obj _35reg1536 = primCons(intern("%builtin"), _35reg1535);
+pushCont(co, 0, _35clofun2922, 2, args, _35reg1536);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.parse")), env);
 } else {
-Obj _35reg1536 = primGT(required, provided);
-if (True == _35reg1536) {
-Obj _35reg1537 = primSub(required, provided);
-pushCont(co, 0, _35clofun2896, 3, op, args, env);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.temp-list")), _35reg1537, Nil);
+Obj _35reg1540 = primGT(required, provided);
+if (True == _35reg1540) {
+Obj _35reg1541 = primSub(required, provided);
+pushCont(co, 0, _35clofun2924, 3, op, args, env);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.temp-list")), _35reg1541, Nil);
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("primitive call mismatch"));
 }
 }
 }
 
-void _35clofun2896(struct Cora* co) {
-Obj _35val1538 = co->args[1];
+void _35clofun2924(struct Cora* co) {
+Obj _35val1542 = co->args[1];
 Obj op = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj tmp = _35val1538;
-Obj _35reg1539 = primCons(op, args);
-pushCont(co, 0, _35clofun2897, 2, tmp, env);
-coraCall(co, 3, globalRef(intern("append")), _35reg1539, tmp);
+Obj tmp = _35val1542;
+Obj _35reg1543 = primCons(op, args);
+pushCont(co, 0, _35clofun2925, 2, tmp, env);
+coraCall(co, 3, globalRef(intern("append")), _35reg1543, tmp);
 }
 
-void _35clofun2897(struct Cora* co) {
-Obj _35val1540 = co->args[1];
+void _35clofun2925(struct Cora* co) {
+Obj _35val1544 = co->args[1];
 Obj tmp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1541 = primCons(_35val1540, Nil);
-Obj _35reg1542 = primCons(tmp, _35reg1541);
-Obj _35reg1543 = primCons(intern("lambda"), _35reg1542);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, _35reg1543);
+Obj _35reg1545 = primCons(_35val1544, Nil);
+Obj _35reg1546 = primCons(tmp, _35reg1545);
+Obj _35reg1547 = primCons(intern("lambda"), _35reg1546);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, _35reg1547);
 }
 
-void _35clofun2894(struct Cora* co) {
-Obj _35val1533 = co->args[1];
+void _35clofun2922(struct Cora* co) {
+Obj _35val1537 = co->args[1];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1532 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2895, 1, _35reg1532);
-coraCall(co, 3, globalRef(intern("map")), _35val1533, args);
+Obj _35reg1536 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun2923, 1, _35reg1536);
+coraCall(co, 3, globalRef(intern("map")), _35val1537, args);
 }
 
-void _35clofun2895(struct Cora* co) {
-Obj _35val1534 = co->args[1];
-Obj _35reg1532 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1535 = primCons(_35reg1532, _35val1534);
-coraReturn(co, _35reg1535);
+void _35clofun2923(struct Cora* co) {
+Obj _35val1538 = co->args[1];
+Obj _35reg1536 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1539 = primCons(_35reg1536, _35val1538);
+coraReturn(co, _35reg1539);
 return;
 }
 
-void _35clofun2888(struct Cora* co) {
-Obj _35cc1250 = makeNative(0, _35clofun2889, 0, 0);
+void _35clofun2916(struct Cora* co) {
+Obj _35cc1250 = makeNative(0, _35clofun2917, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ls = closureRef(co, 1);
-pushCont(co, 0, _35clofun2890, 1, ls);
+pushCont(co, 0, _35clofun2918, 1, ls);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.parse")), env);
 }
 
-void _35clofun2890(struct Cora* co) {
-Obj _35val1523 = co->args[1];
+void _35clofun2918(struct Cora* co) {
+Obj _35val1527 = co->args[1];
 Obj ls = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("map")), _35val1523, ls);
+coraCall(co, 3, globalRef(intern("map")), _35val1527, ls);
 }
 
-void _35clofun2889(struct Cora* co) {
+void _35clofun2917(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2877(struct Cora* co) {
+void _35clofun2905(struct Cora* co) {
 Obj _35p1236 = co->args[1];
 Obj _35p1237 = co->args[2];
-Obj _35cc1238 = makeNative(0, _35clofun2878, 0, 2, _35p1236, _35p1237);
-Obj _35reg1521 = primEQ(makeNumber(0), _35p1236);
-if (True == _35reg1521) {
+Obj _35cc1238 = makeNative(0, _35clofun2906, 0, 2, _35p1236, _35p1237);
+Obj _35reg1525 = primEQ(makeNumber(0), _35p1236);
+if (True == _35reg1525) {
 Obj res = _35p1237;
 coraReturn(co, res);
 return;
@@ -5528,37 +5624,37 @@ coraCall(co, 1, _35cc1238);
 }
 }
 
-void _35clofun2878(struct Cora* co) {
-Obj _35cc1239 = makeNative(0, _35clofun2879, 0, 0);
+void _35clofun2906(struct Cora* co) {
+Obj _35cc1239 = makeNative(0, _35clofun2907, 0, 0);
 Obj n = closureRef(co, 0);
 Obj res = closureRef(co, 1);
-Obj _35reg1518 = primSub(n, makeNumber(1));
-Obj _35reg1519 = primGenSym(intern("tmp"));
-Obj _35reg1520 = primCons(_35reg1519, res);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.temp-list")), _35reg1518, _35reg1520);
+Obj _35reg1522 = primSub(n, makeNumber(1));
+Obj _35reg1523 = primGenSym(intern("tmp"));
+Obj _35reg1524 = primCons(_35reg1523, res);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.temp-list")), _35reg1522, _35reg1524);
 }
 
-void _35clofun2879(struct Cora* co) {
+void _35clofun2907(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2874(struct Cora* co) {
+void _35clofun2902(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, 0, _35clofun2875, 0);
+pushCont(co, 0, _35clofun2903, 0);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), x, globalRef(intern("cora/lib/toc.*builtin-prims*")));
 }
 
-void _35clofun2875(struct Cora* co) {
-Obj _35val1515 = co->args[1];
-Obj find = _35val1515;
-pushCont(co, 0, _35clofun2876, 1, find);
+void _35clofun2903(struct Cora* co) {
+Obj _35val1519 = co->args[1];
+Obj find = _35val1519;
+pushCont(co, 0, _35clofun2904, 1, find);
 coraCall(co, 2, globalRef(intern("null?")), find);
 }
 
-void _35clofun2876(struct Cora* co) {
-Obj _35val1516 = co->args[1];
+void _35clofun2904(struct Cora* co) {
+Obj _35val1520 = co->args[1];
 Obj find = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1516) {
+if (True == _35val1520) {
 coraReturn(co, makeString1("ERROR"));
 return;
 } else {
@@ -5566,23 +5662,23 @@ coraCall(co, 2, globalRef(intern("cadr")), find);
 }
 }
 
-void _35clofun2871(struct Cora* co) {
+void _35clofun2899(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, 0, _35clofun2872, 0);
+pushCont(co, 0, _35clofun2900, 0);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), x, globalRef(intern("cora/lib/toc.*builtin-prims*")));
 }
 
-void _35clofun2872(struct Cora* co) {
-Obj _35val1512 = co->args[1];
-Obj find = _35val1512;
-pushCont(co, 0, _35clofun2873, 1, find);
+void _35clofun2900(struct Cora* co) {
+Obj _35val1516 = co->args[1];
+Obj find = _35val1516;
+pushCont(co, 0, _35clofun2901, 1, find);
 coraCall(co, 2, globalRef(intern("null?")), find);
 }
 
-void _35clofun2873(struct Cora* co) {
-Obj _35val1513 = co->args[1];
+void _35clofun2901(struct Cora* co) {
+Obj _35val1517 = co->args[1];
 Obj find = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1513) {
+if (True == _35val1517) {
 coraReturn(co, makeString1("ERROR"));
 return;
 } else {
@@ -5590,32 +5686,32 @@ coraCall(co, 2, globalRef(intern("caddr")), find);
 }
 }
 
-void _35clofun2868(struct Cora* co) {
+void _35clofun2896(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, 0, _35clofun2869, 0);
+pushCont(co, 0, _35clofun2897, 0);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), x, globalRef(intern("cora/lib/toc.*builtin-prims*")));
 }
 
-void _35clofun2869(struct Cora* co) {
-Obj _35val1508 = co->args[1];
-pushCont(co, 0, _35clofun2870, 0);
-coraCall(co, 2, globalRef(intern("null?")), _35val1508);
+void _35clofun2897(struct Cora* co) {
+Obj _35val1512 = co->args[1];
+pushCont(co, 0, _35clofun2898, 0);
+coraCall(co, 2, globalRef(intern("null?")), _35val1512);
 }
 
-void _35clofun2870(struct Cora* co) {
-Obj _35val1509 = co->args[1];
-Obj _35reg1510 = primNot(_35val1509);
-coraReturn(co, _35reg1510);
+void _35clofun2898(struct Cora* co) {
+Obj _35val1513 = co->args[1];
+Obj _35reg1514 = primNot(_35val1513);
+coraReturn(co, _35reg1514);
 return;
 }
 
-void _35clofun2864(struct Cora* co) {
+void _35clofun2892(struct Cora* co) {
 Obj _35p1232 = co->args[1];
 Obj _35p1233 = co->args[2];
-Obj _35cc1234 = makeNative(0, _35clofun2865, 0, 2, _35p1232, _35p1233);
+Obj _35cc1234 = makeNative(0, _35clofun2893, 0, 2, _35p1232, _35p1233);
 Obj x = _35p1232;
-Obj _35reg1437 = primEQ(Nil, _35p1233);
-if (True == _35reg1437) {
+Obj _35reg1441 = primEQ(Nil, _35p1233);
+if (True == _35reg1441) {
 coraReturn(co, False);
 return;
 } else {
@@ -5623,28 +5719,28 @@ coraCall(co, 1, _35cc1234);
 }
 }
 
-void _35clofun2865(struct Cora* co) {
-Obj _35cc1235 = makeNative(0, _35clofun2866, 0, 0);
+void _35clofun2893(struct Cora* co) {
+Obj _35cc1235 = makeNative(0, _35clofun2894, 0, 0);
 Obj x = closureRef(co, 0);
-Obj _35reg1432 = primIsCons(closureRef(co, 1));
-if (True == _35reg1432) {
-Obj _35reg1433 = primCar(closureRef(co, 1));
-Obj hd = _35reg1433;
-Obj _35reg1434 = primCdr(closureRef(co, 1));
-Obj tl = _35reg1434;
-pushCont(co, 0, _35clofun2867, 2, x, tl);
+Obj _35reg1436 = primIsCons(closureRef(co, 1));
+if (True == _35reg1436) {
+Obj _35reg1437 = primCar(closureRef(co, 1));
+Obj hd = _35reg1437;
+Obj _35reg1438 = primCdr(closureRef(co, 1));
+Obj tl = _35reg1438;
+pushCont(co, 0, _35clofun2895, 2, x, tl);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.index")), x, hd);
 } else {
 coraCall(co, 1, _35cc1235);
 }
 }
 
-void _35clofun2867(struct Cora* co) {
-Obj _35val1435 = co->args[1];
+void _35clofun2895(struct Cora* co) {
+Obj _35val1439 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj tl = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1436 = primLT(_35val1435, makeNumber(0));
-if (True == _35reg1436) {
+Obj _35reg1440 = primLT(_35val1439, makeNumber(0));
+if (True == _35reg1440) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.exist-in-env")), x, tl);
 } else {
 coraReturn(co, True);
@@ -5652,25 +5748,25 @@ return;
 }
 }
 
-void _35clofun2866(struct Cora* co) {
+void _35clofun2894(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2863(struct Cora* co) {
+void _35clofun2891(struct Cora* co) {
 Obj x = co->args[1];
 Obj l = co->args[2];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.pos-in-list0")), makeNumber(0), x, l);
 }
 
-void _35clofun2859(struct Cora* co) {
+void _35clofun2887(struct Cora* co) {
 Obj _35p1226 = co->args[1];
 Obj _35p1227 = co->args[2];
 Obj _35p1228 = co->args[3];
-Obj _35cc1229 = makeNative(0, _35clofun2860, 0, 3, _35p1226, _35p1227, _35p1228);
+Obj _35cc1229 = makeNative(0, _35clofun2888, 0, 3, _35p1226, _35p1227, _35p1228);
 Obj __ = _35p1226;
 Obj x = _35p1227;
-Obj _35reg1429 = primEQ(Nil, _35p1228);
-if (True == _35reg1429) {
+Obj _35reg1433 = primEQ(Nil, _35p1228);
+if (True == _35reg1433) {
 coraReturn(co, makeNumber(-1));
 return;
 } else {
@@ -5678,18 +5774,18 @@ coraCall(co, 1, _35cc1229);
 }
 }
 
-void _35clofun2860(struct Cora* co) {
-Obj _35cc1230 = makeNative(0, _35clofun2861, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun2888(struct Cora* co) {
+Obj _35cc1230 = makeNative(0, _35clofun2889, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1425 = primIsCons(closureRef(co, 2));
-if (True == _35reg1425) {
-Obj _35reg1426 = primCar(closureRef(co, 2));
-Obj a = _35reg1426;
-Obj _35reg1427 = primCdr(closureRef(co, 2));
-Obj b = _35reg1427;
-Obj _35reg1428 = primEQ(x, a);
-if (True == _35reg1428) {
+Obj _35reg1429 = primIsCons(closureRef(co, 2));
+if (True == _35reg1429) {
+Obj _35reg1430 = primCar(closureRef(co, 2));
+Obj a = _35reg1430;
+Obj _35reg1431 = primCdr(closureRef(co, 2));
+Obj b = _35reg1431;
+Obj _35reg1432 = primEQ(x, a);
+if (True == _35reg1432) {
 coraReturn(co, pos);
 return;
 } else {
@@ -5700,36 +5796,36 @@ coraCall(co, 1, _35cc1230);
 }
 }
 
-void _35clofun2861(struct Cora* co) {
-Obj _35cc1231 = makeNative(0, _35clofun2862, 0, 0);
+void _35clofun2889(struct Cora* co) {
+Obj _35cc1231 = makeNative(0, _35clofun2890, 0, 0);
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1421 = primIsCons(closureRef(co, 2));
-if (True == _35reg1421) {
-Obj _35reg1422 = primCar(closureRef(co, 2));
-Obj a = _35reg1422;
-Obj _35reg1423 = primCdr(closureRef(co, 2));
-Obj b = _35reg1423;
-Obj _35reg1424 = primAdd(pos, makeNumber(1));
-coraCall(co, 4, globalRef(intern("cora/lib/toc.pos-in-list0")), _35reg1424, x, b);
+Obj _35reg1425 = primIsCons(closureRef(co, 2));
+if (True == _35reg1425) {
+Obj _35reg1426 = primCar(closureRef(co, 2));
+Obj a = _35reg1426;
+Obj _35reg1427 = primCdr(closureRef(co, 2));
+Obj b = _35reg1427;
+Obj _35reg1428 = primAdd(pos, makeNumber(1));
+coraCall(co, 4, globalRef(intern("cora/lib/toc.pos-in-list0")), _35reg1428, x, b);
 } else {
 coraCall(co, 1, _35cc1231);
 }
 }
 
-void _35clofun2862(struct Cora* co) {
+void _35clofun2890(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2855(struct Cora* co) {
+void _35clofun2883(struct Cora* co) {
 Obj _35p1221 = co->args[1];
 Obj _35p1222 = co->args[2];
 Obj _35p1223 = co->args[3];
-Obj _35cc1224 = makeNative(0, _35clofun2856, 0, 3, _35p1221, _35p1222, _35p1223);
+Obj _35cc1224 = makeNative(0, _35clofun2884, 0, 3, _35p1221, _35p1222, _35p1223);
 Obj f = _35p1221;
 Obj acc = _35p1222;
-Obj _35reg1419 = primEQ(Nil, _35p1223);
-if (True == _35reg1419) {
+Obj _35reg1423 = primEQ(Nil, _35p1223);
+if (True == _35reg1423) {
 coraReturn(co, acc);
 return;
 } else {
@@ -5737,41 +5833,41 @@ coraCall(co, 1, _35cc1224);
 }
 }
 
-void _35clofun2856(struct Cora* co) {
-Obj _35cc1225 = makeNative(0, _35clofun2857, 0, 0);
+void _35clofun2884(struct Cora* co) {
+Obj _35cc1225 = makeNative(0, _35clofun2885, 0, 0);
 Obj f = closureRef(co, 0);
 Obj acc = closureRef(co, 1);
-Obj _35reg1415 = primIsCons(closureRef(co, 2));
-if (True == _35reg1415) {
-Obj _35reg1416 = primCar(closureRef(co, 2));
-Obj x = _35reg1416;
-Obj _35reg1417 = primCdr(closureRef(co, 2));
-Obj y = _35reg1417;
-pushCont(co, 0, _35clofun2858, 2, f, y);
+Obj _35reg1419 = primIsCons(closureRef(co, 2));
+if (True == _35reg1419) {
+Obj _35reg1420 = primCar(closureRef(co, 2));
+Obj x = _35reg1420;
+Obj _35reg1421 = primCdr(closureRef(co, 2));
+Obj y = _35reg1421;
+pushCont(co, 0, _35clofun2886, 2, f, y);
 coraCall(co, 3, f, acc, x);
 } else {
 coraCall(co, 1, _35cc1225);
 }
 }
 
-void _35clofun2858(struct Cora* co) {
-Obj _35val1418 = co->args[1];
+void _35clofun2886(struct Cora* co) {
+Obj _35val1422 = co->args[1];
 Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), f, _35val1418, y);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), f, _35val1422, y);
 }
 
-void _35clofun2857(struct Cora* co) {
+void _35clofun2885(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2851(struct Cora* co) {
+void _35clofun2879(struct Cora* co) {
 Obj _35p1216 = co->args[1];
 Obj _35p1217 = co->args[2];
-Obj _35cc1218 = makeNative(0, _35clofun2852, 0, 2, _35p1216, _35p1217);
+Obj _35cc1218 = makeNative(0, _35clofun2880, 0, 2, _35p1216, _35p1217);
 Obj var = _35p1216;
-Obj _35reg1413 = primEQ(Nil, _35p1217);
-if (True == _35reg1413) {
+Obj _35reg1417 = primEQ(Nil, _35p1217);
+if (True == _35reg1417) {
 coraReturn(co, Nil);
 return;
 } else {
@@ -5779,26 +5875,26 @@ coraCall(co, 1, _35cc1218);
 }
 }
 
-void _35clofun2852(struct Cora* co) {
-Obj _35cc1219 = makeNative(0, _35clofun2853, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2880(struct Cora* co) {
+Obj _35cc1219 = makeNative(0, _35clofun2881, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
-Obj _35reg1403 = primIsCons(closureRef(co, 1));
-if (True == _35reg1403) {
-Obj _35reg1404 = primCar(closureRef(co, 1));
-Obj _35reg1405 = primIsCons(_35reg1404);
-if (True == _35reg1405) {
-Obj _35reg1406 = primCar(closureRef(co, 1));
-Obj _35reg1407 = primCar(_35reg1406);
-Obj x = _35reg1407;
+Obj _35reg1407 = primIsCons(closureRef(co, 1));
+if (True == _35reg1407) {
 Obj _35reg1408 = primCar(closureRef(co, 1));
-Obj _35reg1409 = primCdr(_35reg1408);
-Obj y = _35reg1409;
-Obj _35reg1410 = primCdr(closureRef(co, 1));
-Obj __ = _35reg1410;
-Obj _35reg1411 = primEQ(var, x);
-if (True == _35reg1411) {
-Obj _35reg1412 = primCons(x, y);
-coraReturn(co, _35reg1412);
+Obj _35reg1409 = primIsCons(_35reg1408);
+if (True == _35reg1409) {
+Obj _35reg1410 = primCar(closureRef(co, 1));
+Obj _35reg1411 = primCar(_35reg1410);
+Obj x = _35reg1411;
+Obj _35reg1412 = primCar(closureRef(co, 1));
+Obj _35reg1413 = primCdr(_35reg1412);
+Obj y = _35reg1413;
+Obj _35reg1414 = primCdr(closureRef(co, 1));
+Obj __ = _35reg1414;
+Obj _35reg1415 = primEQ(var, x);
+if (True == _35reg1415) {
+Obj _35reg1416 = primCons(x, y);
+coraReturn(co, _35reg1416);
 return;
 } else {
 coraCall(co, 1, _35cc1219);
@@ -5811,22 +5907,22 @@ coraCall(co, 1, _35cc1219);
 }
 }
 
-void _35clofun2853(struct Cora* co) {
-Obj _35cc1220 = makeNative(0, _35clofun2854, 0, 0);
+void _35clofun2881(struct Cora* co) {
+Obj _35cc1220 = makeNative(0, _35clofun2882, 0, 0);
 Obj var = closureRef(co, 0);
-Obj _35reg1400 = primIsCons(closureRef(co, 1));
-if (True == _35reg1400) {
-Obj _35reg1401 = primCar(closureRef(co, 1));
-Obj __ = _35reg1401;
-Obj _35reg1402 = primCdr(closureRef(co, 1));
-Obj y = _35reg1402;
+Obj _35reg1404 = primIsCons(closureRef(co, 1));
+if (True == _35reg1404) {
+Obj _35reg1405 = primCar(closureRef(co, 1));
+Obj __ = _35reg1405;
+Obj _35reg1406 = primCdr(closureRef(co, 1));
+Obj y = _35reg1406;
 coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), var, y);
 } else {
 coraCall(co, 1, _35cc1220);
 }
 }
 
-void _35clofun2854(struct Cora* co) {
+void _35clofun2882(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 


### PR DESCRIPTION


For example, if let-loop macro is not available before macroexpand, this code cannot work properly, because let-loop would be treat as a function.

```
    (import "cora/lib/let-loop")
    (let-loop recur (n 0 sum 0)
	    (if (= n 100)
		sum
		(recur (+ n 1) (+ sum n))))
```