### PR TITLE
*: support more types and integrate type checker to the system

### DIFF
--- a/init.c
+++ b/init.c
@@ -2,61 +2,59 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun1018(struct Cora* co);
-void _35clofun1037(struct Cora* co);
-void _35clofun1039(struct Cora* co);
-void _35clofun1044(struct Cora* co);
-void _35clofun1053(struct Cora* co);
-void _35clofun1058(struct Cora* co);
+void _35clofun1022(struct Cora* co);
+void _35clofun1041(struct Cora* co);
+void _35clofun1043(struct Cora* co);
+void _35clofun1048(struct Cora* co);
+void _35clofun1057(struct Cora* co);
 void _35clofun1062(struct Cora* co);
 void _35clofun1066(struct Cora* co);
-void _35clofun1072(struct Cora* co);
-void _35clofun1129(struct Cora* co);
-void _35clofun1163(struct Cora* co);
-void _35clofun1207(struct Cora* co);
-void _35clofun1214(struct Cora* co);
-void _35clofun1215(struct Cora* co);
-void _35clofun1208(struct Cora* co);
-void _35clofun1209(struct Cora* co);
-void _35clofun1210(struct Cora* co);
-void _35clofun1213(struct Cora* co);
+void _35clofun1070(struct Cora* co);
+void _35clofun1076(struct Cora* co);
+void _35clofun1133(struct Cora* co);
+void _35clofun1167(struct Cora* co);
 void _35clofun1211(struct Cora* co);
+void _35clofun1220(struct Cora* co);
+void _35clofun1221(struct Cora* co);
+void _35clofun1218(struct Cora* co);
+void _35clofun1219(struct Cora* co);
 void _35clofun1212(struct Cora* co);
-void _35clofun1206(struct Cora* co);
-void _35clofun1201(struct Cora* co);
-void _35clofun1202(struct Cora* co);
-void _35clofun1203(struct Cora* co);
+void _35clofun1213(struct Cora* co);
+void _35clofun1214(struct Cora* co);
+void _35clofun1217(struct Cora* co);
+void _35clofun1215(struct Cora* co);
+void _35clofun1216(struct Cora* co);
+void _35clofun1210(struct Cora* co);
 void _35clofun1205(struct Cora* co);
+void _35clofun1206(struct Cora* co);
+void _35clofun1207(struct Cora* co);
+void _35clofun1209(struct Cora* co);
+void _35clofun1208(struct Cora* co);
+void _35clofun1203(struct Cora* co);
 void _35clofun1204(struct Cora* co);
-void _35clofun1199(struct Cora* co);
-void _35clofun1200(struct Cora* co);
-void _35clofun1176(struct Cora* co);
-void _35clofun1177(struct Cora* co);
-void _35clofun1198(struct Cora* co);
-void _35clofun1178(struct Cora* co);
-void _35clofun1197(struct Cora* co);
-void _35clofun1179(struct Cora* co);
-void _35clofun1196(struct Cora* co);
 void _35clofun1180(struct Cora* co);
+void _35clofun1181(struct Cora* co);
+void _35clofun1202(struct Cora* co);
+void _35clofun1182(struct Cora* co);
+void _35clofun1201(struct Cora* co);
+void _35clofun1183(struct Cora* co);
+void _35clofun1200(struct Cora* co);
+void _35clofun1184(struct Cora* co);
+void _35clofun1198(struct Cora* co);
+void _35clofun1199(struct Cora* co);
+void _35clofun1185(struct Cora* co);
+void _35clofun1197(struct Cora* co);
+void _35clofun1186(struct Cora* co);
+void _35clofun1196(struct Cora* co);
+void _35clofun1187(struct Cora* co);
+void _35clofun1193(struct Cora* co);
 void _35clofun1194(struct Cora* co);
 void _35clofun1195(struct Cora* co);
-void _35clofun1181(struct Cora* co);
-void _35clofun1193(struct Cora* co);
-void _35clofun1182(struct Cora* co);
+void _35clofun1188(struct Cora* co);
 void _35clofun1192(struct Cora* co);
-void _35clofun1183(struct Cora* co);
 void _35clofun1189(struct Cora* co);
 void _35clofun1190(struct Cora* co);
 void _35clofun1191(struct Cora* co);
-void _35clofun1184(struct Cora* co);
-void _35clofun1188(struct Cora* co);
-void _35clofun1185(struct Cora* co);
-void _35clofun1186(struct Cora* co);
-void _35clofun1187(struct Cora* co);
-void _35clofun1164(struct Cora* co);
-void _35clofun1165(struct Cora* co);
-void _35clofun1166(struct Cora* co);
-void _35clofun1167(struct Cora* co);
 void _35clofun1168(struct Cora* co);
 void _35clofun1169(struct Cora* co);
 void _35clofun1170(struct Cora* co);
@@ -65,295 +63,316 @@ void _35clofun1172(struct Cora* co);
 void _35clofun1173(struct Cora* co);
 void _35clofun1174(struct Cora* co);
 void _35clofun1175(struct Cora* co);
-void _35clofun1157(struct Cora* co);
-void _35clofun1158(struct Cora* co);
-void _35clofun1159(struct Cora* co);
-void _35clofun1160(struct Cora* co);
+void _35clofun1176(struct Cora* co);
+void _35clofun1177(struct Cora* co);
+void _35clofun1178(struct Cora* co);
+void _35clofun1179(struct Cora* co);
 void _35clofun1161(struct Cora* co);
 void _35clofun1162(struct Cora* co);
-void _35clofun1155(struct Cora* co);
-void _35clofun1156(struct Cora* co);
-void _35clofun1148(struct Cora* co);
-void _35clofun1149(struct Cora* co);
-void _35clofun1151(struct Cora* co);
-void _35clofun1153(struct Cora* co);
-void _35clofun1154(struct Cora* co);
+void _35clofun1163(struct Cora* co);
+void _35clofun1164(struct Cora* co);
+void _35clofun1165(struct Cora* co);
+void _35clofun1166(struct Cora* co);
+void _35clofun1159(struct Cora* co);
+void _35clofun1160(struct Cora* co);
 void _35clofun1152(struct Cora* co);
+void _35clofun1153(struct Cora* co);
+void _35clofun1155(struct Cora* co);
+void _35clofun1157(struct Cora* co);
+void _35clofun1158(struct Cora* co);
+void _35clofun1156(struct Cora* co);
+void _35clofun1154(struct Cora* co);
 void _35clofun1150(struct Cora* co);
-void _35clofun1146(struct Cora* co);
+void _35clofun1151(struct Cora* co);
+void _35clofun1149(struct Cora* co);
 void _35clofun1147(struct Cora* co);
+void _35clofun1148(struct Cora* co);
+void _35clofun1146(struct Cora* co);
 void _35clofun1145(struct Cora* co);
+void _35clofun1142(struct Cora* co);
 void _35clofun1143(struct Cora* co);
 void _35clofun1144(struct Cora* co);
-void _35clofun1142(struct Cora* co);
 void _35clofun1141(struct Cora* co);
-void _35clofun1138(struct Cora* co);
-void _35clofun1139(struct Cora* co);
-void _35clofun1140(struct Cora* co);
-void _35clofun1137(struct Cora* co);
-void _35clofun1130(struct Cora* co);
-void _35clofun1131(struct Cora* co);
-void _35clofun1136(struct Cora* co);
-void _35clofun1132(struct Cora* co);
-void _35clofun1135(struct Cora* co);
-void _35clofun1133(struct Cora* co);
 void _35clofun1134(struct Cora* co);
+void _35clofun1135(struct Cora* co);
+void _35clofun1140(struct Cora* co);
+void _35clofun1136(struct Cora* co);
+void _35clofun1139(struct Cora* co);
+void _35clofun1137(struct Cora* co);
+void _35clofun1138(struct Cora* co);
+void _35clofun1132(struct Cora* co);
+void _35clofun1125(struct Cora* co);
+void _35clofun1126(struct Cora* co);
+void _35clofun1127(struct Cora* co);
 void _35clofun1128(struct Cora* co);
+void _35clofun1131(struct Cora* co);
+void _35clofun1130(struct Cora* co);
+void _35clofun1129(struct Cora* co);
+void _35clofun1109(struct Cora* co);
+void _35clofun1110(struct Cora* co);
+void _35clofun1111(struct Cora* co);
 void _35clofun1121(struct Cora* co);
 void _35clofun1122(struct Cora* co);
 void _35clofun1123(struct Cora* co);
 void _35clofun1124(struct Cora* co);
-void _35clofun1127(struct Cora* co);
-void _35clofun1126(struct Cora* co);
-void _35clofun1125(struct Cora* co);
-void _35clofun1105(struct Cora* co);
-void _35clofun1106(struct Cora* co);
-void _35clofun1107(struct Cora* co);
+void _35clofun1112(struct Cora* co);
 void _35clofun1117(struct Cora* co);
 void _35clofun1118(struct Cora* co);
 void _35clofun1119(struct Cora* co);
 void _35clofun1120(struct Cora* co);
-void _35clofun1108(struct Cora* co);
 void _35clofun1113(struct Cora* co);
 void _35clofun1114(struct Cora* co);
 void _35clofun1115(struct Cora* co);
 void _35clofun1116(struct Cora* co);
-void _35clofun1109(struct Cora* co);
-void _35clofun1110(struct Cora* co);
-void _35clofun1111(struct Cora* co);
-void _35clofun1112(struct Cora* co);
-void _35clofun1097(struct Cora* co);
-void _35clofun1098(struct Cora* co);
-void _35clofun1103(struct Cora* co);
-void _35clofun1104(struct Cora* co);
 void _35clofun1101(struct Cora* co);
 void _35clofun1102(struct Cora* co);
+void _35clofun1107(struct Cora* co);
+void _35clofun1108(struct Cora* co);
+void _35clofun1105(struct Cora* co);
+void _35clofun1106(struct Cora* co);
+void _35clofun1103(struct Cora* co);
+void _35clofun1104(struct Cora* co);
+void _35clofun1095(struct Cora* co);
+void _35clofun1098(struct Cora* co);
 void _35clofun1099(struct Cora* co);
 void _35clofun1100(struct Cora* co);
-void _35clofun1091(struct Cora* co);
-void _35clofun1094(struct Cora* co);
-void _35clofun1095(struct Cora* co);
 void _35clofun1096(struct Cora* co);
-void _35clofun1092(struct Cora* co);
-void _35clofun1093(struct Cora* co);
-void _35clofun1073(struct Cora* co);
-void _35clofun1074(struct Cora* co);
-void _35clofun1075(struct Cora* co);
-void _35clofun1089(struct Cora* co);
-void _35clofun1090(struct Cora* co);
-void _35clofun1086(struct Cora* co);
-void _35clofun1087(struct Cora* co);
-void _35clofun1088(struct Cora* co);
-void _35clofun1084(struct Cora* co);
-void _35clofun1085(struct Cora* co);
-void _35clofun1081(struct Cora* co);
-void _35clofun1082(struct Cora* co);
-void _35clofun1083(struct Cora* co);
-void _35clofun1079(struct Cora* co);
-void _35clofun1080(struct Cora* co);
-void _35clofun1076(struct Cora* co);
+void _35clofun1097(struct Cora* co);
 void _35clofun1077(struct Cora* co);
 void _35clofun1078(struct Cora* co);
+void _35clofun1079(struct Cora* co);
+void _35clofun1093(struct Cora* co);
+void _35clofun1094(struct Cora* co);
+void _35clofun1090(struct Cora* co);
+void _35clofun1091(struct Cora* co);
+void _35clofun1092(struct Cora* co);
+void _35clofun1088(struct Cora* co);
+void _35clofun1089(struct Cora* co);
+void _35clofun1085(struct Cora* co);
+void _35clofun1086(struct Cora* co);
+void _35clofun1087(struct Cora* co);
+void _35clofun1083(struct Cora* co);
+void _35clofun1084(struct Cora* co);
+void _35clofun1080(struct Cora* co);
+void _35clofun1081(struct Cora* co);
+void _35clofun1082(struct Cora* co);
+void _35clofun1075(struct Cora* co);
+void _35clofun1072(struct Cora* co);
+void _35clofun1073(struct Cora* co);
+void _35clofun1074(struct Cora* co);
 void _35clofun1071(struct Cora* co);
-void _35clofun1068(struct Cora* co);
 void _35clofun1069(struct Cora* co);
-void _35clofun1070(struct Cora* co);
 void _35clofun1067(struct Cora* co);
+void _35clofun1068(struct Cora* co);
 void _35clofun1065(struct Cora* co);
 void _35clofun1063(struct Cora* co);
 void _35clofun1064(struct Cora* co);
-void _35clofun1061(struct Cora* co);
+void _35clofun1058(struct Cora* co);
 void _35clofun1059(struct Cora* co);
 void _35clofun1060(struct Cora* co);
+void _35clofun1061(struct Cora* co);
+void _35clofun1056(struct Cora* co);
+void _35clofun1051(struct Cora* co);
+void _35clofun1052(struct Cora* co);
+void _35clofun1053(struct Cora* co);
 void _35clofun1054(struct Cora* co);
 void _35clofun1055(struct Cora* co);
-void _35clofun1056(struct Cora* co);
-void _35clofun1057(struct Cora* co);
-void _35clofun1052(struct Cora* co);
-void _35clofun1047(struct Cora* co);
-void _35clofun1048(struct Cora* co);
-void _35clofun1049(struct Cora* co);
 void _35clofun1050(struct Cora* co);
-void _35clofun1051(struct Cora* co);
-void _35clofun1046(struct Cora* co);
+void _35clofun1049(struct Cora* co);
+void _35clofun1044(struct Cora* co);
 void _35clofun1045(struct Cora* co);
-void _35clofun1040(struct Cora* co);
-void _35clofun1041(struct Cora* co);
+void _35clofun1046(struct Cora* co);
+void _35clofun1047(struct Cora* co);
 void _35clofun1042(struct Cora* co);
-void _35clofun1043(struct Cora* co);
+void _35clofun1037(struct Cora* co);
 void _35clofun1038(struct Cora* co);
-void _35clofun1033(struct Cora* co);
-void _35clofun1034(struct Cora* co);
+void _35clofun1039(struct Cora* co);
+void _35clofun1040(struct Cora* co);
+void _35clofun1031(struct Cora* co);
 void _35clofun1035(struct Cora* co);
 void _35clofun1036(struct Cora* co);
-void _35clofun1027(struct Cora* co);
-void _35clofun1031(struct Cora* co);
 void _35clofun1032(struct Cora* co);
+void _35clofun1033(struct Cora* co);
+void _35clofun1034(struct Cora* co);
+void _35clofun1030(struct Cora* co);
 void _35clofun1028(struct Cora* co);
 void _35clofun1029(struct Cora* co);
-void _35clofun1030(struct Cora* co);
+void _35clofun1027(struct Cora* co);
 void _35clofun1026(struct Cora* co);
-void _35clofun1024(struct Cora* co);
 void _35clofun1025(struct Cora* co);
 void _35clofun1023(struct Cora* co);
-void _35clofun1022(struct Cora* co);
+void _35clofun1024(struct Cora* co);
 void _35clofun1021(struct Cora* co);
-void _35clofun1019(struct Cora* co);
 void _35clofun1020(struct Cora* co);
+void _35clofun1018(struct Cora* co);
+void _35clofun1019(struct Cora* co);
 void _35clofun1017(struct Cora* co);
 void _35clofun1016(struct Cora* co);
-void _35clofun1014(struct Cora* co);
 void _35clofun1015(struct Cora* co);
+void _35clofun1014(struct Cora* co);
 void _35clofun1013(struct Cora* co);
 void _35clofun1012(struct Cora* co);
 void _35clofun1011(struct Cora* co);
 void _35clofun1010(struct Cora* co);
-void _35clofun1009(struct Cora* co);
-void _35clofun1008(struct Cora* co);
-void _35clofun1007(struct Cora* co);
-void _35clofun1006(struct Cora* co);
 
 void entry(struct Cora* co) {
-Obj _35reg39 = primSet(intern("null?"), makeNative(0, _35clofun1006, 1, 0));
-Obj _35reg42 = primSet(intern("cadr"), makeNative(0, _35clofun1007, 1, 0));
-Obj _35reg45 = primSet(intern("caar"), makeNative(0, _35clofun1008, 1, 0));
-Obj _35reg48 = primSet(intern("cdar"), makeNative(0, _35clofun1009, 1, 0));
-Obj _35reg51 = primSet(intern("cddr"), makeNative(0, _35clofun1010, 1, 0));
-Obj _35reg55 = primSet(intern("caddr"), makeNative(0, _35clofun1011, 1, 0));
-Obj _35reg60 = primSet(intern("cadddr"), makeNative(0, _35clofun1012, 1, 0));
-Obj _35reg64 = primSet(intern("cdddr"), makeNative(0, _35clofun1013, 1, 0));
-Obj _35reg72 = primSet(intern("rcons"), makeNative(0, _35clofun1014, 1, 0));
-Obj _35reg74 = primSet(intern("pair?"), makeNative(0, _35clofun1016, 1, 0));
-Obj _35reg79 = primSet(intern("cora/init.reverse-h"), makeNative(0, _35clofun1017, 2, 0));
-pushCont(co, 0, _35clofun1018, 0);
+Obj _35reg39 = primSet(intern("null?"), makeNative(0, _35clofun1010, 1, 0));
+Obj _35reg42 = primSet(intern("cadr"), makeNative(0, _35clofun1011, 1, 0));
+Obj _35reg45 = primSet(intern("caar"), makeNative(0, _35clofun1012, 1, 0));
+Obj _35reg48 = primSet(intern("cdar"), makeNative(0, _35clofun1013, 1, 0));
+Obj _35reg51 = primSet(intern("cddr"), makeNative(0, _35clofun1014, 1, 0));
+Obj _35reg55 = primSet(intern("caddr"), makeNative(0, _35clofun1015, 1, 0));
+Obj _35reg60 = primSet(intern("cadddr"), makeNative(0, _35clofun1016, 1, 0));
+Obj _35reg64 = primSet(intern("cdddr"), makeNative(0, _35clofun1017, 1, 0));
+Obj _35reg72 = primSet(intern("rcons"), makeNative(0, _35clofun1018, 1, 0));
+Obj _35reg74 = primSet(intern("pair?"), makeNative(0, _35clofun1020, 1, 0));
+Obj _35reg79 = primSet(intern("cora/init.reverse-h"), makeNative(0, _35clofun1021, 2, 0));
+pushCont(co, 0, _35clofun1022, 0);
 coraCall(co, 2, globalRef(intern("cora/init.reverse-h")), Nil);
 }
 
-void _35clofun1018(struct Cora* co) {
+void _35clofun1022(struct Cora* co) {
 Obj _35val80 = co->args[1];
 Obj _35reg81 = primSet(intern("reverse"), _35val80);
-Obj _35reg87 = primSet(intern("map-h"), makeNative(0, _35clofun1019, 3, 0));
-Obj _35reg88 = primSet(intern("map"), makeNative(0, _35clofun1021, 2, 0));
+Obj _35reg87 = primSet(intern("map-h"), makeNative(0, _35clofun1023, 3, 0));
+Obj _35reg88 = primSet(intern("map"), makeNative(0, _35clofun1025, 2, 0));
 Obj _35reg89 = primSet(intern("*macros*"), Nil);
 Obj _35reg90 = primGenSym(intern("protect"));
 Obj _35reg91 = primSet(intern("*protect-symbol*"), _35reg90);
-Obj _35reg93 = primSet(intern("cora/init.protect"), makeNative(0, _35clofun1022, 1, 0));
-Obj _35reg97 = primSet(intern("cora/init.add-to-*macros*"), makeNative(0, _35clofun1023, 2, 0));
-Obj _35reg110 = primSet(intern("cora/init.macroexpand1-h"), makeNative(0, _35clofun1024, 2, 0));
-Obj _35reg111 = primSet(intern("cora/init.macroexpand1"), makeNative(0, _35clofun1026, 1, 0));
-Obj _35reg128 = primSet(intern("cora/init.macroexpand-boot"), makeNative(0, _35clofun1027, 1, 0));
+Obj _35reg93 = primSet(intern("cora/init.protect"), makeNative(0, _35clofun1026, 1, 0));
+Obj _35reg97 = primSet(intern("cora/init.add-to-*macros*"), makeNative(0, _35clofun1027, 2, 0));
+Obj _35reg110 = primSet(intern("cora/init.macroexpand1-h"), makeNative(0, _35clofun1028, 2, 0));
+Obj _35reg111 = primSet(intern("cora/init.macroexpand1"), makeNative(0, _35clofun1030, 1, 0));
+Obj _35reg128 = primSet(intern("cora/init.macroexpand-boot"), makeNative(0, _35clofun1031, 1, 0));
 Obj _35reg129 = primSet(intern("macroexpand"), globalRef(intern("cora/init.macroexpand-boot")));
-Obj _35reg140 = primSet(intern("defmacro-macro"), makeNative(0, _35clofun1033, 1, 0));
-pushCont(co, 0, _35clofun1037, 0);
+Obj _35reg140 = primSet(intern("defmacro-macro"), makeNative(0, _35clofun1037, 1, 0));
+pushCont(co, 0, _35clofun1041, 0);
 coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("defmacro"), globalRef(intern("defmacro-macro")));
 }
 
-void _35clofun1037(struct Cora* co) {
+void _35clofun1041(struct Cora* co) {
 Obj _35val141 = co->args[1];
-pushCont(co, 0, _35clofun1039, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("list"), makeNative(0, _35clofun1038, 1, 0));
+pushCont(co, 0, _35clofun1043, 0);
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("list"), makeNative(0, _35clofun1042, 1, 0));
 }
 
-void _35clofun1039(struct Cora* co) {
+void _35clofun1043(struct Cora* co) {
 Obj _35val143 = co->args[1];
-pushCont(co, 0, _35clofun1044, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("defun"), makeNative(0, _35clofun1040, 1, 0));
+pushCont(co, 0, _35clofun1048, 0);
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("defun"), makeNative(0, _35clofun1044, 1, 0));
 }
 
-void _35clofun1044(struct Cora* co) {
+void _35clofun1048(struct Cora* co) {
 Obj _35val155 = co->args[1];
-Obj _35reg160 = primSet(intern("elem?"), makeNative(0, _35clofun1045, 2, 0));
-Obj _35reg163 = primSet(intern("atom?"), makeNative(0, _35clofun1046, 1, 0));
-Obj _35reg175 = primSet(intern("cora/init.rewrite-let"), makeNative(0, _35clofun1047, 1, 0));
-pushCont(co, 0, _35clofun1053, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("let"), makeNative(0, _35clofun1052, 1, 0));
+Obj _35reg160 = primSet(intern("elem?"), makeNative(0, _35clofun1049, 2, 0));
+Obj _35reg163 = primSet(intern("atom?"), makeNative(0, _35clofun1050, 1, 0));
+Obj _35reg175 = primSet(intern("cora/init.rewrite-let"), makeNative(0, _35clofun1051, 1, 0));
+pushCont(co, 0, _35clofun1057, 0);
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("let"), makeNative(0, _35clofun1056, 1, 0));
 }
 
-void _35clofun1053(struct Cora* co) {
+void _35clofun1057(struct Cora* co) {
 Obj _35val177 = co->args[1];
-pushCont(co, 0, _35clofun1058, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("cond"), makeNative(0, _35clofun1054, 1, 0));
-}
-
-void _35clofun1058(struct Cora* co) {
-Obj _35val191 = co->args[1];
-Obj _35reg203 = primSet(intern("cora/init.rewrite-or"), makeNative(0, _35clofun1059, 1, 0));
 pushCont(co, 0, _35clofun1062, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("or"), makeNative(0, _35clofun1061, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("cond"), makeNative(0, _35clofun1058, 1, 0));
 }
 
 void _35clofun1062(struct Cora* co) {
-Obj _35val205 = co->args[1];
-Obj _35reg217 = primSet(intern("cora/init.rewrite-and"), makeNative(0, _35clofun1063, 1, 0));
+Obj _35val191 = co->args[1];
+Obj _35reg203 = primSet(intern("cora/init.rewrite-or"), makeNative(0, _35clofun1063, 1, 0));
 pushCont(co, 0, _35clofun1066, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("and"), makeNative(0, _35clofun1065, 1, 0));
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("or"), makeNative(0, _35clofun1065, 1, 0));
 }
 
 void _35clofun1066(struct Cora* co) {
+Obj _35val205 = co->args[1];
+Obj _35reg217 = primSet(intern("cora/init.rewrite-and"), makeNative(0, _35clofun1067, 1, 0));
+pushCont(co, 0, _35clofun1070, 0);
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("and"), makeNative(0, _35clofun1069, 1, 0));
+}
+
+void _35clofun1070(struct Cora* co) {
 Obj _35val219 = co->args[1];
-Obj _35reg222 = primSet(intern("boolean?"), makeNative(0, _35clofun1067, 1, 0));
-Obj _35reg232 = primSet(intern("cora/init.rcons1"), makeNative(0, _35clofun1068, 1, 0));
-pushCont(co, 0, _35clofun1072, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("list-rest"), makeNative(0, _35clofun1071, 1, 0));
+Obj _35reg222 = primSet(intern("boolean?"), makeNative(0, _35clofun1071, 1, 0));
+Obj _35reg232 = primSet(intern("cora/init.rcons1"), makeNative(0, _35clofun1072, 1, 0));
+pushCont(co, 0, _35clofun1076, 0);
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("list-rest"), makeNative(0, _35clofun1075, 1, 0));
 }
 
-void _35clofun1072(struct Cora* co) {
+void _35clofun1076(struct Cora* co) {
 Obj _35val234 = co->args[1];
-Obj _35reg288 = primSet(intern("cora/init.match-cons-expander"), makeNative(0, _35clofun1073, 4, 0));
-Obj _35reg321 = primSet(intern("cora/init.match1"), makeNative(0, _35clofun1091, 4, 0));
-Obj _35reg348 = primSet(intern("cora/init.extract-rule-action"), makeNative(0, _35clofun1097, 2, 0));
-Obj _35reg400 = primSet(intern("cora/init.match-helper"), makeNative(0, _35clofun1105, 2, 0));
-Obj _35reg426 = primSet(intern("cora/init.rewrite-match"), makeNative(0, _35clofun1121, 1, 0));
-pushCont(co, 0, _35clofun1129, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("match"), makeNative(0, _35clofun1128, 1, 0));
+Obj _35reg288 = primSet(intern("cora/init.match-cons-expander"), makeNative(0, _35clofun1077, 4, 0));
+Obj _35reg321 = primSet(intern("cora/init.match1"), makeNative(0, _35clofun1095, 4, 0));
+Obj _35reg348 = primSet(intern("cora/init.extract-rule-action"), makeNative(0, _35clofun1101, 2, 0));
+Obj _35reg400 = primSet(intern("cora/init.match-helper"), makeNative(0, _35clofun1109, 2, 0));
+Obj _35reg426 = primSet(intern("cora/init.rewrite-match"), makeNative(0, _35clofun1125, 1, 0));
+pushCont(co, 0, _35clofun1133, 0);
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("match"), makeNative(0, _35clofun1132, 1, 0));
 }
 
-void _35clofun1129(struct Cora* co) {
+void _35clofun1133(struct Cora* co) {
 Obj _35val427 = co->args[1];
-Obj _35reg479 = primSet(intern("cora/init.extract-rules1"), makeNative(0, _35clofun1130, 3, 0));
-Obj _35reg480 = primSet(intern("cora/init.extract-rules"), makeNative(0, _35clofun1137, 1, 0));
-Obj _35reg485 = primSet(intern("cora/init.rules-patterns"), makeNative(0, _35clofun1138, 2, 0));
-Obj _35reg489 = primSet(intern("cora/init.length-h"), makeNative(0, _35clofun1141, 2, 0));
-Obj _35reg490 = primSet(intern("length"), makeNative(0, _35clofun1142, 1, 0));
-Obj _35reg498 = primSet(intern("cora/init.filter-h"), makeNative(0, _35clofun1143, 3, 0));
-Obj _35reg499 = primSet(intern("filter"), makeNative(0, _35clofun1145, 2, 0));
-Obj _35reg505 = primSet(intern("append"), makeNative(0, _35clofun1146, 2, 0));
-Obj _35reg516 = primSet(intern("cora/init.rules-arg-count"), makeNative(0, _35clofun1148, 1, 0));
-Obj _35reg522 = primSet(intern("cora/init.gen-parameters"), makeNative(0, _35clofun1155, 1, 0));
-pushCont(co, 0, _35clofun1163, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("func"), makeNative(0, _35clofun1157, 1, 0));
+Obj _35reg479 = primSet(intern("cora/init.extract-rules1"), makeNative(0, _35clofun1134, 3, 0));
+Obj _35reg480 = primSet(intern("cora/init.extract-rules"), makeNative(0, _35clofun1141, 1, 0));
+Obj _35reg485 = primSet(intern("cora/init.rules-patterns"), makeNative(0, _35clofun1142, 2, 0));
+Obj _35reg489 = primSet(intern("cora/init.length-h"), makeNative(0, _35clofun1145, 2, 0));
+Obj _35reg490 = primSet(intern("length"), makeNative(0, _35clofun1146, 1, 0));
+Obj _35reg498 = primSet(intern("cora/init.filter-h"), makeNative(0, _35clofun1147, 3, 0));
+Obj _35reg499 = primSet(intern("filter"), makeNative(0, _35clofun1149, 2, 0));
+Obj _35reg505 = primSet(intern("append"), makeNative(0, _35clofun1150, 2, 0));
+Obj _35reg516 = primSet(intern("cora/init.rules-arg-count"), makeNative(0, _35clofun1152, 1, 0));
+Obj _35reg522 = primSet(intern("cora/init.gen-parameters"), makeNative(0, _35clofun1159, 1, 0));
+pushCont(co, 0, _35clofun1167, 0);
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("func"), makeNative(0, _35clofun1161, 1, 0));
 }
 
-void _35clofun1163(struct Cora* co) {
+void _35clofun1167(struct Cora* co) {
 Obj _35val535 = co->args[1];
-Obj _35reg798 = primSet(intern("cora/init.propagate-boolean0"), makeNative(0, _35clofun1164, 1, 0));
-Obj _35reg956 = primSet(intern("cora/init.propagate-boolean"), makeNative(0, _35clofun1176, 1, 0));
-Obj _35reg958 = primSet(intern("macroexpand"), makeNative(0, _35clofun1199, 1, 0));
-Obj _35reg982 = primSet(intern("cora/init.rewrite-begin"), makeNative(0, _35clofun1201, 1, 0));
-pushCont(co, 0, _35clofun1207, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("begin"), makeNative(0, _35clofun1206, 1, 0));
+Obj _35reg798 = primSet(intern("cora/init.propagate-boolean0"), makeNative(0, _35clofun1168, 1, 0));
+Obj _35reg956 = primSet(intern("cora/init.propagate-boolean"), makeNative(0, _35clofun1180, 1, 0));
+Obj _35reg958 = primSet(intern("macroexpand"), makeNative(0, _35clofun1203, 1, 0));
+Obj _35reg982 = primSet(intern("cora/init.rewrite-begin"), makeNative(0, _35clofun1205, 1, 0));
+pushCont(co, 0, _35clofun1211, 0);
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("begin"), makeNative(0, _35clofun1210, 1, 0));
 }
 
-void _35clofun1207(struct Cora* co) {
+void _35clofun1211(struct Cora* co) {
 Obj _35val984 = co->args[1];
-Obj _35reg1004 = primSet(intern("cora/init.rewrite-backquote"), makeNative(0, _35clofun1208, 1, 0));
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("backquote"), makeNative(0, _35clofun1214, 1, 0));
+Obj _35reg1004 = primSet(intern("cora/init.rewrite-backquote"), makeNative(0, _35clofun1212, 1, 0));
+pushCont(co, 0, _35clofun1220, 0);
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("backquote"), makeNative(0, _35clofun1218, 1, 0));
 }
 
-void _35clofun1214(struct Cora* co) {
+void _35clofun1220(struct Cora* co) {
+Obj _35val1006 = co->args[1];
+Obj _35reg1009 = primSet(intern("typecheck"), makeNative(0, _35clofun1221, 2, 0));
+coraReturn(co, _35reg1009);
+return;
+}
+
+void _35clofun1221(struct Cora* co) {
+Obj filename = co->args[1];
+Obj pkg = co->args[2];
+Obj _35reg1007 = primCons(intern("fake"), Nil);
+Obj _35reg1008 = primCons(intern("succ"), _35reg1007);
+coraReturn(co, _35reg1008);
+return;
+}
+
+void _35clofun1218(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, 0, _35clofun1215, 0);
+pushCont(co, 0, _35clofun1219, 0);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
-void _35clofun1215(struct Cora* co) {
+void _35clofun1219(struct Cora* co) {
 Obj _35val1005 = co->args[1];
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-backquote")), _35val1005);
 }
 
-void _35clofun1208(struct Cora* co) {
+void _35clofun1212(struct Cora* co) {
 Obj _35p33 = co->args[1];
-Obj _35cc34 = makeNative(0, _35clofun1209, 0, 1, _35p33);
+Obj _35cc34 = makeNative(0, _35clofun1213, 0, 1, _35p33);
 Obj x = _35p33;
 Obj _35reg1001 = primIsSymbol(x);
 if (True == _35reg1001) {
@@ -366,8 +385,8 @@ coraCall(co, 1, _35cc34);
 }
 }
 
-void _35clofun1209(struct Cora* co) {
-Obj _35cc35 = makeNative(0, _35clofun1210, 0, 1, closureRef(co, 0));
+void _35clofun1213(struct Cora* co) {
+Obj _35cc35 = makeNative(0, _35clofun1214, 0, 1, closureRef(co, 0));
 Obj _35reg991 = primIsCons(closureRef(co, 0));
 if (True == _35reg991) {
 Obj _35reg992 = primCar(closureRef(co, 0));
@@ -399,8 +418,8 @@ coraCall(co, 1, _35cc35);
 }
 }
 
-void _35clofun1210(struct Cora* co) {
-Obj _35cc36 = makeNative(0, _35clofun1211, 0, 1, closureRef(co, 0));
+void _35clofun1214(struct Cora* co) {
+Obj _35cc36 = makeNative(0, _35clofun1215, 0, 1, closureRef(co, 0));
 Obj _35reg985 = primIsCons(closureRef(co, 0));
 if (True == _35reg985) {
 Obj _35reg986 = primCar(closureRef(co, 0));
@@ -408,40 +427,40 @@ Obj x = _35reg986;
 Obj _35reg987 = primCdr(closureRef(co, 0));
 Obj more = _35reg987;
 Obj _35reg988 = primCons(x, more);
-pushCont(co, 0, _35clofun1213, 0);
+pushCont(co, 0, _35clofun1217, 0);
 coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/init.rewrite-backquote")), _35reg988);
 } else {
 coraCall(co, 1, _35cc36);
 }
 }
 
-void _35clofun1213(struct Cora* co) {
+void _35clofun1217(struct Cora* co) {
 Obj _35val989 = co->args[1];
 Obj _35reg990 = primCons(intern("list"), _35val989);
 coraReturn(co, _35reg990);
 return;
 }
 
-void _35clofun1211(struct Cora* co) {
-Obj _35cc37 = makeNative(0, _35clofun1212, 0, 0);
+void _35clofun1215(struct Cora* co) {
+Obj _35cc37 = makeNative(0, _35clofun1216, 0, 0);
 Obj x = closureRef(co, 0);
 coraReturn(co, x);
 return;
 }
 
-void _35clofun1212(struct Cora* co) {
+void _35clofun1216(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun1206(struct Cora* co) {
+void _35clofun1210(struct Cora* co) {
 Obj exp = co->args[1];
 Obj _35reg983 = primCdr(exp);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-begin")), _35reg983);
 }
 
-void _35clofun1201(struct Cora* co) {
+void _35clofun1205(struct Cora* co) {
 Obj _35p29 = co->args[1];
-Obj _35cc30 = makeNative(0, _35clofun1202, 0, 1, _35p29);
+Obj _35cc30 = makeNative(0, _35clofun1206, 0, 1, _35p29);
 Obj _35reg978 = primIsCons(_35p29);
 if (True == _35reg978) {
 Obj _35reg979 = primCar(_35p29);
@@ -459,8 +478,8 @@ coraCall(co, 1, _35cc30);
 }
 }
 
-void _35clofun1202(struct Cora* co) {
-Obj _35cc31 = makeNative(0, _35clofun1203, 0, 1, closureRef(co, 0));
+void _35clofun1206(struct Cora* co) {
+Obj _35cc31 = makeNative(0, _35clofun1207, 0, 1, closureRef(co, 0));
 Obj _35reg966 = primIsCons(closureRef(co, 0));
 if (True == _35reg966) {
 Obj _35reg967 = primCar(closureRef(co, 0));
@@ -491,22 +510,22 @@ coraCall(co, 1, _35cc31);
 }
 }
 
-void _35clofun1203(struct Cora* co) {
-Obj _35cc32 = makeNative(0, _35clofun1204, 0, 0);
+void _35clofun1207(struct Cora* co) {
+Obj _35cc32 = makeNative(0, _35clofun1208, 0, 0);
 Obj _35reg959 = primIsCons(closureRef(co, 0));
 if (True == _35reg959) {
 Obj _35reg960 = primCar(closureRef(co, 0));
 Obj x = _35reg960;
 Obj _35reg961 = primCdr(closureRef(co, 0));
 Obj y = _35reg961;
-pushCont(co, 0, _35clofun1205, 1, x);
+pushCont(co, 0, _35clofun1209, 1, x);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-begin")), y);
 } else {
 coraCall(co, 1, _35cc32);
 }
 }
 
-void _35clofun1205(struct Cora* co) {
+void _35clofun1209(struct Cora* co) {
 Obj _35val962 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg963 = primCons(_35val962, Nil);
@@ -516,24 +535,24 @@ coraReturn(co, _35reg965);
 return;
 }
 
-void _35clofun1204(struct Cora* co) {
+void _35clofun1208(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun1199(struct Cora* co) {
+void _35clofun1203(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, 0, _35clofun1200, 0);
+pushCont(co, 0, _35clofun1204, 0);
 coraCall(co, 2, globalRef(intern("cora/init.macroexpand-boot")), exp);
 }
 
-void _35clofun1200(struct Cora* co) {
+void _35clofun1204(struct Cora* co) {
 Obj _35val957 = co->args[1];
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), _35val957);
 }
 
-void _35clofun1176(struct Cora* co) {
+void _35clofun1180(struct Cora* co) {
 Obj _35p17 = co->args[1];
-Obj _35cc18 = makeNative(0, _35clofun1177, 0, 1, _35p17);
+Obj _35cc18 = makeNative(0, _35clofun1181, 0, 1, _35p17);
 Obj _35reg944 = primIsCons(_35p17);
 if (True == _35reg944) {
 Obj _35reg945 = primCar(_35p17);
@@ -567,8 +586,8 @@ coraCall(co, 1, _35cc18);
 }
 }
 
-void _35clofun1177(struct Cora* co) {
-Obj _35cc19 = makeNative(0, _35clofun1178, 0, 1, closureRef(co, 0));
+void _35clofun1181(struct Cora* co) {
+Obj _35cc19 = makeNative(0, _35clofun1182, 0, 1, closureRef(co, 0));
 Obj _35reg931 = primIsCons(closureRef(co, 0));
 if (True == _35reg931) {
 Obj _35reg932 = primCar(closureRef(co, 0));
@@ -584,7 +603,7 @@ Obj _35reg938 = primCdr(closureRef(co, 0));
 Obj _35reg939 = primCdr(_35reg938);
 Obj _35reg940 = primEQ(Nil, _35reg939);
 if (True == _35reg940) {
-pushCont(co, 0, _35clofun1198, 0);
+pushCont(co, 0, _35clofun1202, 0);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc19);
@@ -600,7 +619,7 @@ coraCall(co, 1, _35cc19);
 }
 }
 
-void _35clofun1198(struct Cora* co) {
+void _35clofun1202(struct Cora* co) {
 Obj _35val941 = co->args[1];
 Obj x1 = _35val941;
 Obj _35reg942 = primCons(x1, Nil);
@@ -608,8 +627,8 @@ Obj _35reg943 = primCons(intern("cons?"), _35reg942);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg943);
 }
 
-void _35clofun1178(struct Cora* co) {
-Obj _35cc20 = makeNative(0, _35clofun1179, 0, 1, closureRef(co, 0));
+void _35clofun1182(struct Cora* co) {
+Obj _35cc20 = makeNative(0, _35clofun1183, 0, 1, closureRef(co, 0));
 Obj _35reg918 = primIsCons(closureRef(co, 0));
 if (True == _35reg918) {
 Obj _35reg919 = primCar(closureRef(co, 0));
@@ -625,7 +644,7 @@ Obj _35reg925 = primCdr(closureRef(co, 0));
 Obj _35reg926 = primCdr(_35reg925);
 Obj _35reg927 = primEQ(Nil, _35reg926);
 if (True == _35reg927) {
-pushCont(co, 0, _35clofun1197, 0);
+pushCont(co, 0, _35clofun1201, 0);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc20);
@@ -641,7 +660,7 @@ coraCall(co, 1, _35cc20);
 }
 }
 
-void _35clofun1197(struct Cora* co) {
+void _35clofun1201(struct Cora* co) {
 Obj _35val928 = co->args[1];
 Obj x1 = _35val928;
 Obj _35reg929 = primCons(x1, Nil);
@@ -649,8 +668,8 @@ Obj _35reg930 = primCons(intern("car"), _35reg929);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg930);
 }
 
-void _35clofun1179(struct Cora* co) {
-Obj _35cc21 = makeNative(0, _35clofun1180, 0, 1, closureRef(co, 0));
+void _35clofun1183(struct Cora* co) {
+Obj _35cc21 = makeNative(0, _35clofun1184, 0, 1, closureRef(co, 0));
 Obj _35reg905 = primIsCons(closureRef(co, 0));
 if (True == _35reg905) {
 Obj _35reg906 = primCar(closureRef(co, 0));
@@ -666,7 +685,7 @@ Obj _35reg912 = primCdr(closureRef(co, 0));
 Obj _35reg913 = primCdr(_35reg912);
 Obj _35reg914 = primEQ(Nil, _35reg913);
 if (True == _35reg914) {
-pushCont(co, 0, _35clofun1196, 0);
+pushCont(co, 0, _35clofun1200, 0);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc21);
@@ -682,7 +701,7 @@ coraCall(co, 1, _35cc21);
 }
 }
 
-void _35clofun1196(struct Cora* co) {
+void _35clofun1200(struct Cora* co) {
 Obj _35val915 = co->args[1];
 Obj x1 = _35val915;
 Obj _35reg916 = primCons(x1, Nil);
@@ -690,8 +709,8 @@ Obj _35reg917 = primCons(intern("cdr"), _35reg916);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg917);
 }
 
-void _35clofun1180(struct Cora* co) {
-Obj _35cc22 = makeNative(0, _35clofun1181, 0, 1, closureRef(co, 0));
+void _35clofun1184(struct Cora* co) {
+Obj _35cc22 = makeNative(0, _35clofun1185, 0, 1, closureRef(co, 0));
 Obj _35reg883 = primIsCons(closureRef(co, 0));
 if (True == _35reg883) {
 Obj _35reg884 = primCar(closureRef(co, 0));
@@ -716,7 +735,7 @@ Obj _35reg897 = primCdr(_35reg896);
 Obj _35reg898 = primCdr(_35reg897);
 Obj _35reg899 = primEQ(Nil, _35reg898);
 if (True == _35reg899) {
-pushCont(co, 0, _35clofun1194, 1, y);
+pushCont(co, 0, _35clofun1198, 1, y);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc22);
@@ -735,15 +754,15 @@ coraCall(co, 1, _35cc22);
 }
 }
 
-void _35clofun1194(struct Cora* co) {
+void _35clofun1198(struct Cora* co) {
 Obj _35val900 = co->args[1];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x1 = _35val900;
-pushCont(co, 0, _35clofun1195, 1, x1);
+pushCont(co, 0, _35clofun1199, 1, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
 }
 
-void _35clofun1195(struct Cora* co) {
+void _35clofun1199(struct Cora* co) {
 Obj _35val901 = co->args[1];
 Obj x1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y1 = _35val901;
@@ -753,8 +772,8 @@ Obj _35reg904 = primCons(intern("and"), _35reg903);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg904);
 }
 
-void _35clofun1181(struct Cora* co) {
-Obj _35cc23 = makeNative(0, _35clofun1182, 0, 1, closureRef(co, 0));
+void _35clofun1185(struct Cora* co) {
+Obj _35cc23 = makeNative(0, _35clofun1186, 0, 1, closureRef(co, 0));
 Obj _35reg870 = primIsCons(closureRef(co, 0));
 if (True == _35reg870) {
 Obj _35reg871 = primCar(closureRef(co, 0));
@@ -770,7 +789,7 @@ Obj _35reg877 = primCdr(closureRef(co, 0));
 Obj _35reg878 = primCdr(_35reg877);
 Obj _35reg879 = primEQ(Nil, _35reg878);
 if (True == _35reg879) {
-pushCont(co, 0, _35clofun1193, 0);
+pushCont(co, 0, _35clofun1197, 0);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc23);
@@ -786,7 +805,7 @@ coraCall(co, 1, _35cc23);
 }
 }
 
-void _35clofun1193(struct Cora* co) {
+void _35clofun1197(struct Cora* co) {
 Obj _35val880 = co->args[1];
 Obj x1 = _35val880;
 Obj _35reg881 = primCons(x1, Nil);
@@ -794,8 +813,8 @@ Obj _35reg882 = primCons(intern("null?"), _35reg881);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg882);
 }
 
-void _35clofun1182(struct Cora* co) {
-Obj _35cc24 = makeNative(0, _35clofun1183, 0, 1, closureRef(co, 0));
+void _35clofun1186(struct Cora* co) {
+Obj _35cc24 = makeNative(0, _35clofun1187, 0, 1, closureRef(co, 0));
 Obj _35reg857 = primIsCons(closureRef(co, 0));
 if (True == _35reg857) {
 Obj _35reg858 = primCar(closureRef(co, 0));
@@ -811,7 +830,7 @@ Obj _35reg864 = primCdr(closureRef(co, 0));
 Obj _35reg865 = primCdr(_35reg864);
 Obj _35reg866 = primEQ(Nil, _35reg865);
 if (True == _35reg866) {
-pushCont(co, 0, _35clofun1192, 0);
+pushCont(co, 0, _35clofun1196, 0);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc24);
@@ -827,7 +846,7 @@ coraCall(co, 1, _35cc24);
 }
 }
 
-void _35clofun1192(struct Cora* co) {
+void _35clofun1196(struct Cora* co) {
 Obj _35val867 = co->args[1];
 Obj x1 = _35val867;
 Obj _35reg868 = primCons(x1, Nil);
@@ -835,8 +854,8 @@ Obj _35reg869 = primCons(intern("not"), _35reg868);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg869);
 }
 
-void _35clofun1183(struct Cora* co) {
-Obj _35cc25 = makeNative(0, _35clofun1184, 0, 1, closureRef(co, 0));
+void _35clofun1187(struct Cora* co) {
+Obj _35cc25 = makeNative(0, _35clofun1188, 0, 1, closureRef(co, 0));
 Obj _35reg824 = primIsCons(closureRef(co, 0));
 if (True == _35reg824) {
 Obj _35reg825 = primCar(closureRef(co, 0));
@@ -872,7 +891,7 @@ Obj _35reg847 = primCdr(_35reg846);
 Obj _35reg848 = primCdr(_35reg847);
 Obj _35reg849 = primEQ(Nil, _35reg848);
 if (True == _35reg849) {
-pushCont(co, 0, _35clofun1189, 2, y, z);
+pushCont(co, 0, _35clofun1193, 2, y, z);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), x);
 } else {
 coraCall(co, 1, _35cc25);
@@ -894,25 +913,25 @@ coraCall(co, 1, _35cc25);
 }
 }
 
-void _35clofun1189(struct Cora* co) {
+void _35clofun1193(struct Cora* co) {
 Obj _35val850 = co->args[1];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj z = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj x1 = _35val850;
-pushCont(co, 0, _35clofun1190, 2, z, x1);
+pushCont(co, 0, _35clofun1194, 2, z, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), y);
 }
 
-void _35clofun1190(struct Cora* co) {
+void _35clofun1194(struct Cora* co) {
 Obj _35val851 = co->args[1];
 Obj z = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x1 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj y1 = _35val851;
-pushCont(co, 0, _35clofun1191, 2, y1, x1);
+pushCont(co, 0, _35clofun1195, 2, y1, x1);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), z);
 }
 
-void _35clofun1191(struct Cora* co) {
+void _35clofun1195(struct Cora* co) {
 Obj _35val852 = co->args[1];
 Obj y1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x1 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -924,8 +943,8 @@ Obj _35reg856 = primCons(intern("if"), _35reg855);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean0")), _35reg856);
 }
 
-void _35clofun1184(struct Cora* co) {
-Obj _35cc26 = makeNative(0, _35clofun1185, 0, 1, closureRef(co, 0));
+void _35clofun1188(struct Cora* co) {
+Obj _35cc26 = makeNative(0, _35clofun1189, 0, 1, closureRef(co, 0));
 Obj _35reg803 = primIsCons(closureRef(co, 0));
 if (True == _35reg803) {
 Obj _35reg804 = primCar(closureRef(co, 0));
@@ -950,7 +969,7 @@ Obj _35reg817 = primCdr(_35reg816);
 Obj _35reg818 = primCdr(_35reg817);
 Obj _35reg819 = primEQ(Nil, _35reg818);
 if (True == _35reg819) {
-pushCont(co, 0, _35clofun1188, 1, args);
+pushCont(co, 0, _35clofun1192, 1, args);
 coraCall(co, 2, globalRef(intern("cora/init.propagate-boolean")), body);
 } else {
 coraCall(co, 1, _35cc26);
@@ -969,7 +988,7 @@ coraCall(co, 1, _35cc26);
 }
 }
 
-void _35clofun1188(struct Cora* co) {
+void _35clofun1192(struct Cora* co) {
 Obj _35val820 = co->args[1];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg821 = primCons(_35val820, Nil);
@@ -979,8 +998,8 @@ coraReturn(co, _35reg823);
 return;
 }
 
-void _35clofun1185(struct Cora* co) {
-Obj _35cc27 = makeNative(0, _35clofun1186, 0, 1, closureRef(co, 0));
+void _35clofun1189(struct Cora* co) {
+Obj _35cc27 = makeNative(0, _35clofun1190, 0, 1, closureRef(co, 0));
 Obj _35reg799 = primIsCons(closureRef(co, 0));
 if (True == _35reg799) {
 Obj _35reg800 = primCar(closureRef(co, 0));
@@ -994,20 +1013,20 @@ coraCall(co, 1, _35cc27);
 }
 }
 
-void _35clofun1186(struct Cora* co) {
-Obj _35cc28 = makeNative(0, _35clofun1187, 0, 0);
+void _35clofun1190(struct Cora* co) {
+Obj _35cc28 = makeNative(0, _35clofun1191, 0, 0);
 Obj x = closureRef(co, 0);
 coraReturn(co, x);
 return;
 }
 
-void _35clofun1187(struct Cora* co) {
+void _35clofun1191(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun1164(struct Cora* co) {
+void _35clofun1168(struct Cora* co) {
 Obj _35p5 = co->args[1];
-Obj _35cc6 = makeNative(0, _35clofun1165, 0, 1, _35p5);
+Obj _35cc6 = makeNative(0, _35clofun1169, 0, 1, _35p5);
 Obj _35reg759 = primIsCons(_35p5);
 if (True == _35reg759) {
 Obj _35reg760 = primCar(_35p5);
@@ -1089,8 +1108,8 @@ coraCall(co, 1, _35cc6);
 }
 }
 
-void _35clofun1165(struct Cora* co) {
-Obj _35cc7 = makeNative(0, _35clofun1166, 0, 1, closureRef(co, 0));
+void _35clofun1169(struct Cora* co) {
+Obj _35cc7 = makeNative(0, _35clofun1170, 0, 1, closureRef(co, 0));
 Obj _35reg720 = primIsCons(closureRef(co, 0));
 if (True == _35reg720) {
 Obj _35reg721 = primCar(closureRef(co, 0));
@@ -1172,8 +1191,8 @@ coraCall(co, 1, _35cc7);
 }
 }
 
-void _35clofun1166(struct Cora* co) {
-Obj _35cc8 = makeNative(0, _35clofun1167, 0, 1, closureRef(co, 0));
+void _35clofun1170(struct Cora* co) {
+Obj _35cc8 = makeNative(0, _35clofun1171, 0, 1, closureRef(co, 0));
 Obj _35reg681 = primIsCons(closureRef(co, 0));
 if (True == _35reg681) {
 Obj _35reg682 = primCar(closureRef(co, 0));
@@ -1255,8 +1274,8 @@ coraCall(co, 1, _35cc8);
 }
 }
 
-void _35clofun1167(struct Cora* co) {
-Obj _35cc9 = makeNative(0, _35clofun1168, 0, 1, closureRef(co, 0));
+void _35clofun1171(struct Cora* co) {
+Obj _35cc9 = makeNative(0, _35clofun1172, 0, 1, closureRef(co, 0));
 Obj _35reg662 = primIsCons(closureRef(co, 0));
 if (True == _35reg662) {
 Obj _35reg663 = primCar(closureRef(co, 0));
@@ -1308,8 +1327,8 @@ coraCall(co, 1, _35cc9);
 }
 }
 
-void _35clofun1168(struct Cora* co) {
-Obj _35cc10 = makeNative(0, _35clofun1169, 0, 1, closureRef(co, 0));
+void _35clofun1172(struct Cora* co) {
+Obj _35cc10 = makeNative(0, _35clofun1173, 0, 1, closureRef(co, 0));
 Obj _35reg651 = primIsCons(closureRef(co, 0));
 if (True == _35reg651) {
 Obj _35reg652 = primCar(closureRef(co, 0));
@@ -1345,8 +1364,8 @@ coraCall(co, 1, _35cc10);
 }
 }
 
-void _35clofun1169(struct Cora* co) {
-Obj _35cc11 = makeNative(0, _35clofun1170, 0, 1, closureRef(co, 0));
+void _35clofun1173(struct Cora* co) {
+Obj _35cc11 = makeNative(0, _35clofun1174, 0, 1, closureRef(co, 0));
 Obj _35reg612 = primIsCons(closureRef(co, 0));
 if (True == _35reg612) {
 Obj _35reg613 = primCar(closureRef(co, 0));
@@ -1428,8 +1447,8 @@ coraCall(co, 1, _35cc11);
 }
 }
 
-void _35clofun1170(struct Cora* co) {
-Obj _35cc12 = makeNative(0, _35clofun1171, 0, 1, closureRef(co, 0));
+void _35clofun1174(struct Cora* co) {
+Obj _35cc12 = makeNative(0, _35clofun1175, 0, 1, closureRef(co, 0));
 Obj _35reg601 = primIsCons(closureRef(co, 0));
 if (True == _35reg601) {
 Obj _35reg602 = primCar(closureRef(co, 0));
@@ -1465,8 +1484,8 @@ coraCall(co, 1, _35cc12);
 }
 }
 
-void _35clofun1171(struct Cora* co) {
-Obj _35cc13 = makeNative(0, _35clofun1172, 0, 1, closureRef(co, 0));
+void _35clofun1175(struct Cora* co) {
+Obj _35cc13 = makeNative(0, _35clofun1176, 0, 1, closureRef(co, 0));
 Obj _35reg590 = primIsCons(closureRef(co, 0));
 if (True == _35reg590) {
 Obj _35reg591 = primCar(closureRef(co, 0));
@@ -1502,8 +1521,8 @@ coraCall(co, 1, _35cc13);
 }
 }
 
-void _35clofun1172(struct Cora* co) {
-Obj _35cc14 = makeNative(0, _35clofun1173, 0, 1, closureRef(co, 0));
+void _35clofun1176(struct Cora* co) {
+Obj _35cc14 = makeNative(0, _35clofun1177, 0, 1, closureRef(co, 0));
 Obj _35reg563 = primIsCons(closureRef(co, 0));
 if (True == _35reg563) {
 Obj _35reg564 = primCar(closureRef(co, 0));
@@ -1565,8 +1584,8 @@ coraCall(co, 1, _35cc14);
 }
 }
 
-void _35clofun1173(struct Cora* co) {
-Obj _35cc15 = makeNative(0, _35clofun1174, 0, 1, closureRef(co, 0));
+void _35clofun1177(struct Cora* co) {
+Obj _35cc15 = makeNative(0, _35clofun1178, 0, 1, closureRef(co, 0));
 Obj _35reg536 = primIsCons(closureRef(co, 0));
 if (True == _35reg536) {
 Obj _35reg537 = primCar(closureRef(co, 0));
@@ -1628,57 +1647,57 @@ coraCall(co, 1, _35cc15);
 }
 }
 
-void _35clofun1174(struct Cora* co) {
-Obj _35cc16 = makeNative(0, _35clofun1175, 0, 0);
+void _35clofun1178(struct Cora* co) {
+Obj _35cc16 = makeNative(0, _35clofun1179, 0, 0);
 Obj x = closureRef(co, 0);
 coraReturn(co, x);
 return;
 }
 
-void _35clofun1175(struct Cora* co) {
+void _35clofun1179(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun1157(struct Cora* co) {
+void _35clofun1161(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, 0, _35clofun1158, 1, exp);
+pushCont(co, 0, _35clofun1162, 1, exp);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
-void _35clofun1158(struct Cora* co) {
+void _35clofun1162(struct Cora* co) {
 Obj _35val523 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun1159, 1, exp);
+pushCont(co, 0, _35clofun1163, 1, exp);
 coraCall(co, 2, globalRef(intern("cora/init.extract-rules")), _35val523);
 }
 
-void _35clofun1159(struct Cora* co) {
+void _35clofun1163(struct Cora* co) {
 Obj _35val524 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = _35val524;
-pushCont(co, 0, _35clofun1160, 2, exp, body);
+pushCont(co, 0, _35clofun1164, 2, exp, body);
 coraCall(co, 2, globalRef(intern("cora/init.rules-arg-count")), body);
 }
 
-void _35clofun1160(struct Cora* co) {
+void _35clofun1164(struct Cora* co) {
 Obj _35val525 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj nargs = _35val525;
-pushCont(co, 0, _35clofun1161, 2, exp, body);
+pushCont(co, 0, _35clofun1165, 2, exp, body);
 coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), nargs);
 }
 
-void _35clofun1161(struct Cora* co) {
+void _35clofun1165(struct Cora* co) {
 Obj _35val526 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args = _35val526;
-pushCont(co, 0, _35clofun1162, 2, body, args);
+pushCont(co, 0, _35clofun1166, 2, body, args);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
-void _35clofun1162(struct Cora* co) {
+void _35clofun1166(struct Cora* co) {
 Obj _35val527 = co->args[1];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -1693,7 +1712,7 @@ coraReturn(co, _35reg534);
 return;
 }
 
-void _35clofun1155(struct Cora* co) {
+void _35clofun1159(struct Cora* co) {
 Obj n = co->args[1];
 Obj _35reg517 = primEQ(n, makeNumber(0));
 if (True == _35reg517) {
@@ -1702,12 +1721,12 @@ return;
 } else {
 Obj _35reg518 = primGenSym(intern("p"));
 Obj _35reg519 = primSub(n, makeNumber(1));
-pushCont(co, 0, _35clofun1156, 1, _35reg518);
+pushCont(co, 0, _35clofun1160, 1, _35reg518);
 coraCall(co, 2, globalRef(intern("cora/init.gen-parameters")), _35reg519);
 }
 }
 
-void _35clofun1156(struct Cora* co) {
+void _35clofun1160(struct Cora* co) {
 Obj _35val520 = co->args[1];
 Obj _35reg518 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg521 = primCons(_35reg518, _35val520);
@@ -1715,39 +1734,39 @@ coraReturn(co, _35reg521);
 return;
 }
 
-void _35clofun1148(struct Cora* co) {
+void _35clofun1152(struct Cora* co) {
 Obj rules = co->args[1];
-pushCont(co, 0, _35clofun1149, 0);
+pushCont(co, 0, _35clofun1153, 0);
 coraCall(co, 3, globalRef(intern("cora/init.rules-patterns")), Nil, rules);
 }
 
-void _35clofun1149(struct Cora* co) {
+void _35clofun1153(struct Cora* co) {
 Obj _35val506 = co->args[1];
 Obj pats = _35val506;
-Obj len = makeNative(0, _35clofun1150, 1, 0);
-pushCont(co, 0, _35clofun1151, 0);
+Obj len = makeNative(0, _35clofun1154, 1, 0);
+pushCont(co, 0, _35clofun1155, 0);
 coraCall(co, 3, globalRef(intern("map")), len, pats);
 }
 
-void _35clofun1151(struct Cora* co) {
+void _35clofun1155(struct Cora* co) {
 Obj _35val508 = co->args[1];
 Obj counts = _35val508;
 Obj _35reg509 = primCar(counts);
 Obj n = _35reg509;
-Obj dif = makeNative(0, _35clofun1152, 1, 1, n);
+Obj dif = makeNative(0, _35clofun1156, 1, 1, n);
 Obj _35reg512 = primCdr(counts);
-pushCont(co, 0, _35clofun1153, 1, n);
+pushCont(co, 0, _35clofun1157, 1, n);
 coraCall(co, 3, globalRef(intern("filter")), dif, _35reg512);
 }
 
-void _35clofun1153(struct Cora* co) {
+void _35clofun1157(struct Cora* co) {
 Obj _35val513 = co->args[1];
 Obj n = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun1154, 1, n);
+pushCont(co, 0, _35clofun1158, 1, n);
 coraCall(co, 2, globalRef(intern("null?")), _35val513);
 }
 
-void _35clofun1154(struct Cora* co) {
+void _35clofun1158(struct Cora* co) {
 Obj _35val514 = co->args[1];
 Obj n = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg515 = primNot(_35val514);
@@ -1759,7 +1778,7 @@ return;
 }
 }
 
-void _35clofun1152(struct Cora* co) {
+void _35clofun1156(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg510 = primEQ(closureRef(co, 0), x);
 Obj _35reg511 = primNot(_35reg510);
@@ -1767,13 +1786,13 @@ coraReturn(co, _35reg511);
 return;
 }
 
-void _35clofun1150(struct Cora* co) {
+void _35clofun1154(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg507 = primCdr(x);
 coraCall(co, 2, globalRef(intern("length")), _35reg507);
 }
 
-void _35clofun1146(struct Cora* co) {
+void _35clofun1150(struct Cora* co) {
 Obj l1 = co->args[1];
 Obj l2 = co->args[2];
 Obj _35reg500 = primEQ(l1, Nil);
@@ -1783,12 +1802,12 @@ return;
 } else {
 Obj _35reg501 = primCar(l1);
 Obj _35reg502 = primCdr(l1);
-pushCont(co, 0, _35clofun1147, 1, _35reg501);
+pushCont(co, 0, _35clofun1151, 1, _35reg501);
 coraCall(co, 3, globalRef(intern("append")), _35reg502, l2);
 }
 }
 
-void _35clofun1147(struct Cora* co) {
+void _35clofun1151(struct Cora* co) {
 Obj _35val503 = co->args[1];
 Obj _35reg501 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg504 = primCons(_35reg501, _35val503);
@@ -1796,27 +1815,27 @@ coraReturn(co, _35reg504);
 return;
 }
 
-void _35clofun1145(struct Cora* co) {
+void _35clofun1149(struct Cora* co) {
 Obj fn = co->args[1];
 Obj l = co->args[2];
 coraCall(co, 4, globalRef(intern("cora/init.filter-h")), Nil, fn, l);
 }
 
-void _35clofun1143(struct Cora* co) {
+void _35clofun1147(struct Cora* co) {
 Obj res = co->args[1];
 Obj fn = co->args[2];
 Obj l = co->args[3];
 Obj _35reg491 = primIsCons(l);
 if (True == _35reg491) {
 Obj _35reg492 = primCar(l);
-pushCont(co, 0, _35clofun1144, 3, l, res, fn);
+pushCont(co, 0, _35clofun1148, 3, l, res, fn);
 coraCall(co, 2, fn, _35reg492);
 } else {
 coraCall(co, 2, globalRef(intern("reverse")), res);
 }
 }
 
-void _35clofun1144(struct Cora* co) {
+void _35clofun1148(struct Cora* co) {
 Obj _35val493 = co->args[1];
 Obj l = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj res = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -1832,12 +1851,12 @@ coraCall(co, 4, globalRef(intern("cora/init.filter-h")), res, fn, _35reg497);
 }
 }
 
-void _35clofun1142(struct Cora* co) {
+void _35clofun1146(struct Cora* co) {
 Obj l = co->args[1];
 coraCall(co, 3, globalRef(intern("cora/init.length-h")), makeNumber(0), l);
 }
 
-void _35clofun1141(struct Cora* co) {
+void _35clofun1145(struct Cora* co) {
 Obj i = co->args[1];
 Obj l = co->args[2];
 Obj _35reg486 = primEQ(l, Nil);
@@ -1851,14 +1870,14 @@ coraCall(co, 3, globalRef(intern("cora/init.length-h")), _35reg487, _35reg488);
 }
 }
 
-void _35clofun1138(struct Cora* co) {
+void _35clofun1142(struct Cora* co) {
 Obj res = co->args[1];
 Obj rules = co->args[2];
-pushCont(co, 0, _35clofun1139, 2, res, rules);
+pushCont(co, 0, _35clofun1143, 2, res, rules);
 coraCall(co, 2, globalRef(intern("null?")), rules);
 }
 
-void _35clofun1139(struct Cora* co) {
+void _35clofun1143(struct Cora* co) {
 Obj _35val481 = co->args[1];
 Obj res = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -1867,27 +1886,27 @@ coraCall(co, 2, globalRef(intern("reverse")), res);
 } else {
 Obj _35reg482 = primCar(rules);
 Obj _35reg483 = primCons(_35reg482, res);
-pushCont(co, 0, _35clofun1140, 1, _35reg483);
+pushCont(co, 0, _35clofun1144, 1, _35reg483);
 coraCall(co, 2, globalRef(intern("cddr")), rules);
 }
 }
 
-void _35clofun1140(struct Cora* co) {
+void _35clofun1144(struct Cora* co) {
 Obj _35val484 = co->args[1];
 Obj _35reg483 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/init.rules-patterns")), _35reg483, _35val484);
 }
 
-void _35clofun1137(struct Cora* co) {
+void _35clofun1141(struct Cora* co) {
 Obj input = co->args[1];
 coraCall(co, 4, globalRef(intern("cora/init.extract-rules1")), input, Nil, Nil);
 }
 
-void _35clofun1130(struct Cora* co) {
+void _35clofun1134(struct Cora* co) {
 Obj input = co->args[1];
 Obj current = co->args[2];
 Obj result = co->args[3];
-Obj _35cc1 = makeNative(0, _35clofun1131, 0, 3, input, current, result);
+Obj _35cc1 = makeNative(0, _35clofun1135, 0, 3, input, current, result);
 Obj _35reg478 = primEQ(Nil, input);
 if (True == _35reg478) {
 coraCall(co, 2, globalRef(intern("reverse")), result);
@@ -1896,8 +1915,8 @@ coraCall(co, 1, _35cc1);
 }
 }
 
-void _35clofun1131(struct Cora* co) {
-Obj _35cc2 = makeNative(0, _35clofun1132, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun1135(struct Cora* co) {
+Obj _35cc2 = makeNative(0, _35clofun1136, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj _35reg445 = primIsCons(closureRef(co, 0));
 if (True == _35reg445) {
 Obj _35reg446 = primCar(closureRef(co, 0));
@@ -1933,7 +1952,7 @@ Obj _35reg468 = primCdr(_35reg467);
 Obj _35reg469 = primCdr(_35reg468);
 Obj _35reg470 = primCdr(_35reg469);
 Obj remain = _35reg470;
-pushCont(co, 0, _35clofun1136, 3, act, pred, remain);
+pushCont(co, 0, _35clofun1140, 3, act, pred, remain);
 coraCall(co, 2, globalRef(intern("reverse")), closureRef(co, 1));
 } else {
 coraCall(co, 1, _35cc2);
@@ -1955,7 +1974,7 @@ coraCall(co, 1, _35cc2);
 }
 }
 
-void _35clofun1136(struct Cora* co) {
+void _35clofun1140(struct Cora* co) {
 Obj _35val471 = co->args[1];
 Obj act = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj pred = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -1970,8 +1989,8 @@ Obj _35reg477 = primCons(_35reg475, _35reg476);
 coraCall(co, 4, globalRef(intern("cora/init.extract-rules1")), remain, Nil, _35reg477);
 }
 
-void _35clofun1132(struct Cora* co) {
-Obj _35cc3 = makeNative(0, _35clofun1133, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun1136(struct Cora* co) {
+Obj _35cc3 = makeNative(0, _35clofun1137, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj _35reg432 = primIsCons(closureRef(co, 0));
 if (True == _35reg432) {
 Obj _35reg433 = primCar(closureRef(co, 0));
@@ -1986,7 +2005,7 @@ Obj act = _35reg438;
 Obj _35reg439 = primCdr(closureRef(co, 0));
 Obj _35reg440 = primCdr(_35reg439);
 Obj remain = _35reg440;
-pushCont(co, 0, _35clofun1135, 2, act, remain);
+pushCont(co, 0, _35clofun1139, 2, act, remain);
 coraCall(co, 2, globalRef(intern("reverse")), closureRef(co, 1));
 } else {
 coraCall(co, 1, _35cc3);
@@ -1999,7 +2018,7 @@ coraCall(co, 1, _35cc3);
 }
 }
 
-void _35clofun1135(struct Cora* co) {
+void _35clofun1139(struct Cora* co) {
 Obj _35val441 = co->args[1];
 Obj act = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj remain = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2010,8 +2029,8 @@ Obj _35reg444 = primCons(act, _35reg443);
 coraCall(co, 4, globalRef(intern("cora/init.extract-rules1")), remain, Nil, _35reg444);
 }
 
-void _35clofun1133(struct Cora* co) {
-Obj _35cc4 = makeNative(0, _35clofun1134, 0, 0);
+void _35clofun1137(struct Cora* co) {
+Obj _35cc4 = makeNative(0, _35clofun1138, 0, 0);
 Obj _35reg428 = primIsCons(closureRef(co, 0));
 if (True == _35reg428) {
 Obj _35reg429 = primCar(closureRef(co, 0));
@@ -2025,37 +2044,37 @@ coraCall(co, 1, _35cc4);
 }
 }
 
-void _35clofun1134(struct Cora* co) {
+void _35clofun1138(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun1128(struct Cora* co) {
+void _35clofun1132(struct Cora* co) {
 Obj exp = co->args[1];
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-match")), exp);
 }
 
-void _35clofun1121(struct Cora* co) {
+void _35clofun1125(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, 0, _35clofun1122, 1, exp);
+pushCont(co, 0, _35clofun1126, 1, exp);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
-void _35clofun1122(struct Cora* co) {
+void _35clofun1126(struct Cora* co) {
 Obj _35val401 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun1123, 1, exp);
+pushCont(co, 0, _35clofun1127, 1, exp);
 coraCall(co, 2, globalRef(intern("macroexpand")), _35val401);
 }
 
-void _35clofun1123(struct Cora* co) {
+void _35clofun1127(struct Cora* co) {
 Obj _35val402 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj value = _35val402;
-pushCont(co, 0, _35clofun1124, 1, value);
+pushCont(co, 0, _35clofun1128, 1, value);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
-void _35clofun1124(struct Cora* co) {
+void _35clofun1128(struct Cora* co) {
 Obj _35val403 = co->args[1];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj rules = _35val403;
@@ -2068,7 +2087,7 @@ if (True == _35reg407) {
 if (True == True) {
 Obj _35reg408 = primGenSym(intern("val"));
 Obj val = _35reg408;
-pushCont(co, 0, _35clofun1125, 2, value, val);
+pushCont(co, 0, _35clofun1129, 2, value, val);
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), val, rules);
 } else {
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
@@ -2077,7 +2096,7 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
 if (True == False) {
 Obj _35reg414 = primGenSym(intern("val"));
 Obj val = _35reg414;
-pushCont(co, 0, _35clofun1126, 2, value, val);
+pushCont(co, 0, _35clofun1130, 2, value, val);
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), val, rules);
 } else {
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
@@ -2087,7 +2106,7 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
 if (True == False) {
 Obj _35reg420 = primGenSym(intern("val"));
 Obj val = _35reg420;
-pushCont(co, 0, _35clofun1127, 2, value, val);
+pushCont(co, 0, _35clofun1131, 2, value, val);
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), val, rules);
 } else {
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
@@ -2095,7 +2114,7 @@ coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, rules);
 }
 }
 
-void _35clofun1127(struct Cora* co) {
+void _35clofun1131(struct Cora* co) {
 Obj _35val421 = co->args[1];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj val = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2107,7 +2126,7 @@ coraReturn(co, _35reg425);
 return;
 }
 
-void _35clofun1126(struct Cora* co) {
+void _35clofun1130(struct Cora* co) {
 Obj _35val415 = co->args[1];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj val = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2119,7 +2138,7 @@ coraReturn(co, _35reg419);
 return;
 }
 
-void _35clofun1125(struct Cora* co) {
+void _35clofun1129(struct Cora* co) {
 Obj _35val409 = co->args[1];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj val = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2131,14 +2150,14 @@ coraReturn(co, _35reg413);
 return;
 }
 
-void _35clofun1105(struct Cora* co) {
+void _35clofun1109(struct Cora* co) {
 Obj value = co->args[1];
 Obj rules = co->args[2];
-pushCont(co, 0, _35clofun1106, 2, rules, value);
+pushCont(co, 0, _35clofun1110, 2, rules, value);
 coraCall(co, 2, globalRef(intern("null?")), rules);
 }
 
-void _35clofun1106(struct Cora* co) {
+void _35clofun1110(struct Cora* co) {
 Obj _35val349 = co->args[1];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2148,18 +2167,18 @@ Obj _35reg351 = primCons(intern("error"), _35reg350);
 coraReturn(co, _35reg351);
 return;
 } else {
-pushCont(co, 0, _35clofun1107, 2, rules, value);
+pushCont(co, 0, _35clofun1111, 2, rules, value);
 coraCall(co, 2, globalRef(intern("pair?")), rules);
 }
 }
 
-void _35clofun1107(struct Cora* co) {
+void _35clofun1111(struct Cora* co) {
 Obj _35val352 = co->args[1];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val352) {
 Obj _35reg353 = primCdr(rules);
-pushCont(co, 0, _35clofun1108, 2, rules, value);
+pushCont(co, 0, _35clofun1112, 2, rules, value);
 coraCall(co, 2, globalRef(intern("pair?")), _35reg353);
 } else {
 if (True == False) {
@@ -2167,7 +2186,7 @@ Obj _35reg385 = primCar(rules);
 Obj pat = _35reg385;
 Obj _35reg386 = primGenSym(intern("cc"));
 Obj cc = _35reg386;
-pushCont(co, 0, _35clofun1117, 4, pat, rules, value, cc);
+pushCont(co, 0, _35clofun1121, 4, pat, rules, value, cc);
 coraCall(co, 3, globalRef(intern("cora/init.extract-rule-action")), rules, cc);
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
@@ -2175,28 +2194,28 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 
-void _35clofun1117(struct Cora* co) {
+void _35clofun1121(struct Cora* co) {
 Obj _35val387 = co->args[1];
 Obj pat = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj action = _35val387;
-pushCont(co, 0, _35clofun1118, 4, action, rules, value, cc);
+pushCont(co, 0, _35clofun1122, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 }
 
-void _35clofun1118(struct Cora* co) {
+void _35clofun1122(struct Cora* co) {
 Obj _35val388 = co->args[1];
 Obj action = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun1119, 3, rules, value, cc);
+pushCont(co, 0, _35clofun1123, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val388, value, action, cc);
 }
 
-void _35clofun1119(struct Cora* co) {
+void _35clofun1123(struct Cora* co) {
 Obj _35val389 = co->args[1];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2204,11 +2223,11 @@ Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj curr = _35val389;
 Obj _35reg390 = primCdr(rules);
 Obj _35reg391 = primCdr(_35reg390);
-pushCont(co, 0, _35clofun1120, 2, curr, cc);
+pushCont(co, 0, _35clofun1124, 2, curr, cc);
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg391);
 }
 
-void _35clofun1120(struct Cora* co) {
+void _35clofun1124(struct Cora* co) {
 Obj _35val392 = co->args[1];
 Obj curr = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2224,7 +2243,7 @@ coraReturn(co, _35reg399);
 return;
 }
 
-void _35clofun1108(struct Cora* co) {
+void _35clofun1112(struct Cora* co) {
 Obj _35val354 = co->args[1];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2234,7 +2253,7 @@ Obj _35reg355 = primCar(rules);
 Obj pat = _35reg355;
 Obj _35reg356 = primGenSym(intern("cc"));
 Obj cc = _35reg356;
-pushCont(co, 0, _35clofun1109, 4, pat, rules, value, cc);
+pushCont(co, 0, _35clofun1113, 4, pat, rules, value, cc);
 coraCall(co, 3, globalRef(intern("cora/init.extract-rule-action")), rules, cc);
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
@@ -2245,7 +2264,7 @@ Obj _35reg370 = primCar(rules);
 Obj pat = _35reg370;
 Obj _35reg371 = primGenSym(intern("cc"));
 Obj cc = _35reg371;
-pushCont(co, 0, _35clofun1113, 4, pat, rules, value, cc);
+pushCont(co, 0, _35clofun1117, 4, pat, rules, value, cc);
 coraCall(co, 3, globalRef(intern("cora/init.extract-rule-action")), rules, cc);
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
@@ -2253,28 +2272,28 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 
-void _35clofun1113(struct Cora* co) {
+void _35clofun1117(struct Cora* co) {
 Obj _35val372 = co->args[1];
 Obj pat = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj action = _35val372;
-pushCont(co, 0, _35clofun1114, 4, action, rules, value, cc);
+pushCont(co, 0, _35clofun1118, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 }
 
-void _35clofun1114(struct Cora* co) {
+void _35clofun1118(struct Cora* co) {
 Obj _35val373 = co->args[1];
 Obj action = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun1115, 3, rules, value, cc);
+pushCont(co, 0, _35clofun1119, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val373, value, action, cc);
 }
 
-void _35clofun1115(struct Cora* co) {
+void _35clofun1119(struct Cora* co) {
 Obj _35val374 = co->args[1];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2282,11 +2301,11 @@ Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj curr = _35val374;
 Obj _35reg375 = primCdr(rules);
 Obj _35reg376 = primCdr(_35reg375);
-pushCont(co, 0, _35clofun1116, 2, curr, cc);
+pushCont(co, 0, _35clofun1120, 2, curr, cc);
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg376);
 }
 
-void _35clofun1116(struct Cora* co) {
+void _35clofun1120(struct Cora* co) {
 Obj _35val377 = co->args[1];
 Obj curr = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2302,28 +2321,28 @@ coraReturn(co, _35reg384);
 return;
 }
 
-void _35clofun1109(struct Cora* co) {
+void _35clofun1113(struct Cora* co) {
 Obj _35val357 = co->args[1];
 Obj pat = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj action = _35val357;
-pushCont(co, 0, _35clofun1110, 4, action, rules, value, cc);
+pushCont(co, 0, _35clofun1114, 4, action, rules, value, cc);
 coraCall(co, 2, globalRef(intern("macroexpand")), pat);
 }
 
-void _35clofun1110(struct Cora* co) {
+void _35clofun1114(struct Cora* co) {
 Obj _35val358 = co->args[1];
 Obj action = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun1111, 3, rules, value, cc);
+pushCont(co, 0, _35clofun1115, 3, rules, value, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), _35val358, value, action, cc);
 }
 
-void _35clofun1111(struct Cora* co) {
+void _35clofun1115(struct Cora* co) {
 Obj _35val359 = co->args[1];
 Obj rules = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj value = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2331,11 +2350,11 @@ Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj curr = _35val359;
 Obj _35reg360 = primCdr(rules);
 Obj _35reg361 = primCdr(_35reg360);
-pushCont(co, 0, _35clofun1112, 2, curr, cc);
+pushCont(co, 0, _35clofun1116, 2, curr, cc);
 coraCall(co, 3, globalRef(intern("cora/init.match-helper")), value, _35reg361);
 }
 
-void _35clofun1112(struct Cora* co) {
+void _35clofun1116(struct Cora* co) {
 Obj _35val362 = co->args[1];
 Obj curr = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2351,17 +2370,17 @@ coraReturn(co, _35reg369);
 return;
 }
 
-void _35clofun1097(struct Cora* co) {
+void _35clofun1101(struct Cora* co) {
 Obj rules = co->args[1];
 Obj cc = co->args[2];
 Obj _35reg322 = primCdr(rules);
 Obj _35reg323 = primCar(_35reg322);
 Obj action = _35reg323;
-pushCont(co, 0, _35clofun1098, 2, cc, action);
+pushCont(co, 0, _35clofun1102, 2, cc, action);
 coraCall(co, 2, globalRef(intern("pair?")), action);
 }
 
-void _35clofun1098(struct Cora* co) {
+void _35clofun1102(struct Cora* co) {
 Obj _35val324 = co->args[1];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj action = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2370,41 +2389,41 @@ Obj _35reg325 = primCar(action);
 Obj _35reg326 = primEQ(_35reg325, intern("where"));
 if (True == _35reg326) {
 if (True == True) {
-pushCont(co, 0, _35clofun1099, 2, action, cc);
-coraCall(co, 2, globalRef(intern("cadr")), action);
-} else {
-coraReturn(co, action);
-return;
-}
-} else {
-if (True == False) {
-pushCont(co, 0, _35clofun1101, 2, action, cc);
-coraCall(co, 2, globalRef(intern("cadr")), action);
-} else {
-coraReturn(co, action);
-return;
-}
-}
-} else {
-if (True == False) {
 pushCont(co, 0, _35clofun1103, 2, action, cc);
 coraCall(co, 2, globalRef(intern("cadr")), action);
 } else {
 coraReturn(co, action);
 return;
 }
+} else {
+if (True == False) {
+pushCont(co, 0, _35clofun1105, 2, action, cc);
+coraCall(co, 2, globalRef(intern("cadr")), action);
+} else {
+coraReturn(co, action);
+return;
+}
+}
+} else {
+if (True == False) {
+pushCont(co, 0, _35clofun1107, 2, action, cc);
+coraCall(co, 2, globalRef(intern("cadr")), action);
+} else {
+coraReturn(co, action);
+return;
+}
 }
 }
 
-void _35clofun1103(struct Cora* co) {
+void _35clofun1107(struct Cora* co) {
 Obj _35val341 = co->args[1];
 Obj action = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun1104, 2, cc, _35val341);
+pushCont(co, 0, _35clofun1108, 2, cc, _35val341);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
-void _35clofun1104(struct Cora* co) {
+void _35clofun1108(struct Cora* co) {
 Obj _35val342 = co->args[1];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35val341 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2417,15 +2436,15 @@ coraReturn(co, _35reg347);
 return;
 }
 
-void _35clofun1101(struct Cora* co) {
+void _35clofun1105(struct Cora* co) {
 Obj _35val334 = co->args[1];
 Obj action = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun1102, 2, cc, _35val334);
+pushCont(co, 0, _35clofun1106, 2, cc, _35val334);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
-void _35clofun1102(struct Cora* co) {
+void _35clofun1106(struct Cora* co) {
 Obj _35val335 = co->args[1];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35val334 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2438,15 +2457,15 @@ coraReturn(co, _35reg340);
 return;
 }
 
-void _35clofun1099(struct Cora* co) {
+void _35clofun1103(struct Cora* co) {
 Obj _35val327 = co->args[1];
 Obj action = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun1100, 2, cc, _35val327);
+pushCont(co, 0, _35clofun1104, 2, cc, _35val327);
 coraCall(co, 2, globalRef(intern("caddr")), action);
 }
 
-void _35clofun1100(struct Cora* co) {
+void _35clofun1104(struct Cora* co) {
 Obj _35val328 = co->args[1];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35val327 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2459,17 +2478,17 @@ coraReturn(co, _35reg333);
 return;
 }
 
-void _35clofun1091(struct Cora* co) {
+void _35clofun1095(struct Cora* co) {
 Obj pat = co->args[1];
 Obj expr = co->args[2];
 Obj body = co->args[3];
 Obj cc = co->args[4];
-Obj literal_63 = makeNative(0, _35clofun1092, 1, 0);
-pushCont(co, 0, _35clofun1094, 4, expr, body, cc, pat);
+Obj literal_63 = makeNative(0, _35clofun1096, 1, 0);
+pushCont(co, 0, _35clofun1098, 4, expr, body, cc, pat);
 coraCall(co, 2, literal_63, pat);
 }
 
-void _35clofun1094(struct Cora* co) {
+void _35clofun1098(struct Cora* co) {
 Obj _35val292 = co->args[1];
 Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2502,13 +2521,13 @@ Obj _35reg306 = primCons(intern("let"), _35reg305);
 coraReturn(co, _35reg306);
 return;
 } else {
-pushCont(co, 0, _35clofun1095, 4, expr, body, cc, pat);
+pushCont(co, 0, _35clofun1099, 4, expr, body, cc, pat);
 coraCall(co, 2, globalRef(intern("pair?")), pat);
 }
 }
 }
 
-void _35clofun1095(struct Cora* co) {
+void _35clofun1099(struct Cora* co) {
 Obj _35val307 = co->args[1];
 Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2538,23 +2557,23 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 } else {
-pushCont(co, 0, _35clofun1096, 0);
+pushCont(co, 0, _35clofun1100, 0);
 coraCall(co, 3, globalRef(intern("str")), makeString1("match fail "), pat);
 }
 }
 
-void _35clofun1096(struct Cora* co) {
+void _35clofun1100(struct Cora* co) {
 Obj _35val320 = co->args[1];
 coraCall(co, 2, globalRef(intern("error")), _35val320);
 }
 
-void _35clofun1092(struct Cora* co) {
+void _35clofun1096(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, 0, _35clofun1093, 1, x);
+pushCont(co, 0, _35clofun1097, 1, x);
 coraCall(co, 2, globalRef(intern("atom?")), x);
 }
 
-void _35clofun1093(struct Cora* co) {
+void _35clofun1097(struct Cora* co) {
 Obj _35val289 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val289) {
@@ -2573,27 +2592,27 @@ return;
 }
 }
 
-void _35clofun1073(struct Cora* co) {
+void _35clofun1077(struct Cora* co) {
 Obj pat = co->args[1];
 Obj expr = co->args[2];
 Obj body = co->args[3];
 Obj cc = co->args[4];
-pushCont(co, 0, _35clofun1074, 4, pat, expr, body, cc);
+pushCont(co, 0, _35clofun1078, 4, pat, expr, body, cc);
 coraCall(co, 2, globalRef(intern("cadr")), pat);
 }
 
-void _35clofun1074(struct Cora* co) {
+void _35clofun1078(struct Cora* co) {
 Obj _35val235 = co->args[1];
 Obj pat = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj x = _35val235;
-pushCont(co, 0, _35clofun1075, 4, expr, body, x, cc);
+pushCont(co, 0, _35clofun1079, 4, expr, body, x, cc);
 coraCall(co, 2, globalRef(intern("caddr")), pat);
 }
 
-void _35clofun1075(struct Cora* co) {
+void _35clofun1079(struct Cora* co) {
 Obj _35val236 = co->args[1];
 Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2606,7 +2625,7 @@ Obj _35reg238 = primCar(expr);
 Obj _35reg239 = primEQ(_35reg238, intern("cons"));
 if (True == _35reg239) {
 if (True == True) {
-pushCont(co, 0, _35clofun1076, 5, expr, y, body, x, cc);
+pushCont(co, 0, _35clofun1080, 5, expr, y, body, x, cc);
 coraCall(co, 2, globalRef(intern("cadr")), expr);
 } else {
 Obj _35reg243 = primCons(expr, Nil);
@@ -2615,12 +2634,12 @@ Obj _35reg245 = primCons(expr, Nil);
 Obj _35reg246 = primCons(intern("car"), _35reg245);
 Obj _35reg247 = primCons(expr, Nil);
 Obj _35reg248 = primCons(intern("cdr"), _35reg247);
-pushCont(co, 0, _35clofun1079, 4, x, _35reg246, cc, _35reg244);
+pushCont(co, 0, _35clofun1083, 4, x, _35reg246, cc, _35reg244);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, _35reg248, body, cc);
 }
 } else {
 if (True == False) {
-pushCont(co, 0, _35clofun1081, 5, expr, y, body, x, cc);
+pushCont(co, 0, _35clofun1085, 5, expr, y, body, x, cc);
 coraCall(co, 2, globalRef(intern("cadr")), expr);
 } else {
 Obj _35reg259 = primCons(expr, Nil);
@@ -2629,13 +2648,13 @@ Obj _35reg261 = primCons(expr, Nil);
 Obj _35reg262 = primCons(intern("car"), _35reg261);
 Obj _35reg263 = primCons(expr, Nil);
 Obj _35reg264 = primCons(intern("cdr"), _35reg263);
-pushCont(co, 0, _35clofun1084, 4, x, _35reg262, cc, _35reg260);
+pushCont(co, 0, _35clofun1088, 4, x, _35reg262, cc, _35reg260);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, _35reg264, body, cc);
 }
 }
 } else {
 if (True == False) {
-pushCont(co, 0, _35clofun1086, 5, expr, y, body, x, cc);
+pushCont(co, 0, _35clofun1090, 5, expr, y, body, x, cc);
 coraCall(co, 2, globalRef(intern("cadr")), expr);
 } else {
 Obj _35reg275 = primCons(expr, Nil);
@@ -2644,23 +2663,23 @@ Obj _35reg277 = primCons(expr, Nil);
 Obj _35reg278 = primCons(intern("car"), _35reg277);
 Obj _35reg279 = primCons(expr, Nil);
 Obj _35reg280 = primCons(intern("cdr"), _35reg279);
-pushCont(co, 0, _35clofun1089, 4, x, _35reg278, cc, _35reg276);
+pushCont(co, 0, _35clofun1093, 4, x, _35reg278, cc, _35reg276);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, _35reg280, body, cc);
 }
 }
 }
 
-void _35clofun1089(struct Cora* co) {
+void _35clofun1093(struct Cora* co) {
 Obj _35val281 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg278 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg276 = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun1090, 2, cc, _35reg276);
+pushCont(co, 0, _35clofun1094, 2, cc, _35reg276);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg278, _35val281, cc);
 }
 
-void _35clofun1090(struct Cora* co) {
+void _35clofun1094(struct Cora* co) {
 Obj _35val282 = co->args[1];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg276 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2673,7 +2692,7 @@ coraReturn(co, _35reg287);
 return;
 }
 
-void _35clofun1086(struct Cora* co) {
+void _35clofun1090(struct Cora* co) {
 Obj _35val272 = co->args[1];
 Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2681,11 +2700,11 @@ Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e1 = _35val272;
-pushCont(co, 0, _35clofun1087, 5, y, body, x, e1, cc);
+pushCont(co, 0, _35clofun1091, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
 }
 
-void _35clofun1087(struct Cora* co) {
+void _35clofun1091(struct Cora* co) {
 Obj _35val273 = co->args[1];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2693,11 +2712,11 @@ Obj x = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj e1 = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e2 = _35val273;
-pushCont(co, 0, _35clofun1088, 3, x, e1, cc);
+pushCont(co, 0, _35clofun1092, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 }
 
-void _35clofun1088(struct Cora* co) {
+void _35clofun1092(struct Cora* co) {
 Obj _35val274 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2705,17 +2724,17 @@ Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, e1, _35val274, cc);
 }
 
-void _35clofun1084(struct Cora* co) {
+void _35clofun1088(struct Cora* co) {
 Obj _35val265 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg262 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg260 = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun1085, 2, cc, _35reg260);
+pushCont(co, 0, _35clofun1089, 2, cc, _35reg260);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg262, _35val265, cc);
 }
 
-void _35clofun1085(struct Cora* co) {
+void _35clofun1089(struct Cora* co) {
 Obj _35val266 = co->args[1];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg260 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2728,7 +2747,7 @@ coraReturn(co, _35reg271);
 return;
 }
 
-void _35clofun1081(struct Cora* co) {
+void _35clofun1085(struct Cora* co) {
 Obj _35val256 = co->args[1];
 Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2736,11 +2755,11 @@ Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e1 = _35val256;
-pushCont(co, 0, _35clofun1082, 5, y, body, x, e1, cc);
+pushCont(co, 0, _35clofun1086, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
 }
 
-void _35clofun1082(struct Cora* co) {
+void _35clofun1086(struct Cora* co) {
 Obj _35val257 = co->args[1];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2748,11 +2767,11 @@ Obj x = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj e1 = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e2 = _35val257;
-pushCont(co, 0, _35clofun1083, 3, x, e1, cc);
+pushCont(co, 0, _35clofun1087, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 }
 
-void _35clofun1083(struct Cora* co) {
+void _35clofun1087(struct Cora* co) {
 Obj _35val258 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2760,17 +2779,17 @@ Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, e1, _35val258, cc);
 }
 
-void _35clofun1079(struct Cora* co) {
+void _35clofun1083(struct Cora* co) {
 Obj _35val249 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg246 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg244 = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun1080, 2, cc, _35reg244);
+pushCont(co, 0, _35clofun1084, 2, cc, _35reg244);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, _35reg246, _35val249, cc);
 }
 
-void _35clofun1080(struct Cora* co) {
+void _35clofun1084(struct Cora* co) {
 Obj _35val250 = co->args[1];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg244 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2783,7 +2802,7 @@ coraReturn(co, _35reg255);
 return;
 }
 
-void _35clofun1076(struct Cora* co) {
+void _35clofun1080(struct Cora* co) {
 Obj _35val240 = co->args[1];
 Obj expr = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2791,11 +2810,11 @@ Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e1 = _35val240;
-pushCont(co, 0, _35clofun1077, 5, y, body, x, e1, cc);
+pushCont(co, 0, _35clofun1081, 5, y, body, x, e1, cc);
 coraCall(co, 2, globalRef(intern("caddr")), expr);
 }
 
-void _35clofun1077(struct Cora* co) {
+void _35clofun1081(struct Cora* co) {
 Obj _35val241 = co->args[1];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2803,11 +2822,11 @@ Obj x = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj e1 = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e2 = _35val241;
-pushCont(co, 0, _35clofun1078, 3, x, e1, cc);
+pushCont(co, 0, _35clofun1082, 3, x, e1, cc);
 coraCall(co, 5, globalRef(intern("cora/init.match1")), y, e2, body, cc);
 }
 
-void _35clofun1078(struct Cora* co) {
+void _35clofun1082(struct Cora* co) {
 Obj _35val242 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -2815,20 +2834,20 @@ Obj cc = co->ctx.stk.stack[co->ctx.stk.base + 2];
 coraCall(co, 5, globalRef(intern("cora/init.match1")), x, e1, _35val242, cc);
 }
 
-void _35clofun1071(struct Cora* co) {
+void _35clofun1075(struct Cora* co) {
 Obj exp = co->args[1];
 Obj _35reg233 = primCdr(exp);
 coraCall(co, 2, globalRef(intern("cora/init.rcons1")), _35reg233);
 }
 
-void _35clofun1068(struct Cora* co) {
+void _35clofun1072(struct Cora* co) {
 Obj pat = co->args[1];
 Obj _35reg223 = primCdr(pat);
-pushCont(co, 0, _35clofun1069, 1, pat);
+pushCont(co, 0, _35clofun1073, 1, pat);
 coraCall(co, 2, globalRef(intern("null?")), _35reg223);
 }
 
-void _35clofun1069(struct Cora* co) {
+void _35clofun1073(struct Cora* co) {
 Obj _35val224 = co->args[1];
 Obj pat = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val224) {
@@ -2838,12 +2857,12 @@ return;
 } else {
 Obj _35reg226 = primCar(pat);
 Obj _35reg227 = primCdr(pat);
-pushCont(co, 0, _35clofun1070, 1, _35reg226);
+pushCont(co, 0, _35clofun1074, 1, _35reg226);
 coraCall(co, 2, globalRef(intern("cora/init.rcons1")), _35reg227);
 }
 }
 
-void _35clofun1070(struct Cora* co) {
+void _35clofun1074(struct Cora* co) {
 Obj _35val228 = co->args[1];
 Obj _35reg226 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg229 = primCons(_35val228, Nil);
@@ -2853,7 +2872,7 @@ coraReturn(co, _35reg231);
 return;
 }
 
-void _35clofun1067(struct Cora* co) {
+void _35clofun1071(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg220 = primEQ(x, True);
 if (True == _35reg220) {
@@ -2871,13 +2890,13 @@ return;
 }
 }
 
-void _35clofun1065(struct Cora* co) {
+void _35clofun1069(struct Cora* co) {
 Obj exp = co->args[1];
 Obj _35reg218 = primCdr(exp);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-and")), _35reg218);
 }
 
-void _35clofun1063(struct Cora* co) {
+void _35clofun1067(struct Cora* co) {
 Obj l = co->args[1];
 Obj _35reg206 = primEQ(Nil, l);
 if (True == _35reg206) {
@@ -2891,13 +2910,13 @@ coraReturn(co, False);
 return;
 } else {
 Obj _35reg209 = primCdr(l);
-pushCont(co, 0, _35clofun1064, 1, l);
+pushCont(co, 0, _35clofun1068, 1, l);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-and")), _35reg209);
 }
 }
 }
 
-void _35clofun1064(struct Cora* co) {
+void _35clofun1068(struct Cora* co) {
 Obj _35val210 = co->args[1];
 Obj l = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj more = _35val210;
@@ -2916,13 +2935,13 @@ return;
 }
 }
 
-void _35clofun1061(struct Cora* co) {
+void _35clofun1065(struct Cora* co) {
 Obj exp = co->args[1];
 Obj _35reg204 = primCdr(exp);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-or")), _35reg204);
 }
 
-void _35clofun1059(struct Cora* co) {
+void _35clofun1063(struct Cora* co) {
 Obj l = co->args[1];
 Obj _35reg192 = primEQ(l, Nil);
 if (True == _35reg192) {
@@ -2936,13 +2955,13 @@ coraReturn(co, True);
 return;
 } else {
 Obj _35reg195 = primCdr(l);
-pushCont(co, 0, _35clofun1060, 1, l);
+pushCont(co, 0, _35clofun1064, 1, l);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-or")), _35reg195);
 }
 }
 }
 
-void _35clofun1060(struct Cora* co) {
+void _35clofun1064(struct Cora* co) {
 Obj _35val196 = co->args[1];
 Obj l = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj more = _35val196;
@@ -2961,7 +2980,7 @@ return;
 }
 }
 
-void _35clofun1054(struct Cora* co) {
+void _35clofun1058(struct Cora* co) {
 Obj exp = co->args[1];
 Obj _35reg178 = primCdr(exp);
 Obj _35reg179 = primEQ(Nil, _35reg178);
@@ -2971,29 +2990,29 @@ Obj _35reg181 = primCons(intern("error"), _35reg180);
 coraReturn(co, _35reg181);
 return;
 } else {
-pushCont(co, 0, _35clofun1055, 1, exp);
+pushCont(co, 0, _35clofun1059, 1, exp);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 }
 
-void _35clofun1055(struct Cora* co) {
+void _35clofun1059(struct Cora* co) {
 Obj _35val182 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj curr = _35val182;
 Obj _35reg183 = primCar(curr);
-pushCont(co, 0, _35clofun1056, 2, exp, _35reg183);
+pushCont(co, 0, _35clofun1060, 2, exp, _35reg183);
 coraCall(co, 2, globalRef(intern("cadr")), curr);
 }
 
-void _35clofun1056(struct Cora* co) {
+void _35clofun1060(struct Cora* co) {
 Obj _35val184 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg183 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun1057, 2, _35val184, _35reg183);
+pushCont(co, 0, _35clofun1061, 2, _35val184, _35reg183);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
-void _35clofun1057(struct Cora* co) {
+void _35clofun1061(struct Cora* co) {
 Obj _35val185 = co->args[1];
 Obj _35val184 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg183 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -3006,20 +3025,20 @@ coraReturn(co, _35reg190);
 return;
 }
 
-void _35clofun1052(struct Cora* co) {
+void _35clofun1056(struct Cora* co) {
 Obj exp = co->args[1];
 Obj _35reg176 = primCdr(exp);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-let")), _35reg176);
 }
 
-void _35clofun1047(struct Cora* co) {
+void _35clofun1051(struct Cora* co) {
 Obj exp = co->args[1];
 Obj _35reg164 = primCdr(exp);
-pushCont(co, 0, _35clofun1048, 1, exp);
+pushCont(co, 0, _35clofun1052, 1, exp);
 coraCall(co, 2, globalRef(intern("null?")), _35reg164);
 }
 
-void _35clofun1048(struct Cora* co) {
+void _35clofun1052(struct Cora* co) {
 Obj _35val165 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 if (True == _35val165) {
@@ -3028,28 +3047,28 @@ coraReturn(co, _35reg166);
 return;
 } else {
 Obj _35reg167 = primCar(exp);
-pushCont(co, 0, _35clofun1049, 2, exp, _35reg167);
+pushCont(co, 0, _35clofun1053, 2, exp, _35reg167);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 }
 
-void _35clofun1049(struct Cora* co) {
+void _35clofun1053(struct Cora* co) {
 Obj _35val168 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg167 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun1050, 2, _35val168, _35reg167);
+pushCont(co, 0, _35clofun1054, 2, _35val168, _35reg167);
 coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
-void _35clofun1050(struct Cora* co) {
+void _35clofun1054(struct Cora* co) {
 Obj _35val169 = co->args[1];
 Obj _35val168 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg167 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun1051, 2, _35val168, _35reg167);
+pushCont(co, 0, _35clofun1055, 2, _35val168, _35reg167);
 coraCall(co, 2, globalRef(intern("cora/init.rewrite-let")), _35val169);
 }
 
-void _35clofun1051(struct Cora* co) {
+void _35clofun1055(struct Cora* co) {
 Obj _35val170 = co->args[1];
 Obj _35val168 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg167 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -3061,7 +3080,7 @@ coraReturn(co, _35reg174);
 return;
 }
 
-void _35clofun1046(struct Cora* co) {
+void _35clofun1050(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg161 = primIsCons(x);
 Obj _35reg162 = primNot(_35reg161);
@@ -3069,7 +3088,7 @@ coraReturn(co, _35reg162);
 return;
 }
 
-void _35clofun1045(struct Cora* co) {
+void _35clofun1049(struct Cora* co) {
 Obj x = co->args[1];
 Obj l = co->args[2];
 Obj _35reg156 = primIsCons(l);
@@ -3089,30 +3108,30 @@ return;
 }
 }
 
-void _35clofun1040(struct Cora* co) {
+void _35clofun1044(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, 0, _35clofun1041, 1, exp);
+pushCont(co, 0, _35clofun1045, 1, exp);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
-void _35clofun1041(struct Cora* co) {
+void _35clofun1045(struct Cora* co) {
 Obj _35val144 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg145 = primCons(_35val144, Nil);
 Obj _35reg146 = primCons(intern("quote"), _35reg145);
-pushCont(co, 0, _35clofun1042, 2, exp, _35reg146);
+pushCont(co, 0, _35clofun1046, 2, exp, _35reg146);
 coraCall(co, 2, globalRef(intern("caddr")), exp);
 }
 
-void _35clofun1042(struct Cora* co) {
+void _35clofun1046(struct Cora* co) {
 Obj _35val147 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg146 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun1043, 2, _35val147, _35reg146);
+pushCont(co, 0, _35clofun1047, 2, _35val147, _35reg146);
 coraCall(co, 2, globalRef(intern("cadddr")), exp);
 }
 
-void _35clofun1043(struct Cora* co) {
+void _35clofun1047(struct Cora* co) {
 Obj _35val148 = co->args[1];
 Obj _35val147 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg146 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -3126,36 +3145,36 @@ coraReturn(co, _35reg154);
 return;
 }
 
-void _35clofun1038(struct Cora* co) {
+void _35clofun1042(struct Cora* co) {
 Obj exp = co->args[1];
 Obj _35reg142 = primCdr(exp);
 coraCall(co, 2, globalRef(intern("rcons")), _35reg142);
 }
 
-void _35clofun1033(struct Cora* co) {
+void _35clofun1037(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, 0, _35clofun1034, 1, exp);
+pushCont(co, 0, _35clofun1038, 1, exp);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
-void _35clofun1034(struct Cora* co) {
+void _35clofun1038(struct Cora* co) {
 Obj _35val130 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg131 = primCons(_35val130, Nil);
 Obj _35reg132 = primCons(intern("quote"), _35reg131);
-pushCont(co, 0, _35clofun1035, 2, exp, _35reg132);
+pushCont(co, 0, _35clofun1039, 2, exp, _35reg132);
 coraCall(co, 2, globalRef(intern("caddr")), exp);
 }
 
-void _35clofun1035(struct Cora* co) {
+void _35clofun1039(struct Cora* co) {
 Obj _35val133 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg132 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun1036, 2, _35val133, _35reg132);
+pushCont(co, 0, _35clofun1040, 2, _35val133, _35reg132);
 coraCall(co, 2, globalRef(intern("cdddr")), exp);
 }
 
-void _35clofun1036(struct Cora* co) {
+void _35clofun1040(struct Cora* co) {
 Obj _35val134 = co->args[1];
 Obj _35val133 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg132 = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -3168,7 +3187,7 @@ coraReturn(co, _35reg139);
 return;
 }
 
-void _35clofun1027(struct Cora* co) {
+void _35clofun1031(struct Cora* co) {
 Obj exp = co->args[1];
 Obj _35reg112 = primIsCons(exp);
 if (True == _35reg112) {
@@ -3182,7 +3201,7 @@ return;
 Obj _35reg116 = primCar(exp);
 Obj _35reg117 = primEQ(_35reg116, intern("lambda"));
 if (True == _35reg117) {
-pushCont(co, 0, _35clofun1028, 1, exp);
+pushCont(co, 0, _35clofun1032, 1, exp);
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
 Obj _35reg124 = primCar(exp);
@@ -3191,7 +3210,7 @@ if (True == _35reg125) {
 coraReturn(co, exp);
 return;
 } else {
-pushCont(co, 0, _35clofun1031, 1, exp);
+pushCont(co, 0, _35clofun1035, 1, exp);
 coraCall(co, 2, globalRef(intern("cora/init.macroexpand1")), exp);
 }
 }
@@ -3202,13 +3221,13 @@ return;
 }
 }
 
-void _35clofun1031(struct Cora* co) {
+void _35clofun1035(struct Cora* co) {
 Obj _35val127 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 2, makeNative(0, _35clofun1032, 1, 1, exp), _35val127);
+coraCall(co, 2, makeNative(0, _35clofun1036, 1, 1, exp), _35val127);
 }
 
-void _35clofun1032(struct Cora* co) {
+void _35clofun1036(struct Cora* co) {
 Obj exp1 = co->args[1];
 Obj _35reg126 = primEQ(exp1, closureRef(co, 0));
 if (True == _35reg126) {
@@ -3218,21 +3237,21 @@ coraCall(co, 2, globalRef(intern("cora/init.macroexpand-boot")), exp1);
 }
 }
 
-void _35clofun1028(struct Cora* co) {
+void _35clofun1032(struct Cora* co) {
 Obj _35val118 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun1029, 1, _35val118);
+pushCont(co, 0, _35clofun1033, 1, _35val118);
 coraCall(co, 2, globalRef(intern("caddr")), exp);
 }
 
-void _35clofun1029(struct Cora* co) {
+void _35clofun1033(struct Cora* co) {
 Obj _35val119 = co->args[1];
 Obj _35val118 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun1030, 1, _35val118);
+pushCont(co, 0, _35clofun1034, 1, _35val118);
 coraCall(co, 2, globalRef(intern("cora/init.macroexpand-boot")), _35val119);
 }
 
-void _35clofun1030(struct Cora* co) {
+void _35clofun1034(struct Cora* co) {
 Obj _35val120 = co->args[1];
 Obj _35val118 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg121 = primCons(_35val120, Nil);
@@ -3242,12 +3261,12 @@ coraReturn(co, _35reg123);
 return;
 }
 
-void _35clofun1026(struct Cora* co) {
+void _35clofun1030(struct Cora* co) {
 Obj exp = co->args[1];
 coraCall(co, 3, globalRef(intern("cora/init.macroexpand1-h")), exp, globalRef(intern("*macros*")));
 }
 
-void _35clofun1024(struct Cora* co) {
+void _35clofun1028(struct Cora* co) {
 Obj exp = co->args[1];
 Obj macros = co->args[2];
 Obj _35reg98 = primEQ(Nil, macros);
@@ -3256,11 +3275,11 @@ coraReturn(co, exp);
 return;
 } else {
 Obj _35reg109 = primCar(macros);
-coraCall(co, 2, makeNative(0, _35clofun1025, 1, 2, exp, macros), _35reg109);
+coraCall(co, 2, makeNative(0, _35clofun1029, 1, 2, exp, macros), _35reg109);
 }
 }
 
-void _35clofun1025(struct Cora* co) {
+void _35clofun1029(struct Cora* co) {
 Obj item = co->args[1];
 Obj _35reg99 = primIsCons(closureRef(co, 0));
 if (True == _35reg99) {
@@ -3295,7 +3314,7 @@ coraCall(co, 3, globalRef(intern("cora/init.macroexpand1-h")), closureRef(co, 0)
 }
 }
 
-void _35clofun1023(struct Cora* co) {
+void _35clofun1027(struct Cora* co) {
 Obj n = co->args[1];
 Obj v = co->args[2];
 Obj _35reg94 = primCons(n, v);
@@ -3305,34 +3324,34 @@ coraReturn(co, _35reg96);
 return;
 }
 
-void _35clofun1022(struct Cora* co) {
+void _35clofun1026(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg92 = primCons(globalRef(intern("*protect-symbol*")), x);
 coraReturn(co, _35reg92);
 return;
 }
 
-void _35clofun1021(struct Cora* co) {
+void _35clofun1025(struct Cora* co) {
 Obj f = co->args[1];
 Obj l = co->args[2];
 coraCall(co, 4, globalRef(intern("map-h")), Nil, f, l);
 }
 
-void _35clofun1019(struct Cora* co) {
+void _35clofun1023(struct Cora* co) {
 Obj res = co->args[1];
 Obj f = co->args[2];
 Obj l = co->args[3];
 Obj _35reg82 = primIsCons(l);
 if (True == _35reg82) {
 Obj _35reg83 = primCar(l);
-pushCont(co, 0, _35clofun1020, 3, res, l, f);
+pushCont(co, 0, _35clofun1024, 3, res, l, f);
 coraCall(co, 2, f, _35reg83);
 } else {
 coraCall(co, 2, globalRef(intern("reverse")), res);
 }
 }
 
-void _35clofun1020(struct Cora* co) {
+void _35clofun1024(struct Cora* co) {
 Obj _35val84 = co->args[1];
 Obj res = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj l = co->ctx.stk.stack[co->ctx.stk.base + 1];
@@ -3342,7 +3361,7 @@ Obj _35reg86 = primCdr(l);
 coraCall(co, 4, globalRef(intern("map-h")), _35reg85, f, _35reg86);
 }
 
-void _35clofun1017(struct Cora* co) {
+void _35clofun1021(struct Cora* co) {
 Obj res = co->args[1];
 Obj l = co->args[2];
 Obj _35reg75 = primIsCons(l);
@@ -3357,20 +3376,20 @@ return;
 }
 }
 
-void _35clofun1016(struct Cora* co) {
+void _35clofun1020(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg73 = primIsCons(x);
 coraReturn(co, _35reg73);
 return;
 }
 
-void _35clofun1014(struct Cora* co) {
+void _35clofun1018(struct Cora* co) {
 Obj exp = co->args[1];
 Obj _35reg65 = primIsCons(exp);
 if (True == _35reg65) {
 Obj _35reg66 = primCar(exp);
 Obj _35reg67 = primCdr(exp);
-pushCont(co, 0, _35clofun1015, 1, _35reg66);
+pushCont(co, 0, _35clofun1019, 1, _35reg66);
 coraCall(co, 2, globalRef(intern("rcons")), _35reg67);
 } else {
 coraReturn(co, Nil);
@@ -3378,7 +3397,7 @@ return;
 }
 }
 
-void _35clofun1015(struct Cora* co) {
+void _35clofun1019(struct Cora* co) {
 Obj _35val68 = co->args[1];
 Obj _35reg66 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg69 = primCons(_35val68, Nil);
@@ -3388,7 +3407,7 @@ coraReturn(co, _35reg71);
 return;
 }
 
-void _35clofun1013(struct Cora* co) {
+void _35clofun1017(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg61 = primCdr(x);
 Obj _35reg62 = primCdr(_35reg61);
@@ -3397,7 +3416,7 @@ coraReturn(co, _35reg63);
 return;
 }
 
-void _35clofun1012(struct Cora* co) {
+void _35clofun1016(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg56 = primCdr(x);
 Obj _35reg57 = primCdr(_35reg56);
@@ -3407,7 +3426,7 @@ coraReturn(co, _35reg59);
 return;
 }
 
-void _35clofun1011(struct Cora* co) {
+void _35clofun1015(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg52 = primCdr(x);
 Obj _35reg53 = primCdr(_35reg52);
@@ -3416,7 +3435,7 @@ coraReturn(co, _35reg54);
 return;
 }
 
-void _35clofun1010(struct Cora* co) {
+void _35clofun1014(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg49 = primCdr(x);
 Obj _35reg50 = primCdr(_35reg49);
@@ -3424,7 +3443,7 @@ coraReturn(co, _35reg50);
 return;
 }
 
-void _35clofun1009(struct Cora* co) {
+void _35clofun1013(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg46 = primCar(x);
 Obj _35reg47 = primCdr(_35reg46);
@@ -3432,7 +3451,7 @@ coraReturn(co, _35reg47);
 return;
 }
 
-void _35clofun1008(struct Cora* co) {
+void _35clofun1012(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg43 = primCar(x);
 Obj _35reg44 = primCar(_35reg43);
@@ -3440,7 +3459,7 @@ coraReturn(co, _35reg44);
 return;
 }
 
-void _35clofun1007(struct Cora* co) {
+void _35clofun1011(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg40 = primCdr(x);
 Obj _35reg41 = primCar(_35reg40);
@@ -3448,7 +3467,7 @@ coraReturn(co, _35reg41);
 return;
 }
 
-void _35clofun1006(struct Cora* co) {
+void _35clofun1010(struct Cora* co) {
 Obj x = co->args[1];
 Obj _35reg38 = primEQ(x, Nil);
 coraReturn(co, _35reg38);

--- a/init.cora
+++ b/init.cora
@@ -372,3 +372,8 @@
       
 (defmacro backquote (exp)
   (.rewrite-backquote (cadr exp)))
+
+;; the pseudo type checker, overloaded later.
+(defun typecheck (filename pkg)
+  ['succ 'fake])
+

--- a/lib/infer.cora
+++ b/lib/infer.cora
@@ -18,6 +18,7 @@
       x y s => ['succ s] where (= x y)
       x y s => ['succ [[x . y] . s]] where (and (number? x) (not (occur? x y)))
       x y s => ['succ [[y . x] . s]] where (and (number? y) (not (occur? y x)))
+      ['-> a] ['-> b] s => (unify a b s)
       [a '-> b] [c '-> d] s => (bind-s (unify a c s)
 								 (lambda (s1) (unify b d s1)))
       ['list a] ['list b] s => (unify a b s)
@@ -26,6 +27,7 @@
 (func occur?
       'int _ => false
       'bool _ => false
+	  'string _ => false
       'symbol _ => false
       [a '-> b] t => (or (occur? a t) (occur? b t))
 	  x [a '-> b] => (or (occur? x a) (occur? x b)) where (number? x)
@@ -33,9 +35,11 @@
       v t => (= v t))
 
 (func apply-subst
-      'int s => 'int
-      'bool s => 'bool
+      'int _ => 'int
+      'bool _ => 'bool
       'symbol _ => 'symbol
+	  'string _ => 'string
+      ['-> t] s => ['-> (apply-subst t s)]
       [a '-> b] s => [(apply-subst a s) '-> (apply-subst b s)]
       ['list a] s => ['list (apply-subst a s)]
       v s => (let find (assq v s)
@@ -47,8 +51,10 @@
   (cons (cons v x) env))
 	
 (func check-type-core
+      () t env s => ['succ s] where (number? t) ;; special check rule
       x t env s => (unify 'int t s) where (number? x)
       x t env s => (unify 'bool t s) where (boolean? x)
+      x t env s => (unify 'string t s) where (string? x)
       ['quote s] t env s => (unify 'symbol t s)
       x t env s => (let find (assq x env)
 			(if (null? find)
@@ -59,17 +65,21 @@
 			   (bind-s (check-type e2 t env s1)
 				(lambda (_)
 				 (check-type e3 t env s1)))))
-      ['lambda [x] e] [a '-> b] env s => (check-type e b (extend env x a) s)
+      ['lambda () e] any env s => (let a (tvar)
+										(bind-s (check-type e a env s)
+										(lambda (s1)
+												(unify any ['-> a] s1))))
 	  ['lambda [x] e] any env s => (let tx (tvar)
 									  te (tvar)
 									  (bind-s (check-type e te (extend env x tx) s)
 									   (lambda (s1)
-										(unify any [tx '-> te] s1)))) where (number? any)
+										(unify any [tx '-> te] s1))))
       ['lambda [x . more] e] t env s => (check-type ['lambda [x] ['lambda more e]] t env s) where (not (= () more))
 	  ['let a b c] t env s => (let tb (tvar)
 								(bind-s (check-type b tb env s)
 										(lambda (s1)
 										(check-type c t (extend env a tb) s1))))
+      [f] b env s => (check-type-core f ['-> b] env s)
       [f x] t env s => (let a (tvar) b (tvar)
 						(bind-s (check-type-core f [a '-> b] env s)
 						    (lambda (s1)
@@ -123,19 +133,6 @@
 (set '*type-rule* (cons (cons 'monad type-check-for-monad) *type-rule*))
 
 
-(set '*type-env* ())
-(set '*type-env* (cons (cons 'car (let a (tvar) b (tvar) [a '-> b])) *type-env*))
-(set '*type-env* (cons (cons 'hd (let a (tvar) [['list a] '-> a])) *type-env*))
-(set '*type-env* (cons (cons 'tl (let a (tvar) [['list a] '-> ['list a]])) *type-env*))
-(set '*type-env* (cons (cons '+ `(int -> (int -> int))) *type-env*))
-(set '*type-env* (cons (cons '- `(int -> (int -> int))) *type-env*))
-(set '*type-env* (cons (cons '* `(int -> (int -> int))) *type-env*))
-(set '*type-env* (cons (cons '= (let a (tvar) b (tvar) `(,a -> (,b -> bool)))) *type-env*))
-(set '*type-env* (cons (cons 'set (let a (tvar) ['synbol '-> a])) *type-env*))
-(set '*type-env* (cons (cons 'null? [(tvar) '-> 'bool]) *type-env*))
-(set '*type-env* (cons (cons 'cons? [(tvar) '-> 'bool]) *type-env*))
-
-
 ;; (func type-check-for-fruit
 ;;       x ['fruit] env s => s where (elem? x ['apple 'orange 'banana]))
 ;; 
@@ -155,6 +152,8 @@
 ;; (check-type 'apple '(fruit) () ())
 ;; (check-type ['ok 3] '(option int a) () ())
 
+
+;; (check-type '(if true 3 false) 12 () ())  should fail
 
 ;; (check-type '(lambda (f g) (f (g 1)))
 ;; 	    '((0 -> 1) -> ((int -> 0) -> 1))
@@ -201,3 +200,48 @@
 ;;  (extend *type-env*
 ;;   'reverse-h '((list 1) -> ((list 1) -> (list 1))))
 ;;  ())
+
+(set '*type-env* ())
+
+(func check-sexp
+		['do a b] => (bind-s (check-sexp a)
+						(lambda (_)
+								(check-sexp b)))
+		['declare . _] => ['succ 'ignore]
+		['set ['quote s] v] => (let find (assq s *type-env*) ;; special for global function
+						(if (null? find)
+								(begin
+										(io.display s)
+										(io.display "check set use any\n")
+										(check-type v (tvar) *type-env* ()))
+								(check-type v (cdr find) *type-env* ())))
+		exp => (check-type exp (tvar) *type-env* ()))
+
+(defun check-file (from pkg-str)
+  (let sexp (read-file-as-sexp from pkg-str)
+		(let input (macroexpand sexp)
+				(check-sexp input))))
+
+(defun declare (sym val)
+	(set '*type-env* (cons (cons sym val) *type-env*)))
+
+(set 'hd car)
+(set 'tl cdr)
+
+(declare 'car (let a (tvar) b (tvar) [a '-> b]))
+(declare 'cons [(tvar) '-> [(tvar) '-> (tvar)]])
+(declare 'cdr [(tvar) '-> (tvar)])
+(declare 'hd (let a (tvar) [['list a] '-> a]))
+(declare 'tl (let a (tvar) [['list a] '-> ['list a]]))
+(declare '+ `(int -> (int -> int)))
+(declare '- `(int -> (int -> int)))
+(declare '* `(int -> (int -> int)))
+(declare '= (let a (tvar) b (tvar) `(,a -> (,b -> bool))))
+(declare 'set (let a (tvar) ['symbol '-> [a '-> a]]))
+(declare 'null? [(tvar) '-> 'bool])
+(declare 'cons? [(tvar) '-> 'bool])
+(declare '*type-env* ['list ['tuple 'symbol (tvar)]])
+(declare 'error [(tvar) '-> (tvar)])
+
+(set 'typecheck check-file)
+

--- a/lib/infer.cora
+++ b/lib/infer.cora
@@ -10,19 +10,25 @@
 (defun unify (x y s)
   (unify1 (apply-subst x s) (apply-subst y s) s))
 
+(func bind-s
+      ['succ s] f => (f s)
+	  ['fail . msg] f => ['fail . msg])
+
 (func unify1
-      x y s => s where (= x y)
-      x y s => [[x . y] . s] where (and (number? x) (not (occur? x y)))
-      x y s => [[y . x] . s] where (and (number? y) (not (occur? y x)))
-      [a '-> b] [c '-> d] s => (let s1 (unify a c s)
-				 (unify b d s1))
-      ['list a] ['list b] s => (unify a b s))
+      x y s => ['succ s] where (= x y)
+      x y s => ['succ [[x . y] . s]] where (and (number? x) (not (occur? x y)))
+      x y s => ['succ [[y . x] . s]] where (and (number? y) (not (occur? y x)))
+      [a '-> b] [c '-> d] s => (bind-s (unify a c s)
+								 (lambda (s1) (unify b d s1)))
+      ['list a] ['list b] s => (unify a b s)
+	  _ _ s => ['fail])
 
 (func occur?
       'int _ => false
       'bool _ => false
       'symbol _ => false
       [a '-> b] t => (or (occur? a t) (occur? b t))
+	  x [a '-> b] => (or (occur? x a) (occur? x b)) where (number? x)
       ['list a] t => (occure? a t)
       v t => (= v t))
 
@@ -35,7 +41,7 @@
       v s => (let find (assq v s)
 		  (if (null? find)
 		      v
-		      (cdr find))))
+		      (apply-subst (cdr find) s))))
 
 (defun extend (env v x)
   (cons (cons v x) env))
@@ -46,51 +52,88 @@
       ['quote s] t env s => (unify 'symbol t s)
       x t env s => (let find (assq x env)
 			(if (null? find)
-			    (error "variable not bound")
+			    ['fail "variable not bound" x]
 			    (unify (cdr find) t s))) where (symbol? x)
-      ['if e1 e2 e3] t env s => (let s1 (check-type-core e1 'bool env s)
-				     (let _ (check-type e2 t env s1)
-					  (check-type e3 t env s1)))
-      ['/. x e] [a '-> b] env s => (check-type e b (extend env x a) s)
-      [f g] b env s => (let a (tvar)
-			    (let s1 (check-type g a env s)
-				 (check-type-core f [a '-> b] env s1))))
+	  ['if e1 e2 e3] t env s => (bind-s (check-type-core e1 'bool env s)
+			  (lambda (s1)
+			   (bind-s (check-type e2 t env s1)
+				(lambda (_)
+				 (check-type e3 t env s1)))))
+      ['lambda [x] e] [a '-> b] env s => (check-type e b (extend env x a) s)
+	  ['lambda [x] e] any env s => (let tx (tvar)
+									  te (tvar)
+									  (bind-s (check-type e te (extend env x tx) s)
+									   (lambda (s1)
+										(unify any [tx '-> te] s1)))) where (number? any)
+      ['lambda [x . more] e] t env s => (check-type ['lambda [x] ['lambda more e]] t env s) where (not (= () more))
+	  ['let a b c] t env s => (let tb (tvar)
+								(bind-s (check-type b tb env s)
+										(lambda (s1)
+										(check-type c t (extend env a tb) s1))))
+      [f x] t env s => (let a (tvar) b (tvar)
+						(bind-s (check-type-core f [a '-> b] env s)
+						    (lambda (s1)
+							(bind-s (check-type x (apply-subst a s1) env s1)
+								(lambda (s2)
+								(bind-s (unify t b s2)
+										(lambda (s3)
+										 ['succ (filter (lambda (x)
+														 (let k (car x)
+														  (not (or (= k a) (= k b)))))
+												 s3)])))))))
+	  [f x . more] b env s => (check-type [[f x] . more] b env s)
+	  _ _ env s => ['fail])
 
 (set '*type-rule* ())
 
 (defun check-type (exp typ env subst)
- (let handler (if (pair? typ)	
-	       (let find (assq (car typ) *type-rule*)
-		(if (null? find)
-		 check-type-core
-		 (cdr find)))
-	       check-type-core)
-  (handler exp typ env subst)))
+ (if (pair? typ)	
+  (let find (assq (car typ) *type-rule*)
+   (if (null? find)
+	(check-type-core exp typ env subst)
+	(match ((cdr find) exp typ env subst)
+	 ['fail] (check-type-core exp typ env subst)
+	 succ succ)))
+  (check-type-core exp typ env subst)))
 
 (func type-check-for-list
- [] ['list a] env s => s
- ['cons x y] ['list a] env s => (let s1 (check-type x a env s)
-		 (let s2 (unify t ['list a] s1)
-		  (check-type y ['list a] env s2))))
+ [] ['list a] env s => ['succ s]
+ ['cons x y] ['list a] env s => (bind-s (check-type x a env s)
+		 (lambda (s1)
+		  (check-type y ['list a] env s1)))
+ exp typ env s => ['fail])
 (set '*type-rule* (cons (cons 'list type-check-for-list) *type-rule*))
 
-
 (func type-check-for-tuple
-  ['cons x y] ['tuple a b] env s => (let s1 (check-type x a env s)
-  						(check-type y b env s1)))
+  ['cons x y] ['tuple a b] env s => (bind-s (check-type x a env s)
+										(lambda (s1) 
+												(check-type y b env s1))))
 (set '*type-rule* (cons (cons 'tuple type-check-for-tuple) *type-rule*))
 
 (func type-check-for-maybe
-  [] ['maybe t] env s => s
+  [] ['maybe t] env s => ['succ s]
   exp ['maybe t] env s => (check-type exp t env s))
 (set '*type-rule* (cons (cons 'maybe type-check-for-maybe) *type-rule*))
 
-
 (func type-check-for-monad
- [retrn . x] ['monad a] env s => s
- [bind ma f] ['monad a] env s => (let s1 (check-type ma ['monad a] env s)
-	 (check-type f (let b (tvar) [a '-> ['monad b]]) env s1)))
+ [retrn . x] ['monad a] env s => ['succ s]
+ [bind ma f] ['monad a] env s => (bind-s (check-type ma ['monad a] env s)
+										(lambda (s1)
+										(check-type f (let b (tvar) [a '-> ['monad b]]) env s1))))
 (set '*type-rule* (cons (cons 'monad type-check-for-monad) *type-rule*))
+
+
+(set '*type-env* ())
+(set '*type-env* (cons (cons 'car (let a (tvar) b (tvar) [a '-> b])) *type-env*))
+(set '*type-env* (cons (cons 'hd (let a (tvar) [['list a] '-> a])) *type-env*))
+(set '*type-env* (cons (cons 'tl (let a (tvar) [['list a] '-> ['list a]])) *type-env*))
+(set '*type-env* (cons (cons '+ `(int -> (int -> int))) *type-env*))
+(set '*type-env* (cons (cons '- `(int -> (int -> int))) *type-env*))
+(set '*type-env* (cons (cons '* `(int -> (int -> int))) *type-env*))
+(set '*type-env* (cons (cons '= (let a (tvar) b (tvar) `(,a -> (,b -> bool)))) *type-env*))
+(set '*type-env* (cons (cons 'set (let a (tvar) ['synbol '-> a])) *type-env*))
+(set '*type-env* (cons (cons 'null? [(tvar) '-> 'bool]) *type-env*))
+(set '*type-env* (cons (cons 'cons? [(tvar) '-> 'bool]) *type-env*))
 
 
 ;; (func type-check-for-fruit
@@ -111,3 +154,50 @@
 
 ;; (check-type 'apple '(fruit) () ())
 ;; (check-type ['ok 3] '(option int a) () ())
+
+
+;; (check-type '(lambda (f g) (f (g 1)))
+;; 	    '((0 -> 1) -> ((int -> 0) -> 1))
+;; 	    () ())
+
+;; HM cannot infer high rank polymorphic, but it can check that with annotation.
+;; (check-type
+;;  '(lambda (f)
+;; 		 (if (f true) (f 42) false))
+;;  '((1 -> bool) -> bool)
+;;  () ())
+
+;; This case is invalid for HM to infer 
+;; x : a -> b
+;; f : b -> b -> c
+;; (check-type '(lambda (f x)
+;; 			  (f (x 1) (x true)))
+;; 		'((2 -> (2 -> 3)) -> (1 -> 2))
+;; 		() ())
+
+;; This case should fail, because x is unify with both int and bool
+;; (check-type
+;;  '(lambda (x)
+;; 		 (h (f x) (g x)))
+;;  '(6 -> 7)
+;;  [(cons 'f '(int -> 1))
+;;  (cons 'g '(bool -> 2))
+;;  (cons 'h '(3 -> (4 -> 5)))] ())
+
+
+;; (infer '(lambda (x) (if true (x 1) (x true))) () ())  => fail
+;; (check-type '(lambda (x) (if true (x 1) (x true)))
+;; 	    '((1 -> 2) -> 2)
+;; 	    () ())                                 => ok
+
+
+;; type check reverse function
+;; (check-type  '(lambda (x y)
+;; 			   (if (null? x) y
+;; 				(if (cons? x)
+;; 				 (reverse-h (tl x) (cons (hd x) y))
+;; 				 ())))
+;;  '((list 1) -> ((list 1) -> (list 1)))
+;;  (extend *type-env*
+;;   'reverse-h '((list 1) -> ((list 1) -> (list 1))))
+;;  ())

--- a/toc.c
+++ b/toc.c
@@ -2,23 +2,29 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun2877(struct Cora* co);
-void _35clofun2878(struct Cora* co);
-void _35clofun3188(struct Cora* co);
-void _35clofun3234(struct Cora* co);
-void _35clofun3235(struct Cora* co);
+void _35clofun2883(struct Cora* co);
+void _35clofun2884(struct Cora* co);
+void _35clofun3194(struct Cora* co);
 void _35clofun3240(struct Cora* co);
-void _35clofun3243(struct Cora* co);
+void _35clofun3241(struct Cora* co);
 void _35clofun3246(struct Cora* co);
+void _35clofun3249(struct Cora* co);
+void _35clofun3252(struct Cora* co);
+void _35clofun3253(struct Cora* co);
+void _35clofun3250(struct Cora* co);
+void _35clofun3251(struct Cora* co);
 void _35clofun3247(struct Cora* co);
+void _35clofun3248(struct Cora* co);
 void _35clofun3244(struct Cora* co);
 void _35clofun3245(struct Cora* co);
-void _35clofun3241(struct Cora* co);
 void _35clofun3242(struct Cora* co);
-void _35clofun3238(struct Cora* co);
+void _35clofun3243(struct Cora* co);
 void _35clofun3239(struct Cora* co);
-void _35clofun3236(struct Cora* co);
+void _35clofun3238(struct Cora* co);
 void _35clofun3237(struct Cora* co);
+void _35clofun3236(struct Cora* co);
+void _35clofun3235(struct Cora* co);
+void _35clofun3234(struct Cora* co);
 void _35clofun3233(struct Cora* co);
 void _35clofun3232(struct Cora* co);
 void _35clofun3231(struct Cora* co);
@@ -29,611 +35,605 @@ void _35clofun3227(struct Cora* co);
 void _35clofun3226(struct Cora* co);
 void _35clofun3225(struct Cora* co);
 void _35clofun3224(struct Cora* co);
-void _35clofun3223(struct Cora* co);
-void _35clofun3222(struct Cora* co);
-void _35clofun3221(struct Cora* co);
-void _35clofun3220(struct Cora* co);
-void _35clofun3219(struct Cora* co);
+void _35clofun3217(struct Cora* co);
 void _35clofun3218(struct Cora* co);
-void _35clofun3211(struct Cora* co);
+void _35clofun3219(struct Cora* co);
+void _35clofun3220(struct Cora* co);
+void _35clofun3221(struct Cora* co);
+void _35clofun3222(struct Cora* co);
+void _35clofun3223(struct Cora* co);
 void _35clofun3212(struct Cora* co);
 void _35clofun3213(struct Cora* co);
+void _35clofun3216(struct Cora* co);
 void _35clofun3214(struct Cora* co);
 void _35clofun3215(struct Cora* co);
-void _35clofun3216(struct Cora* co);
-void _35clofun3217(struct Cora* co);
-void _35clofun3206(struct Cora* co);
-void _35clofun3207(struct Cora* co);
-void _35clofun3210(struct Cora* co);
-void _35clofun3208(struct Cora* co);
-void _35clofun3209(struct Cora* co);
-void _35clofun3198(struct Cora* co);
-void _35clofun3199(struct Cora* co);
-void _35clofun3200(struct Cora* co);
-void _35clofun3203(struct Cora* co);
 void _35clofun3204(struct Cora* co);
 void _35clofun3205(struct Cora* co);
+void _35clofun3206(struct Cora* co);
+void _35clofun3209(struct Cora* co);
+void _35clofun3210(struct Cora* co);
+void _35clofun3211(struct Cora* co);
+void _35clofun3207(struct Cora* co);
+void _35clofun3208(struct Cora* co);
+void _35clofun3200(struct Cora* co);
 void _35clofun3201(struct Cora* co);
+void _35clofun3203(struct Cora* co);
 void _35clofun3202(struct Cora* co);
-void _35clofun3194(struct Cora* co);
 void _35clofun3195(struct Cora* co);
-void _35clofun3197(struct Cora* co);
 void _35clofun3196(struct Cora* co);
-void _35clofun3189(struct Cora* co);
-void _35clofun3190(struct Cora* co);
+void _35clofun3197(struct Cora* co);
+void _35clofun3198(struct Cora* co);
+void _35clofun3199(struct Cora* co);
 void _35clofun3191(struct Cora* co);
 void _35clofun3192(struct Cora* co);
 void _35clofun3193(struct Cora* co);
-void _35clofun3185(struct Cora* co);
+void _35clofun3188(struct Cora* co);
+void _35clofun3189(struct Cora* co);
+void _35clofun3190(struct Cora* co);
 void _35clofun3186(struct Cora* co);
 void _35clofun3187(struct Cora* co);
-void _35clofun3182(struct Cora* co);
-void _35clofun3183(struct Cora* co);
+void _35clofun3185(struct Cora* co);
 void _35clofun3184(struct Cora* co);
+void _35clofun3183(struct Cora* co);
+void _35clofun3182(struct Cora* co);
+void _35clofun3175(struct Cora* co);
+void _35clofun3177(struct Cora* co);
+void _35clofun3178(struct Cora* co);
+void _35clofun3179(struct Cora* co);
 void _35clofun3180(struct Cora* co);
 void _35clofun3181(struct Cora* co);
-void _35clofun3179(struct Cora* co);
-void _35clofun3178(struct Cora* co);
-void _35clofun3177(struct Cora* co);
 void _35clofun3176(struct Cora* co);
-void _35clofun3169(struct Cora* co);
+void _35clofun3167(struct Cora* co);
+void _35clofun3168(struct Cora* co);
+void _35clofun3170(struct Cora* co);
 void _35clofun3171(struct Cora* co);
 void _35clofun3172(struct Cora* co);
 void _35clofun3173(struct Cora* co);
 void _35clofun3174(struct Cora* co);
-void _35clofun3175(struct Cora* co);
-void _35clofun3170(struct Cora* co);
-void _35clofun3161(struct Cora* co);
-void _35clofun3162(struct Cora* co);
+void _35clofun3169(struct Cora* co);
+void _35clofun3163(struct Cora* co);
 void _35clofun3164(struct Cora* co);
 void _35clofun3165(struct Cora* co);
 void _35clofun3166(struct Cora* co);
-void _35clofun3167(struct Cora* co);
-void _35clofun3168(struct Cora* co);
-void _35clofun3163(struct Cora* co);
+void _35clofun3162(struct Cora* co);
+void _35clofun3156(struct Cora* co);
 void _35clofun3157(struct Cora* co);
-void _35clofun3158(struct Cora* co);
 void _35clofun3159(struct Cora* co);
 void _35clofun3160(struct Cora* co);
-void _35clofun3156(struct Cora* co);
+void _35clofun3161(struct Cora* co);
+void _35clofun3158(struct Cora* co);
+void _35clofun3145(struct Cora* co);
+void _35clofun3147(struct Cora* co);
+void _35clofun3148(struct Cora* co);
+void _35clofun3149(struct Cora* co);
 void _35clofun3150(struct Cora* co);
 void _35clofun3151(struct Cora* co);
+void _35clofun3152(struct Cora* co);
+void _35clofun3155(struct Cora* co);
 void _35clofun3153(struct Cora* co);
 void _35clofun3154(struct Cora* co);
-void _35clofun3155(struct Cora* co);
-void _35clofun3152(struct Cora* co);
-void _35clofun3139(struct Cora* co);
+void _35clofun3146(struct Cora* co);
+void _35clofun3137(struct Cora* co);
+void _35clofun3138(struct Cora* co);
+void _35clofun3140(struct Cora* co);
 void _35clofun3141(struct Cora* co);
 void _35clofun3142(struct Cora* co);
 void _35clofun3143(struct Cora* co);
 void _35clofun3144(struct Cora* co);
-void _35clofun3145(struct Cora* co);
-void _35clofun3146(struct Cora* co);
-void _35clofun3149(struct Cora* co);
-void _35clofun3147(struct Cora* co);
-void _35clofun3148(struct Cora* co);
-void _35clofun3140(struct Cora* co);
-void _35clofun3131(struct Cora* co);
-void _35clofun3132(struct Cora* co);
+void _35clofun3139(struct Cora* co);
+void _35clofun3065(struct Cora* co);
+void _35clofun3066(struct Cora* co);
 void _35clofun3134(struct Cora* co);
 void _35clofun3135(struct Cora* co);
 void _35clofun3136(struct Cora* co);
-void _35clofun3137(struct Cora* co);
-void _35clofun3138(struct Cora* co);
+void _35clofun3067(struct Cora* co);
+void _35clofun3132(struct Cora* co);
 void _35clofun3133(struct Cora* co);
-void _35clofun3059(struct Cora* co);
-void _35clofun3060(struct Cora* co);
+void _35clofun3068(struct Cora* co);
+void _35clofun3130(struct Cora* co);
+void _35clofun3131(struct Cora* co);
+void _35clofun3069(struct Cora* co);
+void _35clofun3124(struct Cora* co);
+void _35clofun3127(struct Cora* co);
 void _35clofun3128(struct Cora* co);
 void _35clofun3129(struct Cora* co);
-void _35clofun3130(struct Cora* co);
-void _35clofun3061(struct Cora* co);
-void _35clofun3126(struct Cora* co);
-void _35clofun3127(struct Cora* co);
-void _35clofun3062(struct Cora* co);
-void _35clofun3124(struct Cora* co);
 void _35clofun3125(struct Cora* co);
-void _35clofun3063(struct Cora* co);
-void _35clofun3118(struct Cora* co);
+void _35clofun3126(struct Cora* co);
 void _35clofun3121(struct Cora* co);
 void _35clofun3122(struct Cora* co);
 void _35clofun3123(struct Cora* co);
+void _35clofun3070(struct Cora* co);
+void _35clofun3111(struct Cora* co);
+void _35clofun3117(struct Cora* co);
+void _35clofun3118(struct Cora* co);
 void _35clofun3119(struct Cora* co);
 void _35clofun3120(struct Cora* co);
-void _35clofun3115(struct Cora* co);
-void _35clofun3116(struct Cora* co);
-void _35clofun3117(struct Cora* co);
-void _35clofun3064(struct Cora* co);
-void _35clofun3105(struct Cora* co);
-void _35clofun3111(struct Cora* co);
 void _35clofun3112(struct Cora* co);
 void _35clofun3113(struct Cora* co);
 void _35clofun3114(struct Cora* co);
-void _35clofun3106(struct Cora* co);
+void _35clofun3115(struct Cora* co);
+void _35clofun3116(struct Cora* co);
+void _35clofun3071(struct Cora* co);
 void _35clofun3107(struct Cora* co);
 void _35clofun3108(struct Cora* co);
 void _35clofun3109(struct Cora* co);
 void _35clofun3110(struct Cora* co);
-void _35clofun3065(struct Cora* co);
+void _35clofun3072(struct Cora* co);
 void _35clofun3101(struct Cora* co);
 void _35clofun3102(struct Cora* co);
 void _35clofun3103(struct Cora* co);
 void _35clofun3104(struct Cora* co);
-void _35clofun3066(struct Cora* co);
+void _35clofun3105(struct Cora* co);
+void _35clofun3106(struct Cora* co);
+void _35clofun3073(struct Cora* co);
+void _35clofun3091(struct Cora* co);
+void _35clofun3092(struct Cora* co);
+void _35clofun3093(struct Cora* co);
+void _35clofun3094(struct Cora* co);
 void _35clofun3095(struct Cora* co);
 void _35clofun3096(struct Cora* co);
 void _35clofun3097(struct Cora* co);
 void _35clofun3098(struct Cora* co);
 void _35clofun3099(struct Cora* co);
 void _35clofun3100(struct Cora* co);
-void _35clofun3067(struct Cora* co);
-void _35clofun3085(struct Cora* co);
-void _35clofun3086(struct Cora* co);
-void _35clofun3087(struct Cora* co);
-void _35clofun3088(struct Cora* co);
+void _35clofun3074(struct Cora* co);
 void _35clofun3089(struct Cora* co);
 void _35clofun3090(struct Cora* co);
-void _35clofun3091(struct Cora* co);
-void _35clofun3092(struct Cora* co);
-void _35clofun3093(struct Cora* co);
-void _35clofun3094(struct Cora* co);
-void _35clofun3068(struct Cora* co);
-void _35clofun3083(struct Cora* co);
-void _35clofun3084(struct Cora* co);
-void _35clofun3069(struct Cora* co);
+void _35clofun3075(struct Cora* co);
+void _35clofun3087(struct Cora* co);
+void _35clofun3088(struct Cora* co);
+void _35clofun3076(struct Cora* co);
+void _35clofun3077(struct Cora* co);
+void _35clofun3086(struct Cora* co);
+void _35clofun3078(struct Cora* co);
+void _35clofun3080(struct Cora* co);
 void _35clofun3081(struct Cora* co);
 void _35clofun3082(struct Cora* co);
-void _35clofun3070(struct Cora* co);
-void _35clofun3071(struct Cora* co);
-void _35clofun3080(struct Cora* co);
-void _35clofun3072(struct Cora* co);
-void _35clofun3074(struct Cora* co);
-void _35clofun3075(struct Cora* co);
-void _35clofun3076(struct Cora* co);
+void _35clofun3085(struct Cora* co);
+void _35clofun3083(struct Cora* co);
+void _35clofun3084(struct Cora* co);
 void _35clofun3079(struct Cora* co);
-void _35clofun3077(struct Cora* co);
-void _35clofun3078(struct Cora* co);
-void _35clofun3073(struct Cora* co);
-void _35clofun3057(struct Cora* co);
+void _35clofun3063(struct Cora* co);
+void _35clofun3064(struct Cora* co);
 void _35clofun3058(struct Cora* co);
-void _35clofun3052(struct Cora* co);
+void _35clofun3062(struct Cora* co);
+void _35clofun3059(struct Cora* co);
+void _35clofun3061(struct Cora* co);
+void _35clofun3060(struct Cora* co);
+void _35clofun3048(struct Cora* co);
 void _35clofun3056(struct Cora* co);
-void _35clofun3053(struct Cora* co);
-void _35clofun3055(struct Cora* co);
+void _35clofun3057(struct Cora* co);
 void _35clofun3054(struct Cora* co);
-void _35clofun3042(struct Cora* co);
+void _35clofun3055(struct Cora* co);
+void _35clofun3052(struct Cora* co);
+void _35clofun3053(struct Cora* co);
+void _35clofun3049(struct Cora* co);
 void _35clofun3050(struct Cora* co);
 void _35clofun3051(struct Cora* co);
-void _35clofun3048(struct Cora* co);
-void _35clofun3049(struct Cora* co);
-void _35clofun3046(struct Cora* co);
+void _35clofun3030(struct Cora* co);
 void _35clofun3047(struct Cora* co);
+void _35clofun3031(struct Cora* co);
+void _35clofun3032(struct Cora* co);
+void _35clofun3046(struct Cora* co);
+void _35clofun3033(struct Cora* co);
+void _35clofun3041(struct Cora* co);
+void _35clofun3042(struct Cora* co);
 void _35clofun3043(struct Cora* co);
 void _35clofun3044(struct Cora* co);
 void _35clofun3045(struct Cora* co);
-void _35clofun3024(struct Cora* co);
-void _35clofun3041(struct Cora* co);
-void _35clofun3025(struct Cora* co);
-void _35clofun3026(struct Cora* co);
-void _35clofun3040(struct Cora* co);
-void _35clofun3027(struct Cora* co);
-void _35clofun3035(struct Cora* co);
-void _35clofun3036(struct Cora* co);
-void _35clofun3037(struct Cora* co);
+void _35clofun3034(struct Cora* co);
 void _35clofun3038(struct Cora* co);
 void _35clofun3039(struct Cora* co);
-void _35clofun3028(struct Cora* co);
-void _35clofun3032(struct Cora* co);
-void _35clofun3033(struct Cora* co);
-void _35clofun3034(struct Cora* co);
-void _35clofun3029(struct Cora* co);
-void _35clofun3031(struct Cora* co);
-void _35clofun3030(struct Cora* co);
-void _35clofun3014(struct Cora* co);
-void _35clofun3018(struct Cora* co);
-void _35clofun3019(struct Cora* co);
-void _35clofun3023(struct Cora* co);
+void _35clofun3040(struct Cora* co);
+void _35clofun3035(struct Cora* co);
+void _35clofun3037(struct Cora* co);
+void _35clofun3036(struct Cora* co);
 void _35clofun3020(struct Cora* co);
-void _35clofun3022(struct Cora* co);
+void _35clofun3024(struct Cora* co);
+void _35clofun3025(struct Cora* co);
+void _35clofun3029(struct Cora* co);
+void _35clofun3026(struct Cora* co);
+void _35clofun3028(struct Cora* co);
+void _35clofun3027(struct Cora* co);
 void _35clofun3021(struct Cora* co);
-void _35clofun3015(struct Cora* co);
-void _35clofun3017(struct Cora* co);
-void _35clofun3016(struct Cora* co);
-void _35clofun2996(struct Cora* co);
-void _35clofun3013(struct Cora* co);
-void _35clofun2997(struct Cora* co);
-void _35clofun3012(struct Cora* co);
-void _35clofun2998(struct Cora* co);
-void _35clofun3009(struct Cora* co);
-void _35clofun3010(struct Cora* co);
-void _35clofun3011(struct Cora* co);
-void _35clofun2999(struct Cora* co);
-void _35clofun3007(struct Cora* co);
-void _35clofun3008(struct Cora* co);
-void _35clofun3000(struct Cora* co);
-void _35clofun3005(struct Cora* co);
-void _35clofun3006(struct Cora* co);
-void _35clofun3001(struct Cora* co);
-void _35clofun3004(struct Cora* co);
+void _35clofun3023(struct Cora* co);
+void _35clofun3022(struct Cora* co);
 void _35clofun3002(struct Cora* co);
+void _35clofun3019(struct Cora* co);
 void _35clofun3003(struct Cora* co);
-void _35clofun2995(struct Cora* co);
-void _35clofun2980(struct Cora* co);
-void _35clofun2994(struct Cora* co);
-void _35clofun2981(struct Cora* co);
-void _35clofun2993(struct Cora* co);
-void _35clofun2982(struct Cora* co);
-void _35clofun2989(struct Cora* co);
-void _35clofun2990(struct Cora* co);
-void _35clofun2991(struct Cora* co);
-void _35clofun2992(struct Cora* co);
-void _35clofun2983(struct Cora* co);
-void _35clofun2987(struct Cora* co);
-void _35clofun2988(struct Cora* co);
-void _35clofun2984(struct Cora* co);
+void _35clofun3018(struct Cora* co);
+void _35clofun3004(struct Cora* co);
+void _35clofun3015(struct Cora* co);
+void _35clofun3016(struct Cora* co);
+void _35clofun3017(struct Cora* co);
+void _35clofun3005(struct Cora* co);
+void _35clofun3013(struct Cora* co);
+void _35clofun3014(struct Cora* co);
+void _35clofun3006(struct Cora* co);
+void _35clofun3011(struct Cora* co);
+void _35clofun3012(struct Cora* co);
+void _35clofun3007(struct Cora* co);
+void _35clofun3010(struct Cora* co);
+void _35clofun3008(struct Cora* co);
+void _35clofun3009(struct Cora* co);
+void _35clofun3001(struct Cora* co);
 void _35clofun2986(struct Cora* co);
-void _35clofun2985(struct Cora* co);
-void _35clofun2957(struct Cora* co);
-void _35clofun2979(struct Cora* co);
-void _35clofun2958(struct Cora* co);
-void _35clofun2959(struct Cora* co);
-void _35clofun2978(struct Cora* co);
-void _35clofun2960(struct Cora* co);
-void _35clofun2977(struct Cora* co);
-void _35clofun2961(struct Cora* co);
-void _35clofun2976(struct Cora* co);
-void _35clofun2962(struct Cora* co);
-void _35clofun2973(struct Cora* co);
-void _35clofun2974(struct Cora* co);
-void _35clofun2975(struct Cora* co);
+void _35clofun3000(struct Cora* co);
+void _35clofun2987(struct Cora* co);
+void _35clofun2999(struct Cora* co);
+void _35clofun2988(struct Cora* co);
+void _35clofun2995(struct Cora* co);
+void _35clofun2996(struct Cora* co);
+void _35clofun2997(struct Cora* co);
+void _35clofun2998(struct Cora* co);
+void _35clofun2989(struct Cora* co);
+void _35clofun2993(struct Cora* co);
+void _35clofun2994(struct Cora* co);
+void _35clofun2990(struct Cora* co);
+void _35clofun2992(struct Cora* co);
+void _35clofun2991(struct Cora* co);
 void _35clofun2963(struct Cora* co);
+void _35clofun2985(struct Cora* co);
 void _35clofun2964(struct Cora* co);
 void _35clofun2965(struct Cora* co);
-void _35clofun2972(struct Cora* co);
+void _35clofun2984(struct Cora* co);
 void _35clofun2966(struct Cora* co);
+void _35clofun2983(struct Cora* co);
 void _35clofun2967(struct Cora* co);
-void _35clofun2971(struct Cora* co);
+void _35clofun2982(struct Cora* co);
 void _35clofun2968(struct Cora* co);
-void _35clofun2970(struct Cora* co);
+void _35clofun2979(struct Cora* co);
+void _35clofun2980(struct Cora* co);
+void _35clofun2981(struct Cora* co);
 void _35clofun2969(struct Cora* co);
+void _35clofun2970(struct Cora* co);
+void _35clofun2971(struct Cora* co);
+void _35clofun2978(struct Cora* co);
+void _35clofun2972(struct Cora* co);
+void _35clofun2973(struct Cora* co);
+void _35clofun2977(struct Cora* co);
+void _35clofun2974(struct Cora* co);
+void _35clofun2976(struct Cora* co);
+void _35clofun2975(struct Cora* co);
+void _35clofun2956(struct Cora* co);
+void _35clofun2957(struct Cora* co);
+void _35clofun2958(struct Cora* co);
+void _35clofun2959(struct Cora* co);
+void _35clofun2960(struct Cora* co);
+void _35clofun2961(struct Cora* co);
+void _35clofun2962(struct Cora* co);
 void _35clofun2950(struct Cora* co);
 void _35clofun2951(struct Cora* co);
-void _35clofun2952(struct Cora* co);
-void _35clofun2953(struct Cora* co);
-void _35clofun2954(struct Cora* co);
 void _35clofun2955(struct Cora* co);
-void _35clofun2956(struct Cora* co);
+void _35clofun2952(struct Cora* co);
+void _35clofun2954(struct Cora* co);
+void _35clofun2953(struct Cora* co);
 void _35clofun2944(struct Cora* co);
 void _35clofun2945(struct Cora* co);
 void _35clofun2949(struct Cora* co);
 void _35clofun2946(struct Cora* co);
 void _35clofun2948(struct Cora* co);
 void _35clofun2947(struct Cora* co);
+void _35clofun2914(struct Cora* co);
+void _35clofun2941(struct Cora* co);
+void _35clofun2942(struct Cora* co);
+void _35clofun2943(struct Cora* co);
+void _35clofun2915(struct Cora* co);
+void _35clofun2916(struct Cora* co);
+void _35clofun2940(struct Cora* co);
+void _35clofun2917(struct Cora* co);
 void _35clofun2938(struct Cora* co);
 void _35clofun2939(struct Cora* co);
-void _35clofun2943(struct Cora* co);
-void _35clofun2940(struct Cora* co);
-void _35clofun2942(struct Cora* co);
-void _35clofun2941(struct Cora* co);
-void _35clofun2908(struct Cora* co);
-void _35clofun2935(struct Cora* co);
+void _35clofun2918(struct Cora* co);
 void _35clofun2936(struct Cora* co);
 void _35clofun2937(struct Cora* co);
-void _35clofun2909(struct Cora* co);
-void _35clofun2910(struct Cora* co);
+void _35clofun2919(struct Cora* co);
 void _35clofun2934(struct Cora* co);
-void _35clofun2911(struct Cora* co);
+void _35clofun2935(struct Cora* co);
+void _35clofun2920(struct Cora* co);
 void _35clofun2932(struct Cora* co);
 void _35clofun2933(struct Cora* co);
-void _35clofun2912(struct Cora* co);
-void _35clofun2930(struct Cora* co);
-void _35clofun2931(struct Cora* co);
-void _35clofun2913(struct Cora* co);
-void _35clofun2928(struct Cora* co);
-void _35clofun2929(struct Cora* co);
-void _35clofun2914(struct Cora* co);
+void _35clofun2921(struct Cora* co);
+void _35clofun2925(struct Cora* co);
 void _35clofun2926(struct Cora* co);
 void _35clofun2927(struct Cora* co);
-void _35clofun2915(struct Cora* co);
-void _35clofun2919(struct Cora* co);
-void _35clofun2920(struct Cora* co);
-void _35clofun2921(struct Cora* co);
-void _35clofun2924(struct Cora* co);
-void _35clofun2925(struct Cora* co);
+void _35clofun2930(struct Cora* co);
+void _35clofun2931(struct Cora* co);
+void _35clofun2928(struct Cora* co);
+void _35clofun2929(struct Cora* co);
 void _35clofun2922(struct Cora* co);
+void _35clofun2924(struct Cora* co);
 void _35clofun2923(struct Cora* co);
-void _35clofun2916(struct Cora* co);
-void _35clofun2918(struct Cora* co);
-void _35clofun2917(struct Cora* co);
+void _35clofun2911(struct Cora* co);
+void _35clofun2912(struct Cora* co);
+void _35clofun2913(struct Cora* co);
+void _35clofun2908(struct Cora* co);
+void _35clofun2909(struct Cora* co);
+void _35clofun2910(struct Cora* co);
 void _35clofun2905(struct Cora* co);
 void _35clofun2906(struct Cora* co);
 void _35clofun2907(struct Cora* co);
 void _35clofun2902(struct Cora* co);
 void _35clofun2903(struct Cora* co);
 void _35clofun2904(struct Cora* co);
-void _35clofun2899(struct Cora* co);
-void _35clofun2900(struct Cora* co);
-void _35clofun2901(struct Cora* co);
-void _35clofun2896(struct Cora* co);
-void _35clofun2897(struct Cora* co);
 void _35clofun2898(struct Cora* co);
-void _35clofun2892(struct Cora* co);
+void _35clofun2899(struct Cora* co);
+void _35clofun2901(struct Cora* co);
+void _35clofun2900(struct Cora* co);
+void _35clofun2897(struct Cora* co);
 void _35clofun2893(struct Cora* co);
-void _35clofun2895(struct Cora* co);
 void _35clofun2894(struct Cora* co);
-void _35clofun2891(struct Cora* co);
-void _35clofun2887(struct Cora* co);
-void _35clofun2888(struct Cora* co);
+void _35clofun2895(struct Cora* co);
+void _35clofun2896(struct Cora* co);
 void _35clofun2889(struct Cora* co);
 void _35clofun2890(struct Cora* co);
-void _35clofun2883(struct Cora* co);
-void _35clofun2884(struct Cora* co);
-void _35clofun2886(struct Cora* co);
+void _35clofun2892(struct Cora* co);
+void _35clofun2891(struct Cora* co);
 void _35clofun2885(struct Cora* co);
-void _35clofun2879(struct Cora* co);
-void _35clofun2880(struct Cora* co);
-void _35clofun2881(struct Cora* co);
-void _35clofun2882(struct Cora* co);
+void _35clofun2886(struct Cora* co);
+void _35clofun2887(struct Cora* co);
+void _35clofun2888(struct Cora* co);
 
 void entry(struct Cora* co) {
-pushCont(co, 0, _35clofun2877, 0);
+pushCont(co, 0, _35clofun2883, 0);
 coraCall(co, 2, globalRef(intern("import")), makeString1("cora/lib/toc/internal"));
 }
 
-void _35clofun2877(struct Cora* co) {
-Obj _35val1402 = co->args[1];
-pushCont(co, 0, _35clofun2878, 0);
+void _35clofun2883(struct Cora* co) {
+Obj _35val1408 = co->args[1];
+pushCont(co, 0, _35clofun2884, 0);
 coraCall(co, 2, globalRef(intern("import")), makeString1("cora/lib/io"));
 }
 
-void _35clofun2878(struct Cora* co) {
-Obj _35val1403 = co->args[1];
-Obj _35reg1418 = primSet(intern("cora/lib/toc.assq"), makeNative(0, _35clofun2879, 2, 0));
-Obj _35reg1424 = primSet(intern("cora/lib/toc.foldl"), makeNative(0, _35clofun2883, 3, 0));
-Obj _35reg1434 = primSet(intern("cora/lib/toc.pos-in-list0"), makeNative(0, _35clofun2887, 3, 0));
-Obj _35reg1435 = primSet(intern("cora/lib/toc.index"), makeNative(0, _35clofun2891, 2, 0));
-Obj _35reg1442 = primSet(intern("cora/lib/toc.exist-in-env"), makeNative(0, _35clofun2892, 2, 0));
-Obj _35reg1443 = primCons(intern("primSet"), Nil);
-Obj _35reg1444 = primCons(makeNumber(2), _35reg1443);
-Obj _35reg1445 = primCons(intern("set"), _35reg1444);
-Obj _35reg1446 = primCons(intern("primCar"), Nil);
-Obj _35reg1447 = primCons(makeNumber(1), _35reg1446);
-Obj _35reg1448 = primCons(intern("car"), _35reg1447);
-Obj _35reg1449 = primCons(intern("primCdr"), Nil);
-Obj _35reg1450 = primCons(makeNumber(1), _35reg1449);
-Obj _35reg1451 = primCons(intern("cdr"), _35reg1450);
-Obj _35reg1452 = primCons(intern("primCons"), Nil);
-Obj _35reg1453 = primCons(makeNumber(2), _35reg1452);
-Obj _35reg1454 = primCons(intern("cons"), _35reg1453);
-Obj _35reg1455 = primCons(intern("primIsCons"), Nil);
+void _35clofun2884(struct Cora* co) {
+Obj _35val1409 = co->args[1];
+Obj _35reg1424 = primSet(intern("cora/lib/toc.assq"), makeNative(0, _35clofun2885, 2, 0));
+Obj _35reg1430 = primSet(intern("cora/lib/toc.foldl"), makeNative(0, _35clofun2889, 3, 0));
+Obj _35reg1440 = primSet(intern("cora/lib/toc.pos-in-list0"), makeNative(0, _35clofun2893, 3, 0));
+Obj _35reg1441 = primSet(intern("cora/lib/toc.index"), makeNative(0, _35clofun2897, 2, 0));
+Obj _35reg1448 = primSet(intern("cora/lib/toc.exist-in-env"), makeNative(0, _35clofun2898, 2, 0));
+Obj _35reg1449 = primCons(intern("primSet"), Nil);
+Obj _35reg1450 = primCons(makeNumber(2), _35reg1449);
+Obj _35reg1451 = primCons(intern("set"), _35reg1450);
+Obj _35reg1452 = primCons(intern("primCar"), Nil);
+Obj _35reg1453 = primCons(makeNumber(1), _35reg1452);
+Obj _35reg1454 = primCons(intern("car"), _35reg1453);
+Obj _35reg1455 = primCons(intern("primCdr"), Nil);
 Obj _35reg1456 = primCons(makeNumber(1), _35reg1455);
-Obj _35reg1457 = primCons(intern("cons?"), _35reg1456);
-Obj _35reg1458 = primCons(intern("primAdd"), Nil);
+Obj _35reg1457 = primCons(intern("cdr"), _35reg1456);
+Obj _35reg1458 = primCons(intern("primCons"), Nil);
 Obj _35reg1459 = primCons(makeNumber(2), _35reg1458);
-Obj _35reg1460 = primCons(intern("+"), _35reg1459);
-Obj _35reg1461 = primCons(intern("primSub"), Nil);
-Obj _35reg1462 = primCons(makeNumber(2), _35reg1461);
-Obj _35reg1463 = primCons(intern("-"), _35reg1462);
-Obj _35reg1464 = primCons(intern("primMul"), Nil);
+Obj _35reg1460 = primCons(intern("cons"), _35reg1459);
+Obj _35reg1461 = primCons(intern("primIsCons"), Nil);
+Obj _35reg1462 = primCons(makeNumber(1), _35reg1461);
+Obj _35reg1463 = primCons(intern("cons?"), _35reg1462);
+Obj _35reg1464 = primCons(intern("primAdd"), Nil);
 Obj _35reg1465 = primCons(makeNumber(2), _35reg1464);
-Obj _35reg1466 = primCons(intern("*"), _35reg1465);
-Obj _35reg1467 = primCons(intern("primDiv"), Nil);
+Obj _35reg1466 = primCons(intern("+"), _35reg1465);
+Obj _35reg1467 = primCons(intern("primSub"), Nil);
 Obj _35reg1468 = primCons(makeNumber(2), _35reg1467);
-Obj _35reg1469 = primCons(intern("/"), _35reg1468);
-Obj _35reg1470 = primCons(intern("primEQ"), Nil);
+Obj _35reg1469 = primCons(intern("-"), _35reg1468);
+Obj _35reg1470 = primCons(intern("primMul"), Nil);
 Obj _35reg1471 = primCons(makeNumber(2), _35reg1470);
-Obj _35reg1472 = primCons(intern("="), _35reg1471);
-Obj _35reg1473 = primCons(intern("primGT"), Nil);
+Obj _35reg1472 = primCons(intern("*"), _35reg1471);
+Obj _35reg1473 = primCons(intern("primDiv"), Nil);
 Obj _35reg1474 = primCons(makeNumber(2), _35reg1473);
-Obj _35reg1475 = primCons(intern(">"), _35reg1474);
-Obj _35reg1476 = primCons(intern("primLT"), Nil);
+Obj _35reg1475 = primCons(intern("/"), _35reg1474);
+Obj _35reg1476 = primCons(intern("primEQ"), Nil);
 Obj _35reg1477 = primCons(makeNumber(2), _35reg1476);
-Obj _35reg1478 = primCons(intern("<"), _35reg1477);
-Obj _35reg1479 = primCons(intern("primGenSym"), Nil);
-Obj _35reg1480 = primCons(makeNumber(1), _35reg1479);
-Obj _35reg1481 = primCons(intern("gensym"), _35reg1480);
-Obj _35reg1482 = primCons(intern("primIsSymbol"), Nil);
-Obj _35reg1483 = primCons(makeNumber(1), _35reg1482);
-Obj _35reg1484 = primCons(intern("symbol?"), _35reg1483);
-Obj _35reg1485 = primCons(intern("primNot"), Nil);
+Obj _35reg1478 = primCons(intern("="), _35reg1477);
+Obj _35reg1479 = primCons(intern("primGT"), Nil);
+Obj _35reg1480 = primCons(makeNumber(2), _35reg1479);
+Obj _35reg1481 = primCons(intern(">"), _35reg1480);
+Obj _35reg1482 = primCons(intern("primLT"), Nil);
+Obj _35reg1483 = primCons(makeNumber(2), _35reg1482);
+Obj _35reg1484 = primCons(intern("<"), _35reg1483);
+Obj _35reg1485 = primCons(intern("primGenSym"), Nil);
 Obj _35reg1486 = primCons(makeNumber(1), _35reg1485);
-Obj _35reg1487 = primCons(intern("not"), _35reg1486);
-Obj _35reg1488 = primCons(intern("primIsNumber"), Nil);
+Obj _35reg1487 = primCons(intern("gensym"), _35reg1486);
+Obj _35reg1488 = primCons(intern("primIsSymbol"), Nil);
 Obj _35reg1489 = primCons(makeNumber(1), _35reg1488);
-Obj _35reg1490 = primCons(intern("integer?"), _35reg1489);
-Obj _35reg1491 = primCons(intern("primIsString"), Nil);
+Obj _35reg1490 = primCons(intern("symbol?"), _35reg1489);
+Obj _35reg1491 = primCons(intern("primNot"), Nil);
 Obj _35reg1492 = primCons(makeNumber(1), _35reg1491);
-Obj _35reg1493 = primCons(intern("string?"), _35reg1492);
-Obj _35reg1494 = primCons(_35reg1493, Nil);
-Obj _35reg1495 = primCons(_35reg1490, _35reg1494);
-Obj _35reg1496 = primCons(_35reg1487, _35reg1495);
-Obj _35reg1497 = primCons(_35reg1484, _35reg1496);
-Obj _35reg1498 = primCons(_35reg1481, _35reg1497);
-Obj _35reg1499 = primCons(_35reg1478, _35reg1498);
-Obj _35reg1500 = primCons(_35reg1475, _35reg1499);
-Obj _35reg1501 = primCons(_35reg1472, _35reg1500);
-Obj _35reg1502 = primCons(_35reg1469, _35reg1501);
-Obj _35reg1503 = primCons(_35reg1466, _35reg1502);
-Obj _35reg1504 = primCons(_35reg1463, _35reg1503);
-Obj _35reg1505 = primCons(_35reg1460, _35reg1504);
-Obj _35reg1506 = primCons(_35reg1457, _35reg1505);
-Obj _35reg1507 = primCons(_35reg1454, _35reg1506);
-Obj _35reg1508 = primCons(_35reg1451, _35reg1507);
-Obj _35reg1509 = primCons(_35reg1448, _35reg1508);
-Obj _35reg1510 = primCons(_35reg1445, _35reg1509);
-Obj _35reg1511 = primSet(intern("cora/lib/toc.*builtin-prims*"), _35reg1510);
-Obj _35reg1515 = primSet(intern("builtin?"), makeNative(0, _35clofun2896, 1, 0));
-Obj _35reg1518 = primSet(intern("cora/lib/toc.builtin->name"), makeNative(0, _35clofun2899, 1, 0));
-Obj _35reg1521 = primSet(intern("cora/lib/toc.builtin->args"), makeNative(0, _35clofun2902, 1, 0));
-Obj _35reg1526 = primSet(intern("cora/lib/toc.temp-list"), makeNative(0, _35clofun2905, 2, 0));
-Obj _35reg1662 = primSet(intern("cora/lib/toc.parse"), makeNative(0, _35clofun2908, 2, 0));
-Obj _35reg1673 = primSet(intern("cora/lib/toc.union"), makeNative(0, _35clofun2938, 2, 0));
-Obj _35reg1684 = primSet(intern("cora/lib/toc.diff"), makeNative(0, _35clofun2944, 2, 0));
-Obj _35reg1735 = primSet(intern("cora/lib/toc.convert-protect?"), makeNative(0, _35clofun2950, 1, 0));
-Obj _35reg1910 = primSet(intern("cora/lib/toc.free-vars"), makeNative(0, _35clofun2957, 1, 0));
-Obj _35reg1983 = primSet(intern("cora/lib/toc.closure-convert"), makeNative(0, _35clofun2980, 2, 0));
-Obj _35reg1986 = primSet(intern("cora/lib/toc.id"), makeNative(0, _35clofun2995, 1, 0));
-Obj _35reg2123 = primSet(intern("cora/lib/toc.tailify"), makeNative(0, _35clofun2996, 2, 0));
-Obj _35reg2170 = primSet(intern("cora/lib/toc.tailify-list"), makeNative(0, _35clofun3014, 3, 0));
-Obj _35reg2249 = primSet(intern("cora/lib/toc.explicit-stack"), makeNative(0, _35clofun3024, 2, 0));
-Obj _35reg2356 = primSet(intern("cora/lib/toc.collect-lambda"), makeNative(0, _35clofun3042, 3, 0));
-Obj _35reg2363 = primSet(intern("cora/lib/toc.collect-lambda-list"), makeNative(0, _35clofun3052, 4, 0));
-Obj _35reg2370 = primSet(intern("cora/lib/toc.wrap-var"), makeNative(0, _35clofun3057, 2, 0));
-Obj _35reg2621 = primSet(intern("cora/lib/toc.generate-inst"), makeNative(0, _35clofun3059, 3, 0));
-Obj _35reg2632 = primSet(intern("cora/lib/toc.generate-call-args"), makeNative(0, _35clofun3131, 4, 0));
-Obj _35reg2651 = primSet(intern("cora/lib/toc.generate-cont"), makeNative(0, _35clofun3139, 2, 0));
-Obj _35reg2660 = primSet(intern("cora/lib/toc.generate-inst-list-h"), makeNative(0, _35clofun3150, 4, 0));
-Obj _35reg2661 = primSet(intern("cora/lib/toc.generate-inst-list"), makeNative(0, _35clofun3156, 3, 0));
-Obj _35reg2665 = primSet(intern("cora/lib/toc.code-gen-func-declare"), makeNative(0, _35clofun3157, 2, 0));
-Obj _35reg2676 = primSet(intern("cora/lib/toc.generate-call-args-reverse"), makeNative(0, _35clofun3161, 5, 0));
-Obj _35reg2733 = primSet(intern("cora/lib/toc.code-gen-toplevel"), makeNative(0, _35clofun3169, 2, 0));
-Obj _35reg2734 = primSet(intern("cora/lib/toc.parse-pass"), makeNative(0, _35clofun3176, 1, 0));
-Obj _35reg2735 = primSet(intern("cora/lib/toc.closure-convert-pass"), makeNative(0, _35clofun3177, 1, 0));
-Obj _35reg2736 = primSet(intern("cora/lib/toc.tailify-pass"), makeNative(0, _35clofun3178, 1, 0));
-Obj _35reg2737 = primSet(intern("cora/lib/toc.explicit-stack-pass"), makeNative(0, _35clofun3179, 1, 0));
-Obj _35reg2745 = primSet(intern("cora/lib/toc.collect-lambda-pass"), makeNative(0, _35clofun3180, 1, 0));
-Obj _35reg2752 = primSet(intern("cora/lib/toc.rewrite-->macro"), makeNative(0, _35clofun3182, 2, 0));
-pushCont(co, 0, _35clofun3188, 0);
-coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("->"), makeNative(0, _35clofun3185, 1, 0));
+Obj _35reg1493 = primCons(intern("not"), _35reg1492);
+Obj _35reg1494 = primCons(intern("primIsNumber"), Nil);
+Obj _35reg1495 = primCons(makeNumber(1), _35reg1494);
+Obj _35reg1496 = primCons(intern("integer?"), _35reg1495);
+Obj _35reg1497 = primCons(intern("primIsString"), Nil);
+Obj _35reg1498 = primCons(makeNumber(1), _35reg1497);
+Obj _35reg1499 = primCons(intern("string?"), _35reg1498);
+Obj _35reg1500 = primCons(_35reg1499, Nil);
+Obj _35reg1501 = primCons(_35reg1496, _35reg1500);
+Obj _35reg1502 = primCons(_35reg1493, _35reg1501);
+Obj _35reg1503 = primCons(_35reg1490, _35reg1502);
+Obj _35reg1504 = primCons(_35reg1487, _35reg1503);
+Obj _35reg1505 = primCons(_35reg1484, _35reg1504);
+Obj _35reg1506 = primCons(_35reg1481, _35reg1505);
+Obj _35reg1507 = primCons(_35reg1478, _35reg1506);
+Obj _35reg1508 = primCons(_35reg1475, _35reg1507);
+Obj _35reg1509 = primCons(_35reg1472, _35reg1508);
+Obj _35reg1510 = primCons(_35reg1469, _35reg1509);
+Obj _35reg1511 = primCons(_35reg1466, _35reg1510);
+Obj _35reg1512 = primCons(_35reg1463, _35reg1511);
+Obj _35reg1513 = primCons(_35reg1460, _35reg1512);
+Obj _35reg1514 = primCons(_35reg1457, _35reg1513);
+Obj _35reg1515 = primCons(_35reg1454, _35reg1514);
+Obj _35reg1516 = primCons(_35reg1451, _35reg1515);
+Obj _35reg1517 = primSet(intern("cora/lib/toc.*builtin-prims*"), _35reg1516);
+Obj _35reg1521 = primSet(intern("builtin?"), makeNative(0, _35clofun2902, 1, 0));
+Obj _35reg1524 = primSet(intern("cora/lib/toc.builtin->name"), makeNative(0, _35clofun2905, 1, 0));
+Obj _35reg1527 = primSet(intern("cora/lib/toc.builtin->args"), makeNative(0, _35clofun2908, 1, 0));
+Obj _35reg1532 = primSet(intern("cora/lib/toc.temp-list"), makeNative(0, _35clofun2911, 2, 0));
+Obj _35reg1668 = primSet(intern("cora/lib/toc.parse"), makeNative(0, _35clofun2914, 2, 0));
+Obj _35reg1679 = primSet(intern("cora/lib/toc.union"), makeNative(0, _35clofun2944, 2, 0));
+Obj _35reg1690 = primSet(intern("cora/lib/toc.diff"), makeNative(0, _35clofun2950, 2, 0));
+Obj _35reg1741 = primSet(intern("cora/lib/toc.convert-protect?"), makeNative(0, _35clofun2956, 1, 0));
+Obj _35reg1916 = primSet(intern("cora/lib/toc.free-vars"), makeNative(0, _35clofun2963, 1, 0));
+Obj _35reg1989 = primSet(intern("cora/lib/toc.closure-convert"), makeNative(0, _35clofun2986, 2, 0));
+Obj _35reg1992 = primSet(intern("cora/lib/toc.id"), makeNative(0, _35clofun3001, 1, 0));
+Obj _35reg2129 = primSet(intern("cora/lib/toc.tailify"), makeNative(0, _35clofun3002, 2, 0));
+Obj _35reg2176 = primSet(intern("cora/lib/toc.tailify-list"), makeNative(0, _35clofun3020, 3, 0));
+Obj _35reg2255 = primSet(intern("cora/lib/toc.explicit-stack"), makeNative(0, _35clofun3030, 2, 0));
+Obj _35reg2362 = primSet(intern("cora/lib/toc.collect-lambda"), makeNative(0, _35clofun3048, 3, 0));
+Obj _35reg2369 = primSet(intern("cora/lib/toc.collect-lambda-list"), makeNative(0, _35clofun3058, 4, 0));
+Obj _35reg2376 = primSet(intern("cora/lib/toc.wrap-var"), makeNative(0, _35clofun3063, 2, 0));
+Obj _35reg2627 = primSet(intern("cora/lib/toc.generate-inst"), makeNative(0, _35clofun3065, 3, 0));
+Obj _35reg2638 = primSet(intern("cora/lib/toc.generate-call-args"), makeNative(0, _35clofun3137, 4, 0));
+Obj _35reg2657 = primSet(intern("cora/lib/toc.generate-cont"), makeNative(0, _35clofun3145, 2, 0));
+Obj _35reg2666 = primSet(intern("cora/lib/toc.generate-inst-list-h"), makeNative(0, _35clofun3156, 4, 0));
+Obj _35reg2667 = primSet(intern("cora/lib/toc.generate-inst-list"), makeNative(0, _35clofun3162, 3, 0));
+Obj _35reg2671 = primSet(intern("cora/lib/toc.code-gen-func-declare"), makeNative(0, _35clofun3163, 2, 0));
+Obj _35reg2682 = primSet(intern("cora/lib/toc.generate-call-args-reverse"), makeNative(0, _35clofun3167, 5, 0));
+Obj _35reg2739 = primSet(intern("cora/lib/toc.code-gen-toplevel"), makeNative(0, _35clofun3175, 2, 0));
+Obj _35reg2740 = primSet(intern("cora/lib/toc.parse-pass"), makeNative(0, _35clofun3182, 1, 0));
+Obj _35reg2741 = primSet(intern("cora/lib/toc.closure-convert-pass"), makeNative(0, _35clofun3183, 1, 0));
+Obj _35reg2742 = primSet(intern("cora/lib/toc.tailify-pass"), makeNative(0, _35clofun3184, 1, 0));
+Obj _35reg2743 = primSet(intern("cora/lib/toc.explicit-stack-pass"), makeNative(0, _35clofun3185, 1, 0));
+Obj _35reg2751 = primSet(intern("cora/lib/toc.collect-lambda-pass"), makeNative(0, _35clofun3186, 1, 0));
+Obj _35reg2758 = primSet(intern("cora/lib/toc.rewrite-->macro"), makeNative(0, _35clofun3188, 2, 0));
+pushCont(co, 0, _35clofun3194, 0);
+coraCall(co, 3, globalRef(intern("cora/init.add-to-*macros*")), intern("->"), makeNative(0, _35clofun3191, 1, 0));
 }
 
-void _35clofun3188(struct Cora* co) {
-Obj _35val2755 = co->args[1];
-Obj _35reg2760 = primSet(intern("cora/lib/toc.compile"), makeNative(0, _35clofun3189, 1, 0));
-Obj _35reg2766 = primSet(intern("for-each"), makeNative(0, _35clofun3194, 2, 0));
-Obj _35reg2773 = primSet(intern("cora/lib/toc.generate-c"), makeNative(0, _35clofun3198, 2, 0));
-Obj _35reg2796 = primSet(intern("cora/lib/toc.handle-import-eagerly"), makeNative(0, _35clofun3206, 1, 0));
-Obj _35reg2803 = primSet(intern("cora/lib/toc.compile-to-c"), makeNative(0, _35clofun3211, 3, 0));
-Obj _35reg2805 = primSet(intern("set"), makeNative(0, _35clofun3218, 2, 0));
-Obj _35reg2807 = primSet(intern("car"), makeNative(0, _35clofun3219, 1, 0));
-Obj _35reg2809 = primSet(intern("cdr"), makeNative(0, _35clofun3220, 1, 0));
-Obj _35reg2811 = primSet(intern("cons"), makeNative(0, _35clofun3221, 2, 0));
-Obj _35reg2813 = primSet(intern("cons"), makeNative(0, _35clofun3222, 2, 0));
-Obj _35reg2815 = primSet(intern("+"), makeNative(0, _35clofun3223, 2, 0));
-Obj _35reg2817 = primSet(intern("-"), makeNative(0, _35clofun3224, 2, 0));
-Obj _35reg2819 = primSet(intern("*"), makeNative(0, _35clofun3225, 2, 0));
-Obj _35reg2821 = primSet(intern("/"), makeNative(0, _35clofun3226, 2, 0));
-Obj _35reg2823 = primSet(intern("="), makeNative(0, _35clofun3227, 2, 0));
-Obj _35reg2825 = primSet(intern(">"), makeNative(0, _35clofun3228, 2, 0));
-Obj _35reg2827 = primSet(intern("<"), makeNative(0, _35clofun3229, 2, 0));
-Obj _35reg2829 = primSet(intern("gensym"), makeNative(0, _35clofun3230, 1, 0));
-Obj _35reg2831 = primSet(intern("symbol?"), makeNative(0, _35clofun3231, 1, 0));
-Obj _35reg2833 = primSet(intern("not"), makeNative(0, _35clofun3232, 1, 0));
-Obj _35reg2835 = primSet(intern("string?"), makeNative(0, _35clofun3233, 1, 0));
-Obj _35reg2876 = primSet(intern("cora/lib/toc.eval0"), makeNative(0, _35clofun3234, 1, 0));
-coraReturn(co, _35reg2876);
+void _35clofun3194(struct Cora* co) {
+Obj _35val2761 = co->args[1];
+Obj _35reg2766 = primSet(intern("cora/lib/toc.compile"), makeNative(0, _35clofun3195, 1, 0));
+Obj _35reg2772 = primSet(intern("for-each"), makeNative(0, _35clofun3200, 2, 0));
+Obj _35reg2779 = primSet(intern("cora/lib/toc.generate-c"), makeNative(0, _35clofun3204, 2, 0));
+Obj _35reg2802 = primSet(intern("cora/lib/toc.handle-import-eagerly"), makeNative(0, _35clofun3212, 1, 0));
+Obj _35reg2809 = primSet(intern("cora/lib/toc.compile-to-c"), makeNative(0, _35clofun3217, 3, 0));
+Obj _35reg2811 = primSet(intern("set"), makeNative(0, _35clofun3224, 2, 0));
+Obj _35reg2813 = primSet(intern("car"), makeNative(0, _35clofun3225, 1, 0));
+Obj _35reg2815 = primSet(intern("cdr"), makeNative(0, _35clofun3226, 1, 0));
+Obj _35reg2817 = primSet(intern("cons"), makeNative(0, _35clofun3227, 2, 0));
+Obj _35reg2819 = primSet(intern("cons"), makeNative(0, _35clofun3228, 2, 0));
+Obj _35reg2821 = primSet(intern("+"), makeNative(0, _35clofun3229, 2, 0));
+Obj _35reg2823 = primSet(intern("-"), makeNative(0, _35clofun3230, 2, 0));
+Obj _35reg2825 = primSet(intern("*"), makeNative(0, _35clofun3231, 2, 0));
+Obj _35reg2827 = primSet(intern("/"), makeNative(0, _35clofun3232, 2, 0));
+Obj _35reg2829 = primSet(intern("="), makeNative(0, _35clofun3233, 2, 0));
+Obj _35reg2831 = primSet(intern(">"), makeNative(0, _35clofun3234, 2, 0));
+Obj _35reg2833 = primSet(intern("<"), makeNative(0, _35clofun3235, 2, 0));
+Obj _35reg2835 = primSet(intern("gensym"), makeNative(0, _35clofun3236, 1, 0));
+Obj _35reg2837 = primSet(intern("symbol?"), makeNative(0, _35clofun3237, 1, 0));
+Obj _35reg2839 = primSet(intern("not"), makeNative(0, _35clofun3238, 1, 0));
+Obj _35reg2841 = primSet(intern("string?"), makeNative(0, _35clofun3239, 1, 0));
+Obj _35reg2882 = primSet(intern("cora/lib/toc.eval0"), makeNative(0, _35clofun3240, 1, 0));
+coraReturn(co, _35reg2882);
 return;
 }
 
-void _35clofun3234(struct Cora* co) {
+void _35clofun3240(struct Cora* co) {
 Obj exp = co->args[1];
-Obj _35reg2836 = primIsSymbol(exp);
-if (True == _35reg2836) {
+Obj _35reg2842 = primIsSymbol(exp);
+if (True == _35reg2842) {
 coraCall(co, 2, globalRef(intern("value")), exp);
 } else {
-pushCont(co, 0, _35clofun3235, 1, exp);
+pushCont(co, 0, _35clofun3241, 1, exp);
 coraCall(co, 2, globalRef(intern("number?")), exp);
 }
 }
 
-void _35clofun3235(struct Cora* co) {
-Obj _35val2837 = co->args[1];
+void _35clofun3241(struct Cora* co) {
+Obj _35val2843 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val2837) {
+if (True == _35val2843) {
 if (True == True) {
 coraReturn(co, exp);
 return;
 } else {
-Obj _35reg2838 = primIsCons(exp);
-if (True == _35reg2838) {
-Obj _35reg2839 = primCar(exp);
-Obj _35reg2840 = primEQ(_35reg2839, intern("quote"));
-if (True == _35reg2840) {
-coraCall(co, 2, globalRef(intern("cadr")), exp);
-} else {
-Obj _35reg2841 = primCar(exp);
-pushCont(co, 0, _35clofun3236, 1, exp);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2841);
-}
-} else {
-coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
-}
-}
-} else {
-Obj _35reg2845 = primIsString(exp);
-if (True == _35reg2845) {
-if (True == True) {
-coraReturn(co, exp);
-return;
-} else {
-Obj _35reg2846 = primIsCons(exp);
+Obj _35reg2844 = primIsCons(exp);
+if (True == _35reg2844) {
+Obj _35reg2845 = primCar(exp);
+Obj _35reg2846 = primEQ(_35reg2845, intern("quote"));
 if (True == _35reg2846) {
-Obj _35reg2847 = primCar(exp);
-Obj _35reg2848 = primEQ(_35reg2847, intern("quote"));
-if (True == _35reg2848) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
-Obj _35reg2849 = primCar(exp);
-pushCont(co, 0, _35clofun3238, 1, exp);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2849);
+Obj _35reg2847 = primCar(exp);
+pushCont(co, 0, _35clofun3242, 1, exp);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2847);
 }
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 } else {
-pushCont(co, 0, _35clofun3240, 1, exp);
+Obj _35reg2851 = primIsString(exp);
+if (True == _35reg2851) {
+if (True == True) {
+coraReturn(co, exp);
+return;
+} else {
+Obj _35reg2852 = primIsCons(exp);
+if (True == _35reg2852) {
+Obj _35reg2853 = primCar(exp);
+Obj _35reg2854 = primEQ(_35reg2853, intern("quote"));
+if (True == _35reg2854) {
+coraCall(co, 2, globalRef(intern("cadr")), exp);
+} else {
+Obj _35reg2855 = primCar(exp);
+pushCont(co, 0, _35clofun3244, 1, exp);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2855);
+}
+} else {
+coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
+}
+}
+} else {
+pushCont(co, 0, _35clofun3246, 1, exp);
 coraCall(co, 2, globalRef(intern("boolean?")), exp);
 }
 }
 }
 
-void _35clofun3240(struct Cora* co) {
-Obj _35val2853 = co->args[1];
+void _35clofun3246(struct Cora* co) {
+Obj _35val2859 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val2853) {
+if (True == _35val2859) {
 if (True == True) {
 coraReturn(co, exp);
 return;
 } else {
-Obj _35reg2854 = primIsCons(exp);
-if (True == _35reg2854) {
-Obj _35reg2855 = primCar(exp);
-Obj _35reg2856 = primEQ(_35reg2855, intern("quote"));
-if (True == _35reg2856) {
+Obj _35reg2860 = primIsCons(exp);
+if (True == _35reg2860) {
+Obj _35reg2861 = primCar(exp);
+Obj _35reg2862 = primEQ(_35reg2861, intern("quote"));
+if (True == _35reg2862) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
-Obj _35reg2857 = primCar(exp);
-pushCont(co, 0, _35clofun3241, 1, exp);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2857);
+Obj _35reg2863 = primCar(exp);
+pushCont(co, 0, _35clofun3247, 1, exp);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2863);
 }
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 } else {
-pushCont(co, 0, _35clofun3243, 1, exp);
+pushCont(co, 0, _35clofun3249, 1, exp);
 coraCall(co, 2, globalRef(intern("null?")), exp);
 }
 }
 
-void _35clofun3243(struct Cora* co) {
-Obj _35val2861 = co->args[1];
+void _35clofun3249(struct Cora* co) {
+Obj _35val2867 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val2861) {
+if (True == _35val2867) {
 if (True == True) {
 coraReturn(co, exp);
 return;
 } else {
-Obj _35reg2862 = primIsCons(exp);
-if (True == _35reg2862) {
-Obj _35reg2863 = primCar(exp);
-Obj _35reg2864 = primEQ(_35reg2863, intern("quote"));
-if (True == _35reg2864) {
+Obj _35reg2868 = primIsCons(exp);
+if (True == _35reg2868) {
+Obj _35reg2869 = primCar(exp);
+Obj _35reg2870 = primEQ(_35reg2869, intern("quote"));
+if (True == _35reg2870) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
-Obj _35reg2865 = primCar(exp);
-pushCont(co, 0, _35clofun3244, 1, exp);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2865);
+Obj _35reg2871 = primCar(exp);
+pushCont(co, 0, _35clofun3250, 1, exp);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2871);
 }
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
@@ -644,16 +644,16 @@ if (True == False) {
 coraReturn(co, exp);
 return;
 } else {
-Obj _35reg2869 = primIsCons(exp);
-if (True == _35reg2869) {
-Obj _35reg2870 = primCar(exp);
-Obj _35reg2871 = primEQ(_35reg2870, intern("quote"));
-if (True == _35reg2871) {
+Obj _35reg2875 = primIsCons(exp);
+if (True == _35reg2875) {
+Obj _35reg2876 = primCar(exp);
+Obj _35reg2877 = primEQ(_35reg2876, intern("quote"));
+if (True == _35reg2877) {
 coraCall(co, 2, globalRef(intern("cadr")), exp);
 } else {
-Obj _35reg2872 = primCar(exp);
-pushCont(co, 0, _35clofun3246, 1, exp);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2872);
+Obj _35reg2878 = primCar(exp);
+pushCont(co, 0, _35clofun3252, 1, exp);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.eval0")), _35reg2878);
 }
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
@@ -662,1347 +662,1347 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 
-void _35clofun3246(struct Cora* co) {
-Obj _35val2873 = co->args[1];
+void _35clofun3252(struct Cora* co) {
+Obj _35val2879 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2874 = primCdr(exp);
-pushCont(co, 0, _35clofun3247, 1, _35val2873);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2874);
+Obj _35reg2880 = primCdr(exp);
+pushCont(co, 0, _35clofun3253, 1, _35val2879);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2880);
+}
+
+void _35clofun3253(struct Cora* co) {
+Obj _35val2881 = co->args[1];
+Obj _35val2879 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("apply")), _35val2879, _35val2881);
+}
+
+void _35clofun3250(struct Cora* co) {
+Obj _35val2872 = co->args[1];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2873 = primCdr(exp);
+pushCont(co, 0, _35clofun3251, 1, _35val2872);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2873);
+}
+
+void _35clofun3251(struct Cora* co) {
+Obj _35val2874 = co->args[1];
+Obj _35val2872 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("apply")), _35val2872, _35val2874);
 }
 
 void _35clofun3247(struct Cora* co) {
-Obj _35val2875 = co->args[1];
-Obj _35val2873 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("apply")), _35val2873, _35val2875);
+Obj _35val2864 = co->args[1];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2865 = primCdr(exp);
+pushCont(co, 0, _35clofun3248, 1, _35val2864);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2865);
+}
+
+void _35clofun3248(struct Cora* co) {
+Obj _35val2866 = co->args[1];
+Obj _35val2864 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("apply")), _35val2864, _35val2866);
 }
 
 void _35clofun3244(struct Cora* co) {
-Obj _35val2866 = co->args[1];
+Obj _35val2856 = co->args[1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2867 = primCdr(exp);
-pushCont(co, 0, _35clofun3245, 1, _35val2866);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2867);
+Obj _35reg2857 = primCdr(exp);
+pushCont(co, 0, _35clofun3245, 1, _35val2856);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2857);
 }
 
 void _35clofun3245(struct Cora* co) {
-Obj _35val2868 = co->args[1];
-Obj _35val2866 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("apply")), _35val2866, _35val2868);
-}
-
-void _35clofun3241(struct Cora* co) {
 Obj _35val2858 = co->args[1];
-Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2859 = primCdr(exp);
-pushCont(co, 0, _35clofun3242, 1, _35val2858);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2859);
+Obj _35val2856 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("apply")), _35val2856, _35val2858);
 }
 
 void _35clofun3242(struct Cora* co) {
-Obj _35val2860 = co->args[1];
-Obj _35val2858 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("apply")), _35val2858, _35val2860);
+Obj _35val2848 = co->args[1];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2849 = primCdr(exp);
+pushCont(co, 0, _35clofun3243, 1, _35val2848);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2849);
 }
 
-void _35clofun3238(struct Cora* co) {
+void _35clofun3243(struct Cora* co) {
 Obj _35val2850 = co->args[1];
-Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2851 = primCdr(exp);
-pushCont(co, 0, _35clofun3239, 1, _35val2850);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2851);
+Obj _35val2848 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("apply")), _35val2848, _35val2850);
 }
 
 void _35clofun3239(struct Cora* co) {
-Obj _35val2852 = co->args[1];
-Obj _35val2850 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("apply")), _35val2850, _35val2852);
+Obj _35tmp1407 = co->args[1];
+Obj _35reg2840 = primIsString(_35tmp1407);
+coraReturn(co, _35reg2840);
+return;
 }
 
-void _35clofun3236(struct Cora* co) {
-Obj _35val2842 = co->args[1];
-Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2843 = primCdr(exp);
-pushCont(co, 0, _35clofun3237, 1, _35val2842);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.eval0")), _35reg2843);
+void _35clofun3238(struct Cora* co) {
+Obj _35tmp1406 = co->args[1];
+Obj _35reg2838 = primNot(_35tmp1406);
+coraReturn(co, _35reg2838);
+return;
 }
 
 void _35clofun3237(struct Cora* co) {
-Obj _35val2844 = co->args[1];
-Obj _35val2842 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("apply")), _35val2842, _35val2844);
+Obj _35tmp1405 = co->args[1];
+Obj _35reg2836 = primIsSymbol(_35tmp1405);
+coraReturn(co, _35reg2836);
+return;
 }
 
-void _35clofun3233(struct Cora* co) {
-Obj _35tmp1401 = co->args[1];
-Obj _35reg2834 = primIsString(_35tmp1401);
+void _35clofun3236(struct Cora* co) {
+Obj _35tmp1404 = co->args[1];
+Obj _35reg2834 = primGenSym(_35tmp1404);
 coraReturn(co, _35reg2834);
 return;
 }
 
-void _35clofun3232(struct Cora* co) {
-Obj _35tmp1400 = co->args[1];
-Obj _35reg2832 = primNot(_35tmp1400);
+void _35clofun3235(struct Cora* co) {
+Obj _35tmp1403 = co->args[1];
+Obj _35tmp1402 = co->args[2];
+Obj _35reg2832 = primLT(_35tmp1403, _35tmp1402);
 coraReturn(co, _35reg2832);
 return;
 }
 
-void _35clofun3231(struct Cora* co) {
-Obj _35tmp1399 = co->args[1];
-Obj _35reg2830 = primIsSymbol(_35tmp1399);
+void _35clofun3234(struct Cora* co) {
+Obj _35tmp1401 = co->args[1];
+Obj _35tmp1400 = co->args[2];
+Obj _35reg2830 = primGT(_35tmp1401, _35tmp1400);
 coraReturn(co, _35reg2830);
 return;
 }
 
-void _35clofun3230(struct Cora* co) {
-Obj _35tmp1398 = co->args[1];
-Obj _35reg2828 = primGenSym(_35tmp1398);
+void _35clofun3233(struct Cora* co) {
+Obj _35tmp1399 = co->args[1];
+Obj _35tmp1398 = co->args[2];
+Obj _35reg2828 = primEQ(_35tmp1399, _35tmp1398);
 coraReturn(co, _35reg2828);
 return;
 }
 
-void _35clofun3229(struct Cora* co) {
+void _35clofun3232(struct Cora* co) {
 Obj _35tmp1397 = co->args[1];
 Obj _35tmp1396 = co->args[2];
-Obj _35reg2826 = primLT(_35tmp1397, _35tmp1396);
+Obj _35reg2826 = primDiv(_35tmp1397, _35tmp1396);
 coraReturn(co, _35reg2826);
 return;
 }
 
-void _35clofun3228(struct Cora* co) {
+void _35clofun3231(struct Cora* co) {
 Obj _35tmp1395 = co->args[1];
 Obj _35tmp1394 = co->args[2];
-Obj _35reg2824 = primGT(_35tmp1395, _35tmp1394);
+Obj _35reg2824 = primMul(_35tmp1395, _35tmp1394);
 coraReturn(co, _35reg2824);
 return;
 }
 
-void _35clofun3227(struct Cora* co) {
+void _35clofun3230(struct Cora* co) {
 Obj _35tmp1393 = co->args[1];
 Obj _35tmp1392 = co->args[2];
-Obj _35reg2822 = primEQ(_35tmp1393, _35tmp1392);
+Obj _35reg2822 = primSub(_35tmp1393, _35tmp1392);
 coraReturn(co, _35reg2822);
 return;
 }
 
-void _35clofun3226(struct Cora* co) {
+void _35clofun3229(struct Cora* co) {
 Obj _35tmp1391 = co->args[1];
 Obj _35tmp1390 = co->args[2];
-Obj _35reg2820 = primDiv(_35tmp1391, _35tmp1390);
+Obj _35reg2820 = primAdd(_35tmp1391, _35tmp1390);
 coraReturn(co, _35reg2820);
 return;
 }
 
-void _35clofun3225(struct Cora* co) {
+void _35clofun3228(struct Cora* co) {
 Obj _35tmp1389 = co->args[1];
 Obj _35tmp1388 = co->args[2];
-Obj _35reg2818 = primMul(_35tmp1389, _35tmp1388);
+Obj _35reg2818 = primCons(_35tmp1389, _35tmp1388);
 coraReturn(co, _35reg2818);
 return;
 }
 
-void _35clofun3224(struct Cora* co) {
+void _35clofun3227(struct Cora* co) {
 Obj _35tmp1387 = co->args[1];
 Obj _35tmp1386 = co->args[2];
-Obj _35reg2816 = primSub(_35tmp1387, _35tmp1386);
+Obj _35reg2816 = primCons(_35tmp1387, _35tmp1386);
 coraReturn(co, _35reg2816);
 return;
 }
 
-void _35clofun3223(struct Cora* co) {
+void _35clofun3226(struct Cora* co) {
 Obj _35tmp1385 = co->args[1];
-Obj _35tmp1384 = co->args[2];
-Obj _35reg2814 = primAdd(_35tmp1385, _35tmp1384);
+Obj _35reg2814 = primCdr(_35tmp1385);
 coraReturn(co, _35reg2814);
 return;
 }
 
-void _35clofun3222(struct Cora* co) {
-Obj _35tmp1383 = co->args[1];
-Obj _35tmp1382 = co->args[2];
-Obj _35reg2812 = primCons(_35tmp1383, _35tmp1382);
+void _35clofun3225(struct Cora* co) {
+Obj _35tmp1384 = co->args[1];
+Obj _35reg2812 = primCar(_35tmp1384);
 coraReturn(co, _35reg2812);
 return;
 }
 
-void _35clofun3221(struct Cora* co) {
-Obj _35tmp1381 = co->args[1];
-Obj _35tmp1380 = co->args[2];
-Obj _35reg2810 = primCons(_35tmp1381, _35tmp1380);
+void _35clofun3224(struct Cora* co) {
+Obj _35tmp1383 = co->args[1];
+Obj _35tmp1382 = co->args[2];
+Obj _35reg2810 = primSet(_35tmp1383, _35tmp1382);
 coraReturn(co, _35reg2810);
 return;
 }
 
-void _35clofun3220(struct Cora* co) {
-Obj _35tmp1379 = co->args[1];
-Obj _35reg2808 = primCdr(_35tmp1379);
-coraReturn(co, _35reg2808);
-return;
-}
-
-void _35clofun3219(struct Cora* co) {
-Obj _35tmp1378 = co->args[1];
-Obj _35reg2806 = primCar(_35tmp1378);
-coraReturn(co, _35reg2806);
-return;
-}
-
-void _35clofun3218(struct Cora* co) {
-Obj _35tmp1377 = co->args[1];
-Obj _35tmp1376 = co->args[2];
-Obj _35reg2804 = primSet(_35tmp1377, _35tmp1376);
-coraReturn(co, _35reg2804);
-return;
-}
-
-void _35clofun3211(struct Cora* co) {
+void _35clofun3217(struct Cora* co) {
 Obj from = co->args[1];
 Obj to = co->args[2];
 Obj pkg_45str = co->args[3];
-pushCont(co, 0, _35clofun3212, 1, to);
+pushCont(co, 0, _35clofun3218, 1, to);
 coraCall(co, 3, globalRef(intern("read-file-as-sexp")), from, pkg_45str);
 }
 
-void _35clofun3212(struct Cora* co) {
-Obj _35val2797 = co->args[1];
+void _35clofun3218(struct Cora* co) {
+Obj _35val2803 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj sexp = _35val2797;
-pushCont(co, 0, _35clofun3213, 2, sexp, to);
+Obj sexp = _35val2803;
+pushCont(co, 0, _35clofun3219, 2, sexp, to);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.handle-import-eagerly")), sexp);
 }
 
-void _35clofun3213(struct Cora* co) {
-Obj _35val2798 = co->args[1];
+void _35clofun3219(struct Cora* co) {
+Obj _35val2804 = co->args[1];
 Obj sexp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3214, 1, to);
+pushCont(co, 0, _35clofun3220, 1, to);
 coraCall(co, 2, globalRef(intern("macroexpand")), sexp);
 }
 
-void _35clofun3214(struct Cora* co) {
-Obj _35val2799 = co->args[1];
+void _35clofun3220(struct Cora* co) {
+Obj _35val2805 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj input = _35val2799;
-pushCont(co, 0, _35clofun3215, 1, to);
+Obj input = _35val2805;
+pushCont(co, 0, _35clofun3221, 1, to);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.compile")), input);
 }
 
-void _35clofun3215(struct Cora* co) {
-Obj _35val2800 = co->args[1];
+void _35clofun3221(struct Cora* co) {
+Obj _35val2806 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc = _35val2800;
-pushCont(co, 0, _35clofun3216, 1, bc);
+Obj bc = _35val2806;
+pushCont(co, 0, _35clofun3222, 1, bc);
 coraCall(co, 2, globalRef(intern("cora/lib/io.open-output-file")), to);
 }
 
-void _35clofun3216(struct Cora* co) {
-Obj _35val2801 = co->args[1];
+void _35clofun3222(struct Cora* co) {
+Obj _35val2807 = co->args[1];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stream = _35val2801;
-pushCont(co, 0, _35clofun3217, 1, stream);
+Obj stream = _35val2807;
+pushCont(co, 0, _35clofun3223, 1, stream);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.generate-c")), stream, bc);
 }
 
-void _35clofun3217(struct Cora* co) {
-Obj _35val2802 = co->args[1];
+void _35clofun3223(struct Cora* co) {
+Obj _35val2808 = co->args[1];
 Obj stream = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 2, globalRef(intern("cora/lib/io.close-output-file")), stream);
 }
 
-void _35clofun3206(struct Cora* co) {
-Obj _35p1372 = co->args[1];
-Obj _35cc1373 = makeNative(0, _35clofun3207, 0, 1, _35p1372);
-Obj _35reg2792 = primIsCons(_35p1372);
-if (True == _35reg2792) {
-Obj _35reg2793 = primCar(_35p1372);
-Obj _35reg2794 = primEQ(intern("begin"), _35reg2793);
-if (True == _35reg2794) {
-Obj _35reg2795 = primCdr(_35p1372);
-Obj remain = _35reg2795;
+void _35clofun3212(struct Cora* co) {
+Obj _35p1378 = co->args[1];
+Obj _35cc1379 = makeNative(0, _35clofun3213, 0, 1, _35p1378);
+Obj _35reg2798 = primIsCons(_35p1378);
+if (True == _35reg2798) {
+Obj _35reg2799 = primCar(_35p1378);
+Obj _35reg2800 = primEQ(intern("begin"), _35reg2799);
+if (True == _35reg2800) {
+Obj _35reg2801 = primCdr(_35p1378);
+Obj remain = _35reg2801;
 coraCall(co, 2, globalRef(intern("cora/lib/toc.handle-import-eagerly")), remain);
 } else {
-coraCall(co, 1, _35cc1373);
+coraCall(co, 1, _35cc1379);
 }
 } else {
-coraCall(co, 1, _35cc1373);
+coraCall(co, 1, _35cc1379);
 }
 }
 
-void _35clofun3207(struct Cora* co) {
-Obj _35cc1374 = makeNative(0, _35clofun3208, 0, 1, closureRef(co, 0));
-Obj _35reg2774 = primIsCons(closureRef(co, 0));
-if (True == _35reg2774) {
-Obj _35reg2775 = primCar(closureRef(co, 0));
-Obj _35reg2776 = primIsCons(_35reg2775);
-if (True == _35reg2776) {
-Obj _35reg2777 = primCar(closureRef(co, 0));
-Obj _35reg2778 = primCar(_35reg2777);
-Obj _35reg2779 = primEQ(intern("import"), _35reg2778);
-if (True == _35reg2779) {
-Obj _35reg2780 = primCar(closureRef(co, 0));
-Obj _35reg2781 = primCdr(_35reg2780);
+void _35clofun3213(struct Cora* co) {
+Obj _35cc1380 = makeNative(0, _35clofun3214, 0, 1, closureRef(co, 0));
+Obj _35reg2780 = primIsCons(closureRef(co, 0));
+if (True == _35reg2780) {
+Obj _35reg2781 = primCar(closureRef(co, 0));
 Obj _35reg2782 = primIsCons(_35reg2781);
 if (True == _35reg2782) {
 Obj _35reg2783 = primCar(closureRef(co, 0));
-Obj _35reg2784 = primCdr(_35reg2783);
-Obj _35reg2785 = primCar(_35reg2784);
-Obj pkg = _35reg2785;
+Obj _35reg2784 = primCar(_35reg2783);
+Obj _35reg2785 = primEQ(intern("import"), _35reg2784);
+if (True == _35reg2785) {
 Obj _35reg2786 = primCar(closureRef(co, 0));
 Obj _35reg2787 = primCdr(_35reg2786);
-Obj _35reg2788 = primCdr(_35reg2787);
-Obj _35reg2789 = primEQ(Nil, _35reg2788);
-if (True == _35reg2789) {
-Obj _35reg2790 = primCdr(closureRef(co, 0));
-Obj remain = _35reg2790;
-pushCont(co, 0, _35clofun3210, 1, remain);
+Obj _35reg2788 = primIsCons(_35reg2787);
+if (True == _35reg2788) {
+Obj _35reg2789 = primCar(closureRef(co, 0));
+Obj _35reg2790 = primCdr(_35reg2789);
+Obj _35reg2791 = primCar(_35reg2790);
+Obj pkg = _35reg2791;
+Obj _35reg2792 = primCar(closureRef(co, 0));
+Obj _35reg2793 = primCdr(_35reg2792);
+Obj _35reg2794 = primCdr(_35reg2793);
+Obj _35reg2795 = primEQ(Nil, _35reg2794);
+if (True == _35reg2795) {
+Obj _35reg2796 = primCdr(closureRef(co, 0));
+Obj remain = _35reg2796;
+pushCont(co, 0, _35clofun3216, 1, remain);
 coraCall(co, 2, globalRef(intern("import")), pkg);
 } else {
-coraCall(co, 1, _35cc1374);
+coraCall(co, 1, _35cc1380);
 }
 } else {
-coraCall(co, 1, _35cc1374);
+coraCall(co, 1, _35cc1380);
 }
 } else {
-coraCall(co, 1, _35cc1374);
+coraCall(co, 1, _35cc1380);
 }
 } else {
-coraCall(co, 1, _35cc1374);
+coraCall(co, 1, _35cc1380);
 }
 } else {
-coraCall(co, 1, _35cc1374);
+coraCall(co, 1, _35cc1380);
 }
 }
 
-void _35clofun3210(struct Cora* co) {
-Obj _35val2791 = co->args[1];
+void _35clofun3216(struct Cora* co) {
+Obj _35val2797 = co->args[1];
 Obj remain = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 2, globalRef(intern("cora/lib/toc.handle-import-eagerly")), remain);
 }
 
-void _35clofun3208(struct Cora* co) {
-Obj _35cc1375 = makeNative(0, _35clofun3209, 0, 0);
+void _35clofun3214(struct Cora* co) {
+Obj _35cc1381 = makeNative(0, _35clofun3215, 0, 0);
 Obj __ = closureRef(co, 0);
 coraReturn(co, Nil);
 return;
 }
 
-void _35clofun3209(struct Cora* co) {
+void _35clofun3215(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3198(struct Cora* co) {
+void _35clofun3204(struct Cora* co) {
 Obj to = co->args[1];
 Obj bc = co->args[2];
-pushCont(co, 0, _35clofun3199, 2, to, bc);
+pushCont(co, 0, _35clofun3205, 2, to, bc);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("#include \"types.h\"\n"));
 }
 
-void _35clofun3199(struct Cora* co) {
-Obj _35val2767 = co->args[1];
+void _35clofun3205(struct Cora* co) {
+Obj _35val2773 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3200, 2, to, bc);
+pushCont(co, 0, _35clofun3206, 2, to, bc);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("#include \"runtime.h\"\n\n"));
 }
 
-void _35clofun3200(struct Cora* co) {
-Obj _35val2768 = co->args[1];
+void _35clofun3206(struct Cora* co) {
+Obj _35val2774 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3203, 2, to, bc);
-coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3201, 1, 1, to), bc);
+pushCont(co, 0, _35clofun3209, 2, to, bc);
+coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3207, 1, 1, to), bc);
 }
 
-void _35clofun3203(struct Cora* co) {
-Obj _35val2771 = co->args[1];
+void _35clofun3209(struct Cora* co) {
+Obj _35val2777 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3204, 2, to, bc);
+pushCont(co, 0, _35clofun3210, 2, to, bc);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), to, makeString1("\n"));
 }
 
-void _35clofun3204(struct Cora* co) {
-Obj _35val2772 = co->args[1];
+void _35clofun3210(struct Cora* co) {
+Obj _35val2778 = co->args[1];
 Obj to = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = co->ctx.stk.stack[co->ctx.stk.base + 1];
-coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3205, 1, 1, to), bc);
+coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3211, 1, 1, to), bc);
 }
 
-void _35clofun3205(struct Cora* co) {
+void _35clofun3211(struct Cora* co) {
 Obj x = co->args[1];
 coraCall(co, 3, globalRef(intern("cora/lib/toc.code-gen-toplevel")), closureRef(co, 0), x);
 }
 
-void _35clofun3201(struct Cora* co) {
+void _35clofun3207(struct Cora* co) {
 Obj x = co->args[1];
-Obj _35reg2769 = primCar(x);
-pushCont(co, 0, _35clofun3202, 0);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.code-gen-func-declare")), closureRef(co, 0), _35reg2769);
+Obj _35reg2775 = primCar(x);
+pushCont(co, 0, _35clofun3208, 0);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.code-gen-func-declare")), closureRef(co, 0), _35reg2775);
 }
 
-void _35clofun3202(struct Cora* co) {
-Obj _35val2770 = co->args[1];
+void _35clofun3208(struct Cora* co) {
+Obj _35val2776 = co->args[1];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closureRef(co, 0), makeString1(";\n"));
 }
 
-void _35clofun3194(struct Cora* co) {
-Obj _35p1368 = co->args[1];
-Obj _35p1369 = co->args[2];
-Obj _35cc1370 = makeNative(0, _35clofun3195, 0, 2, _35p1368, _35p1369);
-Obj fn = _35p1368;
-Obj _35reg2765 = primEQ(Nil, _35p1369);
-if (True == _35reg2765) {
+void _35clofun3200(struct Cora* co) {
+Obj _35p1374 = co->args[1];
+Obj _35p1375 = co->args[2];
+Obj _35cc1376 = makeNative(0, _35clofun3201, 0, 2, _35p1374, _35p1375);
+Obj fn = _35p1374;
+Obj _35reg2771 = primEQ(Nil, _35p1375);
+if (True == _35reg2771) {
 coraReturn(co, Nil);
 return;
 } else {
-coraCall(co, 1, _35cc1370);
+coraCall(co, 1, _35cc1376);
 }
 }
 
-void _35clofun3195(struct Cora* co) {
-Obj _35cc1371 = makeNative(0, _35clofun3196, 0, 0);
+void _35clofun3201(struct Cora* co) {
+Obj _35cc1377 = makeNative(0, _35clofun3202, 0, 0);
 Obj fn = closureRef(co, 0);
-Obj _35reg2761 = primIsCons(closureRef(co, 1));
-if (True == _35reg2761) {
-Obj _35reg2762 = primCar(closureRef(co, 1));
-Obj x = _35reg2762;
-Obj _35reg2763 = primCdr(closureRef(co, 1));
-Obj y = _35reg2763;
-pushCont(co, 0, _35clofun3197, 2, fn, y);
+Obj _35reg2767 = primIsCons(closureRef(co, 1));
+if (True == _35reg2767) {
+Obj _35reg2768 = primCar(closureRef(co, 1));
+Obj x = _35reg2768;
+Obj _35reg2769 = primCdr(closureRef(co, 1));
+Obj y = _35reg2769;
+pushCont(co, 0, _35clofun3203, 2, fn, y);
 coraCall(co, 2, fn, x);
 } else {
-coraCall(co, 1, _35cc1371);
+coraCall(co, 1, _35cc1377);
 }
 }
 
-void _35clofun3197(struct Cora* co) {
-Obj _35val2764 = co->args[1];
+void _35clofun3203(struct Cora* co) {
+Obj _35val2770 = co->args[1];
 Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
 coraCall(co, 3, globalRef(intern("for-each")), fn, y);
 }
 
-void _35clofun3196(struct Cora* co) {
+void _35clofun3202(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3189(struct Cora* co) {
+void _35clofun3195(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, 0, _35clofun3190, 0);
+pushCont(co, 0, _35clofun3196, 0);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.parse-pass")), exp);
 }
 
-void _35clofun3190(struct Cora* co) {
-Obj _35val2756 = co->args[1];
-pushCont(co, 0, _35clofun3191, 0);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert-pass")), _35val2756);
+void _35clofun3196(struct Cora* co) {
+Obj _35val2762 = co->args[1];
+pushCont(co, 0, _35clofun3197, 0);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert-pass")), _35val2762);
+}
+
+void _35clofun3197(struct Cora* co) {
+Obj _35val2763 = co->args[1];
+pushCont(co, 0, _35clofun3198, 0);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.tailify-pass")), _35val2763);
+}
+
+void _35clofun3198(struct Cora* co) {
+Obj _35val2764 = co->args[1];
+pushCont(co, 0, _35clofun3199, 0);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack-pass")), _35val2764);
+}
+
+void _35clofun3199(struct Cora* co) {
+Obj _35val2765 = co->args[1];
+coraCall(co, 2, globalRef(intern("cora/lib/toc.collect-lambda-pass")), _35val2765);
 }
 
 void _35clofun3191(struct Cora* co) {
-Obj _35val2757 = co->args[1];
-pushCont(co, 0, _35clofun3192, 0);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.tailify-pass")), _35val2757);
+Obj exp = co->args[1];
+pushCont(co, 0, _35clofun3192, 1, exp);
+coraCall(co, 2, globalRef(intern("cadr")), exp);
 }
 
 void _35clofun3192(struct Cora* co) {
-Obj _35val2758 = co->args[1];
-pushCont(co, 0, _35clofun3193, 0);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack-pass")), _35val2758);
+Obj _35val2759 = co->args[1];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj obj = _35val2759;
+pushCont(co, 0, _35clofun3193, 1, obj);
+coraCall(co, 2, globalRef(intern("cddr")), exp);
 }
 
 void _35clofun3193(struct Cora* co) {
-Obj _35val2759 = co->args[1];
-coraCall(co, 2, globalRef(intern("cora/lib/toc.collect-lambda-pass")), _35val2759);
+Obj _35val2760 = co->args[1];
+Obj obj = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fns = _35val2760;
+coraCall(co, 3, globalRef(intern("cora/lib/toc.rewrite-->macro")), obj, fns);
+}
+
+void _35clofun3188(struct Cora* co) {
+Obj _35p1370 = co->args[1];
+Obj _35p1371 = co->args[2];
+Obj _35cc1372 = makeNative(0, _35clofun3189, 0, 2, _35p1370, _35p1371);
+Obj obj = _35p1370;
+Obj _35reg2757 = primEQ(Nil, _35p1371);
+if (True == _35reg2757) {
+coraReturn(co, obj);
+return;
+} else {
+coraCall(co, 1, _35cc1372);
+}
+}
+
+void _35clofun3189(struct Cora* co) {
+Obj _35cc1373 = makeNative(0, _35clofun3190, 0, 0);
+Obj obj = closureRef(co, 0);
+Obj _35reg2752 = primIsCons(closureRef(co, 1));
+if (True == _35reg2752) {
+Obj _35reg2753 = primCar(closureRef(co, 1));
+Obj hd = _35reg2753;
+Obj _35reg2754 = primCdr(closureRef(co, 1));
+Obj more = _35reg2754;
+Obj _35reg2755 = primCons(obj, Nil);
+Obj _35reg2756 = primCons(hd, _35reg2755);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.rewrite-->macro")), _35reg2756, more);
+} else {
+coraCall(co, 1, _35cc1373);
+}
+}
+
+void _35clofun3190(struct Cora* co) {
+coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
+}
+
+void _35clofun3186(struct Cora* co) {
+Obj exp = co->args[1];
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), Nil, exp, makeNative(0, _35clofun3187, 2, 0));
+}
+
+void _35clofun3187(struct Cora* co) {
+Obj ls = co->args[1];
+Obj e1 = co->args[2];
+Obj _35reg2744 = primCons(e1, Nil);
+Obj _35reg2745 = primCons(Nil, _35reg2744);
+Obj _35reg2746 = primCons(Nil, _35reg2745);
+Obj _35reg2747 = primCons(intern("lambda"), _35reg2746);
+Obj _35reg2748 = primCons(_35reg2747, Nil);
+Obj _35reg2749 = primCons(intern("entry"), _35reg2748);
+Obj _35reg2750 = primCons(_35reg2749, ls);
+coraReturn(co, _35reg2750);
+return;
 }
 
 void _35clofun3185(struct Cora* co) {
 Obj exp = co->args[1];
-pushCont(co, 0, _35clofun3186, 1, exp);
-coraCall(co, 2, globalRef(intern("cadr")), exp);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), Nil, exp);
 }
 
-void _35clofun3186(struct Cora* co) {
-Obj _35val2753 = co->args[1];
-Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj obj = _35val2753;
-pushCont(co, 0, _35clofun3187, 1, obj);
-coraCall(co, 2, globalRef(intern("cddr")), exp);
+void _35clofun3184(struct Cora* co) {
+Obj exp = co->args[1];
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), exp, globalRef(intern("cora/lib/toc.id")));
 }
 
-void _35clofun3187(struct Cora* co) {
-Obj _35val2754 = co->args[1];
-Obj obj = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fns = _35val2754;
-coraCall(co, 3, globalRef(intern("cora/lib/toc.rewrite-->macro")), obj, fns);
+void _35clofun3183(struct Cora* co) {
+Obj exp = co->args[1];
+coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), Nil, exp);
 }
 
 void _35clofun3182(struct Cora* co) {
-Obj _35p1364 = co->args[1];
-Obj _35p1365 = co->args[2];
-Obj _35cc1366 = makeNative(0, _35clofun3183, 0, 2, _35p1364, _35p1365);
-Obj obj = _35p1364;
-Obj _35reg2751 = primEQ(Nil, _35p1365);
-if (True == _35reg2751) {
-coraReturn(co, obj);
+Obj exp = co->args[1];
+coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), Nil, exp);
+}
+
+void _35clofun3175(struct Cora* co) {
+Obj _35p1367 = co->args[1];
+Obj _35p1368 = co->args[2];
+Obj _35cc1369 = makeNative(0, _35clofun3176, 0, 0);
+Obj w = _35p1367;
+Obj _35reg2683 = primIsCons(_35p1368);
+if (True == _35reg2683) {
+Obj _35reg2684 = primCar(_35p1368);
+Obj name = _35reg2684;
+Obj _35reg2685 = primCdr(_35p1368);
+Obj _35reg2686 = primIsCons(_35reg2685);
+if (True == _35reg2686) {
+Obj _35reg2687 = primCdr(_35p1368);
+Obj _35reg2688 = primCar(_35reg2687);
+Obj _35reg2689 = primIsCons(_35reg2688);
+if (True == _35reg2689) {
+Obj _35reg2690 = primCdr(_35p1368);
+Obj _35reg2691 = primCar(_35reg2690);
+Obj _35reg2692 = primCar(_35reg2691);
+Obj _35reg2693 = primEQ(intern("lambda"), _35reg2692);
+if (True == _35reg2693) {
+Obj _35reg2694 = primCdr(_35p1368);
+Obj _35reg2695 = primCar(_35reg2694);
+Obj _35reg2696 = primCdr(_35reg2695);
+Obj _35reg2697 = primIsCons(_35reg2696);
+if (True == _35reg2697) {
+Obj _35reg2698 = primCdr(_35p1368);
+Obj _35reg2699 = primCar(_35reg2698);
+Obj _35reg2700 = primCdr(_35reg2699);
+Obj _35reg2701 = primCar(_35reg2700);
+Obj params = _35reg2701;
+Obj _35reg2702 = primCdr(_35p1368);
+Obj _35reg2703 = primCar(_35reg2702);
+Obj _35reg2704 = primCdr(_35reg2703);
+Obj _35reg2705 = primCdr(_35reg2704);
+Obj _35reg2706 = primIsCons(_35reg2705);
+if (True == _35reg2706) {
+Obj _35reg2707 = primCdr(_35p1368);
+Obj _35reg2708 = primCar(_35reg2707);
+Obj _35reg2709 = primCdr(_35reg2708);
+Obj _35reg2710 = primCdr(_35reg2709);
+Obj _35reg2711 = primCar(_35reg2710);
+Obj actives = _35reg2711;
+Obj _35reg2712 = primCdr(_35p1368);
+Obj _35reg2713 = primCar(_35reg2712);
+Obj _35reg2714 = primCdr(_35reg2713);
+Obj _35reg2715 = primCdr(_35reg2714);
+Obj _35reg2716 = primCdr(_35reg2715);
+Obj _35reg2717 = primIsCons(_35reg2716);
+if (True == _35reg2717) {
+Obj _35reg2718 = primCdr(_35p1368);
+Obj _35reg2719 = primCar(_35reg2718);
+Obj _35reg2720 = primCdr(_35reg2719);
+Obj _35reg2721 = primCdr(_35reg2720);
+Obj _35reg2722 = primCdr(_35reg2721);
+Obj _35reg2723 = primCar(_35reg2722);
+Obj body = _35reg2723;
+Obj _35reg2724 = primCdr(_35p1368);
+Obj _35reg2725 = primCar(_35reg2724);
+Obj _35reg2726 = primCdr(_35reg2725);
+Obj _35reg2727 = primCdr(_35reg2726);
+Obj _35reg2728 = primCdr(_35reg2727);
+Obj _35reg2729 = primCdr(_35reg2728);
+Obj _35reg2730 = primEQ(Nil, _35reg2729);
+if (True == _35reg2730) {
+Obj _35reg2731 = primCdr(_35p1368);
+Obj _35reg2732 = primCdr(_35reg2731);
+Obj _35reg2733 = primEQ(Nil, _35reg2732);
+if (True == _35reg2733) {
+pushCont(co, 0, _35clofun3177, 4, actives, params, body, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.code-gen-func-declare")), w, name);
+} else {
+coraCall(co, 1, _35cc1369);
+}
+} else {
+coraCall(co, 1, _35cc1369);
+}
+} else {
+coraCall(co, 1, _35cc1369);
+}
+} else {
+coraCall(co, 1, _35cc1369);
+}
+} else {
+coraCall(co, 1, _35cc1369);
+}
+} else {
+coraCall(co, 1, _35cc1369);
+}
+} else {
+coraCall(co, 1, _35cc1369);
+}
+} else {
+coraCall(co, 1, _35cc1369);
+}
+} else {
+coraCall(co, 1, _35cc1369);
+}
+}
+
+void _35clofun3177(struct Cora* co) {
+Obj _35val2734 = co->args[1];
+Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, _35clofun3178, 4, actives, params, body, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" {\n"));
+}
+
+void _35clofun3178(struct Cora* co) {
+Obj _35val2735 = co->args[1];
+Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, _35clofun3179, 4, actives, params, body, w);
+coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->args["), makeNumber(1), params);
+}
+
+void _35clofun3179(struct Cora* co) {
+Obj _35val2736 = co->args[1];
+Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, _35clofun3180, 3, params, body, w);
+coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->ctx.stk.stack[co->ctx.stk.base + "), makeNumber(0), actives);
+}
+
+void _35clofun3180(struct Cora* co) {
+Obj _35val2737 = co->args[1];
+Obj params = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3181, 1, w);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), params, w, body);
+}
+
+void _35clofun3181(struct Cora* co) {
+Obj _35val2738 = co->args[1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("}\n\n"));
+}
+
+void _35clofun3176(struct Cora* co) {
+coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
+}
+
+void _35clofun3167(struct Cora* co) {
+Obj _35p1360 = co->args[1];
+Obj _35p1361 = co->args[2];
+Obj _35p1362 = co->args[3];
+Obj _35p1363 = co->args[4];
+Obj _35p1364 = co->args[5];
+Obj _35cc1365 = makeNative(0, _35clofun3168, 0, 5, _35p1360, _35p1361, _35p1362, _35p1363, _35p1364);
+Obj env = _35p1360;
+Obj w = _35p1361;
+Obj dest_45str = _35p1362;
+Obj idx = _35p1363;
+Obj _35reg2681 = primEQ(Nil, _35p1364);
+if (True == _35reg2681) {
+coraReturn(co, Nil);
 return;
+} else {
+coraCall(co, 1, _35cc1365);
+}
+}
+
+void _35clofun3168(struct Cora* co) {
+Obj _35cc1366 = makeNative(0, _35clofun3169, 0, 0);
+Obj env = closureRef(co, 0);
+Obj w = closureRef(co, 1);
+Obj dest_45str = closureRef(co, 2);
+Obj idx = closureRef(co, 3);
+Obj _35reg2672 = primIsCons(closureRef(co, 4));
+if (True == _35reg2672) {
+Obj _35reg2673 = primCar(closureRef(co, 4));
+Obj a = _35reg2673;
+Obj _35reg2674 = primCdr(closureRef(co, 4));
+Obj b = _35reg2674;
+pushCont(co, 0, _35clofun3170, 6, a, idx, env, w, dest_45str, b);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("Obj "));
 } else {
 coraCall(co, 1, _35cc1366);
 }
 }
 
-void _35clofun3183(struct Cora* co) {
-Obj _35cc1367 = makeNative(0, _35clofun3184, 0, 0);
-Obj obj = closureRef(co, 0);
-Obj _35reg2746 = primIsCons(closureRef(co, 1));
-if (True == _35reg2746) {
-Obj _35reg2747 = primCar(closureRef(co, 1));
-Obj hd = _35reg2747;
-Obj _35reg2748 = primCdr(closureRef(co, 1));
-Obj more = _35reg2748;
-Obj _35reg2749 = primCons(obj, Nil);
-Obj _35reg2750 = primCons(hd, _35reg2749);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.rewrite-->macro")), _35reg2750, more);
-} else {
-coraCall(co, 1, _35cc1367);
-}
-}
-
-void _35clofun3184(struct Cora* co) {
-coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
-}
-
-void _35clofun3180(struct Cora* co) {
-Obj exp = co->args[1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), Nil, exp, makeNative(0, _35clofun3181, 2, 0));
-}
-
-void _35clofun3181(struct Cora* co) {
-Obj ls = co->args[1];
-Obj e1 = co->args[2];
-Obj _35reg2738 = primCons(e1, Nil);
-Obj _35reg2739 = primCons(Nil, _35reg2738);
-Obj _35reg2740 = primCons(Nil, _35reg2739);
-Obj _35reg2741 = primCons(intern("lambda"), _35reg2740);
-Obj _35reg2742 = primCons(_35reg2741, Nil);
-Obj _35reg2743 = primCons(intern("entry"), _35reg2742);
-Obj _35reg2744 = primCons(_35reg2743, ls);
-coraReturn(co, _35reg2744);
-return;
-}
-
-void _35clofun3179(struct Cora* co) {
-Obj exp = co->args[1];
-coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), Nil, exp);
-}
-
-void _35clofun3178(struct Cora* co) {
-Obj exp = co->args[1];
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), exp, globalRef(intern("cora/lib/toc.id")));
-}
-
-void _35clofun3177(struct Cora* co) {
-Obj exp = co->args[1];
-coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), Nil, exp);
-}
-
-void _35clofun3176(struct Cora* co) {
-Obj exp = co->args[1];
-coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), Nil, exp);
-}
-
-void _35clofun3169(struct Cora* co) {
-Obj _35p1361 = co->args[1];
-Obj _35p1362 = co->args[2];
-Obj _35cc1363 = makeNative(0, _35clofun3170, 0, 0);
-Obj w = _35p1361;
-Obj _35reg2677 = primIsCons(_35p1362);
-if (True == _35reg2677) {
-Obj _35reg2678 = primCar(_35p1362);
-Obj name = _35reg2678;
-Obj _35reg2679 = primCdr(_35p1362);
-Obj _35reg2680 = primIsCons(_35reg2679);
-if (True == _35reg2680) {
-Obj _35reg2681 = primCdr(_35p1362);
-Obj _35reg2682 = primCar(_35reg2681);
-Obj _35reg2683 = primIsCons(_35reg2682);
-if (True == _35reg2683) {
-Obj _35reg2684 = primCdr(_35p1362);
-Obj _35reg2685 = primCar(_35reg2684);
-Obj _35reg2686 = primCar(_35reg2685);
-Obj _35reg2687 = primEQ(intern("lambda"), _35reg2686);
-if (True == _35reg2687) {
-Obj _35reg2688 = primCdr(_35p1362);
-Obj _35reg2689 = primCar(_35reg2688);
-Obj _35reg2690 = primCdr(_35reg2689);
-Obj _35reg2691 = primIsCons(_35reg2690);
-if (True == _35reg2691) {
-Obj _35reg2692 = primCdr(_35p1362);
-Obj _35reg2693 = primCar(_35reg2692);
-Obj _35reg2694 = primCdr(_35reg2693);
-Obj _35reg2695 = primCar(_35reg2694);
-Obj params = _35reg2695;
-Obj _35reg2696 = primCdr(_35p1362);
-Obj _35reg2697 = primCar(_35reg2696);
-Obj _35reg2698 = primCdr(_35reg2697);
-Obj _35reg2699 = primCdr(_35reg2698);
-Obj _35reg2700 = primIsCons(_35reg2699);
-if (True == _35reg2700) {
-Obj _35reg2701 = primCdr(_35p1362);
-Obj _35reg2702 = primCar(_35reg2701);
-Obj _35reg2703 = primCdr(_35reg2702);
-Obj _35reg2704 = primCdr(_35reg2703);
-Obj _35reg2705 = primCar(_35reg2704);
-Obj actives = _35reg2705;
-Obj _35reg2706 = primCdr(_35p1362);
-Obj _35reg2707 = primCar(_35reg2706);
-Obj _35reg2708 = primCdr(_35reg2707);
-Obj _35reg2709 = primCdr(_35reg2708);
-Obj _35reg2710 = primCdr(_35reg2709);
-Obj _35reg2711 = primIsCons(_35reg2710);
-if (True == _35reg2711) {
-Obj _35reg2712 = primCdr(_35p1362);
-Obj _35reg2713 = primCar(_35reg2712);
-Obj _35reg2714 = primCdr(_35reg2713);
-Obj _35reg2715 = primCdr(_35reg2714);
-Obj _35reg2716 = primCdr(_35reg2715);
-Obj _35reg2717 = primCar(_35reg2716);
-Obj body = _35reg2717;
-Obj _35reg2718 = primCdr(_35p1362);
-Obj _35reg2719 = primCar(_35reg2718);
-Obj _35reg2720 = primCdr(_35reg2719);
-Obj _35reg2721 = primCdr(_35reg2720);
-Obj _35reg2722 = primCdr(_35reg2721);
-Obj _35reg2723 = primCdr(_35reg2722);
-Obj _35reg2724 = primEQ(Nil, _35reg2723);
-if (True == _35reg2724) {
-Obj _35reg2725 = primCdr(_35p1362);
-Obj _35reg2726 = primCdr(_35reg2725);
-Obj _35reg2727 = primEQ(Nil, _35reg2726);
-if (True == _35reg2727) {
-pushCont(co, 0, _35clofun3171, 4, actives, params, body, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.code-gen-func-declare")), w, name);
-} else {
-coraCall(co, 1, _35cc1363);
-}
-} else {
-coraCall(co, 1, _35cc1363);
-}
-} else {
-coraCall(co, 1, _35cc1363);
-}
-} else {
-coraCall(co, 1, _35cc1363);
-}
-} else {
-coraCall(co, 1, _35cc1363);
-}
-} else {
-coraCall(co, 1, _35cc1363);
-}
-} else {
-coraCall(co, 1, _35cc1363);
-}
-} else {
-coraCall(co, 1, _35cc1363);
-}
-} else {
-coraCall(co, 1, _35cc1363);
-}
-}
-
-void _35clofun3171(struct Cora* co) {
-Obj _35val2728 = co->args[1];
-Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3172, 4, actives, params, body, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" {\n"));
-}
-
-void _35clofun3172(struct Cora* co) {
-Obj _35val2729 = co->args[1];
-Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3173, 4, actives, params, body, w);
-coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->args["), makeNumber(1), params);
-}
-
-void _35clofun3173(struct Cora* co) {
-Obj _35val2730 = co->args[1];
-Obj actives = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj body = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3174, 3, params, body, w);
-coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), Nil, w, makeString1(" = co->ctx.stk.stack[co->ctx.stk.base + "), makeNumber(0), actives);
-}
-
-void _35clofun3174(struct Cora* co) {
-Obj _35val2731 = co->args[1];
-Obj params = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3175, 1, w);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), params, w, body);
-}
-
-void _35clofun3175(struct Cora* co) {
-Obj _35val2732 = co->args[1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("}\n\n"));
-}
-
 void _35clofun3170(struct Cora* co) {
-coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
-}
-
-void _35clofun3161(struct Cora* co) {
-Obj _35p1354 = co->args[1];
-Obj _35p1355 = co->args[2];
-Obj _35p1356 = co->args[3];
-Obj _35p1357 = co->args[4];
-Obj _35p1358 = co->args[5];
-Obj _35cc1359 = makeNative(0, _35clofun3162, 0, 5, _35p1354, _35p1355, _35p1356, _35p1357, _35p1358);
-Obj env = _35p1354;
-Obj w = _35p1355;
-Obj dest_45str = _35p1356;
-Obj idx = _35p1357;
-Obj _35reg2675 = primEQ(Nil, _35p1358);
-if (True == _35reg2675) {
-coraReturn(co, Nil);
-return;
-} else {
-coraCall(co, 1, _35cc1359);
-}
-}
-
-void _35clofun3162(struct Cora* co) {
-Obj _35cc1360 = makeNative(0, _35clofun3163, 0, 0);
-Obj env = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj dest_45str = closureRef(co, 2);
-Obj idx = closureRef(co, 3);
-Obj _35reg2666 = primIsCons(closureRef(co, 4));
-if (True == _35reg2666) {
-Obj _35reg2667 = primCar(closureRef(co, 4));
-Obj a = _35reg2667;
-Obj _35reg2668 = primCdr(closureRef(co, 4));
-Obj b = _35reg2668;
-pushCont(co, 0, _35clofun3164, 6, a, idx, env, w, dest_45str, b);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("Obj "));
-} else {
-coraCall(co, 1, _35cc1360);
-}
-}
-
-void _35clofun3164(struct Cora* co) {
-Obj _35val2669 = co->args[1];
+Obj _35val2675 = co->args[1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 0, _35clofun3165, 5, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3171, 5, idx, env, w, dest_45str, b);
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
 }
 
-void _35clofun3165(struct Cora* co) {
-Obj _35val2670 = co->args[1];
+void _35clofun3171(struct Cora* co) {
+Obj _35val2676 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3166, 5, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3172, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, dest_45str);
 }
 
-void _35clofun3166(struct Cora* co) {
-Obj _35val2671 = co->args[1];
+void _35clofun3172(struct Cora* co) {
+Obj _35val2677 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3167, 5, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3173, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
-void _35clofun3167(struct Cora* co) {
-Obj _35val2672 = co->args[1];
+void _35clofun3173(struct Cora* co) {
+Obj _35val2678 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3168, 5, idx, env, w, dest_45str, b);
+pushCont(co, 0, _35clofun3174, 5, idx, env, w, dest_45str, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("];\n"));
 }
 
-void _35clofun3168(struct Cora* co) {
-Obj _35val2673 = co->args[1];
+void _35clofun3174(struct Cora* co) {
+Obj _35val2679 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj dest_45str = co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2674 = primAdd(idx, makeNumber(1));
-coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), env, w, dest_45str, _35reg2674, b);
+Obj _35reg2680 = primAdd(idx, makeNumber(1));
+coraCall(co, 6, globalRef(intern("cora/lib/toc.generate-call-args-reverse")), env, w, dest_45str, _35reg2680, b);
 }
 
-void _35clofun3163(struct Cora* co) {
+void _35clofun3169(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3157(struct Cora* co) {
+void _35clofun3163(struct Cora* co) {
 Obj w = co->args[1];
 Obj name = co->args[2];
-pushCont(co, 0, _35clofun3158, 2, name, w);
+pushCont(co, 0, _35clofun3164, 2, name, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("void "));
 }
 
-void _35clofun3158(struct Cora* co) {
-Obj _35val2662 = co->args[1];
+void _35clofun3164(struct Cora* co) {
+Obj _35val2668 = co->args[1];
 Obj name = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3159, 1, w);
+pushCont(co, 0, _35clofun3165, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, name);
 }
 
-void _35clofun3159(struct Cora* co) {
-Obj _35val2663 = co->args[1];
+void _35clofun3165(struct Cora* co) {
+Obj _35val2669 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun3160, 1, w);
+pushCont(co, 0, _35clofun3166, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("(struct Cora* co"));
 }
 
-void _35clofun3160(struct Cora* co) {
-Obj _35val2664 = co->args[1];
+void _35clofun3166(struct Cora* co) {
+Obj _35val2670 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
-void _35clofun3156(struct Cora* co) {
+void _35clofun3162(struct Cora* co) {
 Obj env = co->args[1];
 Obj w = co->args[2];
 Obj l = co->args[3];
 coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-inst-list-h")), env, globalRef(intern("cora/lib/toc.generate-inst")), w, l);
 }
 
-void _35clofun3150(struct Cora* co) {
-Obj _35p1348 = co->args[1];
-Obj _35p1349 = co->args[2];
-Obj _35p1350 = co->args[3];
-Obj _35p1351 = co->args[4];
-Obj _35cc1352 = makeNative(0, _35clofun3151, 0, 4, _35p1348, _35p1349, _35p1350, _35p1351);
-Obj env = _35p1348;
-Obj fn = _35p1349;
-Obj w = _35p1350;
-Obj _35reg2659 = primEQ(Nil, _35p1351);
-if (True == _35reg2659) {
+void _35clofun3156(struct Cora* co) {
+Obj _35p1354 = co->args[1];
+Obj _35p1355 = co->args[2];
+Obj _35p1356 = co->args[3];
+Obj _35p1357 = co->args[4];
+Obj _35cc1358 = makeNative(0, _35clofun3157, 0, 4, _35p1354, _35p1355, _35p1356, _35p1357);
+Obj env = _35p1354;
+Obj fn = _35p1355;
+Obj w = _35p1356;
+Obj _35reg2665 = primEQ(Nil, _35p1357);
+if (True == _35reg2665) {
 coraReturn(co, Nil);
 return;
 } else {
-coraCall(co, 1, _35cc1352);
+coraCall(co, 1, _35cc1358);
 }
 }
 
-void _35clofun3151(struct Cora* co) {
-Obj _35cc1353 = makeNative(0, _35clofun3152, 0, 0);
+void _35clofun3157(struct Cora* co) {
+Obj _35cc1359 = makeNative(0, _35clofun3158, 0, 0);
 Obj env = closureRef(co, 0);
 Obj fn = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2652 = primIsCons(closureRef(co, 3));
-if (True == _35reg2652) {
-Obj _35reg2653 = primCar(closureRef(co, 3));
-Obj a = _35reg2653;
-Obj _35reg2654 = primCdr(closureRef(co, 3));
-Obj b = _35reg2654;
-pushCont(co, 0, _35clofun3153, 4, env, fn, w, b);
+Obj _35reg2658 = primIsCons(closureRef(co, 3));
+if (True == _35reg2658) {
+Obj _35reg2659 = primCar(closureRef(co, 3));
+Obj a = _35reg2659;
+Obj _35reg2660 = primCdr(closureRef(co, 3));
+Obj b = _35reg2660;
+pushCont(co, 0, _35clofun3159, 4, env, fn, w, b);
 coraCall(co, 4, fn, env, w, a);
+} else {
+coraCall(co, 1, _35cc1359);
+}
+}
+
+void _35clofun3159(struct Cora* co) {
+Obj _35val2661 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, _35clofun3160, 4, env, fn, w, b);
+coraCall(co, 2, globalRef(intern("null?")), b);
+}
+
+void _35clofun3160(struct Cora* co) {
+Obj _35val2662 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg2663 = primNot(_35val2662);
+if (True == _35reg2663) {
+pushCont(co, 0, _35clofun3161, 4, env, fn, w, b);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
+} else {
+Nil;
+coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-inst-list-h")), env, fn, w, b);
+}
+}
+
+void _35clofun3161(struct Cora* co) {
+Obj _35val2664 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
+coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-inst-list-h")), env, fn, w, b);
+}
+
+void _35clofun3158(struct Cora* co) {
+coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
+}
+
+void _35clofun3145(struct Cora* co) {
+Obj _35p1351 = co->args[1];
+Obj _35p1352 = co->args[2];
+Obj _35cc1353 = makeNative(0, _35clofun3146, 0, 0);
+Obj w = _35p1351;
+Obj _35reg2639 = primIsCons(_35p1352);
+if (True == _35reg2639) {
+Obj _35reg2640 = primCar(_35p1352);
+Obj _35reg2641 = primEQ(intern("%continuation"), _35reg2640);
+if (True == _35reg2641) {
+Obj _35reg2642 = primCdr(_35p1352);
+Obj _35reg2643 = primIsCons(_35reg2642);
+if (True == _35reg2643) {
+Obj _35reg2644 = primCdr(_35p1352);
+Obj _35reg2645 = primCar(_35reg2644);
+Obj label = _35reg2645;
+Obj _35reg2646 = primCdr(_35p1352);
+Obj _35reg2647 = primCdr(_35reg2646);
+Obj stacks = _35reg2647;
+pushCont(co, 0, _35clofun3147, 3, label, stacks, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("pushCont(co, 0, "));
+} else {
+coraCall(co, 1, _35cc1353);
+}
+} else {
+coraCall(co, 1, _35cc1353);
+}
 } else {
 coraCall(co, 1, _35cc1353);
 }
 }
 
-void _35clofun3153(struct Cora* co) {
-Obj _35val2655 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3154, 4, env, fn, w, b);
-coraCall(co, 2, globalRef(intern("null?")), b);
-}
-
-void _35clofun3154(struct Cora* co) {
-Obj _35val2656 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2657 = primNot(_35val2656);
-if (True == _35reg2657) {
-pushCont(co, 0, _35clofun3155, 4, env, fn, w, b);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
-} else {
-Nil;
-coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-inst-list-h")), env, fn, w, b);
-}
-}
-
-void _35clofun3155(struct Cora* co) {
-Obj _35val2658 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fn = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
-coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-inst-list-h")), env, fn, w, b);
-}
-
-void _35clofun3152(struct Cora* co) {
-coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
-}
-
-void _35clofun3139(struct Cora* co) {
-Obj _35p1345 = co->args[1];
-Obj _35p1346 = co->args[2];
-Obj _35cc1347 = makeNative(0, _35clofun3140, 0, 0);
-Obj w = _35p1345;
-Obj _35reg2633 = primIsCons(_35p1346);
-if (True == _35reg2633) {
-Obj _35reg2634 = primCar(_35p1346);
-Obj _35reg2635 = primEQ(intern("%continuation"), _35reg2634);
-if (True == _35reg2635) {
-Obj _35reg2636 = primCdr(_35p1346);
-Obj _35reg2637 = primIsCons(_35reg2636);
-if (True == _35reg2637) {
-Obj _35reg2638 = primCdr(_35p1346);
-Obj _35reg2639 = primCar(_35reg2638);
-Obj label = _35reg2639;
-Obj _35reg2640 = primCdr(_35p1346);
-Obj _35reg2641 = primCdr(_35reg2640);
-Obj stacks = _35reg2641;
-pushCont(co, 0, _35clofun3141, 3, label, stacks, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("pushCont(co, 0, "));
-} else {
-coraCall(co, 1, _35cc1347);
-}
-} else {
-coraCall(co, 1, _35cc1347);
-}
-} else {
-coraCall(co, 1, _35cc1347);
-}
-}
-
-void _35clofun3141(struct Cora* co) {
-Obj _35val2642 = co->args[1];
+void _35clofun3147(struct Cora* co) {
+Obj _35val2648 = co->args[1];
 Obj label = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3142, 2, stacks, w);
+pushCont(co, 0, _35clofun3148, 2, stacks, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, label);
-}
-
-void _35clofun3142(struct Cora* co) {
-Obj _35val2643 = co->args[1];
-Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3143, 2, stacks, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
-}
-
-void _35clofun3143(struct Cora* co) {
-Obj _35val2644 = co->args[1];
-Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3144, 2, stacks, w);
-coraCall(co, 2, globalRef(intern("length")), stacks);
-}
-
-void _35clofun3144(struct Cora* co) {
-Obj _35val2645 = co->args[1];
-Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3145, 2, stacks, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2645);
-}
-
-void _35clofun3145(struct Cora* co) {
-Obj _35val2646 = co->args[1];
-Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3146, 2, stacks, w);
-coraCall(co, 2, globalRef(intern("null?")), stacks);
-}
-
-void _35clofun3146(struct Cora* co) {
-Obj _35val2647 = co->args[1];
-Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2648 = primNot(_35val2647);
-if (True == _35reg2648) {
-pushCont(co, 0, _35clofun3149, 1, w);
-coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3147, 1, 1, w), stacks);
-} else {
-Nil;
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
-}
-}
-
-void _35clofun3149(struct Cora* co) {
-Obj _35val2650 = co->args[1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
-}
-
-void _35clofun3147(struct Cora* co) {
-Obj x = co->args[1];
-pushCont(co, 0, _35clofun3148, 1, x);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closureRef(co, 0), makeString1(", "));
 }
 
 void _35clofun3148(struct Cora* co) {
 Obj _35val2649 = co->args[1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun3149, 2, stacks, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
+}
+
+void _35clofun3149(struct Cora* co) {
+Obj _35val2650 = co->args[1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun3150, 2, stacks, w);
+coraCall(co, 2, globalRef(intern("length")), stacks);
+}
+
+void _35clofun3150(struct Cora* co) {
+Obj _35val2651 = co->args[1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun3151, 2, stacks, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2651);
+}
+
+void _35clofun3151(struct Cora* co) {
+Obj _35val2652 = co->args[1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun3152, 2, stacks, w);
+coraCall(co, 2, globalRef(intern("null?")), stacks);
+}
+
+void _35clofun3152(struct Cora* co) {
+Obj _35val2653 = co->args[1];
+Obj stacks = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2654 = primNot(_35val2653);
+if (True == _35reg2654) {
+pushCont(co, 0, _35clofun3155, 1, w);
+coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3153, 1, 1, w), stacks);
+} else {
+Nil;
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
+}
+}
+
+void _35clofun3155(struct Cora* co) {
+Obj _35val2656 = co->args[1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
+}
+
+void _35clofun3153(struct Cora* co) {
+Obj x = co->args[1];
+pushCont(co, 0, _35clofun3154, 1, x);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closureRef(co, 0), makeString1(", "));
+}
+
+void _35clofun3154(struct Cora* co) {
+Obj _35val2655 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), Nil, closureRef(co, 0), x);
 }
 
-void _35clofun3140(struct Cora* co) {
+void _35clofun3146(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3131(struct Cora* co) {
-Obj _35p1339 = co->args[1];
-Obj _35p1340 = co->args[2];
-Obj _35p1341 = co->args[3];
-Obj _35p1342 = co->args[4];
-Obj _35cc1343 = makeNative(0, _35clofun3132, 0, 4, _35p1339, _35p1340, _35p1341, _35p1342);
-Obj env = _35p1339;
-Obj w = _35p1340;
-Obj idx = _35p1341;
-Obj _35reg2631 = primEQ(Nil, _35p1342);
-if (True == _35reg2631) {
+void _35clofun3137(struct Cora* co) {
+Obj _35p1345 = co->args[1];
+Obj _35p1346 = co->args[2];
+Obj _35p1347 = co->args[3];
+Obj _35p1348 = co->args[4];
+Obj _35cc1349 = makeNative(0, _35clofun3138, 0, 4, _35p1345, _35p1346, _35p1347, _35p1348);
+Obj env = _35p1345;
+Obj w = _35p1346;
+Obj idx = _35p1347;
+Obj _35reg2637 = primEQ(Nil, _35p1348);
+if (True == _35reg2637) {
 coraReturn(co, Nil);
 return;
 } else {
-coraCall(co, 1, _35cc1343);
+coraCall(co, 1, _35cc1349);
 }
 }
 
-void _35clofun3132(struct Cora* co) {
-Obj _35cc1344 = makeNative(0, _35clofun3133, 0, 0);
+void _35clofun3138(struct Cora* co) {
+Obj _35cc1350 = makeNative(0, _35clofun3139, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj idx = closureRef(co, 2);
-Obj _35reg2622 = primIsCons(closureRef(co, 3));
-if (True == _35reg2622) {
-Obj _35reg2623 = primCar(closureRef(co, 3));
-Obj a = _35reg2623;
-Obj _35reg2624 = primCdr(closureRef(co, 3));
-Obj b = _35reg2624;
-pushCont(co, 0, _35clofun3134, 5, a, idx, env, w, b);
+Obj _35reg2628 = primIsCons(closureRef(co, 3));
+if (True == _35reg2628) {
+Obj _35reg2629 = primCar(closureRef(co, 3));
+Obj a = _35reg2629;
+Obj _35reg2630 = primCdr(closureRef(co, 3));
+Obj b = _35reg2630;
+pushCont(co, 0, _35clofun3140, 5, a, idx, env, w, b);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("co->args["));
 } else {
-coraCall(co, 1, _35cc1344);
+coraCall(co, 1, _35cc1350);
+}
+}
+
+void _35clofun3140(struct Cora* co) {
+Obj _35val2631 = co->args[1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3141, 5, a, idx, env, w, b);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
+}
+
+void _35clofun3141(struct Cora* co) {
+Obj _35val2632 = co->args[1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3142, 5, a, idx, env, w, b);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("] = "));
+}
+
+void _35clofun3142(struct Cora* co) {
+Obj _35val2633 = co->args[1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3143, 4, idx, env, w, b);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
+}
+
+void _35clofun3143(struct Cora* co) {
+Obj _35val2634 = co->args[1];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, _35clofun3144, 4, idx, env, w, b);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
+}
+
+void _35clofun3144(struct Cora* co) {
+Obj _35val2635 = co->args[1];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg2636 = primAdd(idx, makeNumber(1));
+coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-call-args")), env, w, _35reg2636, b);
+}
+
+void _35clofun3139(struct Cora* co) {
+coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
+}
+
+void _35clofun3065(struct Cora* co) {
+Obj _35p1328 = co->args[1];
+Obj _35p1329 = co->args[2];
+Obj _35p1330 = co->args[3];
+Obj _35cc1331 = makeNative(0, _35clofun3066, 0, 3, _35p1328, _35p1329, _35p1330);
+Obj env = _35p1328;
+Obj w = _35p1329;
+Obj x = _35p1330;
+Obj _35reg2626 = primIsSymbol(x);
+if (True == _35reg2626) {
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, x);
+} else {
+coraCall(co, 1, _35cc1331);
+}
+}
+
+void _35clofun3066(struct Cora* co) {
+Obj _35cc1332 = makeNative(0, _35clofun3067, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj env = closureRef(co, 0);
+Obj w = closureRef(co, 1);
+Obj _35reg2613 = primIsCons(closureRef(co, 2));
+if (True == _35reg2613) {
+Obj _35reg2614 = primCar(closureRef(co, 2));
+Obj _35reg2615 = primEQ(intern("%global"), _35reg2614);
+if (True == _35reg2615) {
+Obj _35reg2616 = primCdr(closureRef(co, 2));
+Obj _35reg2617 = primIsCons(_35reg2616);
+if (True == _35reg2617) {
+Obj _35reg2618 = primCdr(closureRef(co, 2));
+Obj _35reg2619 = primCar(_35reg2618);
+Obj x = _35reg2619;
+Obj _35reg2620 = primCdr(closureRef(co, 2));
+Obj _35reg2621 = primCdr(_35reg2620);
+Obj _35reg2622 = primEQ(Nil, _35reg2621);
+if (True == _35reg2622) {
+pushCont(co, 0, _35clofun3134, 2, x, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("globalRef(intern(\""));
+} else {
+coraCall(co, 1, _35cc1332);
+}
+} else {
+coraCall(co, 1, _35cc1332);
+}
+} else {
+coraCall(co, 1, _35cc1332);
+}
+} else {
+coraCall(co, 1, _35cc1332);
 }
 }
 
 void _35clofun3134(struct Cora* co) {
-Obj _35val2625 = co->args[1];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3135, 5, a, idx, env, w, b);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
-}
-
-void _35clofun3135(struct Cora* co) {
-Obj _35val2626 = co->args[1];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3136, 5, a, idx, env, w, b);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("] = "));
-}
-
-void _35clofun3136(struct Cora* co) {
-Obj _35val2627 = co->args[1];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3137, 4, idx, env, w, b);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
-}
-
-void _35clofun3137(struct Cora* co) {
-Obj _35val2628 = co->args[1];
-Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3138, 4, idx, env, w, b);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
-}
-
-void _35clofun3138(struct Cora* co) {
-Obj _35val2629 = co->args[1];
-Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2630 = primAdd(idx, makeNumber(1));
-coraCall(co, 5, globalRef(intern("cora/lib/toc.generate-call-args")), env, w, _35reg2630, b);
-}
-
-void _35clofun3133(struct Cora* co) {
-coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
-}
-
-void _35clofun3059(struct Cora* co) {
-Obj _35p1322 = co->args[1];
-Obj _35p1323 = co->args[2];
-Obj _35p1324 = co->args[3];
-Obj _35cc1325 = makeNative(0, _35clofun3060, 0, 3, _35p1322, _35p1323, _35p1324);
-Obj env = _35p1322;
-Obj w = _35p1323;
-Obj x = _35p1324;
-Obj _35reg2620 = primIsSymbol(x);
-if (True == _35reg2620) {
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, x);
-} else {
-coraCall(co, 1, _35cc1325);
-}
-}
-
-void _35clofun3060(struct Cora* co) {
-Obj _35cc1326 = makeNative(0, _35clofun3061, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj _35reg2607 = primIsCons(closureRef(co, 2));
-if (True == _35reg2607) {
-Obj _35reg2608 = primCar(closureRef(co, 2));
-Obj _35reg2609 = primEQ(intern("%global"), _35reg2608);
-if (True == _35reg2609) {
-Obj _35reg2610 = primCdr(closureRef(co, 2));
-Obj _35reg2611 = primIsCons(_35reg2610);
-if (True == _35reg2611) {
-Obj _35reg2612 = primCdr(closureRef(co, 2));
-Obj _35reg2613 = primCar(_35reg2612);
-Obj x = _35reg2613;
-Obj _35reg2614 = primCdr(closureRef(co, 2));
-Obj _35reg2615 = primCdr(_35reg2614);
-Obj _35reg2616 = primEQ(Nil, _35reg2615);
-if (True == _35reg2616) {
-pushCont(co, 0, _35clofun3128, 2, x, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("globalRef(intern(\""));
-} else {
-coraCall(co, 1, _35cc1326);
-}
-} else {
-coraCall(co, 1, _35cc1326);
-}
-} else {
-coraCall(co, 1, _35cc1326);
-}
-} else {
-coraCall(co, 1, _35cc1326);
-}
-}
-
-void _35clofun3128(struct Cora* co) {
-Obj _35val2617 = co->args[1];
+Obj _35val2623 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3129, 1, w);
+pushCont(co, 0, _35clofun3135, 1, w);
 coraCall(co, 2, globalRef(intern("symbol->string")), x);
 }
 
-void _35clofun3129(struct Cora* co) {
-Obj _35val2618 = co->args[1];
+void _35clofun3135(struct Cora* co) {
+Obj _35val2624 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun3130, 1, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2618);
+pushCont(co, 0, _35clofun3136, 1, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2624);
 }
 
-void _35clofun3130(struct Cora* co) {
-Obj _35val2619 = co->args[1];
+void _35clofun3136(struct Cora* co) {
+Obj _35val2625 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("\"))"));
 }
 
-void _35clofun3061(struct Cora* co) {
-Obj _35cc1327 = makeNative(0, _35clofun3062, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3067(struct Cora* co) {
+Obj _35cc1333 = makeNative(0, _35clofun3068, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2595 = primIsCons(closureRef(co, 2));
-if (True == _35reg2595) {
-Obj _35reg2596 = primCar(closureRef(co, 2));
-Obj _35reg2597 = primEQ(intern("%closure-ref"), _35reg2596);
-if (True == _35reg2597) {
-Obj _35reg2598 = primCdr(closureRef(co, 2));
-Obj _35reg2599 = primIsCons(_35reg2598);
-if (True == _35reg2599) {
-Obj _35reg2600 = primCdr(closureRef(co, 2));
-Obj _35reg2601 = primCar(_35reg2600);
-Obj idx = _35reg2601;
-Obj _35reg2602 = primCdr(closureRef(co, 2));
-Obj _35reg2603 = primCdr(_35reg2602);
-Obj _35reg2604 = primEQ(Nil, _35reg2603);
-if (True == _35reg2604) {
-pushCont(co, 0, _35clofun3126, 2, idx, w);
+Obj _35reg2601 = primIsCons(closureRef(co, 2));
+if (True == _35reg2601) {
+Obj _35reg2602 = primCar(closureRef(co, 2));
+Obj _35reg2603 = primEQ(intern("%closure-ref"), _35reg2602);
+if (True == _35reg2603) {
+Obj _35reg2604 = primCdr(closureRef(co, 2));
+Obj _35reg2605 = primIsCons(_35reg2604);
+if (True == _35reg2605) {
+Obj _35reg2606 = primCdr(closureRef(co, 2));
+Obj _35reg2607 = primCar(_35reg2606);
+Obj idx = _35reg2607;
+Obj _35reg2608 = primCdr(closureRef(co, 2));
+Obj _35reg2609 = primCdr(_35reg2608);
+Obj _35reg2610 = primEQ(Nil, _35reg2609);
+if (True == _35reg2610) {
+pushCont(co, 0, _35clofun3132, 2, idx, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("closureRef(co, "));
 } else {
-coraCall(co, 1, _35cc1327);
+coraCall(co, 1, _35cc1333);
 }
 } else {
-coraCall(co, 1, _35cc1327);
+coraCall(co, 1, _35cc1333);
 }
 } else {
-coraCall(co, 1, _35cc1327);
+coraCall(co, 1, _35cc1333);
 }
 } else {
-coraCall(co, 1, _35cc1327);
+coraCall(co, 1, _35cc1333);
 }
 }
 
-void _35clofun3126(struct Cora* co) {
-Obj _35val2605 = co->args[1];
+void _35clofun3132(struct Cora* co) {
+Obj _35val2611 = co->args[1];
 Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3127, 1, w);
+pushCont(co, 0, _35clofun3133, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
 }
 
-void _35clofun3127(struct Cora* co) {
-Obj _35val2606 = co->args[1];
+void _35clofun3133(struct Cora* co) {
+Obj _35val2612 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
-void _35clofun3062(struct Cora* co) {
-Obj _35cc1328 = makeNative(0, _35clofun3063, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun3068(struct Cora* co) {
+Obj _35cc1334 = makeNative(0, _35clofun3069, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2583 = primIsCons(closureRef(co, 2));
-if (True == _35reg2583) {
-Obj _35reg2584 = primCar(closureRef(co, 2));
-Obj _35reg2585 = primEQ(intern("%stack-ref"), _35reg2584);
-if (True == _35reg2585) {
-Obj _35reg2586 = primCdr(closureRef(co, 2));
-Obj _35reg2587 = primIsCons(_35reg2586);
-if (True == _35reg2587) {
-Obj _35reg2588 = primCdr(closureRef(co, 2));
-Obj _35reg2589 = primCar(_35reg2588);
-Obj idx = _35reg2589;
-Obj _35reg2590 = primCdr(closureRef(co, 2));
-Obj _35reg2591 = primCdr(_35reg2590);
-Obj _35reg2592 = primEQ(Nil, _35reg2591);
-if (True == _35reg2592) {
-pushCont(co, 0, _35clofun3124, 2, idx, w);
+Obj _35reg2589 = primIsCons(closureRef(co, 2));
+if (True == _35reg2589) {
+Obj _35reg2590 = primCar(closureRef(co, 2));
+Obj _35reg2591 = primEQ(intern("%stack-ref"), _35reg2590);
+if (True == _35reg2591) {
+Obj _35reg2592 = primCdr(closureRef(co, 2));
+Obj _35reg2593 = primIsCons(_35reg2592);
+if (True == _35reg2593) {
+Obj _35reg2594 = primCdr(closureRef(co, 2));
+Obj _35reg2595 = primCar(_35reg2594);
+Obj idx = _35reg2595;
+Obj _35reg2596 = primCdr(closureRef(co, 2));
+Obj _35reg2597 = primCdr(_35reg2596);
+Obj _35reg2598 = primEQ(Nil, _35reg2597);
+if (True == _35reg2598) {
+pushCont(co, 0, _35clofun3130, 2, idx, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("stackRef(co, "));
 } else {
-coraCall(co, 1, _35cc1328);
+coraCall(co, 1, _35cc1334);
 }
 } else {
-coraCall(co, 1, _35cc1328);
+coraCall(co, 1, _35cc1334);
 }
 } else {
-coraCall(co, 1, _35cc1328);
+coraCall(co, 1, _35cc1334);
 }
 } else {
-coraCall(co, 1, _35cc1328);
+coraCall(co, 1, _35cc1334);
+}
+}
+
+void _35clofun3130(struct Cora* co) {
+Obj _35val2599 = co->args[1];
+Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun3131, 1, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
+}
+
+void _35clofun3131(struct Cora* co) {
+Obj _35val2600 = co->args[1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
+}
+
+void _35clofun3069(struct Cora* co) {
+Obj _35cc1335 = makeNative(0, _35clofun3070, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj env = closureRef(co, 0);
+Obj w = closureRef(co, 1);
+Obj _35reg2565 = primIsCons(closureRef(co, 2));
+if (True == _35reg2565) {
+Obj _35reg2566 = primCar(closureRef(co, 2));
+Obj _35reg2567 = primEQ(intern("%const"), _35reg2566);
+if (True == _35reg2567) {
+Obj _35reg2568 = primCdr(closureRef(co, 2));
+Obj _35reg2569 = primIsCons(_35reg2568);
+if (True == _35reg2569) {
+Obj _35reg2570 = primCdr(closureRef(co, 2));
+Obj _35reg2571 = primCar(_35reg2570);
+Obj x = _35reg2571;
+Obj _35reg2572 = primCdr(closureRef(co, 2));
+Obj _35reg2573 = primCdr(_35reg2572);
+Obj _35reg2574 = primEQ(Nil, _35reg2573);
+if (True == _35reg2574) {
+Obj _35reg2575 = primIsSymbol(x);
+if (True == _35reg2575) {
+pushCont(co, 0, _35clofun3121, 2, x, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("intern(\""));
+} else {
+pushCont(co, 0, _35clofun3124, 2, x, w);
+coraCall(co, 2, globalRef(intern("number?")), x);
+}
+} else {
+coraCall(co, 1, _35cc1335);
+}
+} else {
+coraCall(co, 1, _35cc1335);
+}
+} else {
+coraCall(co, 1, _35cc1335);
+}
+} else {
+coraCall(co, 1, _35cc1335);
 }
 }
 
 void _35clofun3124(struct Cora* co) {
-Obj _35val2593 = co->args[1];
-Obj idx = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3125, 1, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, idx);
-}
-
-void _35clofun3125(struct Cora* co) {
-Obj _35val2594 = co->args[1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
-}
-
-void _35clofun3063(struct Cora* co) {
-Obj _35cc1329 = makeNative(0, _35clofun3064, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj _35reg2559 = primIsCons(closureRef(co, 2));
-if (True == _35reg2559) {
-Obj _35reg2560 = primCar(closureRef(co, 2));
-Obj _35reg2561 = primEQ(intern("%const"), _35reg2560);
-if (True == _35reg2561) {
-Obj _35reg2562 = primCdr(closureRef(co, 2));
-Obj _35reg2563 = primIsCons(_35reg2562);
-if (True == _35reg2563) {
-Obj _35reg2564 = primCdr(closureRef(co, 2));
-Obj _35reg2565 = primCar(_35reg2564);
-Obj x = _35reg2565;
-Obj _35reg2566 = primCdr(closureRef(co, 2));
-Obj _35reg2567 = primCdr(_35reg2566);
-Obj _35reg2568 = primEQ(Nil, _35reg2567);
-if (True == _35reg2568) {
-Obj _35reg2569 = primIsSymbol(x);
-if (True == _35reg2569) {
-pushCont(co, 0, _35clofun3115, 2, x, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("intern(\""));
-} else {
-pushCont(co, 0, _35clofun3118, 2, x, w);
-coraCall(co, 2, globalRef(intern("number?")), x);
-}
-} else {
-coraCall(co, 1, _35cc1329);
-}
-} else {
-coraCall(co, 1, _35cc1329);
-}
-} else {
-coraCall(co, 1, _35cc1329);
-}
-} else {
-coraCall(co, 1, _35cc1329);
-}
-}
-
-void _35clofun3118(struct Cora* co) {
-Obj _35val2573 = co->args[1];
+Obj _35val2579 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2573) {
-pushCont(co, 0, _35clofun3119, 2, x, w);
+if (True == _35val2579) {
+pushCont(co, 0, _35clofun3125, 2, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeNumber("));
 } else {
-Obj _35reg2576 = primIsString(x);
-if (True == _35reg2576) {
-pushCont(co, 0, _35clofun3121, 2, x, w);
+Obj _35reg2582 = primIsString(x);
+if (True == _35reg2582) {
+pushCont(co, 0, _35clofun3127, 2, x, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeString1(\""));
 } else {
-Obj _35reg2580 = primEQ(x, Nil);
-if (True == _35reg2580) {
+Obj _35reg2586 = primEQ(x, Nil);
+if (True == _35reg2586) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("Nil"));
 } else {
-Obj _35reg2581 = primEQ(x, True);
-if (True == _35reg2581) {
+Obj _35reg2587 = primEQ(x, True);
+if (True == _35reg2587) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("True"));
 } else {
-Obj _35reg2582 = primEQ(x, False);
-if (True == _35reg2582) {
+Obj _35reg2588 = primEQ(x, False);
+if (True == _35reg2588) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("False"));
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
@@ -2013,707 +2013,103 @@ coraCall(co, 2, globalRef(intern("error")), makeString1("no cond match"));
 }
 }
 
-void _35clofun3121(struct Cora* co) {
-Obj _35val2577 = co->args[1];
+void _35clofun3127(struct Cora* co) {
+Obj _35val2583 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3122, 1, w);
+pushCont(co, 0, _35clofun3128, 1, w);
 coraCall(co, 2, globalRef(intern("cora/lib/toc/internal.escape-str")), x);
 }
 
-void _35clofun3122(struct Cora* co) {
-Obj _35val2578 = co->args[1];
+void _35clofun3128(struct Cora* co) {
+Obj _35val2584 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun3123, 1, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2578);
+pushCont(co, 0, _35clofun3129, 1, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2584);
 }
 
-void _35clofun3123(struct Cora* co) {
-Obj _35val2579 = co->args[1];
+void _35clofun3129(struct Cora* co) {
+Obj _35val2585 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("\")"));
 }
 
-void _35clofun3119(struct Cora* co) {
-Obj _35val2574 = co->args[1];
+void _35clofun3125(struct Cora* co) {
+Obj _35val2580 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3120, 1, w);
+pushCont(co, 0, _35clofun3126, 1, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, x);
 }
 
-void _35clofun3120(struct Cora* co) {
-Obj _35val2575 = co->args[1];
+void _35clofun3126(struct Cora* co) {
+Obj _35val2581 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
 }
 
-void _35clofun3115(struct Cora* co) {
-Obj _35val2570 = co->args[1];
+void _35clofun3121(struct Cora* co) {
+Obj _35val2576 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3116, 1, w);
+pushCont(co, 0, _35clofun3122, 1, w);
 coraCall(co, 2, globalRef(intern("symbol->string")), x);
 }
 
-void _35clofun3116(struct Cora* co) {
-Obj _35val2571 = co->args[1];
+void _35clofun3122(struct Cora* co) {
+Obj _35val2577 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun3117, 1, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2571);
+pushCont(co, 0, _35clofun3123, 1, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, _35val2577);
 }
 
-void _35clofun3117(struct Cora* co) {
-Obj _35val2572 = co->args[1];
+void _35clofun3123(struct Cora* co) {
+Obj _35val2578 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("\")"));
-}
-
-void _35clofun3064(struct Cora* co) {
-Obj _35cc1330 = makeNative(0, _35clofun3065, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj _35reg2520 = primIsCons(closureRef(co, 2));
-if (True == _35reg2520) {
-Obj _35reg2521 = primCar(closureRef(co, 2));
-Obj _35reg2522 = primEQ(intern("let"), _35reg2521);
-if (True == _35reg2522) {
-Obj _35reg2523 = primCdr(closureRef(co, 2));
-Obj _35reg2524 = primIsCons(_35reg2523);
-if (True == _35reg2524) {
-Obj _35reg2525 = primCdr(closureRef(co, 2));
-Obj _35reg2526 = primCar(_35reg2525);
-Obj a = _35reg2526;
-Obj _35reg2527 = primCdr(closureRef(co, 2));
-Obj _35reg2528 = primCdr(_35reg2527);
-Obj _35reg2529 = primIsCons(_35reg2528);
-if (True == _35reg2529) {
-Obj _35reg2530 = primCdr(closureRef(co, 2));
-Obj _35reg2531 = primCdr(_35reg2530);
-Obj _35reg2532 = primCar(_35reg2531);
-Obj b = _35reg2532;
-Obj _35reg2533 = primCdr(closureRef(co, 2));
-Obj _35reg2534 = primCdr(_35reg2533);
-Obj _35reg2535 = primCdr(_35reg2534);
-Obj _35reg2536 = primIsCons(_35reg2535);
-if (True == _35reg2536) {
-Obj _35reg2537 = primCdr(closureRef(co, 2));
-Obj _35reg2538 = primCdr(_35reg2537);
-Obj _35reg2539 = primCdr(_35reg2538);
-Obj _35reg2540 = primCar(_35reg2539);
-Obj c = _35reg2540;
-Obj _35reg2541 = primCdr(closureRef(co, 2));
-Obj _35reg2542 = primCdr(_35reg2541);
-Obj _35reg2543 = primCdr(_35reg2542);
-Obj _35reg2544 = primCdr(_35reg2543);
-Obj _35reg2545 = primEQ(Nil, _35reg2544);
-if (True == _35reg2545) {
-pushCont(co, 0, _35clofun3105, 5, b, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.index")), a, env);
-} else {
-coraCall(co, 1, _35cc1330);
-}
-} else {
-coraCall(co, 1, _35cc1330);
-}
-} else {
-coraCall(co, 1, _35cc1330);
-}
-} else {
-coraCall(co, 1, _35cc1330);
-}
-} else {
-coraCall(co, 1, _35cc1330);
-}
-} else {
-coraCall(co, 1, _35cc1330);
-}
-}
-
-void _35clofun3105(struct Cora* co) {
-Obj _35val2546 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val2546;
-Obj _35reg2547 = primLT(idx, makeNumber(0));
-if (True == _35reg2547) {
-pushCont(co, 0, _35clofun3106, 5, b, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("Obj "));
-} else {
-Nil;
-pushCont(co, 0, _35clofun3111, 5, b, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
-}
-}
-
-void _35clofun3111(struct Cora* co) {
-Obj _35val2554 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3112, 5, b, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
-}
-
-void _35clofun3112(struct Cora* co) {
-Obj _35val2555 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3113, 4, a, env, w, c);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
-}
-
-void _35clofun3113(struct Cora* co) {
-Obj _35val2556 = co->args[1];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3114, 4, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
-}
-
-void _35clofun3114(struct Cora* co) {
-Obj _35val2557 = co->args[1];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2558 = primCons(a, env);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2558, w, c);
-}
-
-void _35clofun3106(struct Cora* co) {
-Obj _35val2548 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3107, 5, b, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
-}
-
-void _35clofun3107(struct Cora* co) {
-Obj _35val2549 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3108, 5, b, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
-}
-
-void _35clofun3108(struct Cora* co) {
-Obj _35val2550 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3109, 4, a, env, w, c);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
-}
-
-void _35clofun3109(struct Cora* co) {
-Obj _35val2551 = co->args[1];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3110, 4, a, env, w, c);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
-}
-
-void _35clofun3110(struct Cora* co) {
-Obj _35val2552 = co->args[1];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2553 = primCons(a, env);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2553, w, c);
-}
-
-void _35clofun3065(struct Cora* co) {
-Obj _35cc1331 = makeNative(0, _35clofun3066, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj _35reg2499 = primIsCons(closureRef(co, 2));
-if (True == _35reg2499) {
-Obj _35reg2500 = primCar(closureRef(co, 2));
-Obj _35reg2501 = primIsCons(_35reg2500);
-if (True == _35reg2501) {
-Obj _35reg2502 = primCar(closureRef(co, 2));
-Obj _35reg2503 = primCar(_35reg2502);
-Obj _35reg2504 = primEQ(intern("%builtin"), _35reg2503);
-if (True == _35reg2504) {
-Obj _35reg2505 = primCar(closureRef(co, 2));
-Obj _35reg2506 = primCdr(_35reg2505);
-Obj _35reg2507 = primIsCons(_35reg2506);
-if (True == _35reg2507) {
-Obj _35reg2508 = primCar(closureRef(co, 2));
-Obj _35reg2509 = primCdr(_35reg2508);
-Obj _35reg2510 = primCar(_35reg2509);
-Obj f = _35reg2510;
-Obj _35reg2511 = primCar(closureRef(co, 2));
-Obj _35reg2512 = primCdr(_35reg2511);
-Obj _35reg2513 = primCdr(_35reg2512);
-Obj _35reg2514 = primEQ(Nil, _35reg2513);
-if (True == _35reg2514) {
-Obj _35reg2515 = primCdr(closureRef(co, 2));
-Obj args = _35reg2515;
-pushCont(co, 0, _35clofun3101, 3, env, args, w);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.builtin->name")), f);
-} else {
-coraCall(co, 1, _35cc1331);
-}
-} else {
-coraCall(co, 1, _35cc1331);
-}
-} else {
-coraCall(co, 1, _35cc1331);
-}
-} else {
-coraCall(co, 1, _35cc1331);
-}
-} else {
-coraCall(co, 1, _35cc1331);
-}
-}
-
-void _35clofun3101(struct Cora* co) {
-Obj _35val2516 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3102, 3, env, args, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, _35val2516);
-}
-
-void _35clofun3102(struct Cora* co) {
-Obj _35val2517 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3103, 3, env, args, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("("));
-}
-
-void _35clofun3103(struct Cora* co) {
-Obj _35val2518 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3104, 1, w);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst-list")), env, w, args);
-}
-
-void _35clofun3104(struct Cora* co) {
-Obj _35val2519 = co->args[1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
-}
-
-void _35clofun3066(struct Cora* co) {
-Obj _35cc1332 = makeNative(0, _35clofun3067, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj _35reg2467 = primIsCons(closureRef(co, 2));
-if (True == _35reg2467) {
-Obj _35reg2468 = primCar(closureRef(co, 2));
-Obj _35reg2469 = primEQ(intern("if"), _35reg2468);
-if (True == _35reg2469) {
-Obj _35reg2470 = primCdr(closureRef(co, 2));
-Obj _35reg2471 = primIsCons(_35reg2470);
-if (True == _35reg2471) {
-Obj _35reg2472 = primCdr(closureRef(co, 2));
-Obj _35reg2473 = primCar(_35reg2472);
-Obj a = _35reg2473;
-Obj _35reg2474 = primCdr(closureRef(co, 2));
-Obj _35reg2475 = primCdr(_35reg2474);
-Obj _35reg2476 = primIsCons(_35reg2475);
-if (True == _35reg2476) {
-Obj _35reg2477 = primCdr(closureRef(co, 2));
-Obj _35reg2478 = primCdr(_35reg2477);
-Obj _35reg2479 = primCar(_35reg2478);
-Obj b = _35reg2479;
-Obj _35reg2480 = primCdr(closureRef(co, 2));
-Obj _35reg2481 = primCdr(_35reg2480);
-Obj _35reg2482 = primCdr(_35reg2481);
-Obj _35reg2483 = primIsCons(_35reg2482);
-if (True == _35reg2483) {
-Obj _35reg2484 = primCdr(closureRef(co, 2));
-Obj _35reg2485 = primCdr(_35reg2484);
-Obj _35reg2486 = primCdr(_35reg2485);
-Obj _35reg2487 = primCar(_35reg2486);
-Obj c = _35reg2487;
-Obj _35reg2488 = primCdr(closureRef(co, 2));
-Obj _35reg2489 = primCdr(_35reg2488);
-Obj _35reg2490 = primCdr(_35reg2489);
-Obj _35reg2491 = primCdr(_35reg2490);
-Obj _35reg2492 = primEQ(Nil, _35reg2491);
-if (True == _35reg2492) {
-pushCont(co, 0, _35clofun3095, 5, a, b, env, c, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("if (True == "));
-} else {
-coraCall(co, 1, _35cc1332);
-}
-} else {
-coraCall(co, 1, _35cc1332);
-}
-} else {
-coraCall(co, 1, _35cc1332);
-}
-} else {
-coraCall(co, 1, _35cc1332);
-}
-} else {
-coraCall(co, 1, _35cc1332);
-}
-} else {
-coraCall(co, 1, _35cc1332);
-}
-}
-
-void _35clofun3095(struct Cora* co) {
-Obj _35val2493 = co->args[1];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3096, 4, b, env, c, w);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
-}
-
-void _35clofun3096(struct Cora* co) {
-Obj _35val2494 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3097, 4, b, env, c, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(") {\n"));
-}
-
-void _35clofun3097(struct Cora* co) {
-Obj _35val2495 = co->args[1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3098, 3, env, c, w);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
-}
-
-void _35clofun3098(struct Cora* co) {
-Obj _35val2496 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3099, 3, env, c, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("} else {\n"));
-}
-
-void _35clofun3099(struct Cora* co) {
-Obj _35val2497 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3100, 1, w);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, c);
-}
-
-void _35clofun3100(struct Cora* co) {
-Obj _35val2498 = co->args[1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("}\n"));
-}
-
-void _35clofun3067(struct Cora* co) {
-Obj _35cc1333 = makeNative(0, _35clofun3068, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj _35reg2440 = primIsCons(closureRef(co, 2));
-if (True == _35reg2440) {
-Obj _35reg2441 = primCar(closureRef(co, 2));
-Obj _35reg2442 = primEQ(intern("%closure"), _35reg2441);
-if (True == _35reg2442) {
-Obj _35reg2443 = primCdr(closureRef(co, 2));
-Obj _35reg2444 = primIsCons(_35reg2443);
-if (True == _35reg2444) {
-Obj _35reg2445 = primCdr(closureRef(co, 2));
-Obj _35reg2446 = primCar(_35reg2445);
-Obj label = _35reg2446;
-Obj _35reg2447 = primCdr(closureRef(co, 2));
-Obj _35reg2448 = primCdr(_35reg2447);
-Obj _35reg2449 = primIsCons(_35reg2448);
-if (True == _35reg2449) {
-Obj _35reg2450 = primCdr(closureRef(co, 2));
-Obj _35reg2451 = primCdr(_35reg2450);
-Obj _35reg2452 = primCar(_35reg2451);
-Obj nargs = _35reg2452;
-Obj _35reg2453 = primCdr(closureRef(co, 2));
-Obj _35reg2454 = primCdr(_35reg2453);
-Obj _35reg2455 = primCdr(_35reg2454);
-Obj frees = _35reg2455;
-pushCont(co, 0, _35clofun3085, 5, label, nargs, env, frees, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeNative(0, "));
-} else {
-coraCall(co, 1, _35cc1333);
-}
-} else {
-coraCall(co, 1, _35cc1333);
-}
-} else {
-coraCall(co, 1, _35cc1333);
-}
-} else {
-coraCall(co, 1, _35cc1333);
-}
-}
-
-void _35clofun3085(struct Cora* co) {
-Obj _35val2456 = co->args[1];
-Obj label = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3086, 4, nargs, env, frees, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, label);
-}
-
-void _35clofun3086(struct Cora* co) {
-Obj _35val2457 = co->args[1];
-Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3087, 4, nargs, env, frees, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
-}
-
-void _35clofun3087(struct Cora* co) {
-Obj _35val2458 = co->args[1];
-Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3088, 3, env, frees, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, nargs);
-}
-
-void _35clofun3088(struct Cora* co) {
-Obj _35val2459 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3089, 3, env, frees, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
-}
-
-void _35clofun3089(struct Cora* co) {
-Obj _35val2460 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3090, 3, env, frees, w);
-coraCall(co, 2, globalRef(intern("length")), frees);
-}
-
-void _35clofun3090(struct Cora* co) {
-Obj _35val2461 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3091, 3, env, frees, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2461);
-}
-
-void _35clofun3091(struct Cora* co) {
-Obj _35val2462 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3092, 3, env, frees, w);
-coraCall(co, 2, globalRef(intern("null?")), frees);
-}
-
-void _35clofun3092(struct Cora* co) {
-Obj _35val2463 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2464 = primNot(_35val2463);
-if (True == _35reg2464) {
-pushCont(co, 0, _35clofun3093, 3, env, frees, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
-} else {
-Nil;
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
-}
-}
-
-void _35clofun3093(struct Cora* co) {
-Obj _35val2465 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3094, 1, w);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst-list")), env, w, frees);
-}
-
-void _35clofun3094(struct Cora* co) {
-Obj _35val2466 = co->args[1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
-}
-
-void _35clofun3068(struct Cora* co) {
-Obj _35cc1334 = makeNative(0, _35clofun3069, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj _35reg2421 = primIsCons(closureRef(co, 2));
-if (True == _35reg2421) {
-Obj _35reg2422 = primCar(closureRef(co, 2));
-Obj _35reg2423 = primEQ(intern("do"), _35reg2422);
-if (True == _35reg2423) {
-Obj _35reg2424 = primCdr(closureRef(co, 2));
-Obj _35reg2425 = primIsCons(_35reg2424);
-if (True == _35reg2425) {
-Obj _35reg2426 = primCdr(closureRef(co, 2));
-Obj _35reg2427 = primCar(_35reg2426);
-Obj a = _35reg2427;
-Obj _35reg2428 = primCdr(closureRef(co, 2));
-Obj _35reg2429 = primCdr(_35reg2428);
-Obj _35reg2430 = primIsCons(_35reg2429);
-if (True == _35reg2430) {
-Obj _35reg2431 = primCdr(closureRef(co, 2));
-Obj _35reg2432 = primCdr(_35reg2431);
-Obj _35reg2433 = primCar(_35reg2432);
-Obj b = _35reg2433;
-Obj _35reg2434 = primCdr(closureRef(co, 2));
-Obj _35reg2435 = primCdr(_35reg2434);
-Obj _35reg2436 = primCdr(_35reg2435);
-Obj _35reg2437 = primEQ(Nil, _35reg2436);
-if (True == _35reg2437) {
-pushCont(co, 0, _35clofun3083, 3, env, w, b);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
-} else {
-coraCall(co, 1, _35cc1334);
-}
-} else {
-coraCall(co, 1, _35cc1334);
-}
-} else {
-coraCall(co, 1, _35cc1334);
-}
-} else {
-coraCall(co, 1, _35cc1334);
-}
-} else {
-coraCall(co, 1, _35cc1334);
-}
-}
-
-void _35clofun3083(struct Cora* co) {
-Obj _35val2438 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3084, 3, env, w, b);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
-}
-
-void _35clofun3084(struct Cora* co) {
-Obj _35val2439 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj b = co->ctx.stk.stack[co->ctx.stk.base + 2];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
-}
-
-void _35clofun3069(struct Cora* co) {
-Obj _35cc1335 = makeNative(0, _35clofun3070, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj env = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj _35reg2409 = primIsCons(closureRef(co, 2));
-if (True == _35reg2409) {
-Obj _35reg2410 = primCar(closureRef(co, 2));
-Obj _35reg2411 = primEQ(intern("return"), _35reg2410);
-if (True == _35reg2411) {
-Obj _35reg2412 = primCdr(closureRef(co, 2));
-Obj _35reg2413 = primIsCons(_35reg2412);
-if (True == _35reg2413) {
-Obj _35reg2414 = primCdr(closureRef(co, 2));
-Obj _35reg2415 = primCar(_35reg2414);
-Obj x = _35reg2415;
-Obj _35reg2416 = primCdr(closureRef(co, 2));
-Obj _35reg2417 = primCdr(_35reg2416);
-Obj _35reg2418 = primEQ(Nil, _35reg2417);
-if (True == _35reg2418) {
-pushCont(co, 0, _35clofun3081, 3, env, x, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("coraReturn(co, "));
-} else {
-coraCall(co, 1, _35cc1335);
-}
-} else {
-coraCall(co, 1, _35cc1335);
-}
-} else {
-coraCall(co, 1, _35cc1335);
-}
-} else {
-coraCall(co, 1, _35cc1335);
-}
-}
-
-void _35clofun3081(struct Cora* co) {
-Obj _35val2419 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj x = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3082, 1, w);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, x);
-}
-
-void _35clofun3082(struct Cora* co) {
-Obj _35val2420 = co->args[1];
-Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\nreturn;\n"));
 }
 
 void _35clofun3070(struct Cora* co) {
 Obj _35cc1336 = makeNative(0, _35clofun3071, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2399 = primIsCons(closureRef(co, 2));
-if (True == _35reg2399) {
-Obj _35reg2400 = primCar(closureRef(co, 2));
-Obj _35reg2401 = primEQ(intern("tailcall"), _35reg2400);
-if (True == _35reg2401) {
-Obj _35reg2402 = primCdr(closureRef(co, 2));
-Obj _35reg2403 = primIsCons(_35reg2402);
-if (True == _35reg2403) {
-Obj _35reg2404 = primCdr(closureRef(co, 2));
-Obj _35reg2405 = primCar(_35reg2404);
-Obj exp = _35reg2405;
-Obj _35reg2406 = primCdr(closureRef(co, 2));
-Obj _35reg2407 = primCdr(_35reg2406);
-Obj _35reg2408 = primEQ(Nil, _35reg2407);
-if (True == _35reg2408) {
-coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, exp);
+Obj _35reg2526 = primIsCons(closureRef(co, 2));
+if (True == _35reg2526) {
+Obj _35reg2527 = primCar(closureRef(co, 2));
+Obj _35reg2528 = primEQ(intern("let"), _35reg2527);
+if (True == _35reg2528) {
+Obj _35reg2529 = primCdr(closureRef(co, 2));
+Obj _35reg2530 = primIsCons(_35reg2529);
+if (True == _35reg2530) {
+Obj _35reg2531 = primCdr(closureRef(co, 2));
+Obj _35reg2532 = primCar(_35reg2531);
+Obj a = _35reg2532;
+Obj _35reg2533 = primCdr(closureRef(co, 2));
+Obj _35reg2534 = primCdr(_35reg2533);
+Obj _35reg2535 = primIsCons(_35reg2534);
+if (True == _35reg2535) {
+Obj _35reg2536 = primCdr(closureRef(co, 2));
+Obj _35reg2537 = primCdr(_35reg2536);
+Obj _35reg2538 = primCar(_35reg2537);
+Obj b = _35reg2538;
+Obj _35reg2539 = primCdr(closureRef(co, 2));
+Obj _35reg2540 = primCdr(_35reg2539);
+Obj _35reg2541 = primCdr(_35reg2540);
+Obj _35reg2542 = primIsCons(_35reg2541);
+if (True == _35reg2542) {
+Obj _35reg2543 = primCdr(closureRef(co, 2));
+Obj _35reg2544 = primCdr(_35reg2543);
+Obj _35reg2545 = primCdr(_35reg2544);
+Obj _35reg2546 = primCar(_35reg2545);
+Obj c = _35reg2546;
+Obj _35reg2547 = primCdr(closureRef(co, 2));
+Obj _35reg2548 = primCdr(_35reg2547);
+Obj _35reg2549 = primCdr(_35reg2548);
+Obj _35reg2550 = primCdr(_35reg2549);
+Obj _35reg2551 = primEQ(Nil, _35reg2550);
+if (True == _35reg2551) {
+pushCont(co, 0, _35clofun3111, 5, b, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.index")), a, env);
 } else {
 coraCall(co, 1, _35cc1336);
 }
@@ -2726,38 +2122,158 @@ coraCall(co, 1, _35cc1336);
 } else {
 coraCall(co, 1, _35cc1336);
 }
+} else {
+coraCall(co, 1, _35cc1336);
+}
+} else {
+coraCall(co, 1, _35cc1336);
+}
+}
+
+void _35clofun3111(struct Cora* co) {
+Obj _35val2552 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj idx = _35val2552;
+Obj _35reg2553 = primLT(idx, makeNumber(0));
+if (True == _35reg2553) {
+pushCont(co, 0, _35clofun3112, 5, b, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("Obj "));
+} else {
+Nil;
+pushCont(co, 0, _35clofun3117, 5, b, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
+}
+}
+
+void _35clofun3117(struct Cora* co) {
+Obj _35val2560 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3118, 5, b, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
+}
+
+void _35clofun3118(struct Cora* co) {
+Obj _35val2561 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3119, 4, a, env, w, c);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
+}
+
+void _35clofun3119(struct Cora* co) {
+Obj _35val2562 = co->args[1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, _35clofun3120, 4, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
+}
+
+void _35clofun3120(struct Cora* co) {
+Obj _35val2563 = co->args[1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg2564 = primCons(a, env);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2564, w, c);
+}
+
+void _35clofun3112(struct Cora* co) {
+Obj _35val2554 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3113, 5, b, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, a);
+}
+
+void _35clofun3113(struct Cora* co) {
+Obj _35val2555 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3114, 5, b, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(" = "));
+}
+
+void _35clofun3114(struct Cora* co) {
+Obj _35val2556 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3115, 4, a, env, w, c);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
+}
+
+void _35clofun3115(struct Cora* co) {
+Obj _35val2557 = co->args[1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, _35clofun3116, 4, a, env, w, c);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
+}
+
+void _35clofun3116(struct Cora* co) {
+Obj _35val2558 = co->args[1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg2559 = primCons(a, env);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), _35reg2559, w, c);
 }
 
 void _35clofun3071(struct Cora* co) {
 Obj _35cc1337 = makeNative(0, _35clofun3072, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2381 = primIsCons(closureRef(co, 2));
-if (True == _35reg2381) {
-Obj _35reg2382 = primCar(closureRef(co, 2));
-Obj _35reg2383 = primEQ(intern("call"), _35reg2382);
-if (True == _35reg2383) {
-Obj _35reg2384 = primCdr(closureRef(co, 2));
-Obj _35reg2385 = primIsCons(_35reg2384);
-if (True == _35reg2385) {
-Obj _35reg2386 = primCdr(closureRef(co, 2));
-Obj _35reg2387 = primCar(_35reg2386);
-Obj exp = _35reg2387;
-Obj _35reg2388 = primCdr(closureRef(co, 2));
-Obj _35reg2389 = primCdr(_35reg2388);
-Obj _35reg2390 = primIsCons(_35reg2389);
-if (True == _35reg2390) {
-Obj _35reg2391 = primCdr(closureRef(co, 2));
-Obj _35reg2392 = primCdr(_35reg2391);
-Obj _35reg2393 = primCar(_35reg2392);
-Obj cont = _35reg2393;
-Obj _35reg2394 = primCdr(closureRef(co, 2));
-Obj _35reg2395 = primCdr(_35reg2394);
-Obj _35reg2396 = primCdr(_35reg2395);
-Obj _35reg2397 = primEQ(Nil, _35reg2396);
-if (True == _35reg2397) {
-pushCont(co, 0, _35clofun3080, 3, env, w, exp);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.generate-cont")), w, cont);
+Obj _35reg2505 = primIsCons(closureRef(co, 2));
+if (True == _35reg2505) {
+Obj _35reg2506 = primCar(closureRef(co, 2));
+Obj _35reg2507 = primIsCons(_35reg2506);
+if (True == _35reg2507) {
+Obj _35reg2508 = primCar(closureRef(co, 2));
+Obj _35reg2509 = primCar(_35reg2508);
+Obj _35reg2510 = primEQ(intern("%builtin"), _35reg2509);
+if (True == _35reg2510) {
+Obj _35reg2511 = primCar(closureRef(co, 2));
+Obj _35reg2512 = primCdr(_35reg2511);
+Obj _35reg2513 = primIsCons(_35reg2512);
+if (True == _35reg2513) {
+Obj _35reg2514 = primCar(closureRef(co, 2));
+Obj _35reg2515 = primCdr(_35reg2514);
+Obj _35reg2516 = primCar(_35reg2515);
+Obj f = _35reg2516;
+Obj _35reg2517 = primCar(closureRef(co, 2));
+Obj _35reg2518 = primCdr(_35reg2517);
+Obj _35reg2519 = primCdr(_35reg2518);
+Obj _35reg2520 = primEQ(Nil, _35reg2519);
+if (True == _35reg2520) {
+Obj _35reg2521 = primCdr(closureRef(co, 2));
+Obj args = _35reg2521;
+pushCont(co, 0, _35clofun3107, 3, env, args, w);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.builtin->name")), f);
 } else {
 coraCall(co, 1, _35cc1337);
 }
@@ -2775,775 +2291,1259 @@ coraCall(co, 1, _35cc1337);
 }
 }
 
-void _35clofun3080(struct Cora* co) {
-Obj _35val2398 = co->args[1];
+void _35clofun3107(struct Cora* co) {
+Obj _35val2522 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3108, 3, env, args, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, _35val2522);
+}
+
+void _35clofun3108(struct Cora* co) {
+Obj _35val2523 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3109, 3, env, args, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("("));
+}
+
+void _35clofun3109(struct Cora* co) {
+Obj _35val2524 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3110, 1, w);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst-list")), env, w, args);
+}
+
+void _35clofun3110(struct Cora* co) {
+Obj _35val2525 = co->args[1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
+}
+
+void _35clofun3072(struct Cora* co) {
+Obj _35cc1338 = makeNative(0, _35clofun3073, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj env = closureRef(co, 0);
+Obj w = closureRef(co, 1);
+Obj _35reg2473 = primIsCons(closureRef(co, 2));
+if (True == _35reg2473) {
+Obj _35reg2474 = primCar(closureRef(co, 2));
+Obj _35reg2475 = primEQ(intern("if"), _35reg2474);
+if (True == _35reg2475) {
+Obj _35reg2476 = primCdr(closureRef(co, 2));
+Obj _35reg2477 = primIsCons(_35reg2476);
+if (True == _35reg2477) {
+Obj _35reg2478 = primCdr(closureRef(co, 2));
+Obj _35reg2479 = primCar(_35reg2478);
+Obj a = _35reg2479;
+Obj _35reg2480 = primCdr(closureRef(co, 2));
+Obj _35reg2481 = primCdr(_35reg2480);
+Obj _35reg2482 = primIsCons(_35reg2481);
+if (True == _35reg2482) {
+Obj _35reg2483 = primCdr(closureRef(co, 2));
+Obj _35reg2484 = primCdr(_35reg2483);
+Obj _35reg2485 = primCar(_35reg2484);
+Obj b = _35reg2485;
+Obj _35reg2486 = primCdr(closureRef(co, 2));
+Obj _35reg2487 = primCdr(_35reg2486);
+Obj _35reg2488 = primCdr(_35reg2487);
+Obj _35reg2489 = primIsCons(_35reg2488);
+if (True == _35reg2489) {
+Obj _35reg2490 = primCdr(closureRef(co, 2));
+Obj _35reg2491 = primCdr(_35reg2490);
+Obj _35reg2492 = primCdr(_35reg2491);
+Obj _35reg2493 = primCar(_35reg2492);
+Obj c = _35reg2493;
+Obj _35reg2494 = primCdr(closureRef(co, 2));
+Obj _35reg2495 = primCdr(_35reg2494);
+Obj _35reg2496 = primCdr(_35reg2495);
+Obj _35reg2497 = primCdr(_35reg2496);
+Obj _35reg2498 = primEQ(Nil, _35reg2497);
+if (True == _35reg2498) {
+pushCont(co, 0, _35clofun3101, 5, a, b, env, c, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("if (True == "));
+} else {
+coraCall(co, 1, _35cc1338);
+}
+} else {
+coraCall(co, 1, _35cc1338);
+}
+} else {
+coraCall(co, 1, _35cc1338);
+}
+} else {
+coraCall(co, 1, _35cc1338);
+}
+} else {
+coraCall(co, 1, _35cc1338);
+}
+} else {
+coraCall(co, 1, _35cc1338);
+}
+}
+
+void _35clofun3101(struct Cora* co) {
+Obj _35val2499 = co->args[1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3102, 4, b, env, c, w);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
+}
+
+void _35clofun3102(struct Cora* co) {
+Obj _35val2500 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, _35clofun3103, 4, b, env, c, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(") {\n"));
+}
+
+void _35clofun3103(struct Cora* co) {
+Obj _35val2501 = co->args[1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, _35clofun3104, 3, env, c, w);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
+}
+
+void _35clofun3104(struct Cora* co) {
+Obj _35val2502 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3105, 3, env, c, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("} else {\n"));
+}
+
+void _35clofun3105(struct Cora* co) {
+Obj _35val2503 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3106, 1, w);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, c);
+}
+
+void _35clofun3106(struct Cora* co) {
+Obj _35val2504 = co->args[1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("}\n"));
+}
+
+void _35clofun3073(struct Cora* co) {
+Obj _35cc1339 = makeNative(0, _35clofun3074, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj env = closureRef(co, 0);
+Obj w = closureRef(co, 1);
+Obj _35reg2446 = primIsCons(closureRef(co, 2));
+if (True == _35reg2446) {
+Obj _35reg2447 = primCar(closureRef(co, 2));
+Obj _35reg2448 = primEQ(intern("%closure"), _35reg2447);
+if (True == _35reg2448) {
+Obj _35reg2449 = primCdr(closureRef(co, 2));
+Obj _35reg2450 = primIsCons(_35reg2449);
+if (True == _35reg2450) {
+Obj _35reg2451 = primCdr(closureRef(co, 2));
+Obj _35reg2452 = primCar(_35reg2451);
+Obj label = _35reg2452;
+Obj _35reg2453 = primCdr(closureRef(co, 2));
+Obj _35reg2454 = primCdr(_35reg2453);
+Obj _35reg2455 = primIsCons(_35reg2454);
+if (True == _35reg2455) {
+Obj _35reg2456 = primCdr(closureRef(co, 2));
+Obj _35reg2457 = primCdr(_35reg2456);
+Obj _35reg2458 = primCar(_35reg2457);
+Obj nargs = _35reg2458;
+Obj _35reg2459 = primCdr(closureRef(co, 2));
+Obj _35reg2460 = primCdr(_35reg2459);
+Obj _35reg2461 = primCdr(_35reg2460);
+Obj frees = _35reg2461;
+pushCont(co, 0, _35clofun3091, 5, label, nargs, env, frees, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("makeNative(0, "));
+} else {
+coraCall(co, 1, _35cc1339);
+}
+} else {
+coraCall(co, 1, _35cc1339);
+}
+} else {
+coraCall(co, 1, _35cc1339);
+}
+} else {
+coraCall(co, 1, _35cc1339);
+}
+}
+
+void _35clofun3091(struct Cora* co) {
+Obj _35val2462 = co->args[1];
+Obj label = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 0, _35clofun3092, 4, nargs, env, frees, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-sym")), w, label);
+}
+
+void _35clofun3092(struct Cora* co) {
+Obj _35val2463 = co->args[1];
+Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, _35clofun3093, 4, nargs, env, frees, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
+}
+
+void _35clofun3093(struct Cora* co) {
+Obj _35val2464 = co->args[1];
+Obj nargs = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, _35clofun3094, 3, env, frees, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, nargs);
+}
+
+void _35clofun3094(struct Cora* co) {
+Obj _35val2465 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3095, 3, env, frees, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
+}
+
+void _35clofun3095(struct Cora* co) {
+Obj _35val2466 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3096, 3, env, frees, w);
+coraCall(co, 2, globalRef(intern("length")), frees);
+}
+
+void _35clofun3096(struct Cora* co) {
+Obj _35val2467 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3097, 3, env, frees, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35val2467);
+}
+
+void _35clofun3097(struct Cora* co) {
+Obj _35val2468 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3098, 3, env, frees, w);
+coraCall(co, 2, globalRef(intern("null?")), frees);
+}
+
+void _35clofun3098(struct Cora* co) {
+Obj _35val2469 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg2470 = primNot(_35val2469);
+if (True == _35reg2470) {
+pushCont(co, 0, _35clofun3099, 3, env, frees, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(", "));
+} else {
+Nil;
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
+}
+}
+
+void _35clofun3099(struct Cora* co) {
+Obj _35val2471 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3100, 1, w);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst-list")), env, w, frees);
+}
+
+void _35clofun3100(struct Cora* co) {
+Obj _35val2472 = co->args[1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(")"));
+}
+
+void _35clofun3074(struct Cora* co) {
+Obj _35cc1340 = makeNative(0, _35clofun3075, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj env = closureRef(co, 0);
+Obj w = closureRef(co, 1);
+Obj _35reg2427 = primIsCons(closureRef(co, 2));
+if (True == _35reg2427) {
+Obj _35reg2428 = primCar(closureRef(co, 2));
+Obj _35reg2429 = primEQ(intern("do"), _35reg2428);
+if (True == _35reg2429) {
+Obj _35reg2430 = primCdr(closureRef(co, 2));
+Obj _35reg2431 = primIsCons(_35reg2430);
+if (True == _35reg2431) {
+Obj _35reg2432 = primCdr(closureRef(co, 2));
+Obj _35reg2433 = primCar(_35reg2432);
+Obj a = _35reg2433;
+Obj _35reg2434 = primCdr(closureRef(co, 2));
+Obj _35reg2435 = primCdr(_35reg2434);
+Obj _35reg2436 = primIsCons(_35reg2435);
+if (True == _35reg2436) {
+Obj _35reg2437 = primCdr(closureRef(co, 2));
+Obj _35reg2438 = primCdr(_35reg2437);
+Obj _35reg2439 = primCar(_35reg2438);
+Obj b = _35reg2439;
+Obj _35reg2440 = primCdr(closureRef(co, 2));
+Obj _35reg2441 = primCdr(_35reg2440);
+Obj _35reg2442 = primCdr(_35reg2441);
+Obj _35reg2443 = primEQ(Nil, _35reg2442);
+if (True == _35reg2443) {
+pushCont(co, 0, _35clofun3089, 3, env, w, b);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, a);
+} else {
+coraCall(co, 1, _35cc1340);
+}
+} else {
+coraCall(co, 1, _35cc1340);
+}
+} else {
+coraCall(co, 1, _35cc1340);
+}
+} else {
+coraCall(co, 1, _35cc1340);
+}
+} else {
+coraCall(co, 1, _35cc1340);
+}
+}
+
+void _35clofun3089(struct Cora* co) {
+Obj _35val2444 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3090, 3, env, w, b);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(";\n"));
+}
+
+void _35clofun3090(struct Cora* co) {
+Obj _35val2445 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj b = co->ctx.stk.stack[co->ctx.stk.base + 2];
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, b);
+}
+
+void _35clofun3075(struct Cora* co) {
+Obj _35cc1341 = makeNative(0, _35clofun3076, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj env = closureRef(co, 0);
+Obj w = closureRef(co, 1);
+Obj _35reg2415 = primIsCons(closureRef(co, 2));
+if (True == _35reg2415) {
+Obj _35reg2416 = primCar(closureRef(co, 2));
+Obj _35reg2417 = primEQ(intern("return"), _35reg2416);
+if (True == _35reg2417) {
+Obj _35reg2418 = primCdr(closureRef(co, 2));
+Obj _35reg2419 = primIsCons(_35reg2418);
+if (True == _35reg2419) {
+Obj _35reg2420 = primCdr(closureRef(co, 2));
+Obj _35reg2421 = primCar(_35reg2420);
+Obj x = _35reg2421;
+Obj _35reg2422 = primCdr(closureRef(co, 2));
+Obj _35reg2423 = primCdr(_35reg2422);
+Obj _35reg2424 = primEQ(Nil, _35reg2423);
+if (True == _35reg2424) {
+pushCont(co, 0, _35clofun3087, 3, env, x, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("coraReturn(co, "));
+} else {
+coraCall(co, 1, _35cc1341);
+}
+} else {
+coraCall(co, 1, _35cc1341);
+}
+} else {
+coraCall(co, 1, _35cc1341);
+}
+} else {
+coraCall(co, 1, _35cc1341);
+}
+}
+
+void _35clofun3087(struct Cora* co) {
+Obj _35val2425 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3088, 1, w);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, x);
+}
+
+void _35clofun3088(struct Cora* co) {
+Obj _35val2426 = co->args[1];
+Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\nreturn;\n"));
+}
+
+void _35clofun3076(struct Cora* co) {
+Obj _35cc1342 = makeNative(0, _35clofun3077, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj env = closureRef(co, 0);
+Obj w = closureRef(co, 1);
+Obj _35reg2405 = primIsCons(closureRef(co, 2));
+if (True == _35reg2405) {
+Obj _35reg2406 = primCar(closureRef(co, 2));
+Obj _35reg2407 = primEQ(intern("tailcall"), _35reg2406);
+if (True == _35reg2407) {
+Obj _35reg2408 = primCdr(closureRef(co, 2));
+Obj _35reg2409 = primIsCons(_35reg2408);
+if (True == _35reg2409) {
+Obj _35reg2410 = primCdr(closureRef(co, 2));
+Obj _35reg2411 = primCar(_35reg2410);
+Obj exp = _35reg2411;
+Obj _35reg2412 = primCdr(closureRef(co, 2));
+Obj _35reg2413 = primCdr(_35reg2412);
+Obj _35reg2414 = primEQ(Nil, _35reg2413);
+if (True == _35reg2414) {
+coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, exp);
+} else {
+coraCall(co, 1, _35cc1342);
+}
+} else {
+coraCall(co, 1, _35cc1342);
+}
+} else {
+coraCall(co, 1, _35cc1342);
+}
+} else {
+coraCall(co, 1, _35cc1342);
+}
+}
+
+void _35clofun3077(struct Cora* co) {
+Obj _35cc1343 = makeNative(0, _35clofun3078, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj env = closureRef(co, 0);
+Obj w = closureRef(co, 1);
+Obj _35reg2387 = primIsCons(closureRef(co, 2));
+if (True == _35reg2387) {
+Obj _35reg2388 = primCar(closureRef(co, 2));
+Obj _35reg2389 = primEQ(intern("call"), _35reg2388);
+if (True == _35reg2389) {
+Obj _35reg2390 = primCdr(closureRef(co, 2));
+Obj _35reg2391 = primIsCons(_35reg2390);
+if (True == _35reg2391) {
+Obj _35reg2392 = primCdr(closureRef(co, 2));
+Obj _35reg2393 = primCar(_35reg2392);
+Obj exp = _35reg2393;
+Obj _35reg2394 = primCdr(closureRef(co, 2));
+Obj _35reg2395 = primCdr(_35reg2394);
+Obj _35reg2396 = primIsCons(_35reg2395);
+if (True == _35reg2396) {
+Obj _35reg2397 = primCdr(closureRef(co, 2));
+Obj _35reg2398 = primCdr(_35reg2397);
+Obj _35reg2399 = primCar(_35reg2398);
+Obj cont = _35reg2399;
+Obj _35reg2400 = primCdr(closureRef(co, 2));
+Obj _35reg2401 = primCdr(_35reg2400);
+Obj _35reg2402 = primCdr(_35reg2401);
+Obj _35reg2403 = primEQ(Nil, _35reg2402);
+if (True == _35reg2403) {
+pushCont(co, 0, _35clofun3086, 3, env, w, exp);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.generate-cont")), w, cont);
+} else {
+coraCall(co, 1, _35cc1343);
+}
+} else {
+coraCall(co, 1, _35cc1343);
+}
+} else {
+coraCall(co, 1, _35cc1343);
+}
+} else {
+coraCall(co, 1, _35cc1343);
+}
+} else {
+coraCall(co, 1, _35cc1343);
+}
+}
+
+void _35clofun3086(struct Cora* co) {
+Obj _35val2404 = co->args[1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 2];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), env, w, exp);
 }
 
-void _35clofun3072(struct Cora* co) {
-Obj _35cc1338 = makeNative(0, _35clofun3073, 0, 0);
+void _35clofun3078(struct Cora* co) {
+Obj _35cc1344 = makeNative(0, _35clofun3079, 0, 0);
 Obj env = closureRef(co, 0);
 Obj w = closureRef(co, 1);
-Obj _35reg2371 = primIsCons(closureRef(co, 2));
-if (True == _35reg2371) {
-Obj _35reg2372 = primCar(closureRef(co, 2));
-Obj f = _35reg2372;
-Obj _35reg2373 = primCdr(closureRef(co, 2));
-Obj args = _35reg2373;
-pushCont(co, 0, _35clofun3074, 3, f, args, w);
+Obj _35reg2377 = primIsCons(closureRef(co, 2));
+if (True == _35reg2377) {
+Obj _35reg2378 = primCar(closureRef(co, 2));
+Obj f = _35reg2378;
+Obj _35reg2379 = primCdr(closureRef(co, 2));
+Obj args = _35reg2379;
+pushCont(co, 0, _35clofun3080, 3, f, args, w);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1("coraCall(co, "));
 } else {
-coraCall(co, 1, _35cc1338);
+coraCall(co, 1, _35cc1344);
 }
 }
 
-void _35clofun3074(struct Cora* co) {
-Obj _35val2374 = co->args[1];
+void _35clofun3080(struct Cora* co) {
+Obj _35val2380 = co->args[1];
 Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3075, 3, f, args, w);
+pushCont(co, 0, _35clofun3081, 3, f, args, w);
 coraCall(co, 2, globalRef(intern("length")), args);
 }
 
-void _35clofun3075(struct Cora* co) {
-Obj _35val2375 = co->args[1];
+void _35clofun3081(struct Cora* co) {
+Obj _35val2381 = co->args[1];
 Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2376 = primAdd(makeNumber(1), _35val2375);
-pushCont(co, 0, _35clofun3076, 3, f, args, w);
-coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35reg2376);
+Obj _35reg2382 = primAdd(makeNumber(1), _35val2381);
+pushCont(co, 0, _35clofun3082, 3, f, args, w);
+coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-num")), w, _35reg2382);
 }
 
-void _35clofun3076(struct Cora* co) {
-Obj _35val2377 = co->args[1];
+void _35clofun3082(struct Cora* co) {
+Obj _35val2383 = co->args[1];
 Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2379 = primCons(f, args);
-pushCont(co, 0, _35clofun3079, 1, w);
-coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3077, 1, 1, w), _35reg2379);
+Obj _35reg2385 = primCons(f, args);
+pushCont(co, 0, _35clofun3085, 1, w);
+coraCall(co, 3, globalRef(intern("for-each")), makeNative(0, _35clofun3083, 1, 1, w), _35reg2385);
 }
 
-void _35clofun3079(struct Cora* co) {
-Obj _35val2380 = co->args[1];
+void _35clofun3085(struct Cora* co) {
+Obj _35val2386 = co->args[1];
 Obj w = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), w, makeString1(");\n"));
 }
 
-void _35clofun3077(struct Cora* co) {
+void _35clofun3083(struct Cora* co) {
 Obj x = co->args[1];
-pushCont(co, 0, _35clofun3078, 1, x);
+pushCont(co, 0, _35clofun3084, 1, x);
 coraCall(co, 3, globalRef(intern("cora/lib/toc/internal.generate-str")), closureRef(co, 0), makeString1(", "));
 }
 
-void _35clofun3078(struct Cora* co) {
-Obj _35val2378 = co->args[1];
+void _35clofun3084(struct Cora* co) {
+Obj _35val2384 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.generate-inst")), Nil, closureRef(co, 0), x);
 }
 
-void _35clofun3073(struct Cora* co) {
+void _35clofun3079(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3057(struct Cora* co) {
+void _35clofun3063(struct Cora* co) {
 Obj x = co->args[1];
 Obj k = co->args[2];
-Obj _35reg2364 = primGenSym(intern("reg"));
-Obj tmp = _35reg2364;
-pushCont(co, 0, _35clofun3058, 2, x, tmp);
+Obj _35reg2370 = primGenSym(intern("reg"));
+Obj tmp = _35reg2370;
+pushCont(co, 0, _35clofun3064, 2, x, tmp);
 coraCall(co, 2, k, tmp);
 }
 
-void _35clofun3058(struct Cora* co) {
-Obj _35val2365 = co->args[1];
+void _35clofun3064(struct Cora* co) {
+Obj _35val2371 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj tmp = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2366 = primCons(_35val2365, Nil);
-Obj _35reg2367 = primCons(x, _35reg2366);
-Obj _35reg2368 = primCons(tmp, _35reg2367);
-Obj _35reg2369 = primCons(intern("let"), _35reg2368);
-coraReturn(co, _35reg2369);
+Obj _35reg2372 = primCons(_35val2371, Nil);
+Obj _35reg2373 = primCons(x, _35reg2372);
+Obj _35reg2374 = primCons(tmp, _35reg2373);
+Obj _35reg2375 = primCons(intern("let"), _35reg2374);
+coraReturn(co, _35reg2375);
 return;
 }
 
-void _35clofun3052(struct Cora* co) {
+void _35clofun3058(struct Cora* co) {
+Obj _35p1322 = co->args[1];
+Obj _35p1323 = co->args[2];
+Obj _35p1324 = co->args[3];
+Obj _35p1325 = co->args[4];
+Obj _35cc1326 = makeNative(0, _35clofun3059, 0, 4, _35p1322, _35p1323, _35p1324, _35p1325);
+Obj res = _35p1322;
+Obj init = _35p1323;
+Obj _35reg2367 = primEQ(Nil, _35p1324);
+if (True == _35reg2367) {
+Obj k = _35p1325;
+pushCont(co, 0, _35clofun3062, 2, k, init);
+coraCall(co, 2, globalRef(intern("reverse")), res);
+} else {
+coraCall(co, 1, _35cc1326);
+}
+}
+
+void _35clofun3062(struct Cora* co) {
+Obj _35val2368 = co->args[1];
+Obj k = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj init = co->ctx.stk.stack[co->ctx.stk.base + 1];
+coraCall(co, 3, k, init, _35val2368);
+}
+
+void _35clofun3059(struct Cora* co) {
+Obj _35cc1327 = makeNative(0, _35clofun3060, 0, 0);
+Obj res = closureRef(co, 0);
+Obj init = closureRef(co, 1);
+Obj _35reg2363 = primIsCons(closureRef(co, 2));
+if (True == _35reg2363) {
+Obj _35reg2364 = primCar(closureRef(co, 2));
+Obj x = _35reg2364;
+Obj _35reg2365 = primCdr(closureRef(co, 2));
+Obj y = _35reg2365;
+Obj k = closureRef(co, 3);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), init, x, makeNative(0, _35clofun3061, 2, 3, res, y, k));
+} else {
+coraCall(co, 1, _35cc1327);
+}
+}
+
+void _35clofun3061(struct Cora* co) {
+Obj init1 = co->args[1];
+Obj x1 = co->args[2];
+Obj _35reg2366 = primCons(x1, closureRef(co, 0));
+coraCall(co, 5, globalRef(intern("cora/lib/toc.collect-lambda-list")), _35reg2366, init1, closureRef(co, 1), closureRef(co, 2));
+}
+
+void _35clofun3060(struct Cora* co) {
+coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
+}
+
+void _35clofun3048(struct Cora* co) {
 Obj _35p1316 = co->args[1];
 Obj _35p1317 = co->args[2];
 Obj _35p1318 = co->args[3];
-Obj _35p1319 = co->args[4];
-Obj _35cc1320 = makeNative(0, _35clofun3053, 0, 4, _35p1316, _35p1317, _35p1318, _35p1319);
+Obj _35cc1319 = makeNative(0, _35clofun3049, 0, 3, _35p1316, _35p1317, _35p1318);
 Obj res = _35p1316;
-Obj init = _35p1317;
-Obj _35reg2361 = primEQ(Nil, _35p1318);
-if (True == _35reg2361) {
-Obj k = _35p1319;
-pushCont(co, 0, _35clofun3056, 2, k, init);
-coraCall(co, 2, globalRef(intern("reverse")), res);
+Obj _35reg2257 = primIsCons(_35p1317);
+if (True == _35reg2257) {
+Obj _35reg2258 = primCar(_35p1317);
+Obj clo_45or_45cont = _35reg2258;
+Obj _35reg2259 = primCdr(_35p1317);
+Obj _35reg2260 = primIsCons(_35reg2259);
+if (True == _35reg2260) {
+Obj _35reg2261 = primCdr(_35p1317);
+Obj _35reg2262 = primCar(_35reg2261);
+Obj _35reg2263 = primIsCons(_35reg2262);
+if (True == _35reg2263) {
+Obj _35reg2264 = primCdr(_35p1317);
+Obj _35reg2265 = primCar(_35reg2264);
+Obj _35reg2266 = primCar(_35reg2265);
+Obj _35reg2267 = primEQ(intern("lambda"), _35reg2266);
+if (True == _35reg2267) {
+Obj _35reg2268 = primCdr(_35p1317);
+Obj _35reg2269 = primCar(_35reg2268);
+Obj _35reg2270 = primCdr(_35reg2269);
+Obj _35reg2271 = primIsCons(_35reg2270);
+if (True == _35reg2271) {
+Obj _35reg2272 = primCdr(_35p1317);
+Obj _35reg2273 = primCar(_35reg2272);
+Obj _35reg2274 = primCdr(_35reg2273);
+Obj _35reg2275 = primCar(_35reg2274);
+Obj params = _35reg2275;
+Obj _35reg2276 = primCdr(_35p1317);
+Obj _35reg2277 = primCar(_35reg2276);
+Obj _35reg2278 = primCdr(_35reg2277);
+Obj _35reg2279 = primCdr(_35reg2278);
+Obj _35reg2280 = primIsCons(_35reg2279);
+if (True == _35reg2280) {
+Obj _35reg2281 = primCdr(_35p1317);
+Obj _35reg2282 = primCar(_35reg2281);
+Obj _35reg2283 = primCdr(_35reg2282);
+Obj _35reg2284 = primCdr(_35reg2283);
+Obj _35reg2285 = primCar(_35reg2284);
+Obj body = _35reg2285;
+Obj _35reg2286 = primCdr(_35p1317);
+Obj _35reg2287 = primCar(_35reg2286);
+Obj _35reg2288 = primCdr(_35reg2287);
+Obj _35reg2289 = primCdr(_35reg2288);
+Obj _35reg2290 = primCdr(_35reg2289);
+Obj _35reg2291 = primEQ(Nil, _35reg2290);
+if (True == _35reg2291) {
+Obj _35reg2292 = primCdr(_35p1317);
+Obj _35reg2293 = primCdr(_35reg2292);
+Obj fvs = _35reg2293;
+Obj k = _35p1318;
+Obj _35reg2294 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2294) {
+if (True == True) {
+Obj _35reg2295 = primGenSym(intern("clofun"));
+Obj name = _35reg2295;
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3052, 2, 5, k, params, clo_45or_45cont, name, fvs));
+} else {
+coraCall(co, 1, _35cc1319);
+}
+} else {
+Obj _35reg2317 = primEQ(clo_45or_45cont, intern("%continuation"));
+if (True == _35reg2317) {
+if (True == True) {
+Obj _35reg2318 = primGenSym(intern("clofun"));
+Obj name = _35reg2318;
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3054, 2, 5, k, params, clo_45or_45cont, name, fvs));
+} else {
+coraCall(co, 1, _35cc1319);
+}
+} else {
+if (True == False) {
+Obj _35reg2340 = primGenSym(intern("clofun"));
+Obj name = _35reg2340;
+coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3056, 2, 5, k, params, clo_45or_45cont, name, fvs));
+} else {
+coraCall(co, 1, _35cc1319);
+}
+}
+}
+} else {
+coraCall(co, 1, _35cc1319);
+}
+} else {
+coraCall(co, 1, _35cc1319);
+}
+} else {
+coraCall(co, 1, _35cc1319);
+}
+} else {
+coraCall(co, 1, _35cc1319);
+}
+} else {
+coraCall(co, 1, _35cc1319);
+}
+} else {
+coraCall(co, 1, _35cc1319);
+}
+} else {
+coraCall(co, 1, _35cc1319);
+}
+}
+
+void _35clofun3056(struct Cora* co) {
+Obj res1 = co->args[1];
+Obj body1 = co->args[2];
+Obj _35reg2341 = primEQ(closureRef(co, 2), intern("%closure"));
+if (True == _35reg2341) {
+Obj _35reg2342 = primCons(body1, Nil);
+Obj _35reg2343 = primCons(Nil, _35reg2342);
+Obj _35reg2344 = primCons(closureRef(co, 1), _35reg2343);
+Obj _35reg2345 = primCons(intern("lambda"), _35reg2344);
+Obj _35reg2346 = primCons(_35reg2345, Nil);
+Obj _35reg2347 = primCons(closureRef(co, 3), _35reg2346);
+Obj _35reg2348 = primCons(_35reg2347, res1);
+pushCont(co, 0, _35clofun3057, 1, _35reg2348);
+coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
+} else {
+Obj _35reg2353 = primCons(body1, Nil);
+Obj _35reg2354 = primCons(closureRef(co, 4), _35reg2353);
+Obj _35reg2355 = primCons(closureRef(co, 1), _35reg2354);
+Obj _35reg2356 = primCons(intern("lambda"), _35reg2355);
+Obj _35reg2357 = primCons(_35reg2356, Nil);
+Obj _35reg2358 = primCons(closureRef(co, 3), _35reg2357);
+Obj _35reg2359 = primCons(_35reg2358, res1);
+Obj _35reg2360 = primCons(closureRef(co, 3), closureRef(co, 4));
+Obj _35reg2361 = primCons(closureRef(co, 2), _35reg2360);
+coraCall(co, 3, closureRef(co, 0), _35reg2359, _35reg2361);
+}
+}
+
+void _35clofun3057(struct Cora* co) {
+Obj _35val2349 = co->args[1];
+Obj _35reg2348 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2350 = primCons(_35val2349, closureRef(co, 4));
+Obj _35reg2351 = primCons(closureRef(co, 3), _35reg2350);
+Obj _35reg2352 = primCons(closureRef(co, 2), _35reg2351);
+coraCall(co, 3, closureRef(co, 0), _35reg2348, _35reg2352);
+}
+
+void _35clofun3054(struct Cora* co) {
+Obj res1 = co->args[1];
+Obj body1 = co->args[2];
+Obj _35reg2319 = primEQ(closureRef(co, 2), intern("%closure"));
+if (True == _35reg2319) {
+Obj _35reg2320 = primCons(body1, Nil);
+Obj _35reg2321 = primCons(Nil, _35reg2320);
+Obj _35reg2322 = primCons(closureRef(co, 1), _35reg2321);
+Obj _35reg2323 = primCons(intern("lambda"), _35reg2322);
+Obj _35reg2324 = primCons(_35reg2323, Nil);
+Obj _35reg2325 = primCons(closureRef(co, 3), _35reg2324);
+Obj _35reg2326 = primCons(_35reg2325, res1);
+pushCont(co, 0, _35clofun3055, 1, _35reg2326);
+coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
+} else {
+Obj _35reg2331 = primCons(body1, Nil);
+Obj _35reg2332 = primCons(closureRef(co, 4), _35reg2331);
+Obj _35reg2333 = primCons(closureRef(co, 1), _35reg2332);
+Obj _35reg2334 = primCons(intern("lambda"), _35reg2333);
+Obj _35reg2335 = primCons(_35reg2334, Nil);
+Obj _35reg2336 = primCons(closureRef(co, 3), _35reg2335);
+Obj _35reg2337 = primCons(_35reg2336, res1);
+Obj _35reg2338 = primCons(closureRef(co, 3), closureRef(co, 4));
+Obj _35reg2339 = primCons(closureRef(co, 2), _35reg2338);
+coraCall(co, 3, closureRef(co, 0), _35reg2337, _35reg2339);
+}
+}
+
+void _35clofun3055(struct Cora* co) {
+Obj _35val2327 = co->args[1];
+Obj _35reg2326 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2328 = primCons(_35val2327, closureRef(co, 4));
+Obj _35reg2329 = primCons(closureRef(co, 3), _35reg2328);
+Obj _35reg2330 = primCons(closureRef(co, 2), _35reg2329);
+coraCall(co, 3, closureRef(co, 0), _35reg2326, _35reg2330);
+}
+
+void _35clofun3052(struct Cora* co) {
+Obj res1 = co->args[1];
+Obj body1 = co->args[2];
+Obj _35reg2296 = primEQ(closureRef(co, 2), intern("%closure"));
+if (True == _35reg2296) {
+Obj _35reg2297 = primCons(body1, Nil);
+Obj _35reg2298 = primCons(Nil, _35reg2297);
+Obj _35reg2299 = primCons(closureRef(co, 1), _35reg2298);
+Obj _35reg2300 = primCons(intern("lambda"), _35reg2299);
+Obj _35reg2301 = primCons(_35reg2300, Nil);
+Obj _35reg2302 = primCons(closureRef(co, 3), _35reg2301);
+Obj _35reg2303 = primCons(_35reg2302, res1);
+pushCont(co, 0, _35clofun3053, 1, _35reg2303);
+coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
+} else {
+Obj _35reg2308 = primCons(body1, Nil);
+Obj _35reg2309 = primCons(closureRef(co, 4), _35reg2308);
+Obj _35reg2310 = primCons(closureRef(co, 1), _35reg2309);
+Obj _35reg2311 = primCons(intern("lambda"), _35reg2310);
+Obj _35reg2312 = primCons(_35reg2311, Nil);
+Obj _35reg2313 = primCons(closureRef(co, 3), _35reg2312);
+Obj _35reg2314 = primCons(_35reg2313, res1);
+Obj _35reg2315 = primCons(closureRef(co, 3), closureRef(co, 4));
+Obj _35reg2316 = primCons(closureRef(co, 2), _35reg2315);
+coraCall(co, 3, closureRef(co, 0), _35reg2314, _35reg2316);
+}
+}
+
+void _35clofun3053(struct Cora* co) {
+Obj _35val2304 = co->args[1];
+Obj _35reg2303 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2305 = primCons(_35val2304, closureRef(co, 4));
+Obj _35reg2306 = primCons(closureRef(co, 3), _35reg2305);
+Obj _35reg2307 = primCons(closureRef(co, 2), _35reg2306);
+coraCall(co, 3, closureRef(co, 0), _35reg2303, _35reg2307);
+}
+
+void _35clofun3049(struct Cora* co) {
+Obj _35cc1320 = makeNative(0, _35clofun3050, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj res = closureRef(co, 0);
+Obj f_45args = closureRef(co, 1);
+Obj k = closureRef(co, 2);
+Obj _35reg2256 = primIsCons(f_45args);
+if (True == _35reg2256) {
+coraCall(co, 5, globalRef(intern("cora/lib/toc.collect-lambda-list")), Nil, res, f_45args, k);
 } else {
 coraCall(co, 1, _35cc1320);
 }
 }
 
-void _35clofun3056(struct Cora* co) {
-Obj _35val2362 = co->args[1];
-Obj k = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj init = co->ctx.stk.stack[co->ctx.stk.base + 1];
-coraCall(co, 3, k, init, _35val2362);
-}
-
-void _35clofun3053(struct Cora* co) {
-Obj _35cc1321 = makeNative(0, _35clofun3054, 0, 0);
-Obj res = closureRef(co, 0);
-Obj init = closureRef(co, 1);
-Obj _35reg2357 = primIsCons(closureRef(co, 2));
-if (True == _35reg2357) {
-Obj _35reg2358 = primCar(closureRef(co, 2));
-Obj x = _35reg2358;
-Obj _35reg2359 = primCdr(closureRef(co, 2));
-Obj y = _35reg2359;
-Obj k = closureRef(co, 3);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), init, x, makeNative(0, _35clofun3055, 2, 3, res, y, k));
-} else {
-coraCall(co, 1, _35cc1321);
-}
-}
-
-void _35clofun3055(struct Cora* co) {
-Obj init1 = co->args[1];
-Obj x1 = co->args[2];
-Obj _35reg2360 = primCons(x1, closureRef(co, 0));
-coraCall(co, 5, globalRef(intern("cora/lib/toc.collect-lambda-list")), _35reg2360, init1, closureRef(co, 1), closureRef(co, 2));
-}
-
-void _35clofun3054(struct Cora* co) {
-coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
-}
-
-void _35clofun3042(struct Cora* co) {
-Obj _35p1310 = co->args[1];
-Obj _35p1311 = co->args[2];
-Obj _35p1312 = co->args[3];
-Obj _35cc1313 = makeNative(0, _35clofun3043, 0, 3, _35p1310, _35p1311, _35p1312);
-Obj res = _35p1310;
-Obj _35reg2251 = primIsCons(_35p1311);
-if (True == _35reg2251) {
-Obj _35reg2252 = primCar(_35p1311);
-Obj clo_45or_45cont = _35reg2252;
-Obj _35reg2253 = primCdr(_35p1311);
-Obj _35reg2254 = primIsCons(_35reg2253);
-if (True == _35reg2254) {
-Obj _35reg2255 = primCdr(_35p1311);
-Obj _35reg2256 = primCar(_35reg2255);
-Obj _35reg2257 = primIsCons(_35reg2256);
-if (True == _35reg2257) {
-Obj _35reg2258 = primCdr(_35p1311);
-Obj _35reg2259 = primCar(_35reg2258);
-Obj _35reg2260 = primCar(_35reg2259);
-Obj _35reg2261 = primEQ(intern("lambda"), _35reg2260);
-if (True == _35reg2261) {
-Obj _35reg2262 = primCdr(_35p1311);
-Obj _35reg2263 = primCar(_35reg2262);
-Obj _35reg2264 = primCdr(_35reg2263);
-Obj _35reg2265 = primIsCons(_35reg2264);
-if (True == _35reg2265) {
-Obj _35reg2266 = primCdr(_35p1311);
-Obj _35reg2267 = primCar(_35reg2266);
-Obj _35reg2268 = primCdr(_35reg2267);
-Obj _35reg2269 = primCar(_35reg2268);
-Obj params = _35reg2269;
-Obj _35reg2270 = primCdr(_35p1311);
-Obj _35reg2271 = primCar(_35reg2270);
-Obj _35reg2272 = primCdr(_35reg2271);
-Obj _35reg2273 = primCdr(_35reg2272);
-Obj _35reg2274 = primIsCons(_35reg2273);
-if (True == _35reg2274) {
-Obj _35reg2275 = primCdr(_35p1311);
-Obj _35reg2276 = primCar(_35reg2275);
-Obj _35reg2277 = primCdr(_35reg2276);
-Obj _35reg2278 = primCdr(_35reg2277);
-Obj _35reg2279 = primCar(_35reg2278);
-Obj body = _35reg2279;
-Obj _35reg2280 = primCdr(_35p1311);
-Obj _35reg2281 = primCar(_35reg2280);
-Obj _35reg2282 = primCdr(_35reg2281);
-Obj _35reg2283 = primCdr(_35reg2282);
-Obj _35reg2284 = primCdr(_35reg2283);
-Obj _35reg2285 = primEQ(Nil, _35reg2284);
-if (True == _35reg2285) {
-Obj _35reg2286 = primCdr(_35p1311);
-Obj _35reg2287 = primCdr(_35reg2286);
-Obj fvs = _35reg2287;
-Obj k = _35p1312;
-Obj _35reg2288 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2288) {
-if (True == True) {
-Obj _35reg2289 = primGenSym(intern("clofun"));
-Obj name = _35reg2289;
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3046, 2, 5, k, params, clo_45or_45cont, name, fvs));
-} else {
-coraCall(co, 1, _35cc1313);
-}
-} else {
-Obj _35reg2311 = primEQ(clo_45or_45cont, intern("%continuation"));
-if (True == _35reg2311) {
-if (True == True) {
-Obj _35reg2312 = primGenSym(intern("clofun"));
-Obj name = _35reg2312;
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3048, 2, 5, k, params, clo_45or_45cont, name, fvs));
-} else {
-coraCall(co, 1, _35cc1313);
-}
-} else {
-if (True == False) {
-Obj _35reg2334 = primGenSym(intern("clofun"));
-Obj name = _35reg2334;
-coraCall(co, 4, globalRef(intern("cora/lib/toc.collect-lambda")), res, body, makeNative(0, _35clofun3050, 2, 5, k, params, clo_45or_45cont, name, fvs));
-} else {
-coraCall(co, 1, _35cc1313);
-}
-}
-}
-} else {
-coraCall(co, 1, _35cc1313);
-}
-} else {
-coraCall(co, 1, _35cc1313);
-}
-} else {
-coraCall(co, 1, _35cc1313);
-}
-} else {
-coraCall(co, 1, _35cc1313);
-}
-} else {
-coraCall(co, 1, _35cc1313);
-}
-} else {
-coraCall(co, 1, _35cc1313);
-}
-} else {
-coraCall(co, 1, _35cc1313);
-}
-}
-
 void _35clofun3050(struct Cora* co) {
-Obj res1 = co->args[1];
-Obj body1 = co->args[2];
-Obj _35reg2335 = primEQ(closureRef(co, 2), intern("%closure"));
-if (True == _35reg2335) {
-Obj _35reg2336 = primCons(body1, Nil);
-Obj _35reg2337 = primCons(Nil, _35reg2336);
-Obj _35reg2338 = primCons(closureRef(co, 1), _35reg2337);
-Obj _35reg2339 = primCons(intern("lambda"), _35reg2338);
-Obj _35reg2340 = primCons(_35reg2339, Nil);
-Obj _35reg2341 = primCons(closureRef(co, 3), _35reg2340);
-Obj _35reg2342 = primCons(_35reg2341, res1);
-pushCont(co, 0, _35clofun3051, 1, _35reg2342);
-coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
-} else {
-Obj _35reg2347 = primCons(body1, Nil);
-Obj _35reg2348 = primCons(closureRef(co, 4), _35reg2347);
-Obj _35reg2349 = primCons(closureRef(co, 1), _35reg2348);
-Obj _35reg2350 = primCons(intern("lambda"), _35reg2349);
-Obj _35reg2351 = primCons(_35reg2350, Nil);
-Obj _35reg2352 = primCons(closureRef(co, 3), _35reg2351);
-Obj _35reg2353 = primCons(_35reg2352, res1);
-Obj _35reg2354 = primCons(closureRef(co, 3), closureRef(co, 4));
-Obj _35reg2355 = primCons(closureRef(co, 2), _35reg2354);
-coraCall(co, 3, closureRef(co, 0), _35reg2353, _35reg2355);
-}
-}
-
-void _35clofun3051(struct Cora* co) {
-Obj _35val2343 = co->args[1];
-Obj _35reg2342 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2344 = primCons(_35val2343, closureRef(co, 4));
-Obj _35reg2345 = primCons(closureRef(co, 3), _35reg2344);
-Obj _35reg2346 = primCons(closureRef(co, 2), _35reg2345);
-coraCall(co, 3, closureRef(co, 0), _35reg2342, _35reg2346);
-}
-
-void _35clofun3048(struct Cora* co) {
-Obj res1 = co->args[1];
-Obj body1 = co->args[2];
-Obj _35reg2313 = primEQ(closureRef(co, 2), intern("%closure"));
-if (True == _35reg2313) {
-Obj _35reg2314 = primCons(body1, Nil);
-Obj _35reg2315 = primCons(Nil, _35reg2314);
-Obj _35reg2316 = primCons(closureRef(co, 1), _35reg2315);
-Obj _35reg2317 = primCons(intern("lambda"), _35reg2316);
-Obj _35reg2318 = primCons(_35reg2317, Nil);
-Obj _35reg2319 = primCons(closureRef(co, 3), _35reg2318);
-Obj _35reg2320 = primCons(_35reg2319, res1);
-pushCont(co, 0, _35clofun3049, 1, _35reg2320);
-coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
-} else {
-Obj _35reg2325 = primCons(body1, Nil);
-Obj _35reg2326 = primCons(closureRef(co, 4), _35reg2325);
-Obj _35reg2327 = primCons(closureRef(co, 1), _35reg2326);
-Obj _35reg2328 = primCons(intern("lambda"), _35reg2327);
-Obj _35reg2329 = primCons(_35reg2328, Nil);
-Obj _35reg2330 = primCons(closureRef(co, 3), _35reg2329);
-Obj _35reg2331 = primCons(_35reg2330, res1);
-Obj _35reg2332 = primCons(closureRef(co, 3), closureRef(co, 4));
-Obj _35reg2333 = primCons(closureRef(co, 2), _35reg2332);
-coraCall(co, 3, closureRef(co, 0), _35reg2331, _35reg2333);
-}
-}
-
-void _35clofun3049(struct Cora* co) {
-Obj _35val2321 = co->args[1];
-Obj _35reg2320 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2322 = primCons(_35val2321, closureRef(co, 4));
-Obj _35reg2323 = primCons(closureRef(co, 3), _35reg2322);
-Obj _35reg2324 = primCons(closureRef(co, 2), _35reg2323);
-coraCall(co, 3, closureRef(co, 0), _35reg2320, _35reg2324);
-}
-
-void _35clofun3046(struct Cora* co) {
-Obj res1 = co->args[1];
-Obj body1 = co->args[2];
-Obj _35reg2290 = primEQ(closureRef(co, 2), intern("%closure"));
-if (True == _35reg2290) {
-Obj _35reg2291 = primCons(body1, Nil);
-Obj _35reg2292 = primCons(Nil, _35reg2291);
-Obj _35reg2293 = primCons(closureRef(co, 1), _35reg2292);
-Obj _35reg2294 = primCons(intern("lambda"), _35reg2293);
-Obj _35reg2295 = primCons(_35reg2294, Nil);
-Obj _35reg2296 = primCons(closureRef(co, 3), _35reg2295);
-Obj _35reg2297 = primCons(_35reg2296, res1);
-pushCont(co, 0, _35clofun3047, 1, _35reg2297);
-coraCall(co, 2, globalRef(intern("length")), closureRef(co, 1));
-} else {
-Obj _35reg2302 = primCons(body1, Nil);
-Obj _35reg2303 = primCons(closureRef(co, 4), _35reg2302);
-Obj _35reg2304 = primCons(closureRef(co, 1), _35reg2303);
-Obj _35reg2305 = primCons(intern("lambda"), _35reg2304);
-Obj _35reg2306 = primCons(_35reg2305, Nil);
-Obj _35reg2307 = primCons(closureRef(co, 3), _35reg2306);
-Obj _35reg2308 = primCons(_35reg2307, res1);
-Obj _35reg2309 = primCons(closureRef(co, 3), closureRef(co, 4));
-Obj _35reg2310 = primCons(closureRef(co, 2), _35reg2309);
-coraCall(co, 3, closureRef(co, 0), _35reg2308, _35reg2310);
-}
-}
-
-void _35clofun3047(struct Cora* co) {
-Obj _35val2298 = co->args[1];
-Obj _35reg2297 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2299 = primCons(_35val2298, closureRef(co, 4));
-Obj _35reg2300 = primCons(closureRef(co, 3), _35reg2299);
-Obj _35reg2301 = primCons(closureRef(co, 2), _35reg2300);
-coraCall(co, 3, closureRef(co, 0), _35reg2297, _35reg2301);
-}
-
-void _35clofun3043(struct Cora* co) {
-Obj _35cc1314 = makeNative(0, _35clofun3044, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj res = closureRef(co, 0);
-Obj f_45args = closureRef(co, 1);
-Obj k = closureRef(co, 2);
-Obj _35reg2250 = primIsCons(f_45args);
-if (True == _35reg2250) {
-coraCall(co, 5, globalRef(intern("cora/lib/toc.collect-lambda-list")), Nil, res, f_45args, k);
-} else {
-coraCall(co, 1, _35cc1314);
-}
-}
-
-void _35clofun3044(struct Cora* co) {
-Obj _35cc1315 = makeNative(0, _35clofun3045, 0, 0);
+Obj _35cc1321 = makeNative(0, _35clofun3051, 0, 0);
 Obj res = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 Obj k = closureRef(co, 2);
 coraCall(co, 3, k, res, x);
 }
 
-void _35clofun3045(struct Cora* co) {
+void _35clofun3051(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3024(struct Cora* co) {
-Obj _35p1302 = co->args[1];
-Obj _35p1303 = co->args[2];
-Obj _35cc1304 = makeNative(0, _35clofun3025, 0, 2, _35p1302, _35p1303);
-Obj __ = _35p1302;
-Obj x = _35p1303;
-pushCont(co, 0, _35clofun3041, 2, x, _35cc1304);
+void _35clofun3030(struct Cora* co) {
+Obj _35p1308 = co->args[1];
+Obj _35p1309 = co->args[2];
+Obj _35cc1310 = makeNative(0, _35clofun3031, 0, 2, _35p1308, _35p1309);
+Obj __ = _35p1308;
+Obj x = _35p1309;
+pushCont(co, 0, _35clofun3047, 2, x, _35cc1310);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 
-void _35clofun3041(struct Cora* co) {
-Obj _35val2248 = co->args[1];
+void _35clofun3047(struct Cora* co) {
+Obj _35val2254 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1304 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2248) {
+Obj _35cc1310 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val2254) {
 coraReturn(co, x);
 return;
 } else {
-coraCall(co, 1, _35cc1304);
-}
-}
-
-void _35clofun3025(struct Cora* co) {
-Obj _35cc1305 = makeNative(0, _35clofun3026, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj var = closureRef(co, 1);
-Obj _35reg2247 = primIsSymbol(var);
-if (True == _35reg2247) {
-coraReturn(co, var);
-return;
-} else {
-coraCall(co, 1, _35cc1305);
-}
-}
-
-void _35clofun3026(struct Cora* co) {
-Obj _35cc1306 = makeNative(0, _35clofun3027, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg2226 = primIsCons(closureRef(co, 1));
-if (True == _35reg2226) {
-Obj _35reg2227 = primCar(closureRef(co, 1));
-Obj _35reg2228 = primEQ(intern("lambda"), _35reg2227);
-if (True == _35reg2228) {
-Obj _35reg2229 = primCdr(closureRef(co, 1));
-Obj _35reg2230 = primIsCons(_35reg2229);
-if (True == _35reg2230) {
-Obj _35reg2231 = primCdr(closureRef(co, 1));
-Obj _35reg2232 = primCar(_35reg2231);
-Obj args = _35reg2232;
-Obj _35reg2233 = primCdr(closureRef(co, 1));
-Obj _35reg2234 = primCdr(_35reg2233);
-Obj _35reg2235 = primIsCons(_35reg2234);
-if (True == _35reg2235) {
-Obj _35reg2236 = primCdr(closureRef(co, 1));
-Obj _35reg2237 = primCdr(_35reg2236);
-Obj _35reg2238 = primCar(_35reg2237);
-Obj body = _35reg2238;
-Obj _35reg2239 = primCdr(closureRef(co, 1));
-Obj _35reg2240 = primCdr(_35reg2239);
-Obj _35reg2241 = primCdr(_35reg2240);
-Obj _35reg2242 = primEQ(Nil, _35reg2241);
-if (True == _35reg2242) {
-pushCont(co, 0, _35clofun3040, 1, args);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs, body);
-} else {
-coraCall(co, 1, _35cc1306);
-}
-} else {
-coraCall(co, 1, _35cc1306);
-}
-} else {
-coraCall(co, 1, _35cc1306);
-}
-} else {
-coraCall(co, 1, _35cc1306);
-}
-} else {
-coraCall(co, 1, _35cc1306);
-}
-}
-
-void _35clofun3040(struct Cora* co) {
-Obj _35val2243 = co->args[1];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2244 = primCons(_35val2243, Nil);
-Obj _35reg2245 = primCons(args, _35reg2244);
-Obj _35reg2246 = primCons(intern("lambda"), _35reg2245);
-coraReturn(co, _35reg2246);
-return;
-}
-
-void _35clofun3027(struct Cora* co) {
-Obj _35cc1307 = makeNative(0, _35clofun3028, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg2199 = primIsCons(closureRef(co, 1));
-if (True == _35reg2199) {
-Obj _35reg2200 = primCar(closureRef(co, 1));
-Obj _35reg2201 = primEQ(intern("continuation"), _35reg2200);
-if (True == _35reg2201) {
-Obj _35reg2202 = primCdr(closureRef(co, 1));
-Obj _35reg2203 = primIsCons(_35reg2202);
-if (True == _35reg2203) {
-Obj _35reg2204 = primCdr(closureRef(co, 1));
-Obj _35reg2205 = primCar(_35reg2204);
-Obj val = _35reg2205;
-Obj _35reg2206 = primCdr(closureRef(co, 1));
-Obj _35reg2207 = primCdr(_35reg2206);
-Obj _35reg2208 = primIsCons(_35reg2207);
-if (True == _35reg2208) {
-Obj _35reg2209 = primCdr(closureRef(co, 1));
-Obj _35reg2210 = primCdr(_35reg2209);
-Obj _35reg2211 = primCar(_35reg2210);
-Obj body = _35reg2211;
-Obj _35reg2212 = primCdr(closureRef(co, 1));
-Obj _35reg2213 = primCdr(_35reg2212);
-Obj _35reg2214 = primCdr(_35reg2213);
-Obj _35reg2215 = primEQ(Nil, _35reg2214);
-if (True == _35reg2215) {
-pushCont(co, 0, _35clofun3035, 3, fvs, body, val);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), body);
-} else {
-coraCall(co, 1, _35cc1307);
-}
-} else {
-coraCall(co, 1, _35cc1307);
-}
-} else {
-coraCall(co, 1, _35cc1307);
-}
-} else {
-coraCall(co, 1, _35cc1307);
-}
-} else {
-coraCall(co, 1, _35cc1307);
-}
-}
-
-void _35clofun3035(struct Cora* co) {
-Obj _35val2216 = co->args[1];
-Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3036, 3, fvs, body, val);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val2216, val);
-}
-
-void _35clofun3036(struct Cora* co) {
-Obj _35val2217 = co->args[1];
-Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs1 = _35val2217;
-pushCont(co, 0, _35clofun3037, 3, fvs1, body, val);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
-}
-
-void _35clofun3037(struct Cora* co) {
-Obj _35val2218 = co->args[1];
-Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3038, 3, fvs1, body, val);
-coraCall(co, 3, globalRef(intern("map")), _35val2218, fvs1);
-}
-
-void _35clofun3038(struct Cora* co) {
-Obj _35val2219 = co->args[1];
-Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs2 = _35val2219;
-pushCont(co, 0, _35clofun3039, 2, val, fvs2);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs1, body);
-}
-
-void _35clofun3039(struct Cora* co) {
-Obj _35val2220 = co->args[1];
-Obj val = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fvs2 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2221 = primCons(_35val2220, Nil);
-Obj _35reg2222 = primCons(val, _35reg2221);
-Obj _35reg2223 = primCons(intern("lambda"), _35reg2222);
-Obj _35reg2224 = primCons(_35reg2223, fvs2);
-Obj _35reg2225 = primCons(intern("%continuation"), _35reg2224);
-coraReturn(co, _35reg2225);
-return;
-}
-
-void _35clofun3028(struct Cora* co) {
-Obj _35cc1308 = makeNative(0, _35clofun3029, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg2176 = primIsCons(closureRef(co, 1));
-if (True == _35reg2176) {
-Obj _35reg2177 = primCar(closureRef(co, 1));
-Obj _35reg2178 = primEQ(intern("call"), _35reg2177);
-if (True == _35reg2178) {
-Obj _35reg2179 = primCdr(closureRef(co, 1));
-Obj _35reg2180 = primIsCons(_35reg2179);
-if (True == _35reg2180) {
-Obj _35reg2181 = primCdr(closureRef(co, 1));
-Obj _35reg2182 = primCar(_35reg2181);
-Obj exp = _35reg2182;
-Obj _35reg2183 = primCdr(closureRef(co, 1));
-Obj _35reg2184 = primCdr(_35reg2183);
-Obj _35reg2185 = primIsCons(_35reg2184);
-if (True == _35reg2185) {
-Obj _35reg2186 = primCdr(closureRef(co, 1));
-Obj _35reg2187 = primCdr(_35reg2186);
-Obj _35reg2188 = primCar(_35reg2187);
-Obj cont = _35reg2188;
-Obj _35reg2189 = primCdr(closureRef(co, 1));
-Obj _35reg2190 = primCdr(_35reg2189);
-Obj _35reg2191 = primCdr(_35reg2190);
-Obj _35reg2192 = primEQ(Nil, _35reg2191);
-if (True == _35reg2192) {
-pushCont(co, 0, _35clofun3032, 3, exp, fvs, cont);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
-} else {
-coraCall(co, 1, _35cc1308);
-}
-} else {
-coraCall(co, 1, _35cc1308);
-}
-} else {
-coraCall(co, 1, _35cc1308);
-}
-} else {
-coraCall(co, 1, _35cc1308);
-}
-} else {
-coraCall(co, 1, _35cc1308);
-}
-}
-
-void _35clofun3032(struct Cora* co) {
-Obj _35val2193 = co->args[1];
-Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cont = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun3033, 2, fvs, cont);
-coraCall(co, 3, globalRef(intern("map")), _35val2193, exp);
-}
-
-void _35clofun3033(struct Cora* co) {
-Obj _35val2194 = co->args[1];
-Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj cont = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3034, 1, _35val2194);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs, cont);
-}
-
-void _35clofun3034(struct Cora* co) {
-Obj _35val2195 = co->args[1];
-Obj _35val2194 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2196 = primCons(_35val2195, Nil);
-Obj _35reg2197 = primCons(_35val2194, _35reg2196);
-Obj _35reg2198 = primCons(intern("call"), _35reg2197);
-coraReturn(co, _35reg2198);
-return;
-}
-
-void _35clofun3029(struct Cora* co) {
-Obj _35cc1309 = makeNative(0, _35clofun3030, 0, 0);
-Obj fvs = closureRef(co, 0);
-Obj _35reg2171 = primIsCons(closureRef(co, 1));
-if (True == _35reg2171) {
-Obj _35reg2172 = primCar(closureRef(co, 1));
-Obj f = _35reg2172;
-Obj _35reg2173 = primCdr(closureRef(co, 1));
-Obj args = _35reg2173;
-pushCont(co, 0, _35clofun3031, 2, f, args);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
-} else {
-coraCall(co, 1, _35cc1309);
+coraCall(co, 1, _35cc1310);
 }
 }
 
 void _35clofun3031(struct Cora* co) {
-Obj _35val2174 = co->args[1];
-Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2175 = primCons(f, args);
-coraCall(co, 3, globalRef(intern("map")), _35val2174, _35reg2175);
+Obj _35cc1311 = makeNative(0, _35clofun3032, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj var = closureRef(co, 1);
+Obj _35reg2253 = primIsSymbol(var);
+if (True == _35reg2253) {
+coraReturn(co, var);
+return;
+} else {
+coraCall(co, 1, _35cc1311);
+}
 }
 
-void _35clofun3030(struct Cora* co) {
+void _35clofun3032(struct Cora* co) {
+Obj _35cc1312 = makeNative(0, _35clofun3033, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj _35reg2232 = primIsCons(closureRef(co, 1));
+if (True == _35reg2232) {
+Obj _35reg2233 = primCar(closureRef(co, 1));
+Obj _35reg2234 = primEQ(intern("lambda"), _35reg2233);
+if (True == _35reg2234) {
+Obj _35reg2235 = primCdr(closureRef(co, 1));
+Obj _35reg2236 = primIsCons(_35reg2235);
+if (True == _35reg2236) {
+Obj _35reg2237 = primCdr(closureRef(co, 1));
+Obj _35reg2238 = primCar(_35reg2237);
+Obj args = _35reg2238;
+Obj _35reg2239 = primCdr(closureRef(co, 1));
+Obj _35reg2240 = primCdr(_35reg2239);
+Obj _35reg2241 = primIsCons(_35reg2240);
+if (True == _35reg2241) {
+Obj _35reg2242 = primCdr(closureRef(co, 1));
+Obj _35reg2243 = primCdr(_35reg2242);
+Obj _35reg2244 = primCar(_35reg2243);
+Obj body = _35reg2244;
+Obj _35reg2245 = primCdr(closureRef(co, 1));
+Obj _35reg2246 = primCdr(_35reg2245);
+Obj _35reg2247 = primCdr(_35reg2246);
+Obj _35reg2248 = primEQ(Nil, _35reg2247);
+if (True == _35reg2248) {
+pushCont(co, 0, _35clofun3046, 1, args);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs, body);
+} else {
+coraCall(co, 1, _35cc1312);
+}
+} else {
+coraCall(co, 1, _35cc1312);
+}
+} else {
+coraCall(co, 1, _35cc1312);
+}
+} else {
+coraCall(co, 1, _35cc1312);
+}
+} else {
+coraCall(co, 1, _35cc1312);
+}
+}
+
+void _35clofun3046(struct Cora* co) {
+Obj _35val2249 = co->args[1];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2250 = primCons(_35val2249, Nil);
+Obj _35reg2251 = primCons(args, _35reg2250);
+Obj _35reg2252 = primCons(intern("lambda"), _35reg2251);
+coraReturn(co, _35reg2252);
+return;
+}
+
+void _35clofun3033(struct Cora* co) {
+Obj _35cc1313 = makeNative(0, _35clofun3034, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj _35reg2205 = primIsCons(closureRef(co, 1));
+if (True == _35reg2205) {
+Obj _35reg2206 = primCar(closureRef(co, 1));
+Obj _35reg2207 = primEQ(intern("continuation"), _35reg2206);
+if (True == _35reg2207) {
+Obj _35reg2208 = primCdr(closureRef(co, 1));
+Obj _35reg2209 = primIsCons(_35reg2208);
+if (True == _35reg2209) {
+Obj _35reg2210 = primCdr(closureRef(co, 1));
+Obj _35reg2211 = primCar(_35reg2210);
+Obj val = _35reg2211;
+Obj _35reg2212 = primCdr(closureRef(co, 1));
+Obj _35reg2213 = primCdr(_35reg2212);
+Obj _35reg2214 = primIsCons(_35reg2213);
+if (True == _35reg2214) {
+Obj _35reg2215 = primCdr(closureRef(co, 1));
+Obj _35reg2216 = primCdr(_35reg2215);
+Obj _35reg2217 = primCar(_35reg2216);
+Obj body = _35reg2217;
+Obj _35reg2218 = primCdr(closureRef(co, 1));
+Obj _35reg2219 = primCdr(_35reg2218);
+Obj _35reg2220 = primCdr(_35reg2219);
+Obj _35reg2221 = primEQ(Nil, _35reg2220);
+if (True == _35reg2221) {
+pushCont(co, 0, _35clofun3041, 3, fvs, body, val);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), body);
+} else {
+coraCall(co, 1, _35cc1313);
+}
+} else {
+coraCall(co, 1, _35cc1313);
+}
+} else {
+coraCall(co, 1, _35cc1313);
+}
+} else {
+coraCall(co, 1, _35cc1313);
+}
+} else {
+coraCall(co, 1, _35cc1313);
+}
+}
+
+void _35clofun3041(struct Cora* co) {
+Obj _35val2222 = co->args[1];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3042, 3, fvs, body, val);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val2222, val);
+}
+
+void _35clofun3042(struct Cora* co) {
+Obj _35val2223 = co->args[1];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj fvs1 = _35val2223;
+pushCont(co, 0, _35clofun3043, 3, fvs1, body, val);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
+}
+
+void _35clofun3043(struct Cora* co) {
+Obj _35val2224 = co->args[1];
+Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3044, 3, fvs1, body, val);
+coraCall(co, 3, globalRef(intern("map")), _35val2224, fvs1);
+}
+
+void _35clofun3044(struct Cora* co) {
+Obj _35val2225 = co->args[1];
+Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj fvs2 = _35val2225;
+pushCont(co, 0, _35clofun3045, 2, val, fvs2);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs1, body);
+}
+
+void _35clofun3045(struct Cora* co) {
+Obj _35val2226 = co->args[1];
+Obj val = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs2 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2227 = primCons(_35val2226, Nil);
+Obj _35reg2228 = primCons(val, _35reg2227);
+Obj _35reg2229 = primCons(intern("lambda"), _35reg2228);
+Obj _35reg2230 = primCons(_35reg2229, fvs2);
+Obj _35reg2231 = primCons(intern("%continuation"), _35reg2230);
+coraReturn(co, _35reg2231);
+return;
+}
+
+void _35clofun3034(struct Cora* co) {
+Obj _35cc1314 = makeNative(0, _35clofun3035, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj _35reg2182 = primIsCons(closureRef(co, 1));
+if (True == _35reg2182) {
+Obj _35reg2183 = primCar(closureRef(co, 1));
+Obj _35reg2184 = primEQ(intern("call"), _35reg2183);
+if (True == _35reg2184) {
+Obj _35reg2185 = primCdr(closureRef(co, 1));
+Obj _35reg2186 = primIsCons(_35reg2185);
+if (True == _35reg2186) {
+Obj _35reg2187 = primCdr(closureRef(co, 1));
+Obj _35reg2188 = primCar(_35reg2187);
+Obj exp = _35reg2188;
+Obj _35reg2189 = primCdr(closureRef(co, 1));
+Obj _35reg2190 = primCdr(_35reg2189);
+Obj _35reg2191 = primIsCons(_35reg2190);
+if (True == _35reg2191) {
+Obj _35reg2192 = primCdr(closureRef(co, 1));
+Obj _35reg2193 = primCdr(_35reg2192);
+Obj _35reg2194 = primCar(_35reg2193);
+Obj cont = _35reg2194;
+Obj _35reg2195 = primCdr(closureRef(co, 1));
+Obj _35reg2196 = primCdr(_35reg2195);
+Obj _35reg2197 = primCdr(_35reg2196);
+Obj _35reg2198 = primEQ(Nil, _35reg2197);
+if (True == _35reg2198) {
+pushCont(co, 0, _35clofun3038, 3, exp, fvs, cont);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
+} else {
+coraCall(co, 1, _35cc1314);
+}
+} else {
+coraCall(co, 1, _35cc1314);
+}
+} else {
+coraCall(co, 1, _35cc1314);
+}
+} else {
+coraCall(co, 1, _35cc1314);
+}
+} else {
+coraCall(co, 1, _35cc1314);
+}
+}
+
+void _35clofun3038(struct Cora* co) {
+Obj _35val2199 = co->args[1];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cont = co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, _35clofun3039, 2, fvs, cont);
+coraCall(co, 3, globalRef(intern("map")), _35val2199, exp);
+}
+
+void _35clofun3039(struct Cora* co) {
+Obj _35val2200 = co->args[1];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cont = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun3040, 1, _35val2200);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.explicit-stack")), fvs, cont);
+}
+
+void _35clofun3040(struct Cora* co) {
+Obj _35val2201 = co->args[1];
+Obj _35val2200 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2202 = primCons(_35val2201, Nil);
+Obj _35reg2203 = primCons(_35val2200, _35reg2202);
+Obj _35reg2204 = primCons(intern("call"), _35reg2203);
+coraReturn(co, _35reg2204);
+return;
+}
+
+void _35clofun3035(struct Cora* co) {
+Obj _35cc1315 = makeNative(0, _35clofun3036, 0, 0);
+Obj fvs = closureRef(co, 0);
+Obj _35reg2177 = primIsCons(closureRef(co, 1));
+if (True == _35reg2177) {
+Obj _35reg2178 = primCar(closureRef(co, 1));
+Obj f = _35reg2178;
+Obj _35reg2179 = primCdr(closureRef(co, 1));
+Obj args = _35reg2179;
+pushCont(co, 0, _35clofun3037, 2, f, args);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.explicit-stack")), fvs);
+} else {
+coraCall(co, 1, _35cc1315);
+}
+}
+
+void _35clofun3037(struct Cora* co) {
+Obj _35val2180 = co->args[1];
+Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2181 = primCons(f, args);
+coraCall(co, 3, globalRef(intern("map")), _35val2180, _35reg2181);
+}
+
+void _35clofun3036(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun3014(struct Cora* co) {
-Obj _35p1297 = co->args[1];
-Obj _35p1298 = co->args[2];
-Obj _35p1299 = co->args[3];
-Obj _35cc1300 = makeNative(0, _35clofun3015, 0, 3, _35p1297, _35p1298, _35p1299);
-Obj _35reg2128 = primEQ(Nil, _35p1297);
-if (True == _35reg2128) {
-Obj ls = _35p1298;
-Obj next = _35p1299;
-pushCont(co, 0, _35clofun3018, 1, next);
+void _35clofun3020(struct Cora* co) {
+Obj _35p1303 = co->args[1];
+Obj _35p1304 = co->args[2];
+Obj _35p1305 = co->args[3];
+Obj _35cc1306 = makeNative(0, _35clofun3021, 0, 3, _35p1303, _35p1304, _35p1305);
+Obj _35reg2134 = primEQ(Nil, _35p1303);
+if (True == _35reg2134) {
+Obj ls = _35p1304;
+Obj next = _35p1305;
+pushCont(co, 0, _35clofun3024, 1, next);
 coraCall(co, 2, globalRef(intern("reverse")), ls);
 } else {
-coraCall(co, 1, _35cc1300);
+coraCall(co, 1, _35cc1306);
 }
 }
 
-void _35clofun3018(struct Cora* co) {
-Obj _35val2129 = co->args[1];
+void _35clofun3024(struct Cora* co) {
+Obj _35val2135 = co->args[1];
 Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp = _35val2129;
-Obj _35reg2130 = primCar(exp);
-pushCont(co, 0, _35clofun3019, 2, next, exp);
-coraCall(co, 2, globalRef(intern("pair?")), _35reg2130);
+Obj exp = _35val2135;
+Obj _35reg2136 = primCar(exp);
+pushCont(co, 0, _35clofun3025, 2, next, exp);
+coraCall(co, 2, globalRef(intern("pair?")), _35reg2136);
 }
 
-void _35clofun3019(struct Cora* co) {
-Obj _35val2131 = co->args[1];
+void _35clofun3025(struct Cora* co) {
+Obj _35val2137 = co->args[1];
 Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2131) {
-pushCont(co, 0, _35clofun3020, 2, next, exp);
+if (True == _35val2137) {
+pushCont(co, 0, _35clofun3026, 2, next, exp);
 coraCall(co, 2, globalRef(intern("caar")), exp);
 } else {
 if (True == False) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.wrap-var")), exp, next);
 } else {
-Obj _35reg2158 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
-if (True == _35reg2158) {
-Obj _35reg2159 = primCons(exp, Nil);
-Obj _35reg2160 = primCons(intern("tailcall"), _35reg2159);
-coraReturn(co, _35reg2160);
+Obj _35reg2164 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
+if (True == _35reg2164) {
+Obj _35reg2165 = primCons(exp, Nil);
+Obj _35reg2166 = primCons(intern("tailcall"), _35reg2165);
+coraReturn(co, _35reg2166);
 return;
 } else {
-Obj _35reg2161 = primGenSym(intern("val"));
-Obj val = _35reg2161;
-Obj _35reg2162 = primCons(val, Nil);
-pushCont(co, 0, _35clofun3023, 2, _35reg2162, exp);
+Obj _35reg2167 = primGenSym(intern("val"));
+Obj val = _35reg2167;
+Obj _35reg2168 = primCons(val, Nil);
+pushCont(co, 0, _35clofun3029, 2, _35reg2168, exp);
 coraCall(co, 2, next, val);
 }
 }
 }
 }
 
-void _35clofun3023(struct Cora* co) {
-Obj _35val2163 = co->args[1];
-Obj _35reg2162 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+void _35clofun3029(struct Cora* co) {
+Obj _35val2169 = co->args[1];
+Obj _35reg2168 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2164 = primCons(_35val2163, Nil);
-Obj _35reg2165 = primCons(_35reg2162, _35reg2164);
-Obj _35reg2166 = primCons(intern("continuation"), _35reg2165);
-Obj _35reg2167 = primCons(_35reg2166, Nil);
-Obj _35reg2168 = primCons(exp, _35reg2167);
-Obj _35reg2169 = primCons(intern("call"), _35reg2168);
-coraReturn(co, _35reg2169);
+Obj _35reg2170 = primCons(_35val2169, Nil);
+Obj _35reg2171 = primCons(_35reg2168, _35reg2170);
+Obj _35reg2172 = primCons(intern("continuation"), _35reg2171);
+Obj _35reg2173 = primCons(_35reg2172, Nil);
+Obj _35reg2174 = primCons(exp, _35reg2173);
+Obj _35reg2175 = primCons(intern("call"), _35reg2174);
+coraReturn(co, _35reg2175);
 return;
 }
 
-void _35clofun3020(struct Cora* co) {
-Obj _35val2132 = co->args[1];
+void _35clofun3026(struct Cora* co) {
+Obj _35val2138 = co->args[1];
 Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2133 = primEQ(_35val2132, intern("%builtin"));
-if (True == _35reg2133) {
+Obj _35reg2139 = primEQ(_35val2138, intern("%builtin"));
+if (True == _35reg2139) {
 if (True == True) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.wrap-var")), exp, next);
 } else {
-Obj _35reg2134 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
-if (True == _35reg2134) {
-Obj _35reg2135 = primCons(exp, Nil);
-Obj _35reg2136 = primCons(intern("tailcall"), _35reg2135);
-coraReturn(co, _35reg2136);
+Obj _35reg2140 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
+if (True == _35reg2140) {
+Obj _35reg2141 = primCons(exp, Nil);
+Obj _35reg2142 = primCons(intern("tailcall"), _35reg2141);
+coraReturn(co, _35reg2142);
 return;
 } else {
-Obj _35reg2137 = primGenSym(intern("val"));
-Obj val = _35reg2137;
-Obj _35reg2138 = primCons(val, Nil);
-pushCont(co, 0, _35clofun3021, 2, _35reg2138, exp);
+Obj _35reg2143 = primGenSym(intern("val"));
+Obj val = _35reg2143;
+Obj _35reg2144 = primCons(val, Nil);
+pushCont(co, 0, _35clofun3027, 2, _35reg2144, exp);
 coraCall(co, 2, next, val);
 }
 }
@@ -3551,1039 +3551,745 @@ coraCall(co, 2, next, val);
 if (True == False) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.wrap-var")), exp, next);
 } else {
-Obj _35reg2146 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
-if (True == _35reg2146) {
-Obj _35reg2147 = primCons(exp, Nil);
-Obj _35reg2148 = primCons(intern("tailcall"), _35reg2147);
-coraReturn(co, _35reg2148);
+Obj _35reg2152 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
+if (True == _35reg2152) {
+Obj _35reg2153 = primCons(exp, Nil);
+Obj _35reg2154 = primCons(intern("tailcall"), _35reg2153);
+coraReturn(co, _35reg2154);
 return;
 } else {
-Obj _35reg2149 = primGenSym(intern("val"));
-Obj val = _35reg2149;
-Obj _35reg2150 = primCons(val, Nil);
-pushCont(co, 0, _35clofun3022, 2, _35reg2150, exp);
+Obj _35reg2155 = primGenSym(intern("val"));
+Obj val = _35reg2155;
+Obj _35reg2156 = primCons(val, Nil);
+pushCont(co, 0, _35clofun3028, 2, _35reg2156, exp);
 coraCall(co, 2, next, val);
 }
 }
 }
 }
 
-void _35clofun3022(struct Cora* co) {
-Obj _35val2151 = co->args[1];
-Obj _35reg2150 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+void _35clofun3028(struct Cora* co) {
+Obj _35val2157 = co->args[1];
+Obj _35reg2156 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2152 = primCons(_35val2151, Nil);
-Obj _35reg2153 = primCons(_35reg2150, _35reg2152);
-Obj _35reg2154 = primCons(intern("continuation"), _35reg2153);
-Obj _35reg2155 = primCons(_35reg2154, Nil);
-Obj _35reg2156 = primCons(exp, _35reg2155);
-Obj _35reg2157 = primCons(intern("call"), _35reg2156);
-coraReturn(co, _35reg2157);
+Obj _35reg2158 = primCons(_35val2157, Nil);
+Obj _35reg2159 = primCons(_35reg2156, _35reg2158);
+Obj _35reg2160 = primCons(intern("continuation"), _35reg2159);
+Obj _35reg2161 = primCons(_35reg2160, Nil);
+Obj _35reg2162 = primCons(exp, _35reg2161);
+Obj _35reg2163 = primCons(intern("call"), _35reg2162);
+coraReturn(co, _35reg2163);
+return;
+}
+
+void _35clofun3027(struct Cora* co) {
+Obj _35val2145 = co->args[1];
+Obj _35reg2144 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2146 = primCons(_35val2145, Nil);
+Obj _35reg2147 = primCons(_35reg2144, _35reg2146);
+Obj _35reg2148 = primCons(intern("continuation"), _35reg2147);
+Obj _35reg2149 = primCons(_35reg2148, Nil);
+Obj _35reg2150 = primCons(exp, _35reg2149);
+Obj _35reg2151 = primCons(intern("call"), _35reg2150);
+coraReturn(co, _35reg2151);
 return;
 }
 
 void _35clofun3021(struct Cora* co) {
-Obj _35val2139 = co->args[1];
-Obj _35reg2138 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2140 = primCons(_35val2139, Nil);
-Obj _35reg2141 = primCons(_35reg2138, _35reg2140);
-Obj _35reg2142 = primCons(intern("continuation"), _35reg2141);
-Obj _35reg2143 = primCons(_35reg2142, Nil);
-Obj _35reg2144 = primCons(exp, _35reg2143);
-Obj _35reg2145 = primCons(intern("call"), _35reg2144);
-coraReturn(co, _35reg2145);
+Obj _35cc1307 = makeNative(0, _35clofun3022, 0, 0);
+Obj _35reg2130 = primIsCons(closureRef(co, 0));
+if (True == _35reg2130) {
+Obj _35reg2131 = primCar(closureRef(co, 0));
+Obj hd = _35reg2131;
+Obj _35reg2132 = primCdr(closureRef(co, 0));
+Obj tl = _35reg2132;
+Obj ls = closureRef(co, 1);
+Obj next = closureRef(co, 2);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), hd, makeNative(0, _35clofun3023, 1, 3, tl, ls, next));
+} else {
+coraCall(co, 1, _35cc1307);
+}
+}
+
+void _35clofun3023(struct Cora* co) {
+Obj hd1 = co->args[1];
+Obj _35reg2133 = primCons(hd1, closureRef(co, 1));
+coraCall(co, 4, globalRef(intern("cora/lib/toc.tailify-list")), closureRef(co, 0), _35reg2133, closureRef(co, 2));
+}
+
+void _35clofun3022(struct Cora* co) {
+coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
+}
+
+void _35clofun3002(struct Cora* co) {
+Obj _35p1294 = co->args[1];
+Obj _35p1295 = co->args[2];
+Obj _35cc1296 = makeNative(0, _35clofun3003, 0, 2, _35p1294, _35p1295);
+Obj x = _35p1294;
+Obj next = _35p1295;
+Obj _35reg2127 = primIsSymbol(x);
+if (True == _35reg2127) {
+if (True == True) {
+coraCall(co, 2, next, x);
+} else {
+coraCall(co, 1, _35cc1296);
+}
+} else {
+pushCont(co, 0, _35clofun3019, 3, next, x, _35cc1296);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
+}
+}
+
+void _35clofun3019(struct Cora* co) {
+Obj _35val2128 = co->args[1];
+Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc1296 = co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val2128) {
+if (True == True) {
+coraCall(co, 2, next, x);
+} else {
+coraCall(co, 1, _35cc1296);
+}
+} else {
+if (True == False) {
+coraCall(co, 2, next, x);
+} else {
+coraCall(co, 1, _35cc1296);
+}
+}
+}
+
+void _35clofun3003(struct Cora* co) {
+Obj _35cc1297 = makeNative(0, _35clofun3004, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x = closureRef(co, 0);
+Obj __ = closureRef(co, 1);
+pushCont(co, 0, _35clofun3018, 2, x, _35cc1297);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
+}
+
+void _35clofun3018(struct Cora* co) {
+Obj _35val2126 = co->args[1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1297 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val2126) {
+coraReturn(co, x);
 return;
+} else {
+coraCall(co, 1, _35cc1297);
+}
+}
+
+void _35clofun3004(struct Cora* co) {
+Obj _35cc1298 = makeNative(0, _35clofun3005, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2094 = primIsCons(closureRef(co, 0));
+if (True == _35reg2094) {
+Obj _35reg2095 = primCar(closureRef(co, 0));
+Obj _35reg2096 = primEQ(intern("if"), _35reg2095);
+if (True == _35reg2096) {
+Obj _35reg2097 = primCdr(closureRef(co, 0));
+Obj _35reg2098 = primIsCons(_35reg2097);
+if (True == _35reg2098) {
+Obj _35reg2099 = primCdr(closureRef(co, 0));
+Obj _35reg2100 = primCar(_35reg2099);
+Obj a = _35reg2100;
+Obj _35reg2101 = primCdr(closureRef(co, 0));
+Obj _35reg2102 = primCdr(_35reg2101);
+Obj _35reg2103 = primIsCons(_35reg2102);
+if (True == _35reg2103) {
+Obj _35reg2104 = primCdr(closureRef(co, 0));
+Obj _35reg2105 = primCdr(_35reg2104);
+Obj _35reg2106 = primCar(_35reg2105);
+Obj b = _35reg2106;
+Obj _35reg2107 = primCdr(closureRef(co, 0));
+Obj _35reg2108 = primCdr(_35reg2107);
+Obj _35reg2109 = primCdr(_35reg2108);
+Obj _35reg2110 = primIsCons(_35reg2109);
+if (True == _35reg2110) {
+Obj _35reg2111 = primCdr(closureRef(co, 0));
+Obj _35reg2112 = primCdr(_35reg2111);
+Obj _35reg2113 = primCdr(_35reg2112);
+Obj _35reg2114 = primCar(_35reg2113);
+Obj c = _35reg2114;
+Obj _35reg2115 = primCdr(closureRef(co, 0));
+Obj _35reg2116 = primCdr(_35reg2115);
+Obj _35reg2117 = primCdr(_35reg2116);
+Obj _35reg2118 = primCdr(_35reg2117);
+Obj _35reg2119 = primEQ(Nil, _35reg2118);
+if (True == _35reg2119) {
+Obj next = closureRef(co, 1);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), a, makeNative(0, _35clofun3015, 1, 3, b, c, next));
+} else {
+coraCall(co, 1, _35cc1298);
+}
+} else {
+coraCall(co, 1, _35cc1298);
+}
+} else {
+coraCall(co, 1, _35cc1298);
+}
+} else {
+coraCall(co, 1, _35cc1298);
+}
+} else {
+coraCall(co, 1, _35cc1298);
+}
+} else {
+coraCall(co, 1, _35cc1298);
+}
 }
 
 void _35clofun3015(struct Cora* co) {
-Obj _35cc1301 = makeNative(0, _35clofun3016, 0, 0);
-Obj _35reg2124 = primIsCons(closureRef(co, 0));
-if (True == _35reg2124) {
-Obj _35reg2125 = primCar(closureRef(co, 0));
-Obj hd = _35reg2125;
-Obj _35reg2126 = primCdr(closureRef(co, 0));
-Obj tl = _35reg2126;
-Obj ls = closureRef(co, 1);
-Obj next = closureRef(co, 2);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), hd, makeNative(0, _35clofun3017, 1, 3, tl, ls, next));
+Obj ra = co->args[1];
+pushCont(co, 0, _35clofun3016, 1, ra);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), closureRef(co, 2));
+}
+
+void _35clofun3016(struct Cora* co) {
+Obj _35val2120 = co->args[1];
+Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 0, _35clofun3017, 2, _35val2120, ra);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 1), closureRef(co, 2));
+}
+
+void _35clofun3017(struct Cora* co) {
+Obj _35val2121 = co->args[1];
+Obj _35val2120 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2122 = primCons(_35val2121, Nil);
+Obj _35reg2123 = primCons(_35val2120, _35reg2122);
+Obj _35reg2124 = primCons(ra, _35reg2123);
+Obj _35reg2125 = primCons(intern("if"), _35reg2124);
+coraReturn(co, _35reg2125);
+return;
+}
+
+void _35clofun3005(struct Cora* co) {
+Obj _35cc1299 = makeNative(0, _35clofun3006, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2072 = primIsCons(closureRef(co, 0));
+if (True == _35reg2072) {
+Obj _35reg2073 = primCar(closureRef(co, 0));
+Obj _35reg2074 = primEQ(intern("do"), _35reg2073);
+if (True == _35reg2074) {
+Obj _35reg2075 = primCdr(closureRef(co, 0));
+Obj _35reg2076 = primIsCons(_35reg2075);
+if (True == _35reg2076) {
+Obj _35reg2077 = primCdr(closureRef(co, 0));
+Obj _35reg2078 = primCar(_35reg2077);
+Obj a = _35reg2078;
+Obj _35reg2079 = primCdr(closureRef(co, 0));
+Obj _35reg2080 = primCdr(_35reg2079);
+Obj _35reg2081 = primIsCons(_35reg2080);
+if (True == _35reg2081) {
+Obj _35reg2082 = primCdr(closureRef(co, 0));
+Obj _35reg2083 = primCdr(_35reg2082);
+Obj _35reg2084 = primCar(_35reg2083);
+Obj b = _35reg2084;
+Obj _35reg2085 = primCdr(closureRef(co, 0));
+Obj _35reg2086 = primCdr(_35reg2085);
+Obj _35reg2087 = primCdr(_35reg2086);
+Obj _35reg2088 = primEQ(Nil, _35reg2087);
+if (True == _35reg2088) {
+Obj next = closureRef(co, 1);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), a, makeNative(0, _35clofun3013, 1, 2, b, next));
+} else {
+coraCall(co, 1, _35cc1299);
+}
+} else {
+coraCall(co, 1, _35cc1299);
+}
+} else {
+coraCall(co, 1, _35cc1299);
+}
+} else {
+coraCall(co, 1, _35cc1299);
+}
+} else {
+coraCall(co, 1, _35cc1299);
+}
+}
+
+void _35clofun3013(struct Cora* co) {
+Obj ra = co->args[1];
+Obj _35reg2089 = primIsSymbol(ra);
+if (True == _35reg2089) {
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), closureRef(co, 1));
+} else {
+pushCont(co, 0, _35clofun3014, 1, ra);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), closureRef(co, 1));
+}
+}
+
+void _35clofun3014(struct Cora* co) {
+Obj _35val2090 = co->args[1];
+Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2091 = primCons(_35val2090, Nil);
+Obj _35reg2092 = primCons(ra, _35reg2091);
+Obj _35reg2093 = primCons(intern("do"), _35reg2092);
+coraReturn(co, _35reg2093);
+return;
+}
+
+void _35clofun3006(struct Cora* co) {
+Obj _35cc1300 = makeNative(0, _35clofun3007, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2041 = primIsCons(closureRef(co, 0));
+if (True == _35reg2041) {
+Obj _35reg2042 = primCar(closureRef(co, 0));
+Obj _35reg2043 = primEQ(intern("let"), _35reg2042);
+if (True == _35reg2043) {
+Obj _35reg2044 = primCdr(closureRef(co, 0));
+Obj _35reg2045 = primIsCons(_35reg2044);
+if (True == _35reg2045) {
+Obj _35reg2046 = primCdr(closureRef(co, 0));
+Obj _35reg2047 = primCar(_35reg2046);
+Obj a = _35reg2047;
+Obj _35reg2048 = primCdr(closureRef(co, 0));
+Obj _35reg2049 = primCdr(_35reg2048);
+Obj _35reg2050 = primIsCons(_35reg2049);
+if (True == _35reg2050) {
+Obj _35reg2051 = primCdr(closureRef(co, 0));
+Obj _35reg2052 = primCdr(_35reg2051);
+Obj _35reg2053 = primCar(_35reg2052);
+Obj b = _35reg2053;
+Obj _35reg2054 = primCdr(closureRef(co, 0));
+Obj _35reg2055 = primCdr(_35reg2054);
+Obj _35reg2056 = primCdr(_35reg2055);
+Obj _35reg2057 = primIsCons(_35reg2056);
+if (True == _35reg2057) {
+Obj _35reg2058 = primCdr(closureRef(co, 0));
+Obj _35reg2059 = primCdr(_35reg2058);
+Obj _35reg2060 = primCdr(_35reg2059);
+Obj _35reg2061 = primCar(_35reg2060);
+Obj c = _35reg2061;
+Obj _35reg2062 = primCdr(closureRef(co, 0));
+Obj _35reg2063 = primCdr(_35reg2062);
+Obj _35reg2064 = primCdr(_35reg2063);
+Obj _35reg2065 = primCdr(_35reg2064);
+Obj _35reg2066 = primEQ(Nil, _35reg2065);
+if (True == _35reg2066) {
+Obj next = closureRef(co, 1);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), b, makeNative(0, _35clofun3011, 1, 3, a, c, next));
+} else {
+coraCall(co, 1, _35cc1300);
+}
+} else {
+coraCall(co, 1, _35cc1300);
+}
+} else {
+coraCall(co, 1, _35cc1300);
+}
+} else {
+coraCall(co, 1, _35cc1300);
+}
+} else {
+coraCall(co, 1, _35cc1300);
+}
+} else {
+coraCall(co, 1, _35cc1300);
+}
+}
+
+void _35clofun3011(struct Cora* co) {
+Obj rb = co->args[1];
+pushCont(co, 0, _35clofun3012, 1, rb);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 1), closureRef(co, 2));
+}
+
+void _35clofun3012(struct Cora* co) {
+Obj _35val2067 = co->args[1];
+Obj rb = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2068 = primCons(_35val2067, Nil);
+Obj _35reg2069 = primCons(rb, _35reg2068);
+Obj _35reg2070 = primCons(closureRef(co, 0), _35reg2069);
+Obj _35reg2071 = primCons(intern("let"), _35reg2070);
+coraReturn(co, _35reg2071);
+return;
+}
+
+void _35clofun3007(struct Cora* co) {
+Obj _35cc1301 = makeNative(0, _35clofun3008, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1997 = primIsCons(closureRef(co, 0));
+if (True == _35reg1997) {
+Obj _35reg1998 = primCar(closureRef(co, 0));
+Obj _35reg1999 = primEQ(intern("%closure"), _35reg1998);
+if (True == _35reg1999) {
+Obj _35reg2000 = primCdr(closureRef(co, 0));
+Obj _35reg2001 = primIsCons(_35reg2000);
+if (True == _35reg2001) {
+Obj _35reg2002 = primCdr(closureRef(co, 0));
+Obj _35reg2003 = primCar(_35reg2002);
+Obj _35reg2004 = primIsCons(_35reg2003);
+if (True == _35reg2004) {
+Obj _35reg2005 = primCdr(closureRef(co, 0));
+Obj _35reg2006 = primCar(_35reg2005);
+Obj _35reg2007 = primCar(_35reg2006);
+Obj _35reg2008 = primEQ(intern("lambda"), _35reg2007);
+if (True == _35reg2008) {
+Obj _35reg2009 = primCdr(closureRef(co, 0));
+Obj _35reg2010 = primCar(_35reg2009);
+Obj _35reg2011 = primCdr(_35reg2010);
+Obj _35reg2012 = primIsCons(_35reg2011);
+if (True == _35reg2012) {
+Obj _35reg2013 = primCdr(closureRef(co, 0));
+Obj _35reg2014 = primCar(_35reg2013);
+Obj _35reg2015 = primCdr(_35reg2014);
+Obj _35reg2016 = primCar(_35reg2015);
+Obj args = _35reg2016;
+Obj _35reg2017 = primCdr(closureRef(co, 0));
+Obj _35reg2018 = primCar(_35reg2017);
+Obj _35reg2019 = primCdr(_35reg2018);
+Obj _35reg2020 = primCdr(_35reg2019);
+Obj _35reg2021 = primIsCons(_35reg2020);
+if (True == _35reg2021) {
+Obj _35reg2022 = primCdr(closureRef(co, 0));
+Obj _35reg2023 = primCar(_35reg2022);
+Obj _35reg2024 = primCdr(_35reg2023);
+Obj _35reg2025 = primCdr(_35reg2024);
+Obj _35reg2026 = primCar(_35reg2025);
+Obj body = _35reg2026;
+Obj _35reg2027 = primCdr(closureRef(co, 0));
+Obj _35reg2028 = primCar(_35reg2027);
+Obj _35reg2029 = primCdr(_35reg2028);
+Obj _35reg2030 = primCdr(_35reg2029);
+Obj _35reg2031 = primCdr(_35reg2030);
+Obj _35reg2032 = primEQ(Nil, _35reg2031);
+if (True == _35reg2032) {
+Obj _35reg2033 = primCdr(closureRef(co, 0));
+Obj _35reg2034 = primCdr(_35reg2033);
+Obj frees = _35reg2034;
+Obj next = closureRef(co, 1);
+pushCont(co, 0, _35clofun3010, 3, args, frees, next);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), body, globalRef(intern("cora/lib/toc.id")));
+} else {
+coraCall(co, 1, _35cc1301);
+}
+} else {
+coraCall(co, 1, _35cc1301);
+}
+} else {
+coraCall(co, 1, _35cc1301);
+}
+} else {
+coraCall(co, 1, _35cc1301);
+}
+} else {
+coraCall(co, 1, _35cc1301);
+}
+} else {
+coraCall(co, 1, _35cc1301);
+}
+} else {
+coraCall(co, 1, _35cc1301);
+}
 } else {
 coraCall(co, 1, _35cc1301);
 }
 }
 
-void _35clofun3017(struct Cora* co) {
-Obj hd1 = co->args[1];
-Obj _35reg2127 = primCons(hd1, closureRef(co, 1));
-coraCall(co, 4, globalRef(intern("cora/lib/toc.tailify-list")), closureRef(co, 0), _35reg2127, closureRef(co, 2));
+void _35clofun3010(struct Cora* co) {
+Obj _35val2035 = co->args[1];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj next = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg2036 = primCons(_35val2035, Nil);
+Obj _35reg2037 = primCons(args, _35reg2036);
+Obj _35reg2038 = primCons(intern("lambda"), _35reg2037);
+Obj _35reg2039 = primCons(_35reg2038, frees);
+Obj _35reg2040 = primCons(intern("%closure"), _35reg2039);
+coraCall(co, 2, next, _35reg2040);
 }
 
-void _35clofun3016(struct Cora* co) {
+void _35clofun3008(struct Cora* co) {
+Obj _35cc1302 = makeNative(0, _35clofun3009, 0, 0);
+Obj _35reg1993 = primIsCons(closureRef(co, 0));
+if (True == _35reg1993) {
+Obj _35reg1994 = primCar(closureRef(co, 0));
+Obj f = _35reg1994;
+Obj _35reg1995 = primCdr(closureRef(co, 0));
+Obj args = _35reg1995;
+Obj next = closureRef(co, 1);
+Obj _35reg1996 = primCons(f, args);
+coraCall(co, 4, globalRef(intern("cora/lib/toc.tailify-list")), _35reg1996, Nil, next);
+} else {
+coraCall(co, 1, _35cc1302);
+}
+}
+
+void _35clofun3009(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2996(struct Cora* co) {
-Obj _35p1288 = co->args[1];
-Obj _35p1289 = co->args[2];
-Obj _35cc1290 = makeNative(0, _35clofun2997, 0, 2, _35p1288, _35p1289);
+void _35clofun3001(struct Cora* co) {
+Obj x = co->args[1];
+Obj _35reg1990 = primCons(x, Nil);
+Obj _35reg1991 = primCons(intern("return"), _35reg1990);
+coraReturn(co, _35reg1991);
+return;
+}
+
+void _35clofun2986(struct Cora* co) {
+Obj _35p1287 = co->args[1];
+Obj _35p1288 = co->args[2];
+Obj _35cc1289 = makeNative(0, _35clofun2987, 0, 2, _35p1287, _35p1288);
+Obj __ = _35p1287;
 Obj x = _35p1288;
-Obj next = _35p1289;
-Obj _35reg2121 = primIsSymbol(x);
-if (True == _35reg2121) {
-if (True == True) {
-coraCall(co, 2, next, x);
-} else {
-coraCall(co, 1, _35cc1290);
-}
-} else {
-pushCont(co, 0, _35clofun3013, 3, next, x, _35cc1290);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
-}
-}
-
-void _35clofun3013(struct Cora* co) {
-Obj _35val2122 = co->args[1];
-Obj next = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj x = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc1290 = co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val2122) {
-if (True == True) {
-coraCall(co, 2, next, x);
-} else {
-coraCall(co, 1, _35cc1290);
-}
-} else {
-if (True == False) {
-coraCall(co, 2, next, x);
-} else {
-coraCall(co, 1, _35cc1290);
-}
-}
-}
-
-void _35clofun2997(struct Cora* co) {
-Obj _35cc1291 = makeNative(0, _35clofun2998, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x = closureRef(co, 0);
-Obj __ = closureRef(co, 1);
-pushCont(co, 0, _35clofun3012, 2, x, _35cc1291);
+pushCont(co, 0, _35clofun3000, 2, x, _35cc1289);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 
-void _35clofun3012(struct Cora* co) {
-Obj _35val2120 = co->args[1];
+void _35clofun3000(struct Cora* co) {
+Obj _35val1988 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1291 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2120) {
+Obj _35cc1289 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1988) {
 coraReturn(co, x);
 return;
+} else {
+coraCall(co, 1, _35cc1289);
+}
+}
+
+void _35clofun2987(struct Cora* co) {
+Obj _35cc1290 = makeNative(0, _35clofun2988, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj var = closureRef(co, 1);
+Obj _35reg1983 = primIsSymbol(var);
+if (True == _35reg1983) {
+pushCont(co, 0, _35clofun2999, 1, var);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.index")), var, fvs);
+} else {
+coraCall(co, 1, _35cc1290);
+}
+}
+
+void _35clofun2999(struct Cora* co) {
+Obj _35val1984 = co->args[1];
+Obj var = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj pos = _35val1984;
+Obj _35reg1985 = primEQ(makeNumber(-1), pos);
+if (True == _35reg1985) {
+coraReturn(co, var);
+return;
+} else {
+Obj _35reg1986 = primCons(pos, Nil);
+Obj _35reg1987 = primCons(intern("%closure-ref"), _35reg1986);
+coraReturn(co, _35reg1987);
+return;
+}
+}
+
+void _35clofun2988(struct Cora* co) {
+Obj _35cc1291 = makeNative(0, _35clofun2989, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj _35reg1954 = primIsCons(closureRef(co, 1));
+if (True == _35reg1954) {
+Obj _35reg1955 = primCar(closureRef(co, 1));
+Obj _35reg1956 = primEQ(intern("lambda"), _35reg1955);
+if (True == _35reg1956) {
+Obj _35reg1957 = primCdr(closureRef(co, 1));
+Obj _35reg1958 = primIsCons(_35reg1957);
+if (True == _35reg1958) {
+Obj _35reg1959 = primCdr(closureRef(co, 1));
+Obj _35reg1960 = primCar(_35reg1959);
+Obj args = _35reg1960;
+Obj _35reg1961 = primCdr(closureRef(co, 1));
+Obj _35reg1962 = primCdr(_35reg1961);
+Obj _35reg1963 = primIsCons(_35reg1962);
+if (True == _35reg1963) {
+Obj _35reg1964 = primCdr(closureRef(co, 1));
+Obj _35reg1965 = primCdr(_35reg1964);
+Obj _35reg1966 = primCar(_35reg1965);
+Obj body = _35reg1966;
+Obj _35reg1967 = primCdr(closureRef(co, 1));
+Obj _35reg1968 = primCdr(_35reg1967);
+Obj _35reg1969 = primCdr(_35reg1968);
+Obj _35reg1970 = primEQ(Nil, _35reg1969);
+if (True == _35reg1970) {
+Obj _35reg1971 = primCons(body, Nil);
+Obj _35reg1972 = primCons(args, _35reg1971);
+Obj _35reg1973 = primCons(intern("lambda"), _35reg1972);
+pushCont(co, 0, _35clofun2995, 3, body, args, fvs);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), _35reg1973);
+} else {
+coraCall(co, 1, _35cc1291);
+}
+} else {
+coraCall(co, 1, _35cc1291);
+}
+} else {
+coraCall(co, 1, _35cc1291);
+}
+} else {
+coraCall(co, 1, _35cc1291);
+}
 } else {
 coraCall(co, 1, _35cc1291);
 }
 }
 
-void _35clofun2998(struct Cora* co) {
-Obj _35cc1292 = makeNative(0, _35clofun2999, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2088 = primIsCons(closureRef(co, 0));
-if (True == _35reg2088) {
-Obj _35reg2089 = primCar(closureRef(co, 0));
-Obj _35reg2090 = primEQ(intern("if"), _35reg2089);
-if (True == _35reg2090) {
-Obj _35reg2091 = primCdr(closureRef(co, 0));
-Obj _35reg2092 = primIsCons(_35reg2091);
-if (True == _35reg2092) {
-Obj _35reg2093 = primCdr(closureRef(co, 0));
-Obj _35reg2094 = primCar(_35reg2093);
-Obj a = _35reg2094;
-Obj _35reg2095 = primCdr(closureRef(co, 0));
-Obj _35reg2096 = primCdr(_35reg2095);
-Obj _35reg2097 = primIsCons(_35reg2096);
-if (True == _35reg2097) {
-Obj _35reg2098 = primCdr(closureRef(co, 0));
-Obj _35reg2099 = primCdr(_35reg2098);
-Obj _35reg2100 = primCar(_35reg2099);
-Obj b = _35reg2100;
-Obj _35reg2101 = primCdr(closureRef(co, 0));
-Obj _35reg2102 = primCdr(_35reg2101);
-Obj _35reg2103 = primCdr(_35reg2102);
-Obj _35reg2104 = primIsCons(_35reg2103);
-if (True == _35reg2104) {
-Obj _35reg2105 = primCdr(closureRef(co, 0));
-Obj _35reg2106 = primCdr(_35reg2105);
-Obj _35reg2107 = primCdr(_35reg2106);
-Obj _35reg2108 = primCar(_35reg2107);
-Obj c = _35reg2108;
-Obj _35reg2109 = primCdr(closureRef(co, 0));
-Obj _35reg2110 = primCdr(_35reg2109);
-Obj _35reg2111 = primCdr(_35reg2110);
-Obj _35reg2112 = primCdr(_35reg2111);
-Obj _35reg2113 = primEQ(Nil, _35reg2112);
-if (True == _35reg2113) {
-Obj next = closureRef(co, 1);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), a, makeNative(0, _35clofun3009, 1, 3, b, c, next));
-} else {
-coraCall(co, 1, _35cc1292);
-}
-} else {
-coraCall(co, 1, _35cc1292);
-}
-} else {
-coraCall(co, 1, _35cc1292);
-}
-} else {
-coraCall(co, 1, _35cc1292);
-}
-} else {
-coraCall(co, 1, _35cc1292);
-}
-} else {
-coraCall(co, 1, _35cc1292);
-}
-}
-
-void _35clofun3009(struct Cora* co) {
-Obj ra = co->args[1];
-pushCont(co, 0, _35clofun3010, 1, ra);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), closureRef(co, 2));
-}
-
-void _35clofun3010(struct Cora* co) {
-Obj _35val2114 = co->args[1];
-Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun3011, 2, _35val2114, ra);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 1), closureRef(co, 2));
-}
-
-void _35clofun3011(struct Cora* co) {
-Obj _35val2115 = co->args[1];
-Obj _35val2114 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2116 = primCons(_35val2115, Nil);
-Obj _35reg2117 = primCons(_35val2114, _35reg2116);
-Obj _35reg2118 = primCons(ra, _35reg2117);
-Obj _35reg2119 = primCons(intern("if"), _35reg2118);
-coraReturn(co, _35reg2119);
-return;
-}
-
-void _35clofun2999(struct Cora* co) {
-Obj _35cc1293 = makeNative(0, _35clofun3000, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2066 = primIsCons(closureRef(co, 0));
-if (True == _35reg2066) {
-Obj _35reg2067 = primCar(closureRef(co, 0));
-Obj _35reg2068 = primEQ(intern("do"), _35reg2067);
-if (True == _35reg2068) {
-Obj _35reg2069 = primCdr(closureRef(co, 0));
-Obj _35reg2070 = primIsCons(_35reg2069);
-if (True == _35reg2070) {
-Obj _35reg2071 = primCdr(closureRef(co, 0));
-Obj _35reg2072 = primCar(_35reg2071);
-Obj a = _35reg2072;
-Obj _35reg2073 = primCdr(closureRef(co, 0));
-Obj _35reg2074 = primCdr(_35reg2073);
-Obj _35reg2075 = primIsCons(_35reg2074);
-if (True == _35reg2075) {
-Obj _35reg2076 = primCdr(closureRef(co, 0));
-Obj _35reg2077 = primCdr(_35reg2076);
-Obj _35reg2078 = primCar(_35reg2077);
-Obj b = _35reg2078;
-Obj _35reg2079 = primCdr(closureRef(co, 0));
-Obj _35reg2080 = primCdr(_35reg2079);
-Obj _35reg2081 = primCdr(_35reg2080);
-Obj _35reg2082 = primEQ(Nil, _35reg2081);
-if (True == _35reg2082) {
-Obj next = closureRef(co, 1);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), a, makeNative(0, _35clofun3007, 1, 2, b, next));
-} else {
-coraCall(co, 1, _35cc1293);
-}
-} else {
-coraCall(co, 1, _35cc1293);
-}
-} else {
-coraCall(co, 1, _35cc1293);
-}
-} else {
-coraCall(co, 1, _35cc1293);
-}
-} else {
-coraCall(co, 1, _35cc1293);
-}
-}
-
-void _35clofun3007(struct Cora* co) {
-Obj ra = co->args[1];
-Obj _35reg2083 = primIsSymbol(ra);
-if (True == _35reg2083) {
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), closureRef(co, 1));
-} else {
-pushCont(co, 0, _35clofun3008, 1, ra);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 0), closureRef(co, 1));
-}
-}
-
-void _35clofun3008(struct Cora* co) {
-Obj _35val2084 = co->args[1];
-Obj ra = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2085 = primCons(_35val2084, Nil);
-Obj _35reg2086 = primCons(ra, _35reg2085);
-Obj _35reg2087 = primCons(intern("do"), _35reg2086);
-coraReturn(co, _35reg2087);
-return;
-}
-
-void _35clofun3000(struct Cora* co) {
-Obj _35cc1294 = makeNative(0, _35clofun3001, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2035 = primIsCons(closureRef(co, 0));
-if (True == _35reg2035) {
-Obj _35reg2036 = primCar(closureRef(co, 0));
-Obj _35reg2037 = primEQ(intern("let"), _35reg2036);
-if (True == _35reg2037) {
-Obj _35reg2038 = primCdr(closureRef(co, 0));
-Obj _35reg2039 = primIsCons(_35reg2038);
-if (True == _35reg2039) {
-Obj _35reg2040 = primCdr(closureRef(co, 0));
-Obj _35reg2041 = primCar(_35reg2040);
-Obj a = _35reg2041;
-Obj _35reg2042 = primCdr(closureRef(co, 0));
-Obj _35reg2043 = primCdr(_35reg2042);
-Obj _35reg2044 = primIsCons(_35reg2043);
-if (True == _35reg2044) {
-Obj _35reg2045 = primCdr(closureRef(co, 0));
-Obj _35reg2046 = primCdr(_35reg2045);
-Obj _35reg2047 = primCar(_35reg2046);
-Obj b = _35reg2047;
-Obj _35reg2048 = primCdr(closureRef(co, 0));
-Obj _35reg2049 = primCdr(_35reg2048);
-Obj _35reg2050 = primCdr(_35reg2049);
-Obj _35reg2051 = primIsCons(_35reg2050);
-if (True == _35reg2051) {
-Obj _35reg2052 = primCdr(closureRef(co, 0));
-Obj _35reg2053 = primCdr(_35reg2052);
-Obj _35reg2054 = primCdr(_35reg2053);
-Obj _35reg2055 = primCar(_35reg2054);
-Obj c = _35reg2055;
-Obj _35reg2056 = primCdr(closureRef(co, 0));
-Obj _35reg2057 = primCdr(_35reg2056);
-Obj _35reg2058 = primCdr(_35reg2057);
-Obj _35reg2059 = primCdr(_35reg2058);
-Obj _35reg2060 = primEQ(Nil, _35reg2059);
-if (True == _35reg2060) {
-Obj next = closureRef(co, 1);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), b, makeNative(0, _35clofun3005, 1, 3, a, c, next));
-} else {
-coraCall(co, 1, _35cc1294);
-}
-} else {
-coraCall(co, 1, _35cc1294);
-}
-} else {
-coraCall(co, 1, _35cc1294);
-}
-} else {
-coraCall(co, 1, _35cc1294);
-}
-} else {
-coraCall(co, 1, _35cc1294);
-}
-} else {
-coraCall(co, 1, _35cc1294);
-}
-}
-
-void _35clofun3005(struct Cora* co) {
-Obj rb = co->args[1];
-pushCont(co, 0, _35clofun3006, 1, rb);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), closureRef(co, 1), closureRef(co, 2));
-}
-
-void _35clofun3006(struct Cora* co) {
-Obj _35val2061 = co->args[1];
-Obj rb = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2062 = primCons(_35val2061, Nil);
-Obj _35reg2063 = primCons(rb, _35reg2062);
-Obj _35reg2064 = primCons(closureRef(co, 0), _35reg2063);
-Obj _35reg2065 = primCons(intern("let"), _35reg2064);
-coraReturn(co, _35reg2065);
-return;
-}
-
-void _35clofun3001(struct Cora* co) {
-Obj _35cc1295 = makeNative(0, _35clofun3002, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1991 = primIsCons(closureRef(co, 0));
-if (True == _35reg1991) {
-Obj _35reg1992 = primCar(closureRef(co, 0));
-Obj _35reg1993 = primEQ(intern("%closure"), _35reg1992);
-if (True == _35reg1993) {
-Obj _35reg1994 = primCdr(closureRef(co, 0));
-Obj _35reg1995 = primIsCons(_35reg1994);
-if (True == _35reg1995) {
-Obj _35reg1996 = primCdr(closureRef(co, 0));
-Obj _35reg1997 = primCar(_35reg1996);
-Obj _35reg1998 = primIsCons(_35reg1997);
-if (True == _35reg1998) {
-Obj _35reg1999 = primCdr(closureRef(co, 0));
-Obj _35reg2000 = primCar(_35reg1999);
-Obj _35reg2001 = primCar(_35reg2000);
-Obj _35reg2002 = primEQ(intern("lambda"), _35reg2001);
-if (True == _35reg2002) {
-Obj _35reg2003 = primCdr(closureRef(co, 0));
-Obj _35reg2004 = primCar(_35reg2003);
-Obj _35reg2005 = primCdr(_35reg2004);
-Obj _35reg2006 = primIsCons(_35reg2005);
-if (True == _35reg2006) {
-Obj _35reg2007 = primCdr(closureRef(co, 0));
-Obj _35reg2008 = primCar(_35reg2007);
-Obj _35reg2009 = primCdr(_35reg2008);
-Obj _35reg2010 = primCar(_35reg2009);
-Obj args = _35reg2010;
-Obj _35reg2011 = primCdr(closureRef(co, 0));
-Obj _35reg2012 = primCar(_35reg2011);
-Obj _35reg2013 = primCdr(_35reg2012);
-Obj _35reg2014 = primCdr(_35reg2013);
-Obj _35reg2015 = primIsCons(_35reg2014);
-if (True == _35reg2015) {
-Obj _35reg2016 = primCdr(closureRef(co, 0));
-Obj _35reg2017 = primCar(_35reg2016);
-Obj _35reg2018 = primCdr(_35reg2017);
-Obj _35reg2019 = primCdr(_35reg2018);
-Obj _35reg2020 = primCar(_35reg2019);
-Obj body = _35reg2020;
-Obj _35reg2021 = primCdr(closureRef(co, 0));
-Obj _35reg2022 = primCar(_35reg2021);
-Obj _35reg2023 = primCdr(_35reg2022);
-Obj _35reg2024 = primCdr(_35reg2023);
-Obj _35reg2025 = primCdr(_35reg2024);
-Obj _35reg2026 = primEQ(Nil, _35reg2025);
-if (True == _35reg2026) {
-Obj _35reg2027 = primCdr(closureRef(co, 0));
-Obj _35reg2028 = primCdr(_35reg2027);
-Obj frees = _35reg2028;
-Obj next = closureRef(co, 1);
-pushCont(co, 0, _35clofun3004, 3, args, frees, next);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.tailify")), body, globalRef(intern("cora/lib/toc.id")));
-} else {
-coraCall(co, 1, _35cc1295);
-}
-} else {
-coraCall(co, 1, _35cc1295);
-}
-} else {
-coraCall(co, 1, _35cc1295);
-}
-} else {
-coraCall(co, 1, _35cc1295);
-}
-} else {
-coraCall(co, 1, _35cc1295);
-}
-} else {
-coraCall(co, 1, _35cc1295);
-}
-} else {
-coraCall(co, 1, _35cc1295);
-}
-} else {
-coraCall(co, 1, _35cc1295);
-}
-}
-
-void _35clofun3004(struct Cora* co) {
-Obj _35val2029 = co->args[1];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj next = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2030 = primCons(_35val2029, Nil);
-Obj _35reg2031 = primCons(args, _35reg2030);
-Obj _35reg2032 = primCons(intern("lambda"), _35reg2031);
-Obj _35reg2033 = primCons(_35reg2032, frees);
-Obj _35reg2034 = primCons(intern("%closure"), _35reg2033);
-coraCall(co, 2, next, _35reg2034);
-}
-
-void _35clofun3002(struct Cora* co) {
-Obj _35cc1296 = makeNative(0, _35clofun3003, 0, 0);
-Obj _35reg1987 = primIsCons(closureRef(co, 0));
-if (True == _35reg1987) {
-Obj _35reg1988 = primCar(closureRef(co, 0));
-Obj f = _35reg1988;
-Obj _35reg1989 = primCdr(closureRef(co, 0));
-Obj args = _35reg1989;
-Obj next = closureRef(co, 1);
-Obj _35reg1990 = primCons(f, args);
-coraCall(co, 4, globalRef(intern("cora/lib/toc.tailify-list")), _35reg1990, Nil, next);
-} else {
-coraCall(co, 1, _35cc1296);
-}
-}
-
-void _35clofun3003(struct Cora* co) {
-coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
-}
-
 void _35clofun2995(struct Cora* co) {
-Obj x = co->args[1];
-Obj _35reg1984 = primCons(x, Nil);
-Obj _35reg1985 = primCons(intern("return"), _35reg1984);
-coraReturn(co, _35reg1985);
+Obj _35val1974 = co->args[1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj fvs1 = _35val1974;
+pushCont(co, 0, _35clofun2996, 3, args, fvs, fvs1);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs1, body);
+}
+
+void _35clofun2996(struct Cora* co) {
+Obj _35val1975 = co->args[1];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg1976 = primCons(_35val1975, Nil);
+Obj _35reg1977 = primCons(args, _35reg1976);
+Obj _35reg1978 = primCons(intern("lambda"), _35reg1977);
+pushCont(co, 0, _35clofun2997, 2, fvs1, _35reg1978);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert")), fvs);
+}
+
+void _35clofun2997(struct Cora* co) {
+Obj _35val1979 = co->args[1];
+Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1978 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun2998, 1, _35reg1978);
+coraCall(co, 3, globalRef(intern("map")), _35val1979, fvs1);
+}
+
+void _35clofun2998(struct Cora* co) {
+Obj _35val1980 = co->args[1];
+Obj _35reg1978 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1981 = primCons(_35reg1978, _35val1980);
+Obj _35reg1982 = primCons(intern("%closure"), _35reg1981);
+coraReturn(co, _35reg1982);
 return;
 }
 
-void _35clofun2980(struct Cora* co) {
-Obj _35p1281 = co->args[1];
-Obj _35p1282 = co->args[2];
-Obj _35cc1283 = makeNative(0, _35clofun2981, 0, 2, _35p1281, _35p1282);
-Obj __ = _35p1281;
-Obj x = _35p1282;
-pushCont(co, 0, _35clofun2994, 2, x, _35cc1283);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
-}
-
-void _35clofun2994(struct Cora* co) {
-Obj _35val1982 = co->args[1];
-Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1283 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1982) {
-coraReturn(co, x);
-return;
-} else {
-coraCall(co, 1, _35cc1283);
-}
-}
-
-void _35clofun2981(struct Cora* co) {
-Obj _35cc1284 = makeNative(0, _35clofun2982, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2989(struct Cora* co) {
+Obj _35cc1292 = makeNative(0, _35clofun2990, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj var = closureRef(co, 1);
-Obj _35reg1977 = primIsSymbol(var);
-if (True == _35reg1977) {
-pushCont(co, 0, _35clofun2993, 1, var);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.index")), var, fvs);
+Obj _35reg1922 = primIsCons(closureRef(co, 1));
+if (True == _35reg1922) {
+Obj _35reg1923 = primCar(closureRef(co, 1));
+Obj _35reg1924 = primEQ(intern("let"), _35reg1923);
+if (True == _35reg1924) {
+Obj _35reg1925 = primCdr(closureRef(co, 1));
+Obj _35reg1926 = primIsCons(_35reg1925);
+if (True == _35reg1926) {
+Obj _35reg1927 = primCdr(closureRef(co, 1));
+Obj _35reg1928 = primCar(_35reg1927);
+Obj a = _35reg1928;
+Obj _35reg1929 = primCdr(closureRef(co, 1));
+Obj _35reg1930 = primCdr(_35reg1929);
+Obj _35reg1931 = primIsCons(_35reg1930);
+if (True == _35reg1931) {
+Obj _35reg1932 = primCdr(closureRef(co, 1));
+Obj _35reg1933 = primCdr(_35reg1932);
+Obj _35reg1934 = primCar(_35reg1933);
+Obj b = _35reg1934;
+Obj _35reg1935 = primCdr(closureRef(co, 1));
+Obj _35reg1936 = primCdr(_35reg1935);
+Obj _35reg1937 = primCdr(_35reg1936);
+Obj _35reg1938 = primIsCons(_35reg1937);
+if (True == _35reg1938) {
+Obj _35reg1939 = primCdr(closureRef(co, 1));
+Obj _35reg1940 = primCdr(_35reg1939);
+Obj _35reg1941 = primCdr(_35reg1940);
+Obj _35reg1942 = primCar(_35reg1941);
+Obj c = _35reg1942;
+Obj _35reg1943 = primCdr(closureRef(co, 1));
+Obj _35reg1944 = primCdr(_35reg1943);
+Obj _35reg1945 = primCdr(_35reg1944);
+Obj _35reg1946 = primCdr(_35reg1945);
+Obj _35reg1947 = primEQ(Nil, _35reg1946);
+if (True == _35reg1947) {
+pushCont(co, 0, _35clofun2993, 3, fvs, c, a);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs, b);
 } else {
-coraCall(co, 1, _35cc1284);
+coraCall(co, 1, _35cc1292);
+}
+} else {
+coraCall(co, 1, _35cc1292);
+}
+} else {
+coraCall(co, 1, _35cc1292);
+}
+} else {
+coraCall(co, 1, _35cc1292);
+}
+} else {
+coraCall(co, 1, _35cc1292);
+}
+} else {
+coraCall(co, 1, _35cc1292);
 }
 }
 
 void _35clofun2993(struct Cora* co) {
-Obj _35val1978 = co->args[1];
-Obj var = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj pos = _35val1978;
-Obj _35reg1979 = primEQ(makeNumber(-1), pos);
-if (True == _35reg1979) {
-coraReturn(co, var);
-return;
-} else {
-Obj _35reg1980 = primCons(pos, Nil);
-Obj _35reg1981 = primCons(intern("%closure-ref"), _35reg1980);
-coraReturn(co, _35reg1981);
-return;
-}
-}
-
-void _35clofun2982(struct Cora* co) {
-Obj _35cc1285 = makeNative(0, _35clofun2983, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg1948 = primIsCons(closureRef(co, 1));
-if (True == _35reg1948) {
-Obj _35reg1949 = primCar(closureRef(co, 1));
-Obj _35reg1950 = primEQ(intern("lambda"), _35reg1949);
-if (True == _35reg1950) {
-Obj _35reg1951 = primCdr(closureRef(co, 1));
-Obj _35reg1952 = primIsCons(_35reg1951);
-if (True == _35reg1952) {
-Obj _35reg1953 = primCdr(closureRef(co, 1));
-Obj _35reg1954 = primCar(_35reg1953);
-Obj args = _35reg1954;
-Obj _35reg1955 = primCdr(closureRef(co, 1));
-Obj _35reg1956 = primCdr(_35reg1955);
-Obj _35reg1957 = primIsCons(_35reg1956);
-if (True == _35reg1957) {
-Obj _35reg1958 = primCdr(closureRef(co, 1));
-Obj _35reg1959 = primCdr(_35reg1958);
-Obj _35reg1960 = primCar(_35reg1959);
-Obj body = _35reg1960;
-Obj _35reg1961 = primCdr(closureRef(co, 1));
-Obj _35reg1962 = primCdr(_35reg1961);
-Obj _35reg1963 = primCdr(_35reg1962);
-Obj _35reg1964 = primEQ(Nil, _35reg1963);
-if (True == _35reg1964) {
-Obj _35reg1965 = primCons(body, Nil);
-Obj _35reg1966 = primCons(args, _35reg1965);
-Obj _35reg1967 = primCons(intern("lambda"), _35reg1966);
-pushCont(co, 0, _35clofun2989, 3, body, args, fvs);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), _35reg1967);
-} else {
-coraCall(co, 1, _35cc1285);
-}
-} else {
-coraCall(co, 1, _35cc1285);
-}
-} else {
-coraCall(co, 1, _35cc1285);
-}
-} else {
-coraCall(co, 1, _35cc1285);
-}
-} else {
-coraCall(co, 1, _35cc1285);
-}
-}
-
-void _35clofun2989(struct Cora* co) {
-Obj _35val1968 = co->args[1];
-Obj body = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs1 = _35val1968;
-pushCont(co, 0, _35clofun2990, 3, args, fvs, fvs1);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs1, body);
-}
-
-void _35clofun2990(struct Cora* co) {
-Obj _35val1969 = co->args[1];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1970 = primCons(_35val1969, Nil);
-Obj _35reg1971 = primCons(args, _35reg1970);
-Obj _35reg1972 = primCons(intern("lambda"), _35reg1971);
-pushCont(co, 0, _35clofun2991, 2, fvs1, _35reg1972);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert")), fvs);
-}
-
-void _35clofun2991(struct Cora* co) {
-Obj _35val1973 = co->args[1];
-Obj fvs1 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1972 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2992, 1, _35reg1972);
-coraCall(co, 3, globalRef(intern("map")), _35val1973, fvs1);
-}
-
-void _35clofun2992(struct Cora* co) {
-Obj _35val1974 = co->args[1];
-Obj _35reg1972 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1975 = primCons(_35reg1972, _35val1974);
-Obj _35reg1976 = primCons(intern("%closure"), _35reg1975);
-coraReturn(co, _35reg1976);
-return;
-}
-
-void _35clofun2983(struct Cora* co) {
-Obj _35cc1286 = makeNative(0, _35clofun2984, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg1916 = primIsCons(closureRef(co, 1));
-if (True == _35reg1916) {
-Obj _35reg1917 = primCar(closureRef(co, 1));
-Obj _35reg1918 = primEQ(intern("let"), _35reg1917);
-if (True == _35reg1918) {
-Obj _35reg1919 = primCdr(closureRef(co, 1));
-Obj _35reg1920 = primIsCons(_35reg1919);
-if (True == _35reg1920) {
-Obj _35reg1921 = primCdr(closureRef(co, 1));
-Obj _35reg1922 = primCar(_35reg1921);
-Obj a = _35reg1922;
-Obj _35reg1923 = primCdr(closureRef(co, 1));
-Obj _35reg1924 = primCdr(_35reg1923);
-Obj _35reg1925 = primIsCons(_35reg1924);
-if (True == _35reg1925) {
-Obj _35reg1926 = primCdr(closureRef(co, 1));
-Obj _35reg1927 = primCdr(_35reg1926);
-Obj _35reg1928 = primCar(_35reg1927);
-Obj b = _35reg1928;
-Obj _35reg1929 = primCdr(closureRef(co, 1));
-Obj _35reg1930 = primCdr(_35reg1929);
-Obj _35reg1931 = primCdr(_35reg1930);
-Obj _35reg1932 = primIsCons(_35reg1931);
-if (True == _35reg1932) {
-Obj _35reg1933 = primCdr(closureRef(co, 1));
-Obj _35reg1934 = primCdr(_35reg1933);
-Obj _35reg1935 = primCdr(_35reg1934);
-Obj _35reg1936 = primCar(_35reg1935);
-Obj c = _35reg1936;
-Obj _35reg1937 = primCdr(closureRef(co, 1));
-Obj _35reg1938 = primCdr(_35reg1937);
-Obj _35reg1939 = primCdr(_35reg1938);
-Obj _35reg1940 = primCdr(_35reg1939);
-Obj _35reg1941 = primEQ(Nil, _35reg1940);
-if (True == _35reg1941) {
-pushCont(co, 0, _35clofun2987, 3, fvs, c, a);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs, b);
-} else {
-coraCall(co, 1, _35cc1286);
-}
-} else {
-coraCall(co, 1, _35cc1286);
-}
-} else {
-coraCall(co, 1, _35cc1286);
-}
-} else {
-coraCall(co, 1, _35cc1286);
-}
-} else {
-coraCall(co, 1, _35cc1286);
-}
-} else {
-coraCall(co, 1, _35cc1286);
-}
-}
-
-void _35clofun2987(struct Cora* co) {
-Obj _35val1942 = co->args[1];
+Obj _35val1948 = co->args[1];
 Obj fvs = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 0, _35clofun2988, 2, _35val1942, a);
+pushCont(co, 0, _35clofun2994, 2, _35val1948, a);
 coraCall(co, 3, globalRef(intern("cora/lib/toc.closure-convert")), fvs, c);
 }
 
-void _35clofun2988(struct Cora* co) {
-Obj _35val1943 = co->args[1];
-Obj _35val1942 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+void _35clofun2994(struct Cora* co) {
+Obj _35val1949 = co->args[1];
+Obj _35val1948 = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1944 = primCons(_35val1943, Nil);
-Obj _35reg1945 = primCons(_35val1942, _35reg1944);
-Obj _35reg1946 = primCons(a, _35reg1945);
-Obj _35reg1947 = primCons(intern("let"), _35reg1946);
-coraReturn(co, _35reg1947);
+Obj _35reg1950 = primCons(_35val1949, Nil);
+Obj _35reg1951 = primCons(_35val1948, _35reg1950);
+Obj _35reg1952 = primCons(a, _35reg1951);
+Obj _35reg1953 = primCons(intern("let"), _35reg1952);
+coraReturn(co, _35reg1953);
 return;
 }
 
-void _35clofun2984(struct Cora* co) {
-Obj _35cc1287 = makeNative(0, _35clofun2985, 0, 0);
+void _35clofun2990(struct Cora* co) {
+Obj _35cc1293 = makeNative(0, _35clofun2991, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj _35reg1911 = primIsCons(closureRef(co, 1));
-if (True == _35reg1911) {
-Obj _35reg1912 = primCar(closureRef(co, 1));
-Obj f = _35reg1912;
-Obj _35reg1913 = primCdr(closureRef(co, 1));
-Obj args = _35reg1913;
-pushCont(co, 0, _35clofun2986, 2, f, args);
+Obj _35reg1917 = primIsCons(closureRef(co, 1));
+if (True == _35reg1917) {
+Obj _35reg1918 = primCar(closureRef(co, 1));
+Obj f = _35reg1918;
+Obj _35reg1919 = primCdr(closureRef(co, 1));
+Obj args = _35reg1919;
+pushCont(co, 0, _35clofun2992, 2, f, args);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.closure-convert")), fvs);
 } else {
-coraCall(co, 1, _35cc1287);
+coraCall(co, 1, _35cc1293);
 }
 }
 
-void _35clofun2986(struct Cora* co) {
-Obj _35val1914 = co->args[1];
+void _35clofun2992(struct Cora* co) {
+Obj _35val1920 = co->args[1];
 Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1915 = primCons(f, args);
-coraCall(co, 3, globalRef(intern("map")), _35val1914, _35reg1915);
+Obj _35reg1921 = primCons(f, args);
+coraCall(co, 3, globalRef(intern("map")), _35val1920, _35reg1921);
 }
 
-void _35clofun2985(struct Cora* co) {
+void _35clofun2991(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2957(struct Cora* co) {
-Obj _35p1268 = co->args[1];
-Obj _35cc1269 = makeNative(0, _35clofun2958, 0, 1, _35p1268);
-Obj x = _35p1268;
-pushCont(co, 0, _35clofun2979, 1, _35cc1269);
+void _35clofun2963(struct Cora* co) {
+Obj _35p1274 = co->args[1];
+Obj _35cc1275 = makeNative(0, _35clofun2964, 0, 1, _35p1274);
+Obj x = _35p1274;
+pushCont(co, 0, _35clofun2985, 1, _35cc1275);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.convert-protect?")), x);
 }
 
-void _35clofun2979(struct Cora* co) {
-Obj _35val1909 = co->args[1];
-Obj _35cc1269 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1909) {
+void _35clofun2985(struct Cora* co) {
+Obj _35val1915 = co->args[1];
+Obj _35cc1275 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1915) {
 coraReturn(co, Nil);
 return;
-} else {
-coraCall(co, 1, _35cc1269);
-}
-}
-
-void _35clofun2958(struct Cora* co) {
-Obj _35cc1270 = makeNative(0, _35clofun2959, 0, 1, closureRef(co, 0));
-Obj x = closureRef(co, 0);
-Obj _35reg1907 = primIsSymbol(x);
-if (True == _35reg1907) {
-Obj _35reg1908 = primCons(x, Nil);
-coraReturn(co, _35reg1908);
-return;
-} else {
-coraCall(co, 1, _35cc1270);
-}
-}
-
-void _35clofun2959(struct Cora* co) {
-Obj _35cc1271 = makeNative(0, _35clofun2960, 0, 1, closureRef(co, 0));
-Obj _35reg1889 = primIsCons(closureRef(co, 0));
-if (True == _35reg1889) {
-Obj _35reg1890 = primCar(closureRef(co, 0));
-Obj _35reg1891 = primEQ(intern("lambda"), _35reg1890);
-if (True == _35reg1891) {
-Obj _35reg1892 = primCdr(closureRef(co, 0));
-Obj _35reg1893 = primIsCons(_35reg1892);
-if (True == _35reg1893) {
-Obj _35reg1894 = primCdr(closureRef(co, 0));
-Obj _35reg1895 = primCar(_35reg1894);
-Obj args = _35reg1895;
-Obj _35reg1896 = primCdr(closureRef(co, 0));
-Obj _35reg1897 = primCdr(_35reg1896);
-Obj _35reg1898 = primIsCons(_35reg1897);
-if (True == _35reg1898) {
-Obj _35reg1899 = primCdr(closureRef(co, 0));
-Obj _35reg1900 = primCdr(_35reg1899);
-Obj _35reg1901 = primCar(_35reg1900);
-Obj body = _35reg1901;
-Obj _35reg1902 = primCdr(closureRef(co, 0));
-Obj _35reg1903 = primCdr(_35reg1902);
-Obj _35reg1904 = primCdr(_35reg1903);
-Obj _35reg1905 = primEQ(Nil, _35reg1904);
-if (True == _35reg1905) {
-pushCont(co, 0, _35clofun2978, 1, args);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), body);
-} else {
-coraCall(co, 1, _35cc1271);
-}
-} else {
-coraCall(co, 1, _35cc1271);
-}
-} else {
-coraCall(co, 1, _35cc1271);
-}
-} else {
-coraCall(co, 1, _35cc1271);
-}
-} else {
-coraCall(co, 1, _35cc1271);
-}
-}
-
-void _35clofun2978(struct Cora* co) {
-Obj _35val1906 = co->args[1];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1906, args);
-}
-
-void _35clofun2960(struct Cora* co) {
-Obj _35cc1272 = makeNative(0, _35clofun2961, 0, 1, closureRef(co, 0));
-Obj _35reg1859 = primIsCons(closureRef(co, 0));
-if (True == _35reg1859) {
-Obj _35reg1860 = primCar(closureRef(co, 0));
-Obj _35reg1861 = primEQ(intern("if"), _35reg1860);
-if (True == _35reg1861) {
-Obj _35reg1862 = primCdr(closureRef(co, 0));
-Obj _35reg1863 = primIsCons(_35reg1862);
-if (True == _35reg1863) {
-Obj _35reg1864 = primCdr(closureRef(co, 0));
-Obj _35reg1865 = primCar(_35reg1864);
-Obj x = _35reg1865;
-Obj _35reg1866 = primCdr(closureRef(co, 0));
-Obj _35reg1867 = primCdr(_35reg1866);
-Obj _35reg1868 = primIsCons(_35reg1867);
-if (True == _35reg1868) {
-Obj _35reg1869 = primCdr(closureRef(co, 0));
-Obj _35reg1870 = primCdr(_35reg1869);
-Obj _35reg1871 = primCar(_35reg1870);
-Obj y = _35reg1871;
-Obj _35reg1872 = primCdr(closureRef(co, 0));
-Obj _35reg1873 = primCdr(_35reg1872);
-Obj _35reg1874 = primCdr(_35reg1873);
-Obj _35reg1875 = primIsCons(_35reg1874);
-if (True == _35reg1875) {
-Obj _35reg1876 = primCdr(closureRef(co, 0));
-Obj _35reg1877 = primCdr(_35reg1876);
-Obj _35reg1878 = primCdr(_35reg1877);
-Obj _35reg1879 = primCar(_35reg1878);
-Obj z = _35reg1879;
-Obj _35reg1880 = primCdr(closureRef(co, 0));
-Obj _35reg1881 = primCdr(_35reg1880);
-Obj _35reg1882 = primCdr(_35reg1881);
-Obj _35reg1883 = primCdr(_35reg1882);
-Obj _35reg1884 = primEQ(Nil, _35reg1883);
-if (True == _35reg1884) {
-Obj _35reg1885 = primCons(z, Nil);
-Obj _35reg1886 = primCons(y, _35reg1885);
-Obj _35reg1887 = primCons(x, _35reg1886);
-pushCont(co, 0, _35clofun2977, 0);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1887);
-} else {
-coraCall(co, 1, _35cc1272);
-}
-} else {
-coraCall(co, 1, _35cc1272);
-}
-} else {
-coraCall(co, 1, _35cc1272);
-}
-} else {
-coraCall(co, 1, _35cc1272);
-}
-} else {
-coraCall(co, 1, _35cc1272);
-}
-} else {
-coraCall(co, 1, _35cc1272);
-}
-}
-
-void _35clofun2977(struct Cora* co) {
-Obj _35val1888 = co->args[1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1888);
-}
-
-void _35clofun2961(struct Cora* co) {
-Obj _35cc1273 = makeNative(0, _35clofun2962, 0, 1, closureRef(co, 0));
-Obj _35reg1839 = primIsCons(closureRef(co, 0));
-if (True == _35reg1839) {
-Obj _35reg1840 = primCar(closureRef(co, 0));
-Obj _35reg1841 = primEQ(intern("do"), _35reg1840);
-if (True == _35reg1841) {
-Obj _35reg1842 = primCdr(closureRef(co, 0));
-Obj _35reg1843 = primIsCons(_35reg1842);
-if (True == _35reg1843) {
-Obj _35reg1844 = primCdr(closureRef(co, 0));
-Obj _35reg1845 = primCar(_35reg1844);
-Obj x = _35reg1845;
-Obj _35reg1846 = primCdr(closureRef(co, 0));
-Obj _35reg1847 = primCdr(_35reg1846);
-Obj _35reg1848 = primIsCons(_35reg1847);
-if (True == _35reg1848) {
-Obj _35reg1849 = primCdr(closureRef(co, 0));
-Obj _35reg1850 = primCdr(_35reg1849);
-Obj _35reg1851 = primCar(_35reg1850);
-Obj y = _35reg1851;
-Obj _35reg1852 = primCdr(closureRef(co, 0));
-Obj _35reg1853 = primCdr(_35reg1852);
-Obj _35reg1854 = primCdr(_35reg1853);
-Obj _35reg1855 = primEQ(Nil, _35reg1854);
-if (True == _35reg1855) {
-Obj _35reg1856 = primCons(y, Nil);
-Obj _35reg1857 = primCons(x, _35reg1856);
-pushCont(co, 0, _35clofun2976, 0);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1857);
-} else {
-coraCall(co, 1, _35cc1273);
-}
-} else {
-coraCall(co, 1, _35cc1273);
-}
-} else {
-coraCall(co, 1, _35cc1273);
-}
-} else {
-coraCall(co, 1, _35cc1273);
-}
-} else {
-coraCall(co, 1, _35cc1273);
-}
-}
-
-void _35clofun2976(struct Cora* co) {
-Obj _35val1858 = co->args[1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1858);
-}
-
-void _35clofun2962(struct Cora* co) {
-Obj _35cc1274 = makeNative(0, _35clofun2963, 0, 1, closureRef(co, 0));
-Obj _35reg1809 = primIsCons(closureRef(co, 0));
-if (True == _35reg1809) {
-Obj _35reg1810 = primCar(closureRef(co, 0));
-Obj _35reg1811 = primEQ(intern("let"), _35reg1810);
-if (True == _35reg1811) {
-Obj _35reg1812 = primCdr(closureRef(co, 0));
-Obj _35reg1813 = primIsCons(_35reg1812);
-if (True == _35reg1813) {
-Obj _35reg1814 = primCdr(closureRef(co, 0));
-Obj _35reg1815 = primCar(_35reg1814);
-Obj a = _35reg1815;
-Obj _35reg1816 = primCdr(closureRef(co, 0));
-Obj _35reg1817 = primCdr(_35reg1816);
-Obj _35reg1818 = primIsCons(_35reg1817);
-if (True == _35reg1818) {
-Obj _35reg1819 = primCdr(closureRef(co, 0));
-Obj _35reg1820 = primCdr(_35reg1819);
-Obj _35reg1821 = primCar(_35reg1820);
-Obj b = _35reg1821;
-Obj _35reg1822 = primCdr(closureRef(co, 0));
-Obj _35reg1823 = primCdr(_35reg1822);
-Obj _35reg1824 = primCdr(_35reg1823);
-Obj _35reg1825 = primIsCons(_35reg1824);
-if (True == _35reg1825) {
-Obj _35reg1826 = primCdr(closureRef(co, 0));
-Obj _35reg1827 = primCdr(_35reg1826);
-Obj _35reg1828 = primCdr(_35reg1827);
-Obj _35reg1829 = primCar(_35reg1828);
-Obj c = _35reg1829;
-Obj _35reg1830 = primCdr(closureRef(co, 0));
-Obj _35reg1831 = primCdr(_35reg1830);
-Obj _35reg1832 = primCdr(_35reg1831);
-Obj _35reg1833 = primCdr(_35reg1832);
-Obj _35reg1834 = primEQ(Nil, _35reg1833);
-if (True == _35reg1834) {
-pushCont(co, 0, _35clofun2973, 2, c, a);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), b);
-} else {
-coraCall(co, 1, _35cc1274);
-}
-} else {
-coraCall(co, 1, _35cc1274);
-}
-} else {
-coraCall(co, 1, _35cc1274);
-}
-} else {
-coraCall(co, 1, _35cc1274);
-}
-} else {
-coraCall(co, 1, _35cc1274);
-}
-} else {
-coraCall(co, 1, _35cc1274);
-}
-}
-
-void _35clofun2973(struct Cora* co) {
-Obj _35val1835 = co->args[1];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2974, 2, a, _35val1835);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), c);
-}
-
-void _35clofun2974(struct Cora* co) {
-Obj _35val1836 = co->args[1];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val1835 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1837 = primCons(a, Nil);
-pushCont(co, 0, _35clofun2975, 1, _35val1835);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1836, _35reg1837);
-}
-
-void _35clofun2975(struct Cora* co) {
-Obj _35val1838 = co->args[1];
-Obj _35val1835 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), _35val1835, _35val1838);
-}
-
-void _35clofun2963(struct Cora* co) {
-Obj _35cc1275 = makeNative(0, _35clofun2964, 0, 1, closureRef(co, 0));
-Obj _35reg1799 = primIsCons(closureRef(co, 0));
-if (True == _35reg1799) {
-Obj _35reg1800 = primCar(closureRef(co, 0));
-Obj _35reg1801 = primEQ(intern("%closure"), _35reg1800);
-if (True == _35reg1801) {
-Obj _35reg1802 = primCdr(closureRef(co, 0));
-Obj _35reg1803 = primIsCons(_35reg1802);
-if (True == _35reg1803) {
-Obj _35reg1804 = primCdr(closureRef(co, 0));
-Obj _35reg1805 = primCar(_35reg1804);
-Obj lam = _35reg1805;
-Obj _35reg1806 = primCdr(closureRef(co, 0));
-Obj _35reg1807 = primCdr(_35reg1806);
-Obj more = _35reg1807;
-Obj _35reg1808 = primCons(lam, more);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), _35reg1808);
-} else {
-coraCall(co, 1, _35cc1275);
-}
-} else {
-coraCall(co, 1, _35cc1275);
-}
 } else {
 coraCall(co, 1, _35cc1275);
 }
@@ -4591,31 +4297,12 @@ coraCall(co, 1, _35cc1275);
 
 void _35clofun2964(struct Cora* co) {
 Obj _35cc1276 = makeNative(0, _35clofun2965, 0, 1, closureRef(co, 0));
-Obj _35reg1789 = primIsCons(closureRef(co, 0));
-if (True == _35reg1789) {
-Obj _35reg1790 = primCar(closureRef(co, 0));
-Obj _35reg1791 = primEQ(intern("return"), _35reg1790);
-if (True == _35reg1791) {
-Obj _35reg1792 = primCdr(closureRef(co, 0));
-Obj _35reg1793 = primIsCons(_35reg1792);
-if (True == _35reg1793) {
-Obj _35reg1794 = primCdr(closureRef(co, 0));
-Obj _35reg1795 = primCar(_35reg1794);
-Obj x = _35reg1795;
-Obj _35reg1796 = primCdr(closureRef(co, 0));
-Obj _35reg1797 = primCdr(_35reg1796);
-Obj _35reg1798 = primEQ(Nil, _35reg1797);
-if (True == _35reg1798) {
-coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), x);
-} else {
-coraCall(co, 1, _35cc1276);
-}
-} else {
-coraCall(co, 1, _35cc1276);
-}
-} else {
-coraCall(co, 1, _35cc1276);
-}
+Obj x = closureRef(co, 0);
+Obj _35reg1913 = primIsSymbol(x);
+if (True == _35reg1913) {
+Obj _35reg1914 = primCons(x, Nil);
+coraReturn(co, _35reg1914);
+return;
 } else {
 coraCall(co, 1, _35cc1276);
 }
@@ -4623,34 +4310,32 @@ coraCall(co, 1, _35cc1276);
 
 void _35clofun2965(struct Cora* co) {
 Obj _35cc1277 = makeNative(0, _35clofun2966, 0, 1, closureRef(co, 0));
-Obj _35reg1769 = primIsCons(closureRef(co, 0));
-if (True == _35reg1769) {
-Obj _35reg1770 = primCar(closureRef(co, 0));
-Obj _35reg1771 = primEQ(intern("call"), _35reg1770);
-if (True == _35reg1771) {
-Obj _35reg1772 = primCdr(closureRef(co, 0));
-Obj _35reg1773 = primIsCons(_35reg1772);
-if (True == _35reg1773) {
-Obj _35reg1774 = primCdr(closureRef(co, 0));
-Obj _35reg1775 = primCar(_35reg1774);
-Obj exp = _35reg1775;
-Obj _35reg1776 = primCdr(closureRef(co, 0));
-Obj _35reg1777 = primCdr(_35reg1776);
-Obj _35reg1778 = primIsCons(_35reg1777);
-if (True == _35reg1778) {
-Obj _35reg1779 = primCdr(closureRef(co, 0));
-Obj _35reg1780 = primCdr(_35reg1779);
-Obj _35reg1781 = primCar(_35reg1780);
-Obj cont = _35reg1781;
-Obj _35reg1782 = primCdr(closureRef(co, 0));
-Obj _35reg1783 = primCdr(_35reg1782);
-Obj _35reg1784 = primCdr(_35reg1783);
-Obj _35reg1785 = primEQ(Nil, _35reg1784);
-if (True == _35reg1785) {
-Obj _35reg1786 = primCons(cont, Nil);
-Obj _35reg1787 = primCons(exp, _35reg1786);
-pushCont(co, 0, _35clofun2972, 0);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1787);
+Obj _35reg1895 = primIsCons(closureRef(co, 0));
+if (True == _35reg1895) {
+Obj _35reg1896 = primCar(closureRef(co, 0));
+Obj _35reg1897 = primEQ(intern("lambda"), _35reg1896);
+if (True == _35reg1897) {
+Obj _35reg1898 = primCdr(closureRef(co, 0));
+Obj _35reg1899 = primIsCons(_35reg1898);
+if (True == _35reg1899) {
+Obj _35reg1900 = primCdr(closureRef(co, 0));
+Obj _35reg1901 = primCar(_35reg1900);
+Obj args = _35reg1901;
+Obj _35reg1902 = primCdr(closureRef(co, 0));
+Obj _35reg1903 = primCdr(_35reg1902);
+Obj _35reg1904 = primIsCons(_35reg1903);
+if (True == _35reg1904) {
+Obj _35reg1905 = primCdr(closureRef(co, 0));
+Obj _35reg1906 = primCdr(_35reg1905);
+Obj _35reg1907 = primCar(_35reg1906);
+Obj body = _35reg1907;
+Obj _35reg1908 = primCdr(closureRef(co, 0));
+Obj _35reg1909 = primCdr(_35reg1908);
+Obj _35reg1910 = primCdr(_35reg1909);
+Obj _35reg1911 = primEQ(Nil, _35reg1910);
+if (True == _35reg1911) {
+pushCont(co, 0, _35clofun2984, 1, args);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), body);
 } else {
 coraCall(co, 1, _35cc1277);
 }
@@ -4668,29 +4353,54 @@ coraCall(co, 1, _35cc1277);
 }
 }
 
-void _35clofun2972(struct Cora* co) {
-Obj _35val1788 = co->args[1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1788);
+void _35clofun2984(struct Cora* co) {
+Obj _35val1912 = co->args[1];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1912, args);
 }
 
 void _35clofun2966(struct Cora* co) {
 Obj _35cc1278 = makeNative(0, _35clofun2967, 0, 1, closureRef(co, 0));
-Obj _35reg1759 = primIsCons(closureRef(co, 0));
-if (True == _35reg1759) {
-Obj _35reg1760 = primCar(closureRef(co, 0));
-Obj _35reg1761 = primEQ(intern("tailcall"), _35reg1760);
-if (True == _35reg1761) {
-Obj _35reg1762 = primCdr(closureRef(co, 0));
-Obj _35reg1763 = primIsCons(_35reg1762);
-if (True == _35reg1763) {
-Obj _35reg1764 = primCdr(closureRef(co, 0));
-Obj _35reg1765 = primCar(_35reg1764);
-Obj exp = _35reg1765;
-Obj _35reg1766 = primCdr(closureRef(co, 0));
-Obj _35reg1767 = primCdr(_35reg1766);
-Obj _35reg1768 = primEQ(Nil, _35reg1767);
-if (True == _35reg1768) {
-coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), exp);
+Obj _35reg1865 = primIsCons(closureRef(co, 0));
+if (True == _35reg1865) {
+Obj _35reg1866 = primCar(closureRef(co, 0));
+Obj _35reg1867 = primEQ(intern("if"), _35reg1866);
+if (True == _35reg1867) {
+Obj _35reg1868 = primCdr(closureRef(co, 0));
+Obj _35reg1869 = primIsCons(_35reg1868);
+if (True == _35reg1869) {
+Obj _35reg1870 = primCdr(closureRef(co, 0));
+Obj _35reg1871 = primCar(_35reg1870);
+Obj x = _35reg1871;
+Obj _35reg1872 = primCdr(closureRef(co, 0));
+Obj _35reg1873 = primCdr(_35reg1872);
+Obj _35reg1874 = primIsCons(_35reg1873);
+if (True == _35reg1874) {
+Obj _35reg1875 = primCdr(closureRef(co, 0));
+Obj _35reg1876 = primCdr(_35reg1875);
+Obj _35reg1877 = primCar(_35reg1876);
+Obj y = _35reg1877;
+Obj _35reg1878 = primCdr(closureRef(co, 0));
+Obj _35reg1879 = primCdr(_35reg1878);
+Obj _35reg1880 = primCdr(_35reg1879);
+Obj _35reg1881 = primIsCons(_35reg1880);
+if (True == _35reg1881) {
+Obj _35reg1882 = primCdr(closureRef(co, 0));
+Obj _35reg1883 = primCdr(_35reg1882);
+Obj _35reg1884 = primCdr(_35reg1883);
+Obj _35reg1885 = primCar(_35reg1884);
+Obj z = _35reg1885;
+Obj _35reg1886 = primCdr(closureRef(co, 0));
+Obj _35reg1887 = primCdr(_35reg1886);
+Obj _35reg1888 = primCdr(_35reg1887);
+Obj _35reg1889 = primCdr(_35reg1888);
+Obj _35reg1890 = primEQ(Nil, _35reg1889);
+if (True == _35reg1890) {
+Obj _35reg1891 = primCons(z, Nil);
+Obj _35reg1892 = primCons(y, _35reg1891);
+Obj _35reg1893 = primCons(x, _35reg1892);
+pushCont(co, 0, _35clofun2983, 0);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1893);
 } else {
 coraCall(co, 1, _35cc1278);
 }
@@ -4703,36 +4413,49 @@ coraCall(co, 1, _35cc1278);
 } else {
 coraCall(co, 1, _35cc1278);
 }
+} else {
+coraCall(co, 1, _35cc1278);
+}
+} else {
+coraCall(co, 1, _35cc1278);
+}
+}
+
+void _35clofun2983(struct Cora* co) {
+Obj _35val1894 = co->args[1];
+coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1894);
 }
 
 void _35clofun2967(struct Cora* co) {
 Obj _35cc1279 = makeNative(0, _35clofun2968, 0, 1, closureRef(co, 0));
-Obj _35reg1741 = primIsCons(closureRef(co, 0));
-if (True == _35reg1741) {
-Obj _35reg1742 = primCar(closureRef(co, 0));
-Obj _35reg1743 = primEQ(intern("continuation"), _35reg1742);
-if (True == _35reg1743) {
-Obj _35reg1744 = primCdr(closureRef(co, 0));
-Obj _35reg1745 = primIsCons(_35reg1744);
-if (True == _35reg1745) {
-Obj _35reg1746 = primCdr(closureRef(co, 0));
-Obj _35reg1747 = primCar(_35reg1746);
-Obj arg = _35reg1747;
-Obj _35reg1748 = primCdr(closureRef(co, 0));
-Obj _35reg1749 = primCdr(_35reg1748);
-Obj _35reg1750 = primIsCons(_35reg1749);
-if (True == _35reg1750) {
-Obj _35reg1751 = primCdr(closureRef(co, 0));
-Obj _35reg1752 = primCdr(_35reg1751);
-Obj _35reg1753 = primCar(_35reg1752);
-Obj body = _35reg1753;
-Obj _35reg1754 = primCdr(closureRef(co, 0));
-Obj _35reg1755 = primCdr(_35reg1754);
-Obj _35reg1756 = primCdr(_35reg1755);
-Obj _35reg1757 = primEQ(Nil, _35reg1756);
-if (True == _35reg1757) {
-pushCont(co, 0, _35clofun2971, 1, arg);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), body);
+Obj _35reg1845 = primIsCons(closureRef(co, 0));
+if (True == _35reg1845) {
+Obj _35reg1846 = primCar(closureRef(co, 0));
+Obj _35reg1847 = primEQ(intern("do"), _35reg1846);
+if (True == _35reg1847) {
+Obj _35reg1848 = primCdr(closureRef(co, 0));
+Obj _35reg1849 = primIsCons(_35reg1848);
+if (True == _35reg1849) {
+Obj _35reg1850 = primCdr(closureRef(co, 0));
+Obj _35reg1851 = primCar(_35reg1850);
+Obj x = _35reg1851;
+Obj _35reg1852 = primCdr(closureRef(co, 0));
+Obj _35reg1853 = primCdr(_35reg1852);
+Obj _35reg1854 = primIsCons(_35reg1853);
+if (True == _35reg1854) {
+Obj _35reg1855 = primCdr(closureRef(co, 0));
+Obj _35reg1856 = primCdr(_35reg1855);
+Obj _35reg1857 = primCar(_35reg1856);
+Obj y = _35reg1857;
+Obj _35reg1858 = primCdr(closureRef(co, 0));
+Obj _35reg1859 = primCdr(_35reg1858);
+Obj _35reg1860 = primCdr(_35reg1859);
+Obj _35reg1861 = primEQ(Nil, _35reg1860);
+if (True == _35reg1861) {
+Obj _35reg1862 = primCons(y, Nil);
+Obj _35reg1863 = primCons(x, _35reg1862);
+pushCont(co, 0, _35clofun2982, 0);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1863);
 } else {
 coraCall(co, 1, _35cc1279);
 }
@@ -4750,258 +4473,577 @@ coraCall(co, 1, _35cc1279);
 }
 }
 
-void _35clofun2971(struct Cora* co) {
-Obj _35val1758 = co->args[1];
-Obj arg = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1758, arg);
+void _35clofun2982(struct Cora* co) {
+Obj _35val1864 = co->args[1];
+coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1864);
 }
 
 void _35clofun2968(struct Cora* co) {
-Obj _35cc1280 = makeNative(0, _35clofun2969, 0, 0);
-Obj _35reg1736 = primIsCons(closureRef(co, 0));
-if (True == _35reg1736) {
-Obj _35reg1737 = primCar(closureRef(co, 0));
-Obj f = _35reg1737;
-Obj _35reg1738 = primCdr(closureRef(co, 0));
-Obj args = _35reg1738;
-Obj _35reg1739 = primCons(f, args);
-pushCont(co, 0, _35clofun2970, 0);
-coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1739);
+Obj _35cc1280 = makeNative(0, _35clofun2969, 0, 1, closureRef(co, 0));
+Obj _35reg1815 = primIsCons(closureRef(co, 0));
+if (True == _35reg1815) {
+Obj _35reg1816 = primCar(closureRef(co, 0));
+Obj _35reg1817 = primEQ(intern("let"), _35reg1816);
+if (True == _35reg1817) {
+Obj _35reg1818 = primCdr(closureRef(co, 0));
+Obj _35reg1819 = primIsCons(_35reg1818);
+if (True == _35reg1819) {
+Obj _35reg1820 = primCdr(closureRef(co, 0));
+Obj _35reg1821 = primCar(_35reg1820);
+Obj a = _35reg1821;
+Obj _35reg1822 = primCdr(closureRef(co, 0));
+Obj _35reg1823 = primCdr(_35reg1822);
+Obj _35reg1824 = primIsCons(_35reg1823);
+if (True == _35reg1824) {
+Obj _35reg1825 = primCdr(closureRef(co, 0));
+Obj _35reg1826 = primCdr(_35reg1825);
+Obj _35reg1827 = primCar(_35reg1826);
+Obj b = _35reg1827;
+Obj _35reg1828 = primCdr(closureRef(co, 0));
+Obj _35reg1829 = primCdr(_35reg1828);
+Obj _35reg1830 = primCdr(_35reg1829);
+Obj _35reg1831 = primIsCons(_35reg1830);
+if (True == _35reg1831) {
+Obj _35reg1832 = primCdr(closureRef(co, 0));
+Obj _35reg1833 = primCdr(_35reg1832);
+Obj _35reg1834 = primCdr(_35reg1833);
+Obj _35reg1835 = primCar(_35reg1834);
+Obj c = _35reg1835;
+Obj _35reg1836 = primCdr(closureRef(co, 0));
+Obj _35reg1837 = primCdr(_35reg1836);
+Obj _35reg1838 = primCdr(_35reg1837);
+Obj _35reg1839 = primCdr(_35reg1838);
+Obj _35reg1840 = primEQ(Nil, _35reg1839);
+if (True == _35reg1840) {
+pushCont(co, 0, _35clofun2979, 2, c, a);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), b);
+} else {
+coraCall(co, 1, _35cc1280);
+}
+} else {
+coraCall(co, 1, _35cc1280);
+}
+} else {
+coraCall(co, 1, _35cc1280);
+}
+} else {
+coraCall(co, 1, _35cc1280);
+}
+} else {
+coraCall(co, 1, _35cc1280);
+}
 } else {
 coraCall(co, 1, _35cc1280);
 }
 }
 
-void _35clofun2970(struct Cora* co) {
-Obj _35val1740 = co->args[1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1740);
+void _35clofun2979(struct Cora* co) {
+Obj _35val1841 = co->args[1];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun2980, 2, a, _35val1841);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), c);
+}
+
+void _35clofun2980(struct Cora* co) {
+Obj _35val1842 = co->args[1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val1841 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1843 = primCons(a, Nil);
+pushCont(co, 0, _35clofun2981, 1, _35val1841);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1842, _35reg1843);
+}
+
+void _35clofun2981(struct Cora* co) {
+Obj _35val1844 = co->args[1];
+Obj _35val1841 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), _35val1841, _35val1844);
 }
 
 void _35clofun2969(struct Cora* co) {
+Obj _35cc1281 = makeNative(0, _35clofun2970, 0, 1, closureRef(co, 0));
+Obj _35reg1805 = primIsCons(closureRef(co, 0));
+if (True == _35reg1805) {
+Obj _35reg1806 = primCar(closureRef(co, 0));
+Obj _35reg1807 = primEQ(intern("%closure"), _35reg1806);
+if (True == _35reg1807) {
+Obj _35reg1808 = primCdr(closureRef(co, 0));
+Obj _35reg1809 = primIsCons(_35reg1808);
+if (True == _35reg1809) {
+Obj _35reg1810 = primCdr(closureRef(co, 0));
+Obj _35reg1811 = primCar(_35reg1810);
+Obj lam = _35reg1811;
+Obj _35reg1812 = primCdr(closureRef(co, 0));
+Obj _35reg1813 = primCdr(_35reg1812);
+Obj more = _35reg1813;
+Obj _35reg1814 = primCons(lam, more);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), _35reg1814);
+} else {
+coraCall(co, 1, _35cc1281);
+}
+} else {
+coraCall(co, 1, _35cc1281);
+}
+} else {
+coraCall(co, 1, _35cc1281);
+}
+}
+
+void _35clofun2970(struct Cora* co) {
+Obj _35cc1282 = makeNative(0, _35clofun2971, 0, 1, closureRef(co, 0));
+Obj _35reg1795 = primIsCons(closureRef(co, 0));
+if (True == _35reg1795) {
+Obj _35reg1796 = primCar(closureRef(co, 0));
+Obj _35reg1797 = primEQ(intern("return"), _35reg1796);
+if (True == _35reg1797) {
+Obj _35reg1798 = primCdr(closureRef(co, 0));
+Obj _35reg1799 = primIsCons(_35reg1798);
+if (True == _35reg1799) {
+Obj _35reg1800 = primCdr(closureRef(co, 0));
+Obj _35reg1801 = primCar(_35reg1800);
+Obj x = _35reg1801;
+Obj _35reg1802 = primCdr(closureRef(co, 0));
+Obj _35reg1803 = primCdr(_35reg1802);
+Obj _35reg1804 = primEQ(Nil, _35reg1803);
+if (True == _35reg1804) {
+coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), x);
+} else {
+coraCall(co, 1, _35cc1282);
+}
+} else {
+coraCall(co, 1, _35cc1282);
+}
+} else {
+coraCall(co, 1, _35cc1282);
+}
+} else {
+coraCall(co, 1, _35cc1282);
+}
+}
+
+void _35clofun2971(struct Cora* co) {
+Obj _35cc1283 = makeNative(0, _35clofun2972, 0, 1, closureRef(co, 0));
+Obj _35reg1775 = primIsCons(closureRef(co, 0));
+if (True == _35reg1775) {
+Obj _35reg1776 = primCar(closureRef(co, 0));
+Obj _35reg1777 = primEQ(intern("call"), _35reg1776);
+if (True == _35reg1777) {
+Obj _35reg1778 = primCdr(closureRef(co, 0));
+Obj _35reg1779 = primIsCons(_35reg1778);
+if (True == _35reg1779) {
+Obj _35reg1780 = primCdr(closureRef(co, 0));
+Obj _35reg1781 = primCar(_35reg1780);
+Obj exp = _35reg1781;
+Obj _35reg1782 = primCdr(closureRef(co, 0));
+Obj _35reg1783 = primCdr(_35reg1782);
+Obj _35reg1784 = primIsCons(_35reg1783);
+if (True == _35reg1784) {
+Obj _35reg1785 = primCdr(closureRef(co, 0));
+Obj _35reg1786 = primCdr(_35reg1785);
+Obj _35reg1787 = primCar(_35reg1786);
+Obj cont = _35reg1787;
+Obj _35reg1788 = primCdr(closureRef(co, 0));
+Obj _35reg1789 = primCdr(_35reg1788);
+Obj _35reg1790 = primCdr(_35reg1789);
+Obj _35reg1791 = primEQ(Nil, _35reg1790);
+if (True == _35reg1791) {
+Obj _35reg1792 = primCons(cont, Nil);
+Obj _35reg1793 = primCons(exp, _35reg1792);
+pushCont(co, 0, _35clofun2978, 0);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1793);
+} else {
+coraCall(co, 1, _35cc1283);
+}
+} else {
+coraCall(co, 1, _35cc1283);
+}
+} else {
+coraCall(co, 1, _35cc1283);
+}
+} else {
+coraCall(co, 1, _35cc1283);
+}
+} else {
+coraCall(co, 1, _35cc1283);
+}
+}
+
+void _35clofun2978(struct Cora* co) {
+Obj _35val1794 = co->args[1];
+coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1794);
+}
+
+void _35clofun2972(struct Cora* co) {
+Obj _35cc1284 = makeNative(0, _35clofun2973, 0, 1, closureRef(co, 0));
+Obj _35reg1765 = primIsCons(closureRef(co, 0));
+if (True == _35reg1765) {
+Obj _35reg1766 = primCar(closureRef(co, 0));
+Obj _35reg1767 = primEQ(intern("tailcall"), _35reg1766);
+if (True == _35reg1767) {
+Obj _35reg1768 = primCdr(closureRef(co, 0));
+Obj _35reg1769 = primIsCons(_35reg1768);
+if (True == _35reg1769) {
+Obj _35reg1770 = primCdr(closureRef(co, 0));
+Obj _35reg1771 = primCar(_35reg1770);
+Obj exp = _35reg1771;
+Obj _35reg1772 = primCdr(closureRef(co, 0));
+Obj _35reg1773 = primCdr(_35reg1772);
+Obj _35reg1774 = primEQ(Nil, _35reg1773);
+if (True == _35reg1774) {
+coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), exp);
+} else {
+coraCall(co, 1, _35cc1284);
+}
+} else {
+coraCall(co, 1, _35cc1284);
+}
+} else {
+coraCall(co, 1, _35cc1284);
+}
+} else {
+coraCall(co, 1, _35cc1284);
+}
+}
+
+void _35clofun2973(struct Cora* co) {
+Obj _35cc1285 = makeNative(0, _35clofun2974, 0, 1, closureRef(co, 0));
+Obj _35reg1747 = primIsCons(closureRef(co, 0));
+if (True == _35reg1747) {
+Obj _35reg1748 = primCar(closureRef(co, 0));
+Obj _35reg1749 = primEQ(intern("continuation"), _35reg1748);
+if (True == _35reg1749) {
+Obj _35reg1750 = primCdr(closureRef(co, 0));
+Obj _35reg1751 = primIsCons(_35reg1750);
+if (True == _35reg1751) {
+Obj _35reg1752 = primCdr(closureRef(co, 0));
+Obj _35reg1753 = primCar(_35reg1752);
+Obj arg = _35reg1753;
+Obj _35reg1754 = primCdr(closureRef(co, 0));
+Obj _35reg1755 = primCdr(_35reg1754);
+Obj _35reg1756 = primIsCons(_35reg1755);
+if (True == _35reg1756) {
+Obj _35reg1757 = primCdr(closureRef(co, 0));
+Obj _35reg1758 = primCdr(_35reg1757);
+Obj _35reg1759 = primCar(_35reg1758);
+Obj body = _35reg1759;
+Obj _35reg1760 = primCdr(closureRef(co, 0));
+Obj _35reg1761 = primCdr(_35reg1760);
+Obj _35reg1762 = primCdr(_35reg1761);
+Obj _35reg1763 = primEQ(Nil, _35reg1762);
+if (True == _35reg1763) {
+pushCont(co, 0, _35clofun2977, 1, arg);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.free-vars")), body);
+} else {
+coraCall(co, 1, _35cc1285);
+}
+} else {
+coraCall(co, 1, _35cc1285);
+}
+} else {
+coraCall(co, 1, _35cc1285);
+}
+} else {
+coraCall(co, 1, _35cc1285);
+}
+} else {
+coraCall(co, 1, _35cc1285);
+}
+}
+
+void _35clofun2977(struct Cora* co) {
+Obj _35val1764 = co->args[1];
+Obj arg = co->ctx.stk.stack[co->ctx.stk.base + 0];
+coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), _35val1764, arg);
+}
+
+void _35clofun2974(struct Cora* co) {
+Obj _35cc1286 = makeNative(0, _35clofun2975, 0, 0);
+Obj _35reg1742 = primIsCons(closureRef(co, 0));
+if (True == _35reg1742) {
+Obj _35reg1743 = primCar(closureRef(co, 0));
+Obj f = _35reg1743;
+Obj _35reg1744 = primCdr(closureRef(co, 0));
+Obj args = _35reg1744;
+Obj _35reg1745 = primCons(f, args);
+pushCont(co, 0, _35clofun2976, 0);
+coraCall(co, 3, globalRef(intern("map")), globalRef(intern("cora/lib/toc.free-vars")), _35reg1745);
+} else {
+coraCall(co, 1, _35cc1286);
+}
+}
+
+void _35clofun2976(struct Cora* co) {
+Obj _35val1746 = co->args[1];
+coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), globalRef(intern("cora/lib/toc.union")), Nil, _35val1746);
+}
+
+void _35clofun2975(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2950(struct Cora* co) {
-Obj _35p1261 = co->args[1];
-Obj _35cc1262 = makeNative(0, _35clofun2951, 0, 1, _35p1261);
-Obj _35reg1725 = primIsCons(_35p1261);
+void _35clofun2956(struct Cora* co) {
+Obj _35p1267 = co->args[1];
+Obj _35cc1268 = makeNative(0, _35clofun2957, 0, 1, _35p1267);
+Obj _35reg1731 = primIsCons(_35p1267);
+if (True == _35reg1731) {
+Obj _35reg1732 = primCar(_35p1267);
+Obj _35reg1733 = primEQ(intern("%const"), _35reg1732);
+if (True == _35reg1733) {
+Obj _35reg1734 = primCdr(_35p1267);
+Obj _35reg1735 = primIsCons(_35reg1734);
+if (True == _35reg1735) {
+Obj _35reg1736 = primCdr(_35p1267);
+Obj _35reg1737 = primCar(_35reg1736);
+Obj x = _35reg1737;
+Obj _35reg1738 = primCdr(_35p1267);
+Obj _35reg1739 = primCdr(_35reg1738);
+Obj _35reg1740 = primEQ(Nil, _35reg1739);
+if (True == _35reg1740) {
+coraReturn(co, True);
+return;
+} else {
+coraCall(co, 1, _35cc1268);
+}
+} else {
+coraCall(co, 1, _35cc1268);
+}
+} else {
+coraCall(co, 1, _35cc1268);
+}
+} else {
+coraCall(co, 1, _35cc1268);
+}
+}
+
+void _35clofun2957(struct Cora* co) {
+Obj _35cc1269 = makeNative(0, _35clofun2958, 0, 1, closureRef(co, 0));
+Obj _35reg1721 = primIsCons(closureRef(co, 0));
+if (True == _35reg1721) {
+Obj _35reg1722 = primCar(closureRef(co, 0));
+Obj _35reg1723 = primEQ(intern("%global"), _35reg1722);
+if (True == _35reg1723) {
+Obj _35reg1724 = primCdr(closureRef(co, 0));
+Obj _35reg1725 = primIsCons(_35reg1724);
 if (True == _35reg1725) {
-Obj _35reg1726 = primCar(_35p1261);
-Obj _35reg1727 = primEQ(intern("%const"), _35reg1726);
-if (True == _35reg1727) {
-Obj _35reg1728 = primCdr(_35p1261);
-Obj _35reg1729 = primIsCons(_35reg1728);
-if (True == _35reg1729) {
-Obj _35reg1730 = primCdr(_35p1261);
-Obj _35reg1731 = primCar(_35reg1730);
-Obj x = _35reg1731;
-Obj _35reg1732 = primCdr(_35p1261);
-Obj _35reg1733 = primCdr(_35reg1732);
-Obj _35reg1734 = primEQ(Nil, _35reg1733);
-if (True == _35reg1734) {
+Obj _35reg1726 = primCdr(closureRef(co, 0));
+Obj _35reg1727 = primCar(_35reg1726);
+Obj x = _35reg1727;
+Obj _35reg1728 = primCdr(closureRef(co, 0));
+Obj _35reg1729 = primCdr(_35reg1728);
+Obj _35reg1730 = primEQ(Nil, _35reg1729);
+if (True == _35reg1730) {
 coraReturn(co, True);
 return;
 } else {
-coraCall(co, 1, _35cc1262);
+coraCall(co, 1, _35cc1269);
 }
 } else {
-coraCall(co, 1, _35cc1262);
+coraCall(co, 1, _35cc1269);
 }
 } else {
-coraCall(co, 1, _35cc1262);
+coraCall(co, 1, _35cc1269);
 }
 } else {
-coraCall(co, 1, _35cc1262);
+coraCall(co, 1, _35cc1269);
 }
 }
 
-void _35clofun2951(struct Cora* co) {
-Obj _35cc1263 = makeNative(0, _35clofun2952, 0, 1, closureRef(co, 0));
-Obj _35reg1715 = primIsCons(closureRef(co, 0));
+void _35clofun2958(struct Cora* co) {
+Obj _35cc1270 = makeNative(0, _35clofun2959, 0, 1, closureRef(co, 0));
+Obj _35reg1711 = primIsCons(closureRef(co, 0));
+if (True == _35reg1711) {
+Obj _35reg1712 = primCar(closureRef(co, 0));
+Obj _35reg1713 = primEQ(intern("%builtin"), _35reg1712);
+if (True == _35reg1713) {
+Obj _35reg1714 = primCdr(closureRef(co, 0));
+Obj _35reg1715 = primIsCons(_35reg1714);
 if (True == _35reg1715) {
-Obj _35reg1716 = primCar(closureRef(co, 0));
-Obj _35reg1717 = primEQ(intern("%global"), _35reg1716);
-if (True == _35reg1717) {
+Obj _35reg1716 = primCdr(closureRef(co, 0));
+Obj _35reg1717 = primCar(_35reg1716);
+Obj op = _35reg1717;
 Obj _35reg1718 = primCdr(closureRef(co, 0));
-Obj _35reg1719 = primIsCons(_35reg1718);
-if (True == _35reg1719) {
-Obj _35reg1720 = primCdr(closureRef(co, 0));
-Obj _35reg1721 = primCar(_35reg1720);
-Obj x = _35reg1721;
-Obj _35reg1722 = primCdr(closureRef(co, 0));
-Obj _35reg1723 = primCdr(_35reg1722);
-Obj _35reg1724 = primEQ(Nil, _35reg1723);
-if (True == _35reg1724) {
+Obj _35reg1719 = primCdr(_35reg1718);
+Obj _35reg1720 = primEQ(Nil, _35reg1719);
+if (True == _35reg1720) {
 coraReturn(co, True);
 return;
 } else {
-coraCall(co, 1, _35cc1263);
+coraCall(co, 1, _35cc1270);
 }
 } else {
-coraCall(co, 1, _35cc1263);
+coraCall(co, 1, _35cc1270);
 }
 } else {
-coraCall(co, 1, _35cc1263);
+coraCall(co, 1, _35cc1270);
 }
 } else {
-coraCall(co, 1, _35cc1263);
+coraCall(co, 1, _35cc1270);
 }
 }
 
-void _35clofun2952(struct Cora* co) {
-Obj _35cc1264 = makeNative(0, _35clofun2953, 0, 1, closureRef(co, 0));
-Obj _35reg1705 = primIsCons(closureRef(co, 0));
+void _35clofun2959(struct Cora* co) {
+Obj _35cc1271 = makeNative(0, _35clofun2960, 0, 1, closureRef(co, 0));
+Obj _35reg1701 = primIsCons(closureRef(co, 0));
+if (True == _35reg1701) {
+Obj _35reg1702 = primCar(closureRef(co, 0));
+Obj _35reg1703 = primEQ(intern("quote"), _35reg1702);
+if (True == _35reg1703) {
+Obj _35reg1704 = primCdr(closureRef(co, 0));
+Obj _35reg1705 = primIsCons(_35reg1704);
 if (True == _35reg1705) {
-Obj _35reg1706 = primCar(closureRef(co, 0));
-Obj _35reg1707 = primEQ(intern("%builtin"), _35reg1706);
-if (True == _35reg1707) {
+Obj _35reg1706 = primCdr(closureRef(co, 0));
+Obj _35reg1707 = primCar(_35reg1706);
+Obj x = _35reg1707;
 Obj _35reg1708 = primCdr(closureRef(co, 0));
-Obj _35reg1709 = primIsCons(_35reg1708);
-if (True == _35reg1709) {
-Obj _35reg1710 = primCdr(closureRef(co, 0));
-Obj _35reg1711 = primCar(_35reg1710);
-Obj op = _35reg1711;
-Obj _35reg1712 = primCdr(closureRef(co, 0));
-Obj _35reg1713 = primCdr(_35reg1712);
-Obj _35reg1714 = primEQ(Nil, _35reg1713);
-if (True == _35reg1714) {
+Obj _35reg1709 = primCdr(_35reg1708);
+Obj _35reg1710 = primEQ(Nil, _35reg1709);
+if (True == _35reg1710) {
 coraReturn(co, True);
 return;
 } else {
-coraCall(co, 1, _35cc1264);
+coraCall(co, 1, _35cc1271);
 }
 } else {
-coraCall(co, 1, _35cc1264);
+coraCall(co, 1, _35cc1271);
 }
 } else {
-coraCall(co, 1, _35cc1264);
+coraCall(co, 1, _35cc1271);
 }
 } else {
-coraCall(co, 1, _35cc1264);
+coraCall(co, 1, _35cc1271);
 }
 }
 
-void _35clofun2953(struct Cora* co) {
-Obj _35cc1265 = makeNative(0, _35clofun2954, 0, 1, closureRef(co, 0));
-Obj _35reg1695 = primIsCons(closureRef(co, 0));
+void _35clofun2960(struct Cora* co) {
+Obj _35cc1272 = makeNative(0, _35clofun2961, 0, 1, closureRef(co, 0));
+Obj _35reg1691 = primIsCons(closureRef(co, 0));
+if (True == _35reg1691) {
+Obj _35reg1692 = primCar(closureRef(co, 0));
+Obj _35reg1693 = primEQ(intern("%closure-ref"), _35reg1692);
+if (True == _35reg1693) {
+Obj _35reg1694 = primCdr(closureRef(co, 0));
+Obj _35reg1695 = primIsCons(_35reg1694);
 if (True == _35reg1695) {
-Obj _35reg1696 = primCar(closureRef(co, 0));
-Obj _35reg1697 = primEQ(intern("quote"), _35reg1696);
-if (True == _35reg1697) {
+Obj _35reg1696 = primCdr(closureRef(co, 0));
+Obj _35reg1697 = primCar(_35reg1696);
+Obj __ = _35reg1697;
 Obj _35reg1698 = primCdr(closureRef(co, 0));
-Obj _35reg1699 = primIsCons(_35reg1698);
-if (True == _35reg1699) {
-Obj _35reg1700 = primCdr(closureRef(co, 0));
-Obj _35reg1701 = primCar(_35reg1700);
-Obj x = _35reg1701;
-Obj _35reg1702 = primCdr(closureRef(co, 0));
-Obj _35reg1703 = primCdr(_35reg1702);
-Obj _35reg1704 = primEQ(Nil, _35reg1703);
-if (True == _35reg1704) {
+Obj _35reg1699 = primCdr(_35reg1698);
+Obj _35reg1700 = primEQ(Nil, _35reg1699);
+if (True == _35reg1700) {
 coraReturn(co, True);
 return;
 } else {
-coraCall(co, 1, _35cc1265);
+coraCall(co, 1, _35cc1272);
 }
 } else {
-coraCall(co, 1, _35cc1265);
+coraCall(co, 1, _35cc1272);
 }
 } else {
-coraCall(co, 1, _35cc1265);
+coraCall(co, 1, _35cc1272);
 }
 } else {
-coraCall(co, 1, _35cc1265);
+coraCall(co, 1, _35cc1272);
 }
 }
 
-void _35clofun2954(struct Cora* co) {
-Obj _35cc1266 = makeNative(0, _35clofun2955, 0, 1, closureRef(co, 0));
-Obj _35reg1685 = primIsCons(closureRef(co, 0));
-if (True == _35reg1685) {
-Obj _35reg1686 = primCar(closureRef(co, 0));
-Obj _35reg1687 = primEQ(intern("%closure-ref"), _35reg1686);
-if (True == _35reg1687) {
-Obj _35reg1688 = primCdr(closureRef(co, 0));
-Obj _35reg1689 = primIsCons(_35reg1688);
-if (True == _35reg1689) {
-Obj _35reg1690 = primCdr(closureRef(co, 0));
-Obj _35reg1691 = primCar(_35reg1690);
-Obj __ = _35reg1691;
-Obj _35reg1692 = primCdr(closureRef(co, 0));
-Obj _35reg1693 = primCdr(_35reg1692);
-Obj _35reg1694 = primEQ(Nil, _35reg1693);
-if (True == _35reg1694) {
-coraReturn(co, True);
-return;
-} else {
-coraCall(co, 1, _35cc1266);
-}
-} else {
-coraCall(co, 1, _35cc1266);
-}
-} else {
-coraCall(co, 1, _35cc1266);
-}
-} else {
-coraCall(co, 1, _35cc1266);
-}
-}
-
-void _35clofun2955(struct Cora* co) {
-Obj _35cc1267 = makeNative(0, _35clofun2956, 0, 0);
+void _35clofun2961(struct Cora* co) {
+Obj _35cc1273 = makeNative(0, _35clofun2962, 0, 0);
 Obj x = closureRef(co, 0);
 coraReturn(co, False);
 return;
 }
 
-void _35clofun2956(struct Cora* co) {
+void _35clofun2962(struct Cora* co) {
+coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
+}
+
+void _35clofun2950(struct Cora* co) {
+Obj _35p1262 = co->args[1];
+Obj _35p1263 = co->args[2];
+Obj _35cc1264 = makeNative(0, _35clofun2951, 0, 2, _35p1262, _35p1263);
+Obj _35reg1689 = primEQ(Nil, _35p1262);
+if (True == _35reg1689) {
+Obj __ = _35p1263;
+coraReturn(co, Nil);
+return;
+} else {
+coraCall(co, 1, _35cc1264);
+}
+}
+
+void _35clofun2951(struct Cora* co) {
+Obj _35cc1265 = makeNative(0, _35clofun2952, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1685 = primIsCons(closureRef(co, 0));
+if (True == _35reg1685) {
+Obj _35reg1686 = primCar(closureRef(co, 0));
+Obj x = _35reg1686;
+Obj _35reg1687 = primCdr(closureRef(co, 0));
+Obj y = _35reg1687;
+Obj s2 = closureRef(co, 1);
+pushCont(co, 0, _35clofun2955, 3, y, s2, _35cc1265);
+coraCall(co, 3, globalRef(intern("elem?")), x, s2);
+} else {
+coraCall(co, 1, _35cc1265);
+}
+}
+
+void _35clofun2955(struct Cora* co) {
+Obj _35val1688 = co->args[1];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s2 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc1265 = co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val1688) {
+coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), y, s2);
+} else {
+coraCall(co, 1, _35cc1265);
+}
+}
+
+void _35clofun2952(struct Cora* co) {
+Obj _35cc1266 = makeNative(0, _35clofun2953, 0, 0);
+Obj _35reg1680 = primIsCons(closureRef(co, 0));
+if (True == _35reg1680) {
+Obj _35reg1681 = primCar(closureRef(co, 0));
+Obj x = _35reg1681;
+Obj _35reg1682 = primCdr(closureRef(co, 0));
+Obj y = _35reg1682;
+Obj s2 = closureRef(co, 1);
+pushCont(co, 0, _35clofun2954, 1, x);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), y, s2);
+} else {
+coraCall(co, 1, _35cc1266);
+}
+}
+
+void _35clofun2954(struct Cora* co) {
+Obj _35val1683 = co->args[1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1684 = primCons(x, _35val1683);
+coraReturn(co, _35reg1684);
+return;
+}
+
+void _35clofun2953(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
 void _35clofun2944(struct Cora* co) {
-Obj _35p1256 = co->args[1];
-Obj _35p1257 = co->args[2];
-Obj _35cc1258 = makeNative(0, _35clofun2945, 0, 2, _35p1256, _35p1257);
-Obj _35reg1683 = primEQ(Nil, _35p1256);
-if (True == _35reg1683) {
-Obj __ = _35p1257;
-coraReturn(co, Nil);
+Obj _35p1257 = co->args[1];
+Obj _35p1258 = co->args[2];
+Obj _35cc1259 = makeNative(0, _35clofun2945, 0, 2, _35p1257, _35p1258);
+Obj _35reg1678 = primEQ(Nil, _35p1257);
+if (True == _35reg1678) {
+Obj s2 = _35p1258;
+coraReturn(co, s2);
 return;
 } else {
-coraCall(co, 1, _35cc1258);
+coraCall(co, 1, _35cc1259);
 }
 }
 
 void _35clofun2945(struct Cora* co) {
-Obj _35cc1259 = makeNative(0, _35clofun2946, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1679 = primIsCons(closureRef(co, 0));
-if (True == _35reg1679) {
-Obj _35reg1680 = primCar(closureRef(co, 0));
-Obj x = _35reg1680;
-Obj _35reg1681 = primCdr(closureRef(co, 0));
-Obj y = _35reg1681;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 0, _35clofun2949, 3, y, s2, _35cc1259);
-coraCall(co, 3, globalRef(intern("elem?")), x, s2);
-} else {
-coraCall(co, 1, _35cc1259);
-}
-}
-
-void _35clofun2949(struct Cora* co) {
-Obj _35val1682 = co->args[1];
-Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj s2 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc1259 = co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1682) {
-coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), y, s2);
-} else {
-coraCall(co, 1, _35cc1259);
-}
-}
-
-void _35clofun2946(struct Cora* co) {
-Obj _35cc1260 = makeNative(0, _35clofun2947, 0, 0);
+Obj _35cc1260 = makeNative(0, _35clofun2946, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg1674 = primIsCons(closureRef(co, 0));
 if (True == _35reg1674) {
 Obj _35reg1675 = primCar(closureRef(co, 0));
@@ -5009,18 +5051,46 @@ Obj x = _35reg1675;
 Obj _35reg1676 = primCdr(closureRef(co, 0));
 Obj y = _35reg1676;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 0, _35clofun2948, 1, x);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.diff")), y, s2);
+pushCont(co, 0, _35clofun2949, 3, y, s2, _35cc1260);
+coraCall(co, 3, globalRef(intern("elem?")), x, s2);
 } else {
 coraCall(co, 1, _35cc1260);
 }
 }
 
-void _35clofun2948(struct Cora* co) {
+void _35clofun2949(struct Cora* co) {
 Obj _35val1677 = co->args[1];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s2 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc1260 = co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val1677) {
+coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), y, s2);
+} else {
+coraCall(co, 1, _35cc1260);
+}
+}
+
+void _35clofun2946(struct Cora* co) {
+Obj _35cc1261 = makeNative(0, _35clofun2947, 0, 0);
+Obj _35reg1669 = primIsCons(closureRef(co, 0));
+if (True == _35reg1669) {
+Obj _35reg1670 = primCar(closureRef(co, 0));
+Obj x = _35reg1670;
+Obj _35reg1671 = primCdr(closureRef(co, 0));
+Obj y = _35reg1671;
+Obj s2 = closureRef(co, 1);
+pushCont(co, 0, _35clofun2948, 1, x);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), y, s2);
+} else {
+coraCall(co, 1, _35cc1261);
+}
+}
+
+void _35clofun2948(struct Cora* co) {
+Obj _35val1672 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1678 = primCons(x, _35val1677);
-coraReturn(co, _35reg1678);
+Obj _35reg1673 = primCons(x, _35val1672);
+coraReturn(co, _35reg1673);
 return;
 }
 
@@ -5028,121 +5098,20 @@ void _35clofun2947(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2938(struct Cora* co) {
-Obj _35p1251 = co->args[1];
-Obj _35p1252 = co->args[2];
-Obj _35cc1253 = makeNative(0, _35clofun2939, 0, 2, _35p1251, _35p1252);
-Obj _35reg1672 = primEQ(Nil, _35p1251);
-if (True == _35reg1672) {
-Obj s2 = _35p1252;
-coraReturn(co, s2);
-return;
-} else {
-coraCall(co, 1, _35cc1253);
-}
-}
-
-void _35clofun2939(struct Cora* co) {
-Obj _35cc1254 = makeNative(0, _35clofun2940, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1668 = primIsCons(closureRef(co, 0));
-if (True == _35reg1668) {
-Obj _35reg1669 = primCar(closureRef(co, 0));
-Obj x = _35reg1669;
-Obj _35reg1670 = primCdr(closureRef(co, 0));
-Obj y = _35reg1670;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 0, _35clofun2943, 3, y, s2, _35cc1254);
-coraCall(co, 3, globalRef(intern("elem?")), x, s2);
-} else {
-coraCall(co, 1, _35cc1254);
-}
-}
-
-void _35clofun2943(struct Cora* co) {
-Obj _35val1671 = co->args[1];
-Obj y = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj s2 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc1254 = co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1671) {
-coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), y, s2);
-} else {
-coraCall(co, 1, _35cc1254);
-}
-}
-
-void _35clofun2940(struct Cora* co) {
-Obj _35cc1255 = makeNative(0, _35clofun2941, 0, 0);
-Obj _35reg1663 = primIsCons(closureRef(co, 0));
-if (True == _35reg1663) {
-Obj _35reg1664 = primCar(closureRef(co, 0));
-Obj x = _35reg1664;
-Obj _35reg1665 = primCdr(closureRef(co, 0));
-Obj y = _35reg1665;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 0, _35clofun2942, 1, x);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.union")), y, s2);
-} else {
-coraCall(co, 1, _35cc1255);
-}
-}
-
-void _35clofun2942(struct Cora* co) {
-Obj _35val1666 = co->args[1];
-Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1667 = primCons(x, _35val1666);
-coraReturn(co, _35reg1667);
-return;
-}
-
-void _35clofun2941(struct Cora* co) {
-coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
-}
-
-void _35clofun2908(struct Cora* co) {
-Obj _35p1240 = co->args[1];
-Obj _35p1241 = co->args[2];
-Obj _35cc1242 = makeNative(0, _35clofun2909, 0, 2, _35p1240, _35p1241);
-Obj __ = _35p1240;
-Obj x = _35p1241;
-pushCont(co, 0, _35clofun2935, 2, x, _35cc1242);
+void _35clofun2914(struct Cora* co) {
+Obj _35p1246 = co->args[1];
+Obj _35p1247 = co->args[2];
+Obj _35cc1248 = makeNative(0, _35clofun2915, 0, 2, _35p1246, _35p1247);
+Obj __ = _35p1246;
+Obj x = _35p1247;
+pushCont(co, 0, _35clofun2941, 2, x, _35cc1248);
 coraCall(co, 2, globalRef(intern("number?")), x);
 }
 
-void _35clofun2935(struct Cora* co) {
-Obj _35val1648 = co->args[1];
-Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1242 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1648) {
-if (True == True) {
-Obj _35reg1649 = primCons(x, Nil);
-Obj _35reg1650 = primCons(intern("%const"), _35reg1649);
-coraReturn(co, _35reg1650);
-return;
-} else {
-coraCall(co, 1, _35cc1242);
-}
-} else {
-Obj _35reg1651 = primIsString(x);
-if (True == _35reg1651) {
-if (True == True) {
-Obj _35reg1652 = primCons(x, Nil);
-Obj _35reg1653 = primCons(intern("%const"), _35reg1652);
-coraReturn(co, _35reg1653);
-return;
-} else {
-coraCall(co, 1, _35cc1242);
-}
-} else {
-pushCont(co, 0, _35clofun2936, 2, x, _35cc1242);
-coraCall(co, 2, globalRef(intern("boolean?")), x);
-}
-}
-}
-
-void _35clofun2936(struct Cora* co) {
+void _35clofun2941(struct Cora* co) {
 Obj _35val1654 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1242 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc1248 = co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val1654) {
 if (True == True) {
 Obj _35reg1655 = primCons(x, Nil);
@@ -5150,492 +5119,571 @@ Obj _35reg1656 = primCons(intern("%const"), _35reg1655);
 coraReturn(co, _35reg1656);
 return;
 } else {
-coraCall(co, 1, _35cc1242);
+coraCall(co, 1, _35cc1248);
 }
 } else {
-pushCont(co, 0, _35clofun2937, 2, x, _35cc1242);
-coraCall(co, 2, globalRef(intern("null?")), x);
-}
-}
-
-void _35clofun2937(struct Cora* co) {
-Obj _35val1657 = co->args[1];
-Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1242 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1657) {
+Obj _35reg1657 = primIsString(x);
+if (True == _35reg1657) {
 if (True == True) {
 Obj _35reg1658 = primCons(x, Nil);
 Obj _35reg1659 = primCons(intern("%const"), _35reg1658);
 coraReturn(co, _35reg1659);
 return;
 } else {
-coraCall(co, 1, _35cc1242);
+coraCall(co, 1, _35cc1248);
+}
+} else {
+pushCont(co, 0, _35clofun2942, 2, x, _35cc1248);
+coraCall(co, 2, globalRef(intern("boolean?")), x);
+}
+}
+}
+
+void _35clofun2942(struct Cora* co) {
+Obj _35val1660 = co->args[1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1248 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1660) {
+if (True == True) {
+Obj _35reg1661 = primCons(x, Nil);
+Obj _35reg1662 = primCons(intern("%const"), _35reg1661);
+coraReturn(co, _35reg1662);
+return;
+} else {
+coraCall(co, 1, _35cc1248);
+}
+} else {
+pushCont(co, 0, _35clofun2943, 2, x, _35cc1248);
+coraCall(co, 2, globalRef(intern("null?")), x);
+}
+}
+
+void _35clofun2943(struct Cora* co) {
+Obj _35val1663 = co->args[1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1248 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1663) {
+if (True == True) {
+Obj _35reg1664 = primCons(x, Nil);
+Obj _35reg1665 = primCons(intern("%const"), _35reg1664);
+coraReturn(co, _35reg1665);
+return;
+} else {
+coraCall(co, 1, _35cc1248);
 }
 } else {
 if (True == False) {
-Obj _35reg1660 = primCons(x, Nil);
-Obj _35reg1661 = primCons(intern("%const"), _35reg1660);
-coraReturn(co, _35reg1661);
+Obj _35reg1666 = primCons(x, Nil);
+Obj _35reg1667 = primCons(intern("%const"), _35reg1666);
+coraReturn(co, _35reg1667);
 return;
-} else {
-coraCall(co, 1, _35cc1242);
-}
-}
-}
-
-void _35clofun2909(struct Cora* co) {
-Obj _35cc1243 = makeNative(0, _35clofun2910, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj __ = closureRef(co, 0);
-Obj _35reg1636 = primIsCons(closureRef(co, 1));
-if (True == _35reg1636) {
-Obj _35reg1637 = primCar(closureRef(co, 1));
-Obj _35reg1638 = primEQ(intern("quote"), _35reg1637);
-if (True == _35reg1638) {
-Obj _35reg1639 = primCdr(closureRef(co, 1));
-Obj _35reg1640 = primIsCons(_35reg1639);
-if (True == _35reg1640) {
-Obj _35reg1641 = primCdr(closureRef(co, 1));
-Obj _35reg1642 = primCar(_35reg1641);
-Obj x = _35reg1642;
-Obj _35reg1643 = primCdr(closureRef(co, 1));
-Obj _35reg1644 = primCdr(_35reg1643);
-Obj _35reg1645 = primEQ(Nil, _35reg1644);
-if (True == _35reg1645) {
-Obj _35reg1646 = primCons(x, Nil);
-Obj _35reg1647 = primCons(intern("%const"), _35reg1646);
-coraReturn(co, _35reg1647);
-return;
-} else {
-coraCall(co, 1, _35cc1243);
-}
-} else {
-coraCall(co, 1, _35cc1243);
-}
-} else {
-coraCall(co, 1, _35cc1243);
-}
-} else {
-coraCall(co, 1, _35cc1243);
-}
-}
-
-void _35clofun2910(struct Cora* co) {
-Obj _35cc1244 = makeNative(0, _35clofun2911, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj env = closureRef(co, 0);
-Obj x = closureRef(co, 1);
-Obj _35reg1632 = primIsSymbol(x);
-if (True == _35reg1632) {
-pushCont(co, 0, _35clofun2934, 1, x);
-coraCall(co, 3, globalRef(intern("elem?")), x, env);
-} else {
-coraCall(co, 1, _35cc1244);
-}
-}
-
-void _35clofun2934(struct Cora* co) {
-Obj _35val1633 = co->args[1];
-Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1633) {
-coraReturn(co, x);
-return;
-} else {
-Obj _35reg1634 = primCons(x, Nil);
-Obj _35reg1635 = primCons(intern("%global"), _35reg1634);
-coraReturn(co, _35reg1635);
-return;
-}
-}
-
-void _35clofun2911(struct Cora* co) {
-Obj _35cc1245 = makeNative(0, _35clofun2912, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj env = closureRef(co, 0);
-Obj _35reg1610 = primIsCons(closureRef(co, 1));
-if (True == _35reg1610) {
-Obj _35reg1611 = primCar(closureRef(co, 1));
-Obj _35reg1612 = primEQ(intern("lambda"), _35reg1611);
-if (True == _35reg1612) {
-Obj _35reg1613 = primCdr(closureRef(co, 1));
-Obj _35reg1614 = primIsCons(_35reg1613);
-if (True == _35reg1614) {
-Obj _35reg1615 = primCdr(closureRef(co, 1));
-Obj _35reg1616 = primCar(_35reg1615);
-Obj args = _35reg1616;
-Obj _35reg1617 = primCdr(closureRef(co, 1));
-Obj _35reg1618 = primCdr(_35reg1617);
-Obj _35reg1619 = primIsCons(_35reg1618);
-if (True == _35reg1619) {
-Obj _35reg1620 = primCdr(closureRef(co, 1));
-Obj _35reg1621 = primCdr(_35reg1620);
-Obj _35reg1622 = primCar(_35reg1621);
-Obj body = _35reg1622;
-Obj _35reg1623 = primCdr(closureRef(co, 1));
-Obj _35reg1624 = primCdr(_35reg1623);
-Obj _35reg1625 = primCdr(_35reg1624);
-Obj _35reg1626 = primEQ(Nil, _35reg1625);
-if (True == _35reg1626) {
-pushCont(co, 0, _35clofun2932, 2, body, args);
-coraCall(co, 3, globalRef(intern("append")), args, env);
-} else {
-coraCall(co, 1, _35cc1245);
-}
-} else {
-coraCall(co, 1, _35cc1245);
-}
-} else {
-coraCall(co, 1, _35cc1245);
-}
-} else {
-coraCall(co, 1, _35cc1245);
-}
-} else {
-coraCall(co, 1, _35cc1245);
-}
-}
-
-void _35clofun2932(struct Cora* co) {
-Obj _35val1627 = co->args[1];
-Obj body = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2933, 1, args);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35val1627, body);
-}
-
-void _35clofun2933(struct Cora* co) {
-Obj _35val1628 = co->args[1];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1629 = primCons(_35val1628, Nil);
-Obj _35reg1630 = primCons(args, _35reg1629);
-Obj _35reg1631 = primCons(intern("lambda"), _35reg1630);
-coraReturn(co, _35reg1631);
-return;
-}
-
-void _35clofun2912(struct Cora* co) {
-Obj _35cc1246 = makeNative(0, _35clofun2913, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj env = closureRef(co, 0);
-Obj _35reg1603 = primIsCons(closureRef(co, 1));
-if (True == _35reg1603) {
-Obj _35reg1604 = primCar(closureRef(co, 1));
-Obj _35reg1605 = primEQ(intern("if"), _35reg1604);
-if (True == _35reg1605) {
-Obj _35reg1606 = primCdr(closureRef(co, 1));
-Obj args = _35reg1606;
-pushCont(co, 0, _35clofun2930, 1, args);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.parse")), env);
-} else {
-coraCall(co, 1, _35cc1246);
-}
-} else {
-coraCall(co, 1, _35cc1246);
-}
-}
-
-void _35clofun2930(struct Cora* co) {
-Obj _35val1607 = co->args[1];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun2931, 0);
-coraCall(co, 3, globalRef(intern("map")), _35val1607, args);
-}
-
-void _35clofun2931(struct Cora* co) {
-Obj _35val1608 = co->args[1];
-Obj _35reg1609 = primCons(intern("if"), _35val1608);
-coraReturn(co, _35reg1609);
-return;
-}
-
-void _35clofun2913(struct Cora* co) {
-Obj _35cc1247 = makeNative(0, _35clofun2914, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj env = closureRef(co, 0);
-Obj _35reg1581 = primIsCons(closureRef(co, 1));
-if (True == _35reg1581) {
-Obj _35reg1582 = primCar(closureRef(co, 1));
-Obj _35reg1583 = primEQ(intern("do"), _35reg1582);
-if (True == _35reg1583) {
-Obj _35reg1584 = primCdr(closureRef(co, 1));
-Obj _35reg1585 = primIsCons(_35reg1584);
-if (True == _35reg1585) {
-Obj _35reg1586 = primCdr(closureRef(co, 1));
-Obj _35reg1587 = primCar(_35reg1586);
-Obj x = _35reg1587;
-Obj _35reg1588 = primCdr(closureRef(co, 1));
-Obj _35reg1589 = primCdr(_35reg1588);
-Obj _35reg1590 = primIsCons(_35reg1589);
-if (True == _35reg1590) {
-Obj _35reg1591 = primCdr(closureRef(co, 1));
-Obj _35reg1592 = primCdr(_35reg1591);
-Obj _35reg1593 = primCar(_35reg1592);
-Obj y = _35reg1593;
-Obj _35reg1594 = primCdr(closureRef(co, 1));
-Obj _35reg1595 = primCdr(_35reg1594);
-Obj _35reg1596 = primCdr(_35reg1595);
-Obj _35reg1597 = primEQ(Nil, _35reg1596);
-if (True == _35reg1597) {
-pushCont(co, 0, _35clofun2928, 2, env, y);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, x);
-} else {
-coraCall(co, 1, _35cc1247);
-}
-} else {
-coraCall(co, 1, _35cc1247);
-}
-} else {
-coraCall(co, 1, _35cc1247);
-}
-} else {
-coraCall(co, 1, _35cc1247);
-}
-} else {
-coraCall(co, 1, _35cc1247);
-}
-}
-
-void _35clofun2928(struct Cora* co) {
-Obj _35val1598 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2929, 1, _35val1598);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, y);
-}
-
-void _35clofun2929(struct Cora* co) {
-Obj _35val1599 = co->args[1];
-Obj _35val1598 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1600 = primCons(_35val1599, Nil);
-Obj _35reg1601 = primCons(_35val1598, _35reg1600);
-Obj _35reg1602 = primCons(intern("do"), _35reg1601);
-coraReturn(co, _35reg1602);
-return;
-}
-
-void _35clofun2914(struct Cora* co) {
-Obj _35cc1248 = makeNative(0, _35clofun2915, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj env = closureRef(co, 0);
-Obj _35reg1548 = primIsCons(closureRef(co, 1));
-if (True == _35reg1548) {
-Obj _35reg1549 = primCar(closureRef(co, 1));
-Obj _35reg1550 = primEQ(intern("let"), _35reg1549);
-if (True == _35reg1550) {
-Obj _35reg1551 = primCdr(closureRef(co, 1));
-Obj _35reg1552 = primIsCons(_35reg1551);
-if (True == _35reg1552) {
-Obj _35reg1553 = primCdr(closureRef(co, 1));
-Obj _35reg1554 = primCar(_35reg1553);
-Obj a = _35reg1554;
-Obj _35reg1555 = primCdr(closureRef(co, 1));
-Obj _35reg1556 = primCdr(_35reg1555);
-Obj _35reg1557 = primIsCons(_35reg1556);
-if (True == _35reg1557) {
-Obj _35reg1558 = primCdr(closureRef(co, 1));
-Obj _35reg1559 = primCdr(_35reg1558);
-Obj _35reg1560 = primCar(_35reg1559);
-Obj b = _35reg1560;
-Obj _35reg1561 = primCdr(closureRef(co, 1));
-Obj _35reg1562 = primCdr(_35reg1561);
-Obj _35reg1563 = primCdr(_35reg1562);
-Obj _35reg1564 = primIsCons(_35reg1563);
-if (True == _35reg1564) {
-Obj _35reg1565 = primCdr(closureRef(co, 1));
-Obj _35reg1566 = primCdr(_35reg1565);
-Obj _35reg1567 = primCdr(_35reg1566);
-Obj _35reg1568 = primCar(_35reg1567);
-Obj c = _35reg1568;
-Obj _35reg1569 = primCdr(closureRef(co, 1));
-Obj _35reg1570 = primCdr(_35reg1569);
-Obj _35reg1571 = primCdr(_35reg1570);
-Obj _35reg1572 = primCdr(_35reg1571);
-Obj _35reg1573 = primEQ(Nil, _35reg1572);
-if (True == _35reg1573) {
-pushCont(co, 0, _35clofun2926, 3, env, c, a);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, b);
-} else {
-coraCall(co, 1, _35cc1248);
-}
-} else {
-coraCall(co, 1, _35cc1248);
-}
-} else {
-coraCall(co, 1, _35cc1248);
-}
-} else {
-coraCall(co, 1, _35cc1248);
-}
-} else {
-coraCall(co, 1, _35cc1248);
-}
 } else {
 coraCall(co, 1, _35cc1248);
 }
 }
-
-void _35clofun2926(struct Cora* co) {
-Obj _35val1574 = co->args[1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1575 = primCons(a, env);
-pushCont(co, 0, _35clofun2927, 2, _35val1574, a);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35reg1575, c);
-}
-
-void _35clofun2927(struct Cora* co) {
-Obj _35val1576 = co->args[1];
-Obj _35val1574 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1577 = primCons(_35val1576, Nil);
-Obj _35reg1578 = primCons(_35val1574, _35reg1577);
-Obj _35reg1579 = primCons(a, _35reg1578);
-Obj _35reg1580 = primCons(intern("let"), _35reg1579);
-coraReturn(co, _35reg1580);
-return;
 }
 
 void _35clofun2915(struct Cora* co) {
 Obj _35cc1249 = makeNative(0, _35clofun2916, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj env = closureRef(co, 0);
-Obj _35reg1528 = primIsCons(closureRef(co, 1));
-if (True == _35reg1528) {
-Obj _35reg1529 = primCar(closureRef(co, 1));
-Obj op = _35reg1529;
-Obj _35reg1530 = primCdr(closureRef(co, 1));
-Obj args = _35reg1530;
-pushCont(co, 0, _35clofun2919, 4, op, args, env, _35cc1249);
-coraCall(co, 2, globalRef(intern("builtin?")), op);
+Obj __ = closureRef(co, 0);
+Obj _35reg1642 = primIsCons(closureRef(co, 1));
+if (True == _35reg1642) {
+Obj _35reg1643 = primCar(closureRef(co, 1));
+Obj _35reg1644 = primEQ(intern("quote"), _35reg1643);
+if (True == _35reg1644) {
+Obj _35reg1645 = primCdr(closureRef(co, 1));
+Obj _35reg1646 = primIsCons(_35reg1645);
+if (True == _35reg1646) {
+Obj _35reg1647 = primCdr(closureRef(co, 1));
+Obj _35reg1648 = primCar(_35reg1647);
+Obj x = _35reg1648;
+Obj _35reg1649 = primCdr(closureRef(co, 1));
+Obj _35reg1650 = primCdr(_35reg1649);
+Obj _35reg1651 = primEQ(Nil, _35reg1650);
+if (True == _35reg1651) {
+Obj _35reg1652 = primCons(x, Nil);
+Obj _35reg1653 = primCons(intern("%const"), _35reg1652);
+coraReturn(co, _35reg1653);
+return;
 } else {
 coraCall(co, 1, _35cc1249);
 }
+} else {
+coraCall(co, 1, _35cc1249);
+}
+} else {
+coraCall(co, 1, _35cc1249);
+}
+} else {
+coraCall(co, 1, _35cc1249);
+}
+}
+
+void _35clofun2916(struct Cora* co) {
+Obj _35cc1250 = makeNative(0, _35clofun2917, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj env = closureRef(co, 0);
+Obj x = closureRef(co, 1);
+Obj _35reg1638 = primIsSymbol(x);
+if (True == _35reg1638) {
+pushCont(co, 0, _35clofun2940, 1, x);
+coraCall(co, 3, globalRef(intern("elem?")), x, env);
+} else {
+coraCall(co, 1, _35cc1250);
+}
+}
+
+void _35clofun2940(struct Cora* co) {
+Obj _35val1639 = co->args[1];
+Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1639) {
+coraReturn(co, x);
+return;
+} else {
+Obj _35reg1640 = primCons(x, Nil);
+Obj _35reg1641 = primCons(intern("%global"), _35reg1640);
+coraReturn(co, _35reg1641);
+return;
+}
+}
+
+void _35clofun2917(struct Cora* co) {
+Obj _35cc1251 = makeNative(0, _35clofun2918, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj env = closureRef(co, 0);
+Obj _35reg1616 = primIsCons(closureRef(co, 1));
+if (True == _35reg1616) {
+Obj _35reg1617 = primCar(closureRef(co, 1));
+Obj _35reg1618 = primEQ(intern("lambda"), _35reg1617);
+if (True == _35reg1618) {
+Obj _35reg1619 = primCdr(closureRef(co, 1));
+Obj _35reg1620 = primIsCons(_35reg1619);
+if (True == _35reg1620) {
+Obj _35reg1621 = primCdr(closureRef(co, 1));
+Obj _35reg1622 = primCar(_35reg1621);
+Obj args = _35reg1622;
+Obj _35reg1623 = primCdr(closureRef(co, 1));
+Obj _35reg1624 = primCdr(_35reg1623);
+Obj _35reg1625 = primIsCons(_35reg1624);
+if (True == _35reg1625) {
+Obj _35reg1626 = primCdr(closureRef(co, 1));
+Obj _35reg1627 = primCdr(_35reg1626);
+Obj _35reg1628 = primCar(_35reg1627);
+Obj body = _35reg1628;
+Obj _35reg1629 = primCdr(closureRef(co, 1));
+Obj _35reg1630 = primCdr(_35reg1629);
+Obj _35reg1631 = primCdr(_35reg1630);
+Obj _35reg1632 = primEQ(Nil, _35reg1631);
+if (True == _35reg1632) {
+pushCont(co, 0, _35clofun2938, 2, body, args);
+coraCall(co, 3, globalRef(intern("append")), args, env);
+} else {
+coraCall(co, 1, _35cc1251);
+}
+} else {
+coraCall(co, 1, _35cc1251);
+}
+} else {
+coraCall(co, 1, _35cc1251);
+}
+} else {
+coraCall(co, 1, _35cc1251);
+}
+} else {
+coraCall(co, 1, _35cc1251);
+}
+}
+
+void _35clofun2938(struct Cora* co) {
+Obj _35val1633 = co->args[1];
+Obj body = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun2939, 1, args);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35val1633, body);
+}
+
+void _35clofun2939(struct Cora* co) {
+Obj _35val1634 = co->args[1];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1635 = primCons(_35val1634, Nil);
+Obj _35reg1636 = primCons(args, _35reg1635);
+Obj _35reg1637 = primCons(intern("lambda"), _35reg1636);
+coraReturn(co, _35reg1637);
+return;
+}
+
+void _35clofun2918(struct Cora* co) {
+Obj _35cc1252 = makeNative(0, _35clofun2919, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj env = closureRef(co, 0);
+Obj _35reg1609 = primIsCons(closureRef(co, 1));
+if (True == _35reg1609) {
+Obj _35reg1610 = primCar(closureRef(co, 1));
+Obj _35reg1611 = primEQ(intern("if"), _35reg1610);
+if (True == _35reg1611) {
+Obj _35reg1612 = primCdr(closureRef(co, 1));
+Obj args = _35reg1612;
+pushCont(co, 0, _35clofun2936, 1, args);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.parse")), env);
+} else {
+coraCall(co, 1, _35cc1252);
+}
+} else {
+coraCall(co, 1, _35cc1252);
+}
+}
+
+void _35clofun2936(struct Cora* co) {
+Obj _35val1613 = co->args[1];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 0, _35clofun2937, 0);
+coraCall(co, 3, globalRef(intern("map")), _35val1613, args);
+}
+
+void _35clofun2937(struct Cora* co) {
+Obj _35val1614 = co->args[1];
+Obj _35reg1615 = primCons(intern("if"), _35val1614);
+coraReturn(co, _35reg1615);
+return;
 }
 
 void _35clofun2919(struct Cora* co) {
-Obj _35val1531 = co->args[1];
-Obj op = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35cc1249 = co->ctx.stk.stack[co->ctx.stk.base + 3];
-if (True == _35val1531) {
-pushCont(co, 0, _35clofun2920, 3, op, args, env);
-coraCall(co, 2, globalRef(intern("cora/lib/toc.builtin->args")), op);
+Obj _35cc1253 = makeNative(0, _35clofun2920, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj env = closureRef(co, 0);
+Obj _35reg1587 = primIsCons(closureRef(co, 1));
+if (True == _35reg1587) {
+Obj _35reg1588 = primCar(closureRef(co, 1));
+Obj _35reg1589 = primEQ(intern("do"), _35reg1588);
+if (True == _35reg1589) {
+Obj _35reg1590 = primCdr(closureRef(co, 1));
+Obj _35reg1591 = primIsCons(_35reg1590);
+if (True == _35reg1591) {
+Obj _35reg1592 = primCdr(closureRef(co, 1));
+Obj _35reg1593 = primCar(_35reg1592);
+Obj x = _35reg1593;
+Obj _35reg1594 = primCdr(closureRef(co, 1));
+Obj _35reg1595 = primCdr(_35reg1594);
+Obj _35reg1596 = primIsCons(_35reg1595);
+if (True == _35reg1596) {
+Obj _35reg1597 = primCdr(closureRef(co, 1));
+Obj _35reg1598 = primCdr(_35reg1597);
+Obj _35reg1599 = primCar(_35reg1598);
+Obj y = _35reg1599;
+Obj _35reg1600 = primCdr(closureRef(co, 1));
+Obj _35reg1601 = primCdr(_35reg1600);
+Obj _35reg1602 = primCdr(_35reg1601);
+Obj _35reg1603 = primEQ(Nil, _35reg1602);
+if (True == _35reg1603) {
+pushCont(co, 0, _35clofun2934, 2, env, y);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, x);
 } else {
-coraCall(co, 1, _35cc1249);
+coraCall(co, 1, _35cc1253);
 }
+} else {
+coraCall(co, 1, _35cc1253);
+}
+} else {
+coraCall(co, 1, _35cc1253);
+}
+} else {
+coraCall(co, 1, _35cc1253);
+}
+} else {
+coraCall(co, 1, _35cc1253);
+}
+}
+
+void _35clofun2934(struct Cora* co) {
+Obj _35val1604 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun2935, 1, _35val1604);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, y);
+}
+
+void _35clofun2935(struct Cora* co) {
+Obj _35val1605 = co->args[1];
+Obj _35val1604 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1606 = primCons(_35val1605, Nil);
+Obj _35reg1607 = primCons(_35val1604, _35reg1606);
+Obj _35reg1608 = primCons(intern("do"), _35reg1607);
+coraReturn(co, _35reg1608);
+return;
 }
 
 void _35clofun2920(struct Cora* co) {
-Obj _35val1532 = co->args[1];
-Obj op = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj required = _35val1532;
-pushCont(co, 0, _35clofun2921, 4, required, op, args, env);
-coraCall(co, 2, globalRef(intern("length")), args);
+Obj _35cc1254 = makeNative(0, _35clofun2921, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj env = closureRef(co, 0);
+Obj _35reg1554 = primIsCons(closureRef(co, 1));
+if (True == _35reg1554) {
+Obj _35reg1555 = primCar(closureRef(co, 1));
+Obj _35reg1556 = primEQ(intern("let"), _35reg1555);
+if (True == _35reg1556) {
+Obj _35reg1557 = primCdr(closureRef(co, 1));
+Obj _35reg1558 = primIsCons(_35reg1557);
+if (True == _35reg1558) {
+Obj _35reg1559 = primCdr(closureRef(co, 1));
+Obj _35reg1560 = primCar(_35reg1559);
+Obj a = _35reg1560;
+Obj _35reg1561 = primCdr(closureRef(co, 1));
+Obj _35reg1562 = primCdr(_35reg1561);
+Obj _35reg1563 = primIsCons(_35reg1562);
+if (True == _35reg1563) {
+Obj _35reg1564 = primCdr(closureRef(co, 1));
+Obj _35reg1565 = primCdr(_35reg1564);
+Obj _35reg1566 = primCar(_35reg1565);
+Obj b = _35reg1566;
+Obj _35reg1567 = primCdr(closureRef(co, 1));
+Obj _35reg1568 = primCdr(_35reg1567);
+Obj _35reg1569 = primCdr(_35reg1568);
+Obj _35reg1570 = primIsCons(_35reg1569);
+if (True == _35reg1570) {
+Obj _35reg1571 = primCdr(closureRef(co, 1));
+Obj _35reg1572 = primCdr(_35reg1571);
+Obj _35reg1573 = primCdr(_35reg1572);
+Obj _35reg1574 = primCar(_35reg1573);
+Obj c = _35reg1574;
+Obj _35reg1575 = primCdr(closureRef(co, 1));
+Obj _35reg1576 = primCdr(_35reg1575);
+Obj _35reg1577 = primCdr(_35reg1576);
+Obj _35reg1578 = primCdr(_35reg1577);
+Obj _35reg1579 = primEQ(Nil, _35reg1578);
+if (True == _35reg1579) {
+pushCont(co, 0, _35clofun2932, 3, env, c, a);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, b);
+} else {
+coraCall(co, 1, _35cc1254);
+}
+} else {
+coraCall(co, 1, _35cc1254);
+}
+} else {
+coraCall(co, 1, _35cc1254);
+}
+} else {
+coraCall(co, 1, _35cc1254);
+}
+} else {
+coraCall(co, 1, _35cc1254);
+}
+} else {
+coraCall(co, 1, _35cc1254);
+}
+}
+
+void _35clofun2932(struct Cora* co) {
+Obj _35val1580 = co->args[1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj c = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg1581 = primCons(a, env);
+pushCont(co, 0, _35clofun2933, 2, _35val1580, a);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), _35reg1581, c);
+}
+
+void _35clofun2933(struct Cora* co) {
+Obj _35val1582 = co->args[1];
+Obj _35val1580 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1583 = primCons(_35val1582, Nil);
+Obj _35reg1584 = primCons(_35val1580, _35reg1583);
+Obj _35reg1585 = primCons(a, _35reg1584);
+Obj _35reg1586 = primCons(intern("let"), _35reg1585);
+coraReturn(co, _35reg1586);
+return;
 }
 
 void _35clofun2921(struct Cora* co) {
-Obj _35val1533 = co->args[1];
+Obj _35cc1255 = makeNative(0, _35clofun2922, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj env = closureRef(co, 0);
+Obj _35reg1534 = primIsCons(closureRef(co, 1));
+if (True == _35reg1534) {
+Obj _35reg1535 = primCar(closureRef(co, 1));
+Obj op = _35reg1535;
+Obj _35reg1536 = primCdr(closureRef(co, 1));
+Obj args = _35reg1536;
+pushCont(co, 0, _35clofun2925, 4, op, args, env, _35cc1255);
+coraCall(co, 2, globalRef(intern("builtin?")), op);
+} else {
+coraCall(co, 1, _35cc1255);
+}
+}
+
+void _35clofun2925(struct Cora* co) {
+Obj _35val1537 = co->args[1];
+Obj op = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35cc1255 = co->ctx.stk.stack[co->ctx.stk.base + 3];
+if (True == _35val1537) {
+pushCont(co, 0, _35clofun2926, 3, op, args, env);
+coraCall(co, 2, globalRef(intern("cora/lib/toc.builtin->args")), op);
+} else {
+coraCall(co, 1, _35cc1255);
+}
+}
+
+void _35clofun2926(struct Cora* co) {
+Obj _35val1538 = co->args[1];
+Obj op = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj required = _35val1538;
+pushCont(co, 0, _35clofun2927, 4, required, op, args, env);
+coraCall(co, 2, globalRef(intern("length")), args);
+}
+
+void _35clofun2927(struct Cora* co) {
+Obj _35val1539 = co->args[1];
 Obj required = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj op = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj provided = _35val1533;
-Obj _35reg1534 = primEQ(required, provided);
-if (True == _35reg1534) {
-Obj _35reg1535 = primCons(op, Nil);
-Obj _35reg1536 = primCons(intern("%builtin"), _35reg1535);
-pushCont(co, 0, _35clofun2922, 2, args, _35reg1536);
+Obj provided = _35val1539;
+Obj _35reg1540 = primEQ(required, provided);
+if (True == _35reg1540) {
+Obj _35reg1541 = primCons(op, Nil);
+Obj _35reg1542 = primCons(intern("%builtin"), _35reg1541);
+pushCont(co, 0, _35clofun2928, 2, args, _35reg1542);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.parse")), env);
 } else {
-Obj _35reg1540 = primGT(required, provided);
-if (True == _35reg1540) {
-Obj _35reg1541 = primSub(required, provided);
-pushCont(co, 0, _35clofun2924, 3, op, args, env);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.temp-list")), _35reg1541, Nil);
+Obj _35reg1546 = primGT(required, provided);
+if (True == _35reg1546) {
+Obj _35reg1547 = primSub(required, provided);
+pushCont(co, 0, _35clofun2930, 3, op, args, env);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.temp-list")), _35reg1547, Nil);
 } else {
 coraCall(co, 2, globalRef(intern("error")), makeString1("primitive call mismatch"));
 }
 }
 }
 
-void _35clofun2924(struct Cora* co) {
-Obj _35val1542 = co->args[1];
+void _35clofun2930(struct Cora* co) {
+Obj _35val1548 = co->args[1];
 Obj op = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args = co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj tmp = _35val1542;
-Obj _35reg1543 = primCons(op, args);
-pushCont(co, 0, _35clofun2925, 2, tmp, env);
-coraCall(co, 3, globalRef(intern("append")), _35reg1543, tmp);
+Obj tmp = _35val1548;
+Obj _35reg1549 = primCons(op, args);
+pushCont(co, 0, _35clofun2931, 2, tmp, env);
+coraCall(co, 3, globalRef(intern("append")), _35reg1549, tmp);
 }
 
-void _35clofun2925(struct Cora* co) {
-Obj _35val1544 = co->args[1];
+void _35clofun2931(struct Cora* co) {
+Obj _35val1550 = co->args[1];
 Obj tmp = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1545 = primCons(_35val1544, Nil);
-Obj _35reg1546 = primCons(tmp, _35reg1545);
-Obj _35reg1547 = primCons(intern("lambda"), _35reg1546);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, _35reg1547);
+Obj _35reg1551 = primCons(_35val1550, Nil);
+Obj _35reg1552 = primCons(tmp, _35reg1551);
+Obj _35reg1553 = primCons(intern("lambda"), _35reg1552);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.parse")), env, _35reg1553);
+}
+
+void _35clofun2928(struct Cora* co) {
+Obj _35val1543 = co->args[1];
+Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1542 = co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, _35clofun2929, 1, _35reg1542);
+coraCall(co, 3, globalRef(intern("map")), _35val1543, args);
+}
+
+void _35clofun2929(struct Cora* co) {
+Obj _35val1544 = co->args[1];
+Obj _35reg1542 = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1545 = primCons(_35reg1542, _35val1544);
+coraReturn(co, _35reg1545);
+return;
 }
 
 void _35clofun2922(struct Cora* co) {
-Obj _35val1537 = co->args[1];
-Obj args = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1536 = co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2923, 1, _35reg1536);
-coraCall(co, 3, globalRef(intern("map")), _35val1537, args);
-}
-
-void _35clofun2923(struct Cora* co) {
-Obj _35val1538 = co->args[1];
-Obj _35reg1536 = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1539 = primCons(_35reg1536, _35val1538);
-coraReturn(co, _35reg1539);
-return;
-}
-
-void _35clofun2916(struct Cora* co) {
-Obj _35cc1250 = makeNative(0, _35clofun2917, 0, 0);
+Obj _35cc1256 = makeNative(0, _35clofun2923, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ls = closureRef(co, 1);
-pushCont(co, 0, _35clofun2918, 1, ls);
+pushCont(co, 0, _35clofun2924, 1, ls);
 coraCall(co, 2, globalRef(intern("cora/lib/toc.parse")), env);
 }
 
-void _35clofun2918(struct Cora* co) {
-Obj _35val1527 = co->args[1];
+void _35clofun2924(struct Cora* co) {
+Obj _35val1533 = co->args[1];
 Obj ls = co->ctx.stk.stack[co->ctx.stk.base + 0];
-coraCall(co, 3, globalRef(intern("map")), _35val1527, ls);
+coraCall(co, 3, globalRef(intern("map")), _35val1533, ls);
 }
 
-void _35clofun2917(struct Cora* co) {
+void _35clofun2923(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2905(struct Cora* co) {
-Obj _35p1236 = co->args[1];
-Obj _35p1237 = co->args[2];
-Obj _35cc1238 = makeNative(0, _35clofun2906, 0, 2, _35p1236, _35p1237);
-Obj _35reg1525 = primEQ(makeNumber(0), _35p1236);
-if (True == _35reg1525) {
-Obj res = _35p1237;
+void _35clofun2911(struct Cora* co) {
+Obj _35p1242 = co->args[1];
+Obj _35p1243 = co->args[2];
+Obj _35cc1244 = makeNative(0, _35clofun2912, 0, 2, _35p1242, _35p1243);
+Obj _35reg1531 = primEQ(makeNumber(0), _35p1242);
+if (True == _35reg1531) {
+Obj res = _35p1243;
 coraReturn(co, res);
 return;
 } else {
-coraCall(co, 1, _35cc1238);
+coraCall(co, 1, _35cc1244);
 }
+}
+
+void _35clofun2912(struct Cora* co) {
+Obj _35cc1245 = makeNative(0, _35clofun2913, 0, 0);
+Obj n = closureRef(co, 0);
+Obj res = closureRef(co, 1);
+Obj _35reg1528 = primSub(n, makeNumber(1));
+Obj _35reg1529 = primGenSym(intern("tmp"));
+Obj _35reg1530 = primCons(_35reg1529, res);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.temp-list")), _35reg1528, _35reg1530);
+}
+
+void _35clofun2913(struct Cora* co) {
+coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
+}
+
+void _35clofun2908(struct Cora* co) {
+Obj x = co->args[1];
+pushCont(co, 0, _35clofun2909, 0);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), x, globalRef(intern("cora/lib/toc.*builtin-prims*")));
+}
+
+void _35clofun2909(struct Cora* co) {
+Obj _35val1525 = co->args[1];
+Obj find = _35val1525;
+pushCont(co, 0, _35clofun2910, 1, find);
+coraCall(co, 2, globalRef(intern("null?")), find);
+}
+
+void _35clofun2910(struct Cora* co) {
+Obj _35val1526 = co->args[1];
+Obj find = co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1526) {
+coraReturn(co, makeString1("ERROR"));
+return;
+} else {
+coraCall(co, 2, globalRef(intern("cadr")), find);
+}
+}
+
+void _35clofun2905(struct Cora* co) {
+Obj x = co->args[1];
+pushCont(co, 0, _35clofun2906, 0);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), x, globalRef(intern("cora/lib/toc.*builtin-prims*")));
 }
 
 void _35clofun2906(struct Cora* co) {
-Obj _35cc1239 = makeNative(0, _35clofun2907, 0, 0);
-Obj n = closureRef(co, 0);
-Obj res = closureRef(co, 1);
-Obj _35reg1522 = primSub(n, makeNumber(1));
-Obj _35reg1523 = primGenSym(intern("tmp"));
-Obj _35reg1524 = primCons(_35reg1523, res);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.temp-list")), _35reg1522, _35reg1524);
+Obj _35val1522 = co->args[1];
+Obj find = _35val1522;
+pushCont(co, 0, _35clofun2907, 1, find);
+coraCall(co, 2, globalRef(intern("null?")), find);
 }
 
 void _35clofun2907(struct Cora* co) {
-coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
+Obj _35val1523 = co->args[1];
+Obj find = co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1523) {
+coraReturn(co, makeString1("ERROR"));
+return;
+} else {
+coraCall(co, 2, globalRef(intern("caddr")), find);
+}
 }
 
 void _35clofun2902(struct Cora* co) {
@@ -5645,102 +5693,54 @@ coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), x, globalRef(intern("cor
 }
 
 void _35clofun2903(struct Cora* co) {
-Obj _35val1519 = co->args[1];
-Obj find = _35val1519;
-pushCont(co, 0, _35clofun2904, 1, find);
-coraCall(co, 2, globalRef(intern("null?")), find);
+Obj _35val1518 = co->args[1];
+pushCont(co, 0, _35clofun2904, 0);
+coraCall(co, 2, globalRef(intern("null?")), _35val1518);
 }
 
 void _35clofun2904(struct Cora* co) {
-Obj _35val1520 = co->args[1];
-Obj find = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1520) {
-coraReturn(co, makeString1("ERROR"));
+Obj _35val1519 = co->args[1];
+Obj _35reg1520 = primNot(_35val1519);
+coraReturn(co, _35reg1520);
+return;
+}
+
+void _35clofun2898(struct Cora* co) {
+Obj _35p1238 = co->args[1];
+Obj _35p1239 = co->args[2];
+Obj _35cc1240 = makeNative(0, _35clofun2899, 0, 2, _35p1238, _35p1239);
+Obj x = _35p1238;
+Obj _35reg1447 = primEQ(Nil, _35p1239);
+if (True == _35reg1447) {
+coraReturn(co, False);
 return;
 } else {
-coraCall(co, 2, globalRef(intern("cadr")), find);
+coraCall(co, 1, _35cc1240);
 }
 }
 
 void _35clofun2899(struct Cora* co) {
-Obj x = co->args[1];
-pushCont(co, 0, _35clofun2900, 0);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), x, globalRef(intern("cora/lib/toc.*builtin-prims*")));
+Obj _35cc1241 = makeNative(0, _35clofun2900, 0, 0);
+Obj x = closureRef(co, 0);
+Obj _35reg1442 = primIsCons(closureRef(co, 1));
+if (True == _35reg1442) {
+Obj _35reg1443 = primCar(closureRef(co, 1));
+Obj hd = _35reg1443;
+Obj _35reg1444 = primCdr(closureRef(co, 1));
+Obj tl = _35reg1444;
+pushCont(co, 0, _35clofun2901, 2, x, tl);
+coraCall(co, 3, globalRef(intern("cora/lib/toc.index")), x, hd);
+} else {
+coraCall(co, 1, _35cc1241);
 }
-
-void _35clofun2900(struct Cora* co) {
-Obj _35val1516 = co->args[1];
-Obj find = _35val1516;
-pushCont(co, 0, _35clofun2901, 1, find);
-coraCall(co, 2, globalRef(intern("null?")), find);
 }
 
 void _35clofun2901(struct Cora* co) {
-Obj _35val1517 = co->args[1];
-Obj find = co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1517) {
-coraReturn(co, makeString1("ERROR"));
-return;
-} else {
-coraCall(co, 2, globalRef(intern("caddr")), find);
-}
-}
-
-void _35clofun2896(struct Cora* co) {
-Obj x = co->args[1];
-pushCont(co, 0, _35clofun2897, 0);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), x, globalRef(intern("cora/lib/toc.*builtin-prims*")));
-}
-
-void _35clofun2897(struct Cora* co) {
-Obj _35val1512 = co->args[1];
-pushCont(co, 0, _35clofun2898, 0);
-coraCall(co, 2, globalRef(intern("null?")), _35val1512);
-}
-
-void _35clofun2898(struct Cora* co) {
-Obj _35val1513 = co->args[1];
-Obj _35reg1514 = primNot(_35val1513);
-coraReturn(co, _35reg1514);
-return;
-}
-
-void _35clofun2892(struct Cora* co) {
-Obj _35p1232 = co->args[1];
-Obj _35p1233 = co->args[2];
-Obj _35cc1234 = makeNative(0, _35clofun2893, 0, 2, _35p1232, _35p1233);
-Obj x = _35p1232;
-Obj _35reg1441 = primEQ(Nil, _35p1233);
-if (True == _35reg1441) {
-coraReturn(co, False);
-return;
-} else {
-coraCall(co, 1, _35cc1234);
-}
-}
-
-void _35clofun2893(struct Cora* co) {
-Obj _35cc1235 = makeNative(0, _35clofun2894, 0, 0);
-Obj x = closureRef(co, 0);
-Obj _35reg1436 = primIsCons(closureRef(co, 1));
-if (True == _35reg1436) {
-Obj _35reg1437 = primCar(closureRef(co, 1));
-Obj hd = _35reg1437;
-Obj _35reg1438 = primCdr(closureRef(co, 1));
-Obj tl = _35reg1438;
-pushCont(co, 0, _35clofun2895, 2, x, tl);
-coraCall(co, 3, globalRef(intern("cora/lib/toc.index")), x, hd);
-} else {
-coraCall(co, 1, _35cc1235);
-}
-}
-
-void _35clofun2895(struct Cora* co) {
-Obj _35val1439 = co->args[1];
+Obj _35val1445 = co->args[1];
 Obj x = co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj tl = co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1440 = primLT(_35val1439, makeNumber(0));
-if (True == _35reg1440) {
+Obj _35reg1446 = primLT(_35val1445, makeNumber(0));
+if (True == _35reg1446) {
 coraCall(co, 3, globalRef(intern("cora/lib/toc.exist-in-env")), x, tl);
 } else {
 coraReturn(co, True);
@@ -5748,181 +5748,181 @@ return;
 }
 }
 
-void _35clofun2894(struct Cora* co) {
+void _35clofun2900(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2891(struct Cora* co) {
+void _35clofun2897(struct Cora* co) {
 Obj x = co->args[1];
 Obj l = co->args[2];
 coraCall(co, 4, globalRef(intern("cora/lib/toc.pos-in-list0")), makeNumber(0), x, l);
 }
 
-void _35clofun2887(struct Cora* co) {
-Obj _35p1226 = co->args[1];
-Obj _35p1227 = co->args[2];
-Obj _35p1228 = co->args[3];
-Obj _35cc1229 = makeNative(0, _35clofun2888, 0, 3, _35p1226, _35p1227, _35p1228);
-Obj __ = _35p1226;
-Obj x = _35p1227;
-Obj _35reg1433 = primEQ(Nil, _35p1228);
-if (True == _35reg1433) {
+void _35clofun2893(struct Cora* co) {
+Obj _35p1232 = co->args[1];
+Obj _35p1233 = co->args[2];
+Obj _35p1234 = co->args[3];
+Obj _35cc1235 = makeNative(0, _35clofun2894, 0, 3, _35p1232, _35p1233, _35p1234);
+Obj __ = _35p1232;
+Obj x = _35p1233;
+Obj _35reg1439 = primEQ(Nil, _35p1234);
+if (True == _35reg1439) {
 coraReturn(co, makeNumber(-1));
 return;
 } else {
-coraCall(co, 1, _35cc1229);
+coraCall(co, 1, _35cc1235);
 }
 }
 
-void _35clofun2888(struct Cora* co) {
-Obj _35cc1230 = makeNative(0, _35clofun2889, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+void _35clofun2894(struct Cora* co) {
+Obj _35cc1236 = makeNative(0, _35clofun2895, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1429 = primIsCons(closureRef(co, 2));
-if (True == _35reg1429) {
-Obj _35reg1430 = primCar(closureRef(co, 2));
-Obj a = _35reg1430;
-Obj _35reg1431 = primCdr(closureRef(co, 2));
-Obj b = _35reg1431;
-Obj _35reg1432 = primEQ(x, a);
-if (True == _35reg1432) {
+Obj _35reg1435 = primIsCons(closureRef(co, 2));
+if (True == _35reg1435) {
+Obj _35reg1436 = primCar(closureRef(co, 2));
+Obj a = _35reg1436;
+Obj _35reg1437 = primCdr(closureRef(co, 2));
+Obj b = _35reg1437;
+Obj _35reg1438 = primEQ(x, a);
+if (True == _35reg1438) {
 coraReturn(co, pos);
+return;
+} else {
+coraCall(co, 1, _35cc1236);
+}
+} else {
+coraCall(co, 1, _35cc1236);
+}
+}
+
+void _35clofun2895(struct Cora* co) {
+Obj _35cc1237 = makeNative(0, _35clofun2896, 0, 0);
+Obj pos = closureRef(co, 0);
+Obj x = closureRef(co, 1);
+Obj _35reg1431 = primIsCons(closureRef(co, 2));
+if (True == _35reg1431) {
+Obj _35reg1432 = primCar(closureRef(co, 2));
+Obj a = _35reg1432;
+Obj _35reg1433 = primCdr(closureRef(co, 2));
+Obj b = _35reg1433;
+Obj _35reg1434 = primAdd(pos, makeNumber(1));
+coraCall(co, 4, globalRef(intern("cora/lib/toc.pos-in-list0")), _35reg1434, x, b);
+} else {
+coraCall(co, 1, _35cc1237);
+}
+}
+
+void _35clofun2896(struct Cora* co) {
+coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
+}
+
+void _35clofun2889(struct Cora* co) {
+Obj _35p1227 = co->args[1];
+Obj _35p1228 = co->args[2];
+Obj _35p1229 = co->args[3];
+Obj _35cc1230 = makeNative(0, _35clofun2890, 0, 3, _35p1227, _35p1228, _35p1229);
+Obj f = _35p1227;
+Obj acc = _35p1228;
+Obj _35reg1429 = primEQ(Nil, _35p1229);
+if (True == _35reg1429) {
+coraReturn(co, acc);
 return;
 } else {
 coraCall(co, 1, _35cc1230);
 }
-} else {
-coraCall(co, 1, _35cc1230);
-}
 }
 
-void _35clofun2889(struct Cora* co) {
-Obj _35cc1231 = makeNative(0, _35clofun2890, 0, 0);
-Obj pos = closureRef(co, 0);
-Obj x = closureRef(co, 1);
+void _35clofun2890(struct Cora* co) {
+Obj _35cc1231 = makeNative(0, _35clofun2891, 0, 0);
+Obj f = closureRef(co, 0);
+Obj acc = closureRef(co, 1);
 Obj _35reg1425 = primIsCons(closureRef(co, 2));
 if (True == _35reg1425) {
 Obj _35reg1426 = primCar(closureRef(co, 2));
-Obj a = _35reg1426;
+Obj x = _35reg1426;
 Obj _35reg1427 = primCdr(closureRef(co, 2));
-Obj b = _35reg1427;
-Obj _35reg1428 = primAdd(pos, makeNumber(1));
-coraCall(co, 4, globalRef(intern("cora/lib/toc.pos-in-list0")), _35reg1428, x, b);
+Obj y = _35reg1427;
+pushCont(co, 0, _35clofun2892, 2, f, y);
+coraCall(co, 3, f, acc, x);
 } else {
 coraCall(co, 1, _35cc1231);
 }
 }
 
-void _35clofun2890(struct Cora* co) {
+void _35clofun2892(struct Cora* co) {
+Obj _35val1428 = co->args[1];
+Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
+coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), f, _35val1428, y);
+}
+
+void _35clofun2891(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 
-void _35clofun2883(struct Cora* co) {
-Obj _35p1221 = co->args[1];
-Obj _35p1222 = co->args[2];
-Obj _35p1223 = co->args[3];
-Obj _35cc1224 = makeNative(0, _35clofun2884, 0, 3, _35p1221, _35p1222, _35p1223);
-Obj f = _35p1221;
-Obj acc = _35p1222;
+void _35clofun2885(struct Cora* co) {
+Obj _35p1222 = co->args[1];
+Obj _35p1223 = co->args[2];
+Obj _35cc1224 = makeNative(0, _35clofun2886, 0, 2, _35p1222, _35p1223);
+Obj var = _35p1222;
 Obj _35reg1423 = primEQ(Nil, _35p1223);
 if (True == _35reg1423) {
-coraReturn(co, acc);
+coraReturn(co, Nil);
 return;
 } else {
 coraCall(co, 1, _35cc1224);
 }
 }
 
-void _35clofun2884(struct Cora* co) {
-Obj _35cc1225 = makeNative(0, _35clofun2885, 0, 0);
-Obj f = closureRef(co, 0);
-Obj acc = closureRef(co, 1);
-Obj _35reg1419 = primIsCons(closureRef(co, 2));
-if (True == _35reg1419) {
-Obj _35reg1420 = primCar(closureRef(co, 2));
-Obj x = _35reg1420;
-Obj _35reg1421 = primCdr(closureRef(co, 2));
-Obj y = _35reg1421;
-pushCont(co, 0, _35clofun2886, 2, f, y);
-coraCall(co, 3, f, acc, x);
+void _35clofun2886(struct Cora* co) {
+Obj _35cc1225 = makeNative(0, _35clofun2887, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj var = closureRef(co, 0);
+Obj _35reg1413 = primIsCons(closureRef(co, 1));
+if (True == _35reg1413) {
+Obj _35reg1414 = primCar(closureRef(co, 1));
+Obj _35reg1415 = primIsCons(_35reg1414);
+if (True == _35reg1415) {
+Obj _35reg1416 = primCar(closureRef(co, 1));
+Obj _35reg1417 = primCar(_35reg1416);
+Obj x = _35reg1417;
+Obj _35reg1418 = primCar(closureRef(co, 1));
+Obj _35reg1419 = primCdr(_35reg1418);
+Obj y = _35reg1419;
+Obj _35reg1420 = primCdr(closureRef(co, 1));
+Obj __ = _35reg1420;
+Obj _35reg1421 = primEQ(var, x);
+if (True == _35reg1421) {
+Obj _35reg1422 = primCons(x, y);
+coraReturn(co, _35reg1422);
+return;
+} else {
+coraCall(co, 1, _35cc1225);
+}
+} else {
+coraCall(co, 1, _35cc1225);
+}
 } else {
 coraCall(co, 1, _35cc1225);
 }
 }
 
-void _35clofun2886(struct Cora* co) {
-Obj _35val1422 = co->args[1];
-Obj f = co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj y = co->ctx.stk.stack[co->ctx.stk.base + 1];
-coraCall(co, 4, globalRef(intern("cora/lib/toc.foldl")), f, _35val1422, y);
-}
-
-void _35clofun2885(struct Cora* co) {
-coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
-}
-
-void _35clofun2879(struct Cora* co) {
-Obj _35p1216 = co->args[1];
-Obj _35p1217 = co->args[2];
-Obj _35cc1218 = makeNative(0, _35clofun2880, 0, 2, _35p1216, _35p1217);
-Obj var = _35p1216;
-Obj _35reg1417 = primEQ(Nil, _35p1217);
-if (True == _35reg1417) {
-coraReturn(co, Nil);
-return;
-} else {
-coraCall(co, 1, _35cc1218);
-}
-}
-
-void _35clofun2880(struct Cora* co) {
-Obj _35cc1219 = makeNative(0, _35clofun2881, 0, 2, closureRef(co, 0), closureRef(co, 1));
+void _35clofun2887(struct Cora* co) {
+Obj _35cc1226 = makeNative(0, _35clofun2888, 0, 0);
 Obj var = closureRef(co, 0);
-Obj _35reg1407 = primIsCons(closureRef(co, 1));
-if (True == _35reg1407) {
-Obj _35reg1408 = primCar(closureRef(co, 1));
-Obj _35reg1409 = primIsCons(_35reg1408);
-if (True == _35reg1409) {
-Obj _35reg1410 = primCar(closureRef(co, 1));
-Obj _35reg1411 = primCar(_35reg1410);
-Obj x = _35reg1411;
-Obj _35reg1412 = primCar(closureRef(co, 1));
-Obj _35reg1413 = primCdr(_35reg1412);
-Obj y = _35reg1413;
-Obj _35reg1414 = primCdr(closureRef(co, 1));
-Obj __ = _35reg1414;
-Obj _35reg1415 = primEQ(var, x);
-if (True == _35reg1415) {
-Obj _35reg1416 = primCons(x, y);
-coraReturn(co, _35reg1416);
-return;
-} else {
-coraCall(co, 1, _35cc1219);
-}
-} else {
-coraCall(co, 1, _35cc1219);
-}
-} else {
-coraCall(co, 1, _35cc1219);
-}
-}
-
-void _35clofun2881(struct Cora* co) {
-Obj _35cc1220 = makeNative(0, _35clofun2882, 0, 0);
-Obj var = closureRef(co, 0);
-Obj _35reg1404 = primIsCons(closureRef(co, 1));
-if (True == _35reg1404) {
-Obj _35reg1405 = primCar(closureRef(co, 1));
-Obj __ = _35reg1405;
-Obj _35reg1406 = primCdr(closureRef(co, 1));
-Obj y = _35reg1406;
+Obj _35reg1410 = primIsCons(closureRef(co, 1));
+if (True == _35reg1410) {
+Obj _35reg1411 = primCar(closureRef(co, 1));
+Obj __ = _35reg1411;
+Obj _35reg1412 = primCdr(closureRef(co, 1));
+Obj y = _35reg1412;
 coraCall(co, 3, globalRef(intern("cora/lib/toc.assq")), var, y);
 } else {
-coraCall(co, 1, _35cc1220);
+coraCall(co, 1, _35cc1226);
 }
 }
 
-void _35clofun2882(struct Cora* co) {
+void _35clofun2888(struct Cora* co) {
 coraCall(co, 2, globalRef(intern("error")), makeString1("no match-help found!"));
 }
 


### PR DESCRIPTION
In init.cora, a pseudo `typecheck` function is added, which will be overwrite by lib/infer.cora later.
During cora file loading, if the `typecheck` function is available, it will be called.
The type checker can now check lambda with zero paramenters.
polymorphic parameter will be initialized when the function is called, that's more reasonable than the let-polymorphism in HM.