### PR TITLE
*: generate the code for type check as a preprocess

### DIFF
--- a/example/type.cora
+++ b/example/type.cora
@@ -1,39 +1,43 @@
 (import "cora/lib/infer")
-(typecheck true)
 
-(declare 'member (let a (tvar) b (tvar) `(,a -> ((list ,b) -> bool))))
+(:declare 'member (let a (tvar) b (tvar) `(,a -> ((list ,b) -> bool))))
 (func member
       x [] => false
       x [y . z] => (or (= x y)
 		       (member x z)))
 
-(declare 'assq (let a (tvar) b (tvar) `(,a -> ((list (tuple ,a ,b)) -> (maybe (tuple ,a ,b))))))
+(:declare 'assq (let a (tvar) b (tvar) `(,a -> ((list (tuple ,a ,b)) -> (maybe (tuple ,a ,b))))))
 (func assq
       var [] => ()
       var [(cons x y) . _] => (cons x y) where (= var x)
       var [_ . y] => (assq var y))
 
-(declare 'foldl (let a (tvar) b (tvar) c (tvar) `((,a -> (,b -> ,c)) -> (,a -> ((list ,b) -> ,c)))))
+(:declare 'foldl (let a (tvar) b (tvar) c (tvar) `((,a -> (,b -> ,c)) -> (,a -> ((list ,b) -> ,c)))))
 (func foldl
       f acc [] => acc
       f acc [x . y] => (foldl f (f acc x) y))
 
-(declare 'for-each (let a (tvar) b (tvar) c (tvar) `((,a -> ,b) -> ((list ,a) -> ,c))))
+(:declare 'for-each (let a (tvar) b (tvar) c (tvar) `((,a -> ,b) -> ((list ,a) -> ,c))))
 (func for-each
       fn [] => []
       fn [x . y] => (begin
                      (fn x)
                      (for-each fn y)))
 
-(deftype 'ignore-check (lambda (exp typ env subst) ['succ 'ignore]))
-(declare 'type-check-for-fruit `(ignore-check))
-(func type-check-for-fruit
-      ['quote x] ['fruit] env s => ['succ s] where (elem? x ['apple 'orange 'banana])
-	  _ _ env s => ['fail])
+(:type
+ (deftype 'ignore-check (lambda (exp typ env subst) ['succ 'ignore])))
 
+(:declare 'type-check-for-fruit `(ignore-check))
 
-(deftype 'fruit type-check-for-fruit)
-(declare 'f `((fruit) -> bool))
+(:type
+ (func type-check-for-fruit
+  ['quote x] ['fruit] env s => ['succ s] where (elem? x ['apple 'orange 'banana])
+  _ _ env s => ['fail])
+
+ (deftype 'fruit type-check-for-fruit)
+ )
+
+(:declare 'f `((fruit) -> bool))
 (defun f (x)
        (= x 'xxx))
 

--- a/init.c
+++ b/init.c
@@ -2,17 +2,16 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun1020(struct Cora* co);
-void _35clofun1019(struct Cora* co);
-void _35clofun1018(struct Cora* co);
-void _35clofun1017(struct Cora* co);
-void _35clofun1016(struct Cora* co);
 void _35clofun1015(struct Cora* co);
 void _35clofun1014(struct Cora* co);
 void _35clofun1013(struct Cora* co);
 void _35clofun1012(struct Cora* co);
 void _35clofun1011(struct Cora* co);
 void _35clofun1010(struct Cora* co);
+void _35clofun1009(struct Cora* co);
+void _35clofun1008(struct Cora* co);
+void _35clofun1007(struct Cora* co);
+void _35clofun1006(struct Cora* co);
 
 
 void entry(struct Cora* co){
@@ -28,18 +27,18 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35reg39 = primSet(intern("null?"), makeNative(0, _35clofun1010, 1, 0));
-Obj _35reg42 = primSet(intern("cadr"), makeNative(1, _35clofun1010, 1, 0));
-Obj _35reg45 = primSet(intern("caar"), makeNative(2, _35clofun1010, 1, 0));
-Obj _35reg48 = primSet(intern("cdar"), makeNative(3, _35clofun1010, 1, 0));
-Obj _35reg51 = primSet(intern("cddr"), makeNative(4, _35clofun1010, 1, 0));
-Obj _35reg55 = primSet(intern("caddr"), makeNative(5, _35clofun1010, 1, 0));
-Obj _35reg60 = primSet(intern("cadddr"), makeNative(6, _35clofun1010, 1, 0));
-Obj _35reg64 = primSet(intern("cdddr"), makeNative(7, _35clofun1010, 1, 0));
-Obj _35reg72 = primSet(intern("rcons"), makeNative(9, _35clofun1010, 1, 0));
-Obj _35reg74 = primSet(intern("pair?"), makeNative(10, _35clofun1010, 1, 0));
-Obj _35reg79 = primSet(intern("cora/init.reverse-h"), makeNative(11, _35clofun1010, 2, 0));
-pushCont(co, 1, _35clofun1020, 0);
+Obj _35reg39 = primSet(intern("null?"), makeNative(0, _35clofun1006, 1, 0));
+Obj _35reg42 = primSet(intern("cadr"), makeNative(1, _35clofun1006, 1, 0));
+Obj _35reg45 = primSet(intern("caar"), makeNative(2, _35clofun1006, 1, 0));
+Obj _35reg48 = primSet(intern("cdar"), makeNative(3, _35clofun1006, 1, 0));
+Obj _35reg51 = primSet(intern("cddr"), makeNative(4, _35clofun1006, 1, 0));
+Obj _35reg55 = primSet(intern("caddr"), makeNative(5, _35clofun1006, 1, 0));
+Obj _35reg60 = primSet(intern("cadddr"), makeNative(6, _35clofun1006, 1, 0));
+Obj _35reg64 = primSet(intern("cdddr"), makeNative(7, _35clofun1006, 1, 0));
+Obj _35reg72 = primSet(intern("rcons"), makeNative(9, _35clofun1006, 1, 0));
+Obj _35reg74 = primSet(intern("pair?"), makeNative(10, _35clofun1006, 1, 0));
+Obj _35reg79 = primSet(intern("cora/init.reverse-h"), makeNative(11, _35clofun1006, 2, 0));
+pushCont(co, 20, _35clofun1015, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.reverse-h"));
 __arg1 = Nil;
@@ -59,70 +58,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1020(struct Cora* co){
-int __nargs = co->nargs;
-Obj __arg0 = co->args[0];
-Obj __arg1 = co->args[1];
-Obj __arg2 = co->args[2];
-Obj __arg3 = co->args[3];
-
-static void* jumpTable[] = {&&label0, &&label1};
-
-goto *jumpTable[co->ctx.pc.label];
-
-label0:
-{
-Obj _35val141 = __arg1;
-pushCont(co, 20, _35clofun1019, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init.add-to-*macros*"));
-__arg1 = intern("list");
-__arg2 = makeNative(9, _35clofun1011, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1020) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35val80 = __arg1;
-Obj _35reg81 = primSet(intern("reverse"), _35val80);
-Obj _35reg87 = primSet(intern("map-h"), makeNative(13, _35clofun1010, 3, 0));
-Obj _35reg88 = primSet(intern("map"), makeNative(14, _35clofun1010, 2, 0));
-Obj _35reg89 = primSet(intern("*macros*"), Nil);
-Obj _35reg90 = primGenSym(intern("protect"));
-Obj _35reg91 = primSet(intern("*protect-symbol*"), _35reg90);
-Obj _35reg93 = primSet(intern("cora/init.protect"), makeNative(15, _35clofun1010, 1, 0));
-Obj _35reg97 = primSet(intern("cora/init.add-to-*macros*"), makeNative(16, _35clofun1010, 2, 0));
-Obj _35reg110 = primSet(intern("cora/init.macroexpand1-h"), makeNative(18, _35clofun1010, 2, 0));
-Obj _35reg111 = primSet(intern("cora/init.macroexpand1"), makeNative(19, _35clofun1010, 1, 0));
-Obj _35reg128 = primSet(intern("cora/init.macroexpand-boot"), makeNative(4, _35clofun1011, 1, 0));
-Obj _35reg129 = primSet(intern("macroexpand"), globalRef(intern("cora/init.macroexpand-boot")));
-Obj _35reg140 = primSet(intern("defmacro-macro"), makeNative(8, _35clofun1011, 1, 0));
-pushCont(co, 0, _35clofun1020, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init.add-to-*macros*"));
-__arg1 = intern("defmacro");
-__arg2 = globalRef(intern("defmacro-macro"));
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1020) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-fail:
-co->nargs = __nargs;
-co->args[0] = __arg0;
-co->args[1] = __arg1;
-co->args[2] = __arg2;
-co->args[3] = __arg3;
-
-}
-
-void _35clofun1019(struct Cora* co){
+void _35clofun1015(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -143,7 +79,7 @@ __arg1 = _35reg983;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -155,18 +91,18 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35cc37 = makeNative(1, _35clofun1019, 0, 0);
+Obj _35cc37 = makeNative(1, _35clofun1015, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1019) { goto fail; }
+if (co->ctx.pc.func != _35clofun1015) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -177,13 +113,13 @@ Obj _35reg990 = primCons(intern("list"), _35val989);
 __nargs = 2;
 __arg1 = _35reg990;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1019) { goto fail; }
+if (co->ctx.pc.func != _35clofun1015) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label4:
 {
-Obj _35cc36 = makeNative(2, _35clofun1019, 0, 1, closureRef(co, 0));
+Obj _35cc36 = makeNative(2, _35clofun1015, 0, 1, closureRef(co, 0));
 Obj _35reg985 = primIsCons(closureRef(co, 0));
 if (True == _35reg985) {
 Obj _35reg986 = primCar(closureRef(co, 0));
@@ -191,7 +127,7 @@ Obj x = _35reg986;
 Obj _35reg987 = primCdr(closureRef(co, 0));
 Obj more = _35reg987;
 Obj _35reg988 = primCons(x, more);
-pushCont(co, 3, _35clofun1019, 0);
+pushCont(co, 3, _35clofun1015, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("map"));
 __arg1 = globalRef(intern("cora/init.rewrite-backquote"));
@@ -199,7 +135,7 @@ __arg2 = _35reg988;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -207,14 +143,14 @@ __arg0 = _35cc36;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35cc35 = makeNative(4, _35clofun1019, 0, 1, closureRef(co, 0));
+Obj _35cc35 = makeNative(4, _35clofun1015, 0, 1, closureRef(co, 0));
 Obj _35reg991 = primIsCons(closureRef(co, 0));
 if (True == _35reg991) {
 Obj _35reg992 = primCar(closureRef(co, 0));
@@ -233,7 +169,7 @@ if (True == _35reg1000) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1019) { goto fail; }
+if (co->ctx.pc.func != _35clofun1015) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -241,7 +177,7 @@ __arg0 = _35cc35;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -250,7 +186,7 @@ __arg0 = _35cc35;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -259,7 +195,7 @@ __arg0 = _35cc35;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -268,7 +204,7 @@ __arg0 = _35cc35;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -276,7 +212,7 @@ goto *jumpTable[ps.label];
 label6:
 {
 Obj _35p33 = __arg1;
-Obj _35cc34 = makeNative(5, _35clofun1019, 0, 1, _35p33);
+Obj _35cc34 = makeNative(5, _35clofun1015, 0, 1, _35p33);
 Obj x = _35p33;
 Obj _35reg1001 = primIsSymbol(x);
 if (True == _35reg1001) {
@@ -285,7 +221,7 @@ Obj _35reg1003 = primCons(intern("quote"), _35reg1002);
 __nargs = 2;
 __arg1 = _35reg1003;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1019) { goto fail; }
+if (co->ctx.pc.func != _35clofun1015) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -293,7 +229,7 @@ __arg0 = _35cc34;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -307,222 +243,240 @@ __arg1 = _35val1005;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
 Obj exp = __arg1;
-pushCont(co, 7, _35clofun1019, 0);
+pushCont(co, 7, _35clofun1015, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj filename = __arg1;
-Obj pkg = __arg2;
-Obj _35reg1007 = primCons(intern("fake"), Nil);
-Obj _35reg1008 = primCons(intern("succ"), _35reg1007);
-__nargs = 2;
-__arg1 = _35reg1008;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1019) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val984 = __arg1;
+Obj _35reg1004 = primSet(intern("cora/init.rewrite-backquote"), makeNative(6, _35clofun1015, 1, 0));
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init.add-to-*macros*"));
+__arg1 = intern("backquote");
+__arg2 = makeNative(8, _35clofun1015, 1, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val1006 = __arg1;
-Obj _35reg1009 = primSet(intern("typechecker"), makeNative(9, _35clofun1019, 2, 0));
-__nargs = 2;
-__arg1 = _35reg1009;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1019) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val535 = __arg1;
+Obj _35reg798 = primSet(intern("cora/init.propagate-boolean0"), makeNative(11, _35clofun1013, 1, 0));
+Obj _35reg956 = primSet(intern("cora/init.propagate-boolean"), makeNative(13, _35clofun1014, 1, 0));
+Obj _35reg958 = primSet(intern("macroexpand"), makeNative(15, _35clofun1014, 1, 0));
+Obj _35reg982 = primSet(intern("cora/init.rewrite-begin"), makeNative(20, _35clofun1014, 1, 0));
+pushCont(co, 9, _35clofun1015, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init.add-to-*macros*"));
+__arg1 = intern("begin");
+__arg2 = makeNative(0, _35clofun1015, 1, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val984 = __arg1;
-Obj _35reg1004 = primSet(intern("cora/init.rewrite-backquote"), makeNative(6, _35clofun1019, 1, 0));
-pushCont(co, 10, _35clofun1019, 0);
+Obj _35val427 = __arg1;
+Obj _35reg479 = primSet(intern("cora/init.extract-rules1"), makeNative(15, _35clofun1011, 3, 0));
+Obj _35reg480 = primSet(intern("cora/init.extract-rules"), makeNative(16, _35clofun1011, 1, 0));
+Obj _35reg485 = primSet(intern("cora/init.rules-patterns"), makeNative(19, _35clofun1011, 2, 0));
+Obj _35reg489 = primSet(intern("cora/init.length-h"), makeNative(20, _35clofun1011, 2, 0));
+Obj _35reg490 = primSet(intern("length"), makeNative(0, _35clofun1012, 1, 0));
+Obj _35reg498 = primSet(intern("cora/init.filter-h"), makeNative(2, _35clofun1012, 3, 0));
+Obj _35reg499 = primSet(intern("filter"), makeNative(3, _35clofun1012, 2, 0));
+Obj _35reg505 = primSet(intern("append"), makeNative(5, _35clofun1012, 2, 0));
+Obj _35reg516 = primSet(intern("cora/init.rules-arg-count"), makeNative(12, _35clofun1012, 1, 0));
+Obj _35reg522 = primSet(intern("cora/init.gen-parameters"), makeNative(14, _35clofun1012, 1, 0));
+pushCont(co, 10, _35clofun1015, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.add-to-*macros*"));
-__arg1 = intern("backquote");
-__arg2 = makeNative(8, _35clofun1019, 1, 0);
+__arg1 = intern("func");
+__arg2 = makeNative(20, _35clofun1012, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val535 = __arg1;
-Obj _35reg798 = primSet(intern("cora/init.propagate-boolean0"), makeNative(11, _35clofun1017, 1, 0));
-Obj _35reg956 = primSet(intern("cora/init.propagate-boolean"), makeNative(13, _35clofun1018, 1, 0));
-Obj _35reg958 = primSet(intern("macroexpand"), makeNative(15, _35clofun1018, 1, 0));
-Obj _35reg982 = primSet(intern("cora/init.rewrite-begin"), makeNative(20, _35clofun1018, 1, 0));
-pushCont(co, 11, _35clofun1019, 0);
+Obj _35val234 = __arg1;
+Obj _35reg288 = primSet(intern("cora/init.match-cons-expander"), makeNative(12, _35clofun1009, 4, 0));
+Obj _35reg321 = primSet(intern("cora/init.match1"), makeNative(18, _35clofun1009, 4, 0));
+Obj _35reg348 = primSet(intern("cora/init.extract-rule-action"), makeNative(5, _35clofun1010, 2, 0));
+Obj _35reg400 = primSet(intern("cora/init.match-helper"), makeNative(0, _35clofun1011, 2, 0));
+Obj _35reg426 = primSet(intern("cora/init.rewrite-match"), makeNative(7, _35clofun1011, 1, 0));
+pushCont(co, 11, _35clofun1015, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.add-to-*macros*"));
-__arg1 = intern("begin");
-__arg2 = makeNative(0, _35clofun1019, 1, 0);
+__arg1 = intern("match");
+__arg2 = makeNative(8, _35clofun1011, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val427 = __arg1;
-Obj _35reg479 = primSet(intern("cora/init.extract-rules1"), makeNative(15, _35clofun1015, 3, 0));
-Obj _35reg480 = primSet(intern("cora/init.extract-rules"), makeNative(16, _35clofun1015, 1, 0));
-Obj _35reg485 = primSet(intern("cora/init.rules-patterns"), makeNative(19, _35clofun1015, 2, 0));
-Obj _35reg489 = primSet(intern("cora/init.length-h"), makeNative(20, _35clofun1015, 2, 0));
-Obj _35reg490 = primSet(intern("length"), makeNative(0, _35clofun1016, 1, 0));
-Obj _35reg498 = primSet(intern("cora/init.filter-h"), makeNative(2, _35clofun1016, 3, 0));
-Obj _35reg499 = primSet(intern("filter"), makeNative(3, _35clofun1016, 2, 0));
-Obj _35reg505 = primSet(intern("append"), makeNative(5, _35clofun1016, 2, 0));
-Obj _35reg516 = primSet(intern("cora/init.rules-arg-count"), makeNative(12, _35clofun1016, 1, 0));
-Obj _35reg522 = primSet(intern("cora/init.gen-parameters"), makeNative(14, _35clofun1016, 1, 0));
-pushCont(co, 12, _35clofun1019, 0);
+Obj _35val219 = __arg1;
+Obj _35reg222 = primSet(intern("boolean?"), makeNative(11, _35clofun1008, 1, 0));
+Obj _35reg232 = primSet(intern("cora/init.rcons1"), makeNative(14, _35clofun1008, 1, 0));
+pushCont(co, 12, _35clofun1015, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.add-to-*macros*"));
-__arg1 = intern("func");
-__arg2 = makeNative(20, _35clofun1016, 1, 0);
+__arg1 = intern("list-rest");
+__arg2 = makeNative(15, _35clofun1008, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val234 = __arg1;
-Obj _35reg288 = primSet(intern("cora/init.match-cons-expander"), makeNative(12, _35clofun1013, 4, 0));
-Obj _35reg321 = primSet(intern("cora/init.match1"), makeNative(18, _35clofun1013, 4, 0));
-Obj _35reg348 = primSet(intern("cora/init.extract-rule-action"), makeNative(5, _35clofun1014, 2, 0));
-Obj _35reg400 = primSet(intern("cora/init.match-helper"), makeNative(0, _35clofun1015, 2, 0));
-Obj _35reg426 = primSet(intern("cora/init.rewrite-match"), makeNative(7, _35clofun1015, 1, 0));
-pushCont(co, 13, _35clofun1019, 0);
+Obj _35val205 = __arg1;
+Obj _35reg217 = primSet(intern("cora/init.rewrite-and"), makeNative(9, _35clofun1008, 1, 0));
+pushCont(co, 13, _35clofun1015, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.add-to-*macros*"));
-__arg1 = intern("match");
-__arg2 = makeNative(8, _35clofun1015, 1, 0);
+__arg1 = intern("and");
+__arg2 = makeNative(10, _35clofun1008, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val219 = __arg1;
-Obj _35reg222 = primSet(intern("boolean?"), makeNative(11, _35clofun1012, 1, 0));
-Obj _35reg232 = primSet(intern("cora/init.rcons1"), makeNative(14, _35clofun1012, 1, 0));
-pushCont(co, 14, _35clofun1019, 0);
+Obj _35val191 = __arg1;
+Obj _35reg203 = primSet(intern("cora/init.rewrite-or"), makeNative(6, _35clofun1008, 1, 0));
+pushCont(co, 14, _35clofun1015, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.add-to-*macros*"));
-__arg1 = intern("list-rest");
-__arg2 = makeNative(15, _35clofun1012, 1, 0);
+__arg1 = intern("or");
+__arg2 = makeNative(7, _35clofun1008, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val205 = __arg1;
-Obj _35reg217 = primSet(intern("cora/init.rewrite-and"), makeNative(9, _35clofun1012, 1, 0));
-pushCont(co, 15, _35clofun1019, 0);
+Obj _35val177 = __arg1;
+pushCont(co, 15, _35clofun1015, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.add-to-*macros*"));
-__arg1 = intern("and");
-__arg2 = makeNative(10, _35clofun1012, 1, 0);
+__arg1 = intern("cond");
+__arg2 = makeNative(4, _35clofun1008, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val191 = __arg1;
-Obj _35reg203 = primSet(intern("cora/init.rewrite-or"), makeNative(6, _35clofun1012, 1, 0));
-pushCont(co, 16, _35clofun1019, 0);
+Obj _35val155 = __arg1;
+Obj _35reg160 = primSet(intern("elem?"), makeNative(14, _35clofun1007, 2, 0));
+Obj _35reg163 = primSet(intern("atom?"), makeNative(15, _35clofun1007, 1, 0));
+Obj _35reg175 = primSet(intern("cora/init.rewrite-let"), makeNative(20, _35clofun1007, 1, 0));
+pushCont(co, 16, _35clofun1015, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.add-to-*macros*"));
-__arg1 = intern("or");
-__arg2 = makeNative(7, _35clofun1012, 1, 0);
+__arg1 = intern("let");
+__arg2 = makeNative(0, _35clofun1008, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val177 = __arg1;
-pushCont(co, 17, _35clofun1019, 0);
+Obj _35val143 = __arg1;
+pushCont(co, 17, _35clofun1015, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.add-to-*macros*"));
-__arg1 = intern("cond");
-__arg2 = makeNative(4, _35clofun1012, 1, 0);
+__arg1 = intern("defun");
+__arg2 = makeNative(13, _35clofun1007, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val155 = __arg1;
-Obj _35reg160 = primSet(intern("elem?"), makeNative(14, _35clofun1011, 2, 0));
-Obj _35reg163 = primSet(intern("atom?"), makeNative(15, _35clofun1011, 1, 0));
-Obj _35reg175 = primSet(intern("cora/init.rewrite-let"), makeNative(20, _35clofun1011, 1, 0));
-pushCont(co, 18, _35clofun1019, 0);
+Obj _35val141 = __arg1;
+pushCont(co, 18, _35clofun1015, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.add-to-*macros*"));
-__arg1 = intern("let");
-__arg2 = makeNative(0, _35clofun1012, 1, 0);
+__arg1 = intern("list");
+__arg2 = makeNative(9, _35clofun1007, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val143 = __arg1;
-pushCont(co, 19, _35clofun1019, 0);
+Obj _35val80 = __arg1;
+Obj _35reg81 = primSet(intern("reverse"), _35val80);
+Obj _35reg87 = primSet(intern("map-h"), makeNative(13, _35clofun1006, 3, 0));
+Obj _35reg88 = primSet(intern("map"), makeNative(14, _35clofun1006, 2, 0));
+Obj _35reg89 = primSet(intern("*macros*"), Nil);
+Obj _35reg90 = primGenSym(intern("protect"));
+Obj _35reg91 = primSet(intern("*protect-symbol*"), _35reg90);
+Obj _35reg93 = primSet(intern("cora/init.protect"), makeNative(15, _35clofun1006, 1, 0));
+Obj _35reg97 = primSet(intern("cora/init.add-to-*macros*"), makeNative(16, _35clofun1006, 2, 0));
+Obj _35reg110 = primSet(intern("cora/init.macroexpand1-h"), makeNative(18, _35clofun1006, 2, 0));
+Obj _35reg111 = primSet(intern("cora/init.macroexpand1"), makeNative(19, _35clofun1006, 1, 0));
+Obj _35reg128 = primSet(intern("cora/init.macroexpand-boot"), makeNative(4, _35clofun1007, 1, 0));
+Obj _35reg129 = primSet(intern("macroexpand"), globalRef(intern("cora/init.macroexpand-boot")));
+Obj _35reg140 = primSet(intern("defmacro-macro"), makeNative(8, _35clofun1007, 1, 0));
+pushCont(co, 19, _35clofun1015, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.add-to-*macros*"));
-__arg1 = intern("defun");
-__arg2 = makeNative(13, _35clofun1011, 1, 0);
+__arg1 = intern("defmacro");
+__arg2 = globalRef(intern("defmacro-macro"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1019) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -535,7 +489,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1018(struct Cora* co){
+void _35clofun1014(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -558,13 +512,13 @@ __arg1 = _35reg869;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35cc24 = makeNative(20, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc24 = makeNative(20, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg857 = primIsCons(closureRef(co, 0));
 if (True == _35reg857) {
 Obj _35reg858 = primCar(closureRef(co, 0));
@@ -580,14 +534,14 @@ Obj _35reg864 = primCdr(closureRef(co, 0));
 Obj _35reg865 = primCdr(_35reg864);
 Obj _35reg866 = primEQ(Nil, _35reg865);
 if (True == _35reg866) {
-pushCont(co, 0, _35clofun1018, 0);
+pushCont(co, 0, _35clofun1014, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.propagate-boolean"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -595,16 +549,7 @@ __arg0 = _35cc24;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc24;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -613,7 +558,7 @@ __arg0 = _35cc24;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -622,7 +567,16 @@ __arg0 = _35cc24;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc24;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -639,13 +593,13 @@ __arg1 = _35reg882;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc23 = makeNative(1, _35clofun1018, 0, 1, closureRef(co, 0));
+Obj _35cc23 = makeNative(1, _35clofun1014, 0, 1, closureRef(co, 0));
 Obj _35reg870 = primIsCons(closureRef(co, 0));
 if (True == _35reg870) {
 Obj _35reg871 = primCar(closureRef(co, 0));
@@ -661,14 +615,14 @@ Obj _35reg877 = primCdr(closureRef(co, 0));
 Obj _35reg878 = primCdr(_35reg877);
 Obj _35reg879 = primEQ(Nil, _35reg878);
 if (True == _35reg879) {
-pushCont(co, 2, _35clofun1018, 0);
+pushCont(co, 2, _35clofun1014, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.propagate-boolean"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -676,16 +630,7 @@ __arg0 = _35cc23;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc23;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -694,7 +639,7 @@ __arg0 = _35cc23;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -703,7 +648,16 @@ __arg0 = _35cc23;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc23;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -722,7 +676,7 @@ __arg1 = _35reg904;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -731,20 +685,20 @@ label5:
 Obj _35val900 = __arg1;
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x1 = _35val900;
-pushCont(co, 4, _35clofun1018, 1, x1);
+pushCont(co, 4, _35clofun1014, 1, x1);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.propagate-boolean"));
 __arg1 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc22 = makeNative(3, _35clofun1018, 0, 1, closureRef(co, 0));
+Obj _35cc22 = makeNative(3, _35clofun1014, 0, 1, closureRef(co, 0));
 Obj _35reg883 = primIsCons(closureRef(co, 0));
 if (True == _35reg883) {
 Obj _35reg884 = primCar(closureRef(co, 0));
@@ -769,14 +723,14 @@ Obj _35reg897 = primCdr(_35reg896);
 Obj _35reg898 = primCdr(_35reg897);
 Obj _35reg899 = primEQ(Nil, _35reg898);
 if (True == _35reg899) {
-pushCont(co, 5, _35clofun1018, 1, y);
+pushCont(co, 5, _35clofun1014, 1, y);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.propagate-boolean"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -784,16 +738,7 @@ __arg0 = _35cc22;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc22;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -802,7 +747,7 @@ __arg0 = _35cc22;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -811,7 +756,7 @@ __arg0 = _35cc22;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -820,7 +765,16 @@ __arg0 = _35cc22;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc22;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -837,13 +791,13 @@ __arg1 = _35reg917;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35cc21 = makeNative(6, _35clofun1018, 0, 1, closureRef(co, 0));
+Obj _35cc21 = makeNative(6, _35clofun1014, 0, 1, closureRef(co, 0));
 Obj _35reg905 = primIsCons(closureRef(co, 0));
 if (True == _35reg905) {
 Obj _35reg906 = primCar(closureRef(co, 0));
@@ -859,14 +813,14 @@ Obj _35reg912 = primCdr(closureRef(co, 0));
 Obj _35reg913 = primCdr(_35reg912);
 Obj _35reg914 = primEQ(Nil, _35reg913);
 if (True == _35reg914) {
-pushCont(co, 7, _35clofun1018, 0);
+pushCont(co, 7, _35clofun1014, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.propagate-boolean"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -874,16 +828,7 @@ __arg0 = _35cc21;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc21;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -892,7 +837,7 @@ __arg0 = _35cc21;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -901,7 +846,16 @@ __arg0 = _35cc21;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc21;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -918,13 +872,13 @@ __arg1 = _35reg930;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35cc20 = makeNative(8, _35clofun1018, 0, 1, closureRef(co, 0));
+Obj _35cc20 = makeNative(8, _35clofun1014, 0, 1, closureRef(co, 0));
 Obj _35reg918 = primIsCons(closureRef(co, 0));
 if (True == _35reg918) {
 Obj _35reg919 = primCar(closureRef(co, 0));
@@ -940,14 +894,14 @@ Obj _35reg925 = primCdr(closureRef(co, 0));
 Obj _35reg926 = primCdr(_35reg925);
 Obj _35reg927 = primEQ(Nil, _35reg926);
 if (True == _35reg927) {
-pushCont(co, 9, _35clofun1018, 0);
+pushCont(co, 9, _35clofun1014, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.propagate-boolean"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -955,16 +909,7 @@ __arg0 = _35cc20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc20;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -973,7 +918,7 @@ __arg0 = _35cc20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -982,7 +927,16 @@ __arg0 = _35cc20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc20;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -999,13 +953,13 @@ __arg1 = _35reg943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35cc19 = makeNative(10, _35clofun1018, 0, 1, closureRef(co, 0));
+Obj _35cc19 = makeNative(10, _35clofun1014, 0, 1, closureRef(co, 0));
 Obj _35reg931 = primIsCons(closureRef(co, 0));
 if (True == _35reg931) {
 Obj _35reg932 = primCar(closureRef(co, 0));
@@ -1021,14 +975,14 @@ Obj _35reg938 = primCdr(closureRef(co, 0));
 Obj _35reg939 = primCdr(_35reg938);
 Obj _35reg940 = primEQ(Nil, _35reg939);
 if (True == _35reg940) {
-pushCont(co, 11, _35clofun1018, 0);
+pushCont(co, 11, _35clofun1014, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.propagate-boolean"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -1036,16 +990,7 @@ __arg0 = _35cc19;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc19;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1054,7 +999,7 @@ __arg0 = _35cc19;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1063,7 +1008,16 @@ __arg0 = _35cc19;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc19;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -1071,7 +1025,7 @@ goto *jumpTable[ps.label];
 label13:
 {
 Obj _35p17 = __arg1;
-Obj _35cc18 = makeNative(12, _35clofun1018, 0, 1, _35p17);
+Obj _35cc18 = makeNative(12, _35clofun1014, 0, 1, _35p17);
 Obj _35reg944 = primIsCons(_35p17);
 if (True == _35reg944) {
 Obj _35reg945 = primCar(_35p17);
@@ -1092,7 +1046,7 @@ Obj _35reg955 = primCons(intern("quote"), _35reg954);
 __nargs = 2;
 __arg1 = _35reg955;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1014) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -1100,7 +1054,7 @@ __arg0 = _35cc18;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1109,7 +1063,7 @@ __arg0 = _35cc18;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1118,7 +1072,7 @@ __arg0 = _35cc18;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1127,7 +1081,7 @@ __arg0 = _35cc18;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -1141,21 +1095,21 @@ __arg1 = _35val957;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
 Obj exp = __arg1;
-pushCont(co, 14, _35clofun1018, 0);
+pushCont(co, 14, _35clofun1014, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.macroexpand-boot"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1167,7 +1121,7 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1181,27 +1135,27 @@ Obj _35reg965 = primCons(intern("do"), _35reg964);
 __nargs = 2;
 __arg1 = _35reg965;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1014) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label18:
 {
-Obj _35cc32 = makeNative(16, _35clofun1018, 0, 0);
+Obj _35cc32 = makeNative(16, _35clofun1014, 0, 0);
 Obj _35reg959 = primIsCons(closureRef(co, 0));
 if (True == _35reg959) {
 Obj _35reg960 = primCar(closureRef(co, 0));
 Obj x = _35reg960;
 Obj _35reg961 = primCdr(closureRef(co, 0));
 Obj y = _35reg961;
-pushCont(co, 17, _35clofun1018, 1, x);
+pushCont(co, 17, _35clofun1014, 1, x);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.rewrite-begin"));
 __arg1 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -1209,14 +1163,14 @@ __arg0 = _35cc32;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label19:
 {
-Obj _35cc31 = makeNative(18, _35clofun1018, 0, 1, closureRef(co, 0));
+Obj _35cc31 = makeNative(18, _35clofun1014, 0, 1, closureRef(co, 0));
 Obj _35reg966 = primIsCons(closureRef(co, 0));
 if (True == _35reg966) {
 Obj _35reg967 = primCar(closureRef(co, 0));
@@ -1237,7 +1191,7 @@ Obj _35reg977 = primCons(intern("do"), _35reg976);
 __nargs = 2;
 __arg1 = _35reg977;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1014) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -1245,7 +1199,7 @@ __arg0 = _35cc31;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1254,7 +1208,7 @@ __arg0 = _35cc31;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1263,7 +1217,7 @@ __arg0 = _35cc31;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -1271,7 +1225,7 @@ goto *jumpTable[ps.label];
 label20:
 {
 Obj _35p29 = __arg1;
-Obj _35cc30 = makeNative(19, _35clofun1018, 0, 1, _35p29);
+Obj _35cc30 = makeNative(19, _35clofun1014, 0, 1, _35p29);
 Obj _35reg978 = primIsCons(_35p29);
 if (True == _35reg978) {
 Obj _35reg979 = primCar(_35p29);
@@ -1282,7 +1236,7 @@ if (True == _35reg981) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1014) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -1290,7 +1244,7 @@ __arg0 = _35cc30;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1299,7 +1253,7 @@ __arg0 = _35cc30;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -1313,7 +1267,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1017(struct Cora* co){
+void _35clofun1013(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -1332,24 +1286,24 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35cc16 = makeNative(0, _35clofun1017, 0, 0);
+Obj _35cc16 = makeNative(0, _35clofun1013, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35cc15 = makeNative(1, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc15 = makeNative(1, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg536 = primIsCons(closureRef(co, 0));
 if (True == _35reg536) {
 Obj _35reg537 = primCar(closureRef(co, 0));
@@ -1389,7 +1343,7 @@ if (True == _35reg562) {
 __nargs = 2;
 __arg1 = z;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -1397,7 +1351,7 @@ __arg0 = _35cc15;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1406,7 +1360,7 @@ __arg0 = _35cc15;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1415,7 +1369,7 @@ __arg0 = _35cc15;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1424,7 +1378,7 @@ __arg0 = _35cc15;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1433,7 +1387,7 @@ __arg0 = _35cc15;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1442,7 +1396,7 @@ __arg0 = _35cc15;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1451,14 +1405,14 @@ __arg0 = _35cc15;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35cc14 = makeNative(2, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc14 = makeNative(2, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg563 = primIsCons(closureRef(co, 0));
 if (True == _35reg563) {
 Obj _35reg564 = primCar(closureRef(co, 0));
@@ -1498,7 +1452,7 @@ if (True == _35reg589) {
 __nargs = 2;
 __arg1 = y;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -1506,7 +1460,7 @@ __arg0 = _35cc14;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1515,7 +1469,7 @@ __arg0 = _35cc14;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1524,7 +1478,7 @@ __arg0 = _35cc14;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1533,7 +1487,7 @@ __arg0 = _35cc14;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1542,7 +1496,7 @@ __arg0 = _35cc14;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1551,7 +1505,7 @@ __arg0 = _35cc14;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1560,14 +1514,14 @@ __arg0 = _35cc14;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35cc13 = makeNative(3, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc13 = makeNative(3, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg590 = primIsCons(closureRef(co, 0));
 if (True == _35reg590) {
 Obj _35reg591 = primCar(closureRef(co, 0));
@@ -1587,7 +1541,7 @@ if (True == _35reg600) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -1595,7 +1549,7 @@ __arg0 = _35cc13;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1604,7 +1558,7 @@ __arg0 = _35cc13;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1613,7 +1567,7 @@ __arg0 = _35cc13;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1622,7 +1576,7 @@ __arg0 = _35cc13;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1631,14 +1585,14 @@ __arg0 = _35cc13;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35cc12 = makeNative(4, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc12 = makeNative(4, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg601 = primIsCons(closureRef(co, 0));
 if (True == _35reg601) {
 Obj _35reg602 = primCar(closureRef(co, 0));
@@ -1658,7 +1612,7 @@ if (True == _35reg611) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -1666,7 +1620,7 @@ __arg0 = _35cc12;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1675,7 +1629,7 @@ __arg0 = _35cc12;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1684,7 +1638,7 @@ __arg0 = _35cc12;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1693,7 +1647,7 @@ __arg0 = _35cc12;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1702,14 +1656,14 @@ __arg0 = _35cc12;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label6:
 {
-Obj _35cc11 = makeNative(5, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc11 = makeNative(5, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg612 = primIsCons(closureRef(co, 0));
 if (True == _35reg612) {
 Obj _35reg613 = primCar(closureRef(co, 0));
@@ -1763,7 +1717,7 @@ if (True == _35reg650) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -1771,7 +1725,7 @@ __arg0 = _35cc11;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1780,7 +1734,7 @@ __arg0 = _35cc11;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1789,7 +1743,7 @@ __arg0 = _35cc11;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1798,7 +1752,7 @@ __arg0 = _35cc11;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1807,7 +1761,7 @@ __arg0 = _35cc11;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1816,7 +1770,7 @@ __arg0 = _35cc11;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1825,7 +1779,7 @@ __arg0 = _35cc11;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1834,7 +1788,7 @@ __arg0 = _35cc11;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1843,14 +1797,14 @@ __arg0 = _35cc11;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35cc10 = makeNative(6, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc10 = makeNative(6, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg651 = primIsCons(closureRef(co, 0));
 if (True == _35reg651) {
 Obj _35reg652 = primCar(closureRef(co, 0));
@@ -1870,7 +1824,7 @@ if (True == _35reg661) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -1878,7 +1832,7 @@ __arg0 = _35cc10;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1887,7 +1841,7 @@ __arg0 = _35cc10;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1896,7 +1850,7 @@ __arg0 = _35cc10;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1905,7 +1859,7 @@ __arg0 = _35cc10;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1914,14 +1868,14 @@ __arg0 = _35cc10;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35cc9 = makeNative(7, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc9 = makeNative(7, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg662 = primIsCons(closureRef(co, 0));
 if (True == _35reg662) {
 Obj _35reg663 = primCar(closureRef(co, 0));
@@ -1951,7 +1905,7 @@ if (True == _35reg680) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -1959,7 +1913,7 @@ __arg0 = _35cc9;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1968,7 +1922,7 @@ __arg0 = _35cc9;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1977,7 +1931,7 @@ __arg0 = _35cc9;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1986,7 +1940,7 @@ __arg0 = _35cc9;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1995,7 +1949,7 @@ __arg0 = _35cc9;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2004,7 +1958,7 @@ __arg0 = _35cc9;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2013,14 +1967,14 @@ __arg0 = _35cc9;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label9:
 {
-Obj _35cc8 = makeNative(8, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc8 = makeNative(8, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg681 = primIsCons(closureRef(co, 0));
 if (True == _35reg681) {
 Obj _35reg682 = primCar(closureRef(co, 0));
@@ -2074,7 +2028,7 @@ if (True == _35reg719) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -2082,7 +2036,7 @@ __arg0 = _35cc8;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2091,7 +2045,7 @@ __arg0 = _35cc8;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2100,7 +2054,7 @@ __arg0 = _35cc8;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2109,7 +2063,7 @@ __arg0 = _35cc8;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2118,7 +2072,7 @@ __arg0 = _35cc8;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2127,7 +2081,7 @@ __arg0 = _35cc8;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2136,7 +2090,7 @@ __arg0 = _35cc8;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2145,7 +2099,7 @@ __arg0 = _35cc8;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2154,14 +2108,14 @@ __arg0 = _35cc8;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35cc7 = makeNative(9, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc7 = makeNative(9, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg720 = primIsCons(closureRef(co, 0));
 if (True == _35reg720) {
 Obj _35reg721 = primCar(closureRef(co, 0));
@@ -2215,7 +2169,7 @@ if (True == _35reg758) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -2223,7 +2177,7 @@ __arg0 = _35cc7;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2232,7 +2186,7 @@ __arg0 = _35cc7;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2241,7 +2195,7 @@ __arg0 = _35cc7;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2250,7 +2204,7 @@ __arg0 = _35cc7;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2259,7 +2213,7 @@ __arg0 = _35cc7;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2268,7 +2222,7 @@ __arg0 = _35cc7;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2277,7 +2231,7 @@ __arg0 = _35cc7;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2286,7 +2240,7 @@ __arg0 = _35cc7;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2295,7 +2249,7 @@ __arg0 = _35cc7;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2303,7 +2257,7 @@ goto *jumpTable[ps.label];
 label11:
 {
 Obj _35p5 = __arg1;
-Obj _35cc6 = makeNative(10, _35clofun1017, 0, 1, _35p5);
+Obj _35cc6 = makeNative(10, _35clofun1013, 0, 1, _35p5);
 Obj _35reg759 = primIsCons(_35p5);
 if (True == _35reg759) {
 Obj _35reg760 = primCar(_35p5);
@@ -2357,7 +2311,7 @@ if (True == _35reg797) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -2365,7 +2319,7 @@ __arg0 = _35cc6;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2374,7 +2328,7 @@ __arg0 = _35cc6;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2383,7 +2337,7 @@ __arg0 = _35cc6;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2392,7 +2346,7 @@ __arg0 = _35cc6;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2401,7 +2355,7 @@ __arg0 = _35cc6;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2410,7 +2364,7 @@ __arg0 = _35cc6;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2419,7 +2373,7 @@ __arg0 = _35cc6;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2428,7 +2382,7 @@ __arg0 = _35cc6;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2437,7 +2391,7 @@ __arg0 = _35cc6;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2450,24 +2404,24 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35cc28 = makeNative(12, _35clofun1017, 0, 0);
+Obj _35cc28 = makeNative(12, _35clofun1013, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label14:
 {
-Obj _35cc27 = makeNative(13, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc27 = makeNative(13, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg799 = primIsCons(closureRef(co, 0));
 if (True == _35reg799) {
 Obj _35reg800 = primCar(closureRef(co, 0));
@@ -2482,7 +2436,7 @@ __arg2 = _35reg802;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -2490,7 +2444,7 @@ __arg0 = _35cc27;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2505,13 +2459,13 @@ Obj _35reg823 = primCons(intern("lambda"), _35reg822);
 __nargs = 2;
 __arg1 = _35reg823;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1013) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label16:
 {
-Obj _35cc26 = makeNative(14, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc26 = makeNative(14, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg803 = primIsCons(closureRef(co, 0));
 if (True == _35reg803) {
 Obj _35reg804 = primCar(closureRef(co, 0));
@@ -2536,14 +2490,14 @@ Obj _35reg817 = primCdr(_35reg816);
 Obj _35reg818 = primCdr(_35reg817);
 Obj _35reg819 = primEQ(Nil, _35reg818);
 if (True == _35reg819) {
-pushCont(co, 15, _35clofun1017, 1, args);
+pushCont(co, 15, _35clofun1013, 1, args);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.propagate-boolean"));
 __arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -2551,16 +2505,7 @@ __arg0 = _35cc26;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc26;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2569,7 +2514,7 @@ __arg0 = _35cc26;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2578,7 +2523,7 @@ __arg0 = _35cc26;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2587,7 +2532,16 @@ __arg0 = _35cc26;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc26;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2608,7 +2562,7 @@ __arg1 = _35reg856;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2618,14 +2572,14 @@ Obj _35val851 = __arg1;
 Obj z= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x1= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj y1 = _35val851;
-pushCont(co, 17, _35clofun1017, 2, y1, x1);
+pushCont(co, 17, _35clofun1013, 2, y1, x1);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.propagate-boolean"));
 __arg1 = z;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2635,20 +2589,20 @@ Obj _35val850 = __arg1;
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj z= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj x1 = _35val850;
-pushCont(co, 18, _35clofun1017, 2, z, x1);
+pushCont(co, 18, _35clofun1013, 2, z, x1);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.propagate-boolean"));
 __arg1 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35cc25 = makeNative(16, _35clofun1017, 0, 1, closureRef(co, 0));
+Obj _35cc25 = makeNative(16, _35clofun1013, 0, 1, closureRef(co, 0));
 Obj _35reg824 = primIsCons(closureRef(co, 0));
 if (True == _35reg824) {
 Obj _35reg825 = primCar(closureRef(co, 0));
@@ -2684,14 +2638,14 @@ Obj _35reg847 = primCdr(_35reg846);
 Obj _35reg848 = primCdr(_35reg847);
 Obj _35reg849 = primEQ(Nil, _35reg848);
 if (True == _35reg849) {
-pushCont(co, 19, _35clofun1017, 2, y, z);
+pushCont(co, 19, _35clofun1013, 2, y, z);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.propagate-boolean"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -2699,16 +2653,7 @@ __arg0 = _35cc25;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc25;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2717,7 +2662,7 @@ __arg0 = _35cc25;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2726,7 +2671,7 @@ __arg0 = _35cc25;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2735,7 +2680,7 @@ __arg0 = _35cc25;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -2744,7 +2689,16 @@ __arg0 = _35cc25;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc25;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2758,7 +2712,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1016(struct Cora* co){
+void _35clofun1012(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -2779,7 +2733,7 @@ __arg2 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2801,7 +2755,7 @@ __arg3 = _35reg496;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg497 = primCdr(l);
@@ -2813,7 +2767,7 @@ __arg3 = _35reg497;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2826,14 +2780,14 @@ Obj l = __arg3;
 Obj _35reg491 = primIsCons(l);
 if (True == _35reg491) {
 Obj _35reg492 = primCar(l);
-pushCont(co, 1, _35clofun1016, 3, l, res, fn);
+pushCont(co, 1, _35clofun1012, 3, l, res, fn);
 __nargs = 2;
 __arg0 = fn;
 __arg1 = _35reg492;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -2842,7 +2796,7 @@ __arg1 = res;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2859,7 +2813,7 @@ __arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2871,7 +2825,7 @@ Obj _35reg504 = primCons(_35reg501, _35val503);
 __nargs = 2;
 __arg1 = _35reg504;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1016) { goto fail; }
+if (co->ctx.pc.func != _35clofun1012) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -2884,12 +2838,12 @@ if (True == _35reg500) {
 __nargs = 2;
 __arg1 = l2;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1016) { goto fail; }
+if (co->ctx.pc.func != _35clofun1012) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg501 = primCar(l1);
 Obj _35reg502 = primCdr(l1);
-pushCont(co, 4, _35clofun1016, 1, _35reg501);
+pushCont(co, 4, _35clofun1012, 1, _35reg501);
 __nargs = 3;
 __arg0 = globalRef(intern("append"));
 __arg1 = _35reg502;
@@ -2897,7 +2851,7 @@ __arg2 = l2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2912,7 +2866,7 @@ __arg1 = _35reg507;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2924,7 +2878,7 @@ Obj _35reg511 = primNot(_35reg510);
 __nargs = 2;
 __arg1 = _35reg511;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1016) { goto fail; }
+if (co->ctx.pc.func != _35clofun1012) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -2940,13 +2894,13 @@ __arg1 = makeString1("inconsistent func rule args count");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = n;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1016) { goto fail; }
+if (co->ctx.pc.func != _35clofun1012) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -2955,14 +2909,14 @@ label9:
 {
 Obj _35val513 = __arg1;
 Obj n= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 8, _35clofun1016, 1, n);
+pushCont(co, 8, _35clofun1012, 1, n);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
 __arg1 = _35val513;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2972,9 +2926,9 @@ Obj _35val508 = __arg1;
 Obj counts = _35val508;
 Obj _35reg509 = primCar(counts);
 Obj n = _35reg509;
-Obj dif = makeNative(7, _35clofun1016, 1, 1, n);
+Obj dif = makeNative(7, _35clofun1012, 1, 1, n);
 Obj _35reg512 = primCdr(counts);
-pushCont(co, 9, _35clofun1016, 1, n);
+pushCont(co, 9, _35clofun1012, 1, n);
 __nargs = 3;
 __arg0 = globalRef(intern("filter"));
 __arg1 = dif;
@@ -2982,7 +2936,7 @@ __arg2 = _35reg512;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2990,8 +2944,8 @@ label11:
 {
 Obj _35val506 = __arg1;
 Obj pats = _35val506;
-Obj len = makeNative(6, _35clofun1016, 1, 0);
-pushCont(co, 10, _35clofun1016, 0);
+Obj len = makeNative(6, _35clofun1012, 1, 0);
+pushCont(co, 10, _35clofun1012, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("map"));
 __arg1 = len;
@@ -2999,14 +2953,14 @@ __arg2 = pats;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
 Obj rules = __arg1;
-pushCont(co, 11, _35clofun1016, 0);
+pushCont(co, 11, _35clofun1012, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.rules-patterns"));
 __arg1 = Nil;
@@ -3014,7 +2968,7 @@ __arg2 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3026,7 +2980,7 @@ Obj _35reg521 = primCons(_35reg518, _35val520);
 __nargs = 2;
 __arg1 = _35reg521;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1016) { goto fail; }
+if (co->ctx.pc.func != _35clofun1012) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -3038,19 +2992,19 @@ if (True == _35reg517) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1016) { goto fail; }
+if (co->ctx.pc.func != _35clofun1012) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg518 = primGenSym(intern("p"));
 Obj _35reg519 = primSub(n, makeNumber(1));
-pushCont(co, 13, _35clofun1016, 1, _35reg518);
+pushCont(co, 13, _35clofun1012, 1, _35reg518);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.gen-parameters"));
 __arg1 = _35reg519;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3070,7 +3024,7 @@ Obj _35reg534 = primCons(intern("defun"), _35reg533);
 __nargs = 2;
 __arg1 = _35reg534;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1016) { goto fail; }
+if (co->ctx.pc.func != _35clofun1012) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -3080,14 +3034,14 @@ Obj _35val526 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args = _35val526;
-pushCont(co, 15, _35clofun1016, 2, body, args);
+pushCont(co, 15, _35clofun1012, 2, body, args);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3097,14 +3051,14 @@ Obj _35val525 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj nargs = _35val525;
-pushCont(co, 16, _35clofun1016, 2, exp, body);
+pushCont(co, 16, _35clofun1012, 2, exp, body);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.gen-parameters"));
 __arg1 = nargs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3113,14 +3067,14 @@ label18:
 Obj _35val524 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body = _35val524;
-pushCont(co, 17, _35clofun1016, 2, exp, body);
+pushCont(co, 17, _35clofun1012, 2, exp, body);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.rules-arg-count"));
 __arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3128,28 +3082,28 @@ label19:
 {
 Obj _35val523 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 18, _35clofun1016, 1, exp);
+pushCont(co, 18, _35clofun1012, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.extract-rules"));
 __arg1 = _35val523;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
 Obj exp = __arg1;
-pushCont(co, 19, _35clofun1016, 1, exp);
+pushCont(co, 19, _35clofun1012, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3162,7 +3116,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1015(struct Cora* co){
+void _35clofun1011(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -3177,14 +3131,14 @@ label0:
 {
 Obj value = __arg1;
 Obj rules = __arg2;
-pushCont(co, 20, _35clofun1014, 2, rules, value);
+pushCont(co, 20, _35clofun1010, 2, rules, value);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
 __arg1 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3200,7 +3154,7 @@ Obj _35reg413 = primCons(intern("let"), _35reg412);
 __nargs = 2;
 __arg1 = _35reg413;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1015) { goto fail; }
+if (co->ctx.pc.func != _35clofun1011) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -3216,7 +3170,7 @@ Obj _35reg419 = primCons(intern("let"), _35reg418);
 __nargs = 2;
 __arg1 = _35reg419;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1015) { goto fail; }
+if (co->ctx.pc.func != _35clofun1011) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -3232,7 +3186,7 @@ Obj _35reg425 = primCons(intern("let"), _35reg424);
 __nargs = 2;
 __arg1 = _35reg425;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1015) { goto fail; }
+if (co->ctx.pc.func != _35clofun1011) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -3250,7 +3204,7 @@ if (True == _35reg407) {
 if (True == True) {
 Obj _35reg408 = primGenSym(intern("val"));
 Obj val = _35reg408;
-pushCont(co, 1, _35clofun1015, 2, value, val);
+pushCont(co, 1, _35clofun1011, 2, value, val);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.match-helper"));
 __arg1 = val;
@@ -3258,7 +3212,7 @@ __arg2 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 3;
@@ -3268,14 +3222,14 @@ __arg2 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
 Obj _35reg414 = primGenSym(intern("val"));
 Obj val = _35reg414;
-pushCont(co, 2, _35clofun1015, 2, value, val);
+pushCont(co, 2, _35clofun1011, 2, value, val);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.match-helper"));
 __arg1 = val;
@@ -3283,7 +3237,7 @@ __arg2 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 3;
@@ -3293,7 +3247,7 @@ __arg2 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3301,7 +3255,7 @@ goto *jumpTable[ps.label];
 if (True == False) {
 Obj _35reg420 = primGenSym(intern("val"));
 Obj val = _35reg420;
-pushCont(co, 3, _35clofun1015, 2, value, val);
+pushCont(co, 3, _35clofun1011, 2, value, val);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.match-helper"));
 __arg1 = val;
@@ -3309,7 +3263,7 @@ __arg2 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 3;
@@ -3319,7 +3273,7 @@ __arg2 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3330,14 +3284,14 @@ label5:
 Obj _35val402 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj value = _35val402;
-pushCont(co, 4, _35clofun1015, 1, value);
+pushCont(co, 4, _35clofun1011, 1, value);
 __nargs = 2;
 __arg0 = globalRef(intern("cddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3345,28 +3299,28 @@ label6:
 {
 Obj _35val401 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 5, _35clofun1015, 1, exp);
+pushCont(co, 5, _35clofun1011, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("macroexpand"));
 __arg1 = _35val401;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
 Obj exp = __arg1;
-pushCont(co, 6, _35clofun1015, 1, exp);
+pushCont(co, 6, _35clofun1011, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3379,7 +3333,7 @@ __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3391,13 +3345,13 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35cc4 = makeNative(9, _35clofun1015, 0, 0);
+Obj _35cc4 = makeNative(9, _35clofun1011, 0, 0);
 Obj _35reg428 = primIsCons(closureRef(co, 0));
 if (True == _35reg428) {
 Obj _35reg429 = primCar(closureRef(co, 0));
@@ -3413,7 +3367,7 @@ __arg3 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -3421,7 +3375,7 @@ __arg0 = _35cc4;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3443,13 +3397,13 @@ __arg3 = _35reg444;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35cc3 = makeNative(10, _35clofun1015, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc3 = makeNative(10, _35clofun1011, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj _35reg432 = primIsCons(closureRef(co, 0));
 if (True == _35reg432) {
 Obj _35reg433 = primCar(closureRef(co, 0));
@@ -3464,14 +3418,14 @@ Obj act = _35reg438;
 Obj _35reg439 = primCdr(closureRef(co, 0));
 Obj _35reg440 = primCdr(_35reg439);
 Obj remain = _35reg440;
-pushCont(co, 11, _35clofun1015, 2, act, remain);
+pushCont(co, 11, _35clofun1011, 2, act, remain);
 __nargs = 2;
 __arg0 = globalRef(intern("reverse"));
 __arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -3479,16 +3433,7 @@ __arg0 = _35cc3;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc3;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3497,7 +3442,16 @@ __arg0 = _35cc3;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc3;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3523,13 +3477,13 @@ __arg3 = _35reg477;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35cc2 = makeNative(12, _35clofun1015, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc2 = makeNative(12, _35clofun1011, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj _35reg445 = primIsCons(closureRef(co, 0));
 if (True == _35reg445) {
 Obj _35reg446 = primCar(closureRef(co, 0));
@@ -3565,14 +3519,14 @@ Obj _35reg468 = primCdr(_35reg467);
 Obj _35reg469 = primCdr(_35reg468);
 Obj _35reg470 = primCdr(_35reg469);
 Obj remain = _35reg470;
-pushCont(co, 13, _35clofun1015, 3, act, pred, remain);
+pushCont(co, 13, _35clofun1011, 3, act, pred, remain);
 __nargs = 2;
 __arg0 = globalRef(intern("reverse"));
 __arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -3580,16 +3534,7 @@ __arg0 = _35cc2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3598,7 +3543,7 @@ __arg0 = _35cc2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3607,7 +3552,7 @@ __arg0 = _35cc2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3616,7 +3561,7 @@ __arg0 = _35cc2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3625,7 +3570,16 @@ __arg0 = _35cc2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3635,7 +3589,7 @@ label15:
 Obj input = __arg1;
 Obj current = __arg2;
 Obj result = __arg3;
-Obj _35cc1 = makeNative(14, _35clofun1015, 0, 3, input, current, result);
+Obj _35cc1 = makeNative(14, _35clofun1011, 0, 3, input, current, result);
 Obj _35reg478 = primEQ(Nil, input);
 if (True == _35reg478) {
 __nargs = 2;
@@ -3644,7 +3598,7 @@ __arg1 = result;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -3652,7 +3606,7 @@ __arg0 = _35cc1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3668,7 +3622,7 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3683,7 +3637,7 @@ __arg2 = _35val484;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3699,19 +3653,19 @@ __arg1 = res;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg482 = primCar(rules);
 Obj _35reg483 = primCons(_35reg482, res);
-pushCont(co, 17, _35clofun1015, 1, _35reg483);
+pushCont(co, 17, _35clofun1011, 1, _35reg483);
 __nargs = 2;
 __arg0 = globalRef(intern("cddr"));
 __arg1 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3720,14 +3674,14 @@ label19:
 {
 Obj res = __arg1;
 Obj rules = __arg2;
-pushCont(co, 18, _35clofun1015, 2, res, rules);
+pushCont(co, 18, _35clofun1011, 2, res, rules);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
 __arg1 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3740,7 +3694,7 @@ if (True == _35reg486) {
 __nargs = 2;
 __arg1 = i;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1015) { goto fail; }
+if (co->ctx.pc.func != _35clofun1011) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg487 = primAdd(i, makeNumber(1));
@@ -3752,7 +3706,7 @@ __arg2 = _35reg488;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3766,7 +3720,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1014(struct Cora* co){
+void _35clofun1010(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -3790,7 +3744,7 @@ Obj _35reg340 = primCons(intern("if"), _35reg339);
 __nargs = 2;
 __arg1 = _35reg340;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1014) { goto fail; }
+if (co->ctx.pc.func != _35clofun1010) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -3799,14 +3753,14 @@ label1:
 Obj _35val334 = __arg1;
 Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun1014, 2, cc, _35val334);
+pushCont(co, 0, _35clofun1010, 2, cc, _35val334);
 __nargs = 2;
 __arg0 = globalRef(intern("caddr"));
 __arg1 = action;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3823,7 +3777,7 @@ Obj _35reg347 = primCons(intern("if"), _35reg346);
 __nargs = 2;
 __arg1 = _35reg347;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1014) { goto fail; }
+if (co->ctx.pc.func != _35clofun1010) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -3832,14 +3786,14 @@ label3:
 Obj _35val341 = __arg1;
 Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun1014, 2, cc, _35val341);
+pushCont(co, 2, _35clofun1010, 2, cc, _35val341);
 __nargs = 2;
 __arg0 = globalRef(intern("caddr"));
 __arg1 = action;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3853,57 +3807,57 @@ Obj _35reg325 = primCar(action);
 Obj _35reg326 = primEQ(_35reg325, intern("where"));
 if (True == _35reg326) {
 if (True == True) {
-pushCont(co, 20, _35clofun1013, 2, action, cc);
+pushCont(co, 20, _35clofun1009, 2, action, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = action;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = action;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1014) { goto fail; }
+if (co->ctx.pc.func != _35clofun1010) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 } else {
 if (True == False) {
-pushCont(co, 1, _35clofun1014, 2, action, cc);
+pushCont(co, 1, _35clofun1010, 2, action, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = action;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = action;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1014) { goto fail; }
+if (co->ctx.pc.func != _35clofun1010) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
 } else {
 if (True == False) {
-pushCont(co, 3, _35clofun1014, 2, action, cc);
+pushCont(co, 3, _35clofun1010, 2, action, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = action;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = action;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1014) { goto fail; }
+if (co->ctx.pc.func != _35clofun1010) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -3916,14 +3870,14 @@ Obj cc = __arg2;
 Obj _35reg322 = primCdr(rules);
 Obj _35reg323 = primCar(_35reg322);
 Obj action = _35reg323;
-pushCont(co, 4, _35clofun1014, 2, cc, action);
+pushCont(co, 4, _35clofun1010, 2, cc, action);
 __nargs = 2;
 __arg0 = globalRef(intern("pair?"));
 __arg1 = action;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3943,7 +3897,7 @@ Obj _35reg369 = primCons(intern("let"), _35reg368);
 __nargs = 2;
 __arg1 = _35reg369;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1014) { goto fail; }
+if (co->ctx.pc.func != _35clofun1010) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -3956,7 +3910,7 @@ Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj curr = _35val359;
 Obj _35reg360 = primCdr(rules);
 Obj _35reg361 = primCdr(_35reg360);
-pushCont(co, 6, _35clofun1014, 2, curr, cc);
+pushCont(co, 6, _35clofun1010, 2, curr, cc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.match-helper"));
 __arg1 = value;
@@ -3964,7 +3918,7 @@ __arg2 = _35reg361;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3975,7 +3929,7 @@ Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 7, _35clofun1014, 3, rules, value, cc);
+pushCont(co, 7, _35clofun1010, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init.match1"));
 __arg1 = _35val358;
@@ -3985,7 +3939,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3997,14 +3951,14 @@ Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj action = _35val357;
-pushCont(co, 8, _35clofun1014, 4, action, rules, value, cc);
+pushCont(co, 8, _35clofun1010, 4, action, rules, value, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("macroexpand"));
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4024,7 +3978,7 @@ Obj _35reg384 = primCons(intern("let"), _35reg383);
 __nargs = 2;
 __arg1 = _35reg384;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1014) { goto fail; }
+if (co->ctx.pc.func != _35clofun1010) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -4037,7 +3991,7 @@ Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj curr = _35val374;
 Obj _35reg375 = primCdr(rules);
 Obj _35reg376 = primCdr(_35reg375);
-pushCont(co, 10, _35clofun1014, 2, curr, cc);
+pushCont(co, 10, _35clofun1010, 2, curr, cc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.match-helper"));
 __arg1 = value;
@@ -4045,7 +3999,7 @@ __arg2 = _35reg376;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4056,7 +4010,7 @@ Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 11, _35clofun1014, 3, rules, value, cc);
+pushCont(co, 11, _35clofun1010, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init.match1"));
 __arg1 = _35val373;
@@ -4066,7 +4020,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4078,14 +4032,14 @@ Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj action = _35val372;
-pushCont(co, 12, _35clofun1014, 4, action, rules, value, cc);
+pushCont(co, 12, _35clofun1010, 4, action, rules, value, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("macroexpand"));
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4100,7 +4054,7 @@ Obj _35reg355 = primCar(rules);
 Obj pat = _35reg355;
 Obj _35reg356 = primGenSym(intern("cc"));
 Obj cc = _35reg356;
-pushCont(co, 9, _35clofun1014, 4, pat, rules, value, cc);
+pushCont(co, 9, _35clofun1010, 4, pat, rules, value, cc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.extract-rule-action"));
 __arg1 = rules;
@@ -4108,7 +4062,7 @@ __arg2 = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -4117,7 +4071,7 @@ __arg1 = makeString1("no cond match");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4126,7 +4080,7 @@ Obj _35reg370 = primCar(rules);
 Obj pat = _35reg370;
 Obj _35reg371 = primGenSym(intern("cc"));
 Obj cc = _35reg371;
-pushCont(co, 13, _35clofun1014, 4, pat, rules, value, cc);
+pushCont(co, 13, _35clofun1010, 4, pat, rules, value, cc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.extract-rule-action"));
 __arg1 = rules;
@@ -4134,7 +4088,7 @@ __arg2 = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -4143,7 +4097,7 @@ __arg1 = makeString1("no cond match");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4165,7 +4119,7 @@ Obj _35reg399 = primCons(intern("let"), _35reg398);
 __nargs = 2;
 __arg1 = _35reg399;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1014) { goto fail; }
+if (co->ctx.pc.func != _35clofun1010) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -4178,7 +4132,7 @@ Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj curr = _35val389;
 Obj _35reg390 = primCdr(rules);
 Obj _35reg391 = primCdr(_35reg390);
-pushCont(co, 15, _35clofun1014, 2, curr, cc);
+pushCont(co, 15, _35clofun1010, 2, curr, cc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.match-helper"));
 __arg1 = value;
@@ -4186,7 +4140,7 @@ __arg2 = _35reg391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4197,7 +4151,7 @@ Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 16, _35clofun1014, 3, rules, value, cc);
+pushCont(co, 16, _35clofun1010, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init.match1"));
 __arg1 = _35val388;
@@ -4207,7 +4161,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4219,14 +4173,14 @@ Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj action = _35val387;
-pushCont(co, 17, _35clofun1014, 4, action, rules, value, cc);
+pushCont(co, 17, _35clofun1010, 4, action, rules, value, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("macroexpand"));
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4237,14 +4191,14 @@ Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val352) {
 Obj _35reg353 = primCdr(rules);
-pushCont(co, 14, _35clofun1014, 2, rules, value);
+pushCont(co, 14, _35clofun1010, 2, rules, value);
 __nargs = 2;
 __arg0 = globalRef(intern("pair?"));
 __arg1 = _35reg353;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 if (True == False) {
@@ -4252,7 +4206,7 @@ Obj _35reg385 = primCar(rules);
 Obj pat = _35reg385;
 Obj _35reg386 = primGenSym(intern("cc"));
 Obj cc = _35reg386;
-pushCont(co, 18, _35clofun1014, 4, pat, rules, value, cc);
+pushCont(co, 18, _35clofun1010, 4, pat, rules, value, cc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.extract-rule-action"));
 __arg1 = rules;
@@ -4260,7 +4214,7 @@ __arg2 = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -4269,7 +4223,7 @@ __arg1 = makeString1("no cond match");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4286,17 +4240,17 @@ Obj _35reg351 = primCons(intern("error"), _35reg350);
 __nargs = 2;
 __arg1 = _35reg351;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1014) { goto fail; }
+if (co->ctx.pc.func != _35clofun1010) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 19, _35clofun1014, 2, rules, value);
+pushCont(co, 19, _35clofun1010, 2, rules, value);
 __nargs = 2;
 __arg0 = globalRef(intern("pair?"));
 __arg1 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4310,7 +4264,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1013(struct Cora* co){
+void _35clofun1009(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -4336,7 +4290,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4349,7 +4303,7 @@ Obj x= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e2 = _35val257;
-pushCont(co, 0, _35clofun1013, 3, x, e1, cc);
+pushCont(co, 0, _35clofun1009, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init.match1"));
 __arg1 = y;
@@ -4359,7 +4313,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4372,14 +4326,14 @@ Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e1 = _35val256;
-pushCont(co, 1, _35clofun1013, 5, y, body, x, e1, cc);
+pushCont(co, 1, _35clofun1009, 5, y, body, x, e1, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("caddr"));
 __arg1 = expr;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4396,7 +4350,7 @@ Obj _35reg271 = primCons(intern("if"), _35reg270);
 __nargs = 2;
 __arg1 = _35reg271;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1013) { goto fail; }
+if (co->ctx.pc.func != _35clofun1009) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -4407,7 +4361,7 @@ Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg262= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg260= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 3, _35clofun1013, 2, cc, _35reg260);
+pushCont(co, 3, _35clofun1009, 2, cc, _35reg260);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init.match1"));
 __arg1 = x;
@@ -4417,7 +4371,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4436,7 +4390,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4449,7 +4403,7 @@ Obj x= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e2 = _35val273;
-pushCont(co, 5, _35clofun1013, 3, x, e1, cc);
+pushCont(co, 5, _35clofun1009, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init.match1"));
 __arg1 = y;
@@ -4459,7 +4413,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4472,14 +4426,14 @@ Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e1 = _35val272;
-pushCont(co, 6, _35clofun1013, 5, y, body, x, e1, cc);
+pushCont(co, 6, _35clofun1009, 5, y, body, x, e1, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("caddr"));
 __arg1 = expr;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4496,7 +4450,7 @@ Obj _35reg287 = primCons(intern("if"), _35reg286);
 __nargs = 2;
 __arg1 = _35reg287;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1013) { goto fail; }
+if (co->ctx.pc.func != _35clofun1009) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -4507,7 +4461,7 @@ Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg278= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg276= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 8, _35clofun1013, 2, cc, _35reg276);
+pushCont(co, 8, _35clofun1009, 2, cc, _35reg276);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init.match1"));
 __arg1 = x;
@@ -4517,7 +4471,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4535,14 +4489,14 @@ Obj _35reg238 = primCar(expr);
 Obj _35reg239 = primEQ(_35reg238, intern("cons"));
 if (True == _35reg239) {
 if (True == True) {
-pushCont(co, 18, _35clofun1012, 5, expr, y, body, x, cc);
+pushCont(co, 18, _35clofun1008, 5, expr, y, body, x, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = expr;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg243 = primCons(expr, Nil);
@@ -4551,7 +4505,7 @@ Obj _35reg245 = primCons(expr, Nil);
 Obj _35reg246 = primCons(intern("car"), _35reg245);
 Obj _35reg247 = primCons(expr, Nil);
 Obj _35reg248 = primCons(intern("cdr"), _35reg247);
-pushCont(co, 20, _35clofun1012, 4, x, _35reg246, cc, _35reg244);
+pushCont(co, 20, _35clofun1008, 4, x, _35reg246, cc, _35reg244);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init.match1"));
 __arg1 = y;
@@ -4561,19 +4515,19 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-pushCont(co, 2, _35clofun1013, 5, expr, y, body, x, cc);
+pushCont(co, 2, _35clofun1009, 5, expr, y, body, x, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = expr;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg259 = primCons(expr, Nil);
@@ -4582,7 +4536,7 @@ Obj _35reg261 = primCons(expr, Nil);
 Obj _35reg262 = primCons(intern("car"), _35reg261);
 Obj _35reg263 = primCons(expr, Nil);
 Obj _35reg264 = primCons(intern("cdr"), _35reg263);
-pushCont(co, 4, _35clofun1013, 4, x, _35reg262, cc, _35reg260);
+pushCont(co, 4, _35clofun1009, 4, x, _35reg262, cc, _35reg260);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init.match1"));
 __arg1 = y;
@@ -4592,20 +4546,20 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 } else {
 if (True == False) {
-pushCont(co, 7, _35clofun1013, 5, expr, y, body, x, cc);
+pushCont(co, 7, _35clofun1009, 5, expr, y, body, x, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = expr;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg275 = primCons(expr, Nil);
@@ -4614,7 +4568,7 @@ Obj _35reg277 = primCons(expr, Nil);
 Obj _35reg278 = primCons(intern("car"), _35reg277);
 Obj _35reg279 = primCons(expr, Nil);
 Obj _35reg280 = primCons(intern("cdr"), _35reg279);
-pushCont(co, 9, _35clofun1013, 4, x, _35reg278, cc, _35reg276);
+pushCont(co, 9, _35clofun1009, 4, x, _35reg278, cc, _35reg276);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init.match1"));
 __arg1 = y;
@@ -4624,7 +4578,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4638,14 +4592,14 @@ Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj x = _35val235;
-pushCont(co, 10, _35clofun1013, 4, expr, body, x, cc);
+pushCont(co, 10, _35clofun1009, 4, expr, body, x, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("caddr"));
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4655,14 +4609,14 @@ Obj pat = __arg1;
 Obj expr = __arg2;
 Obj body = __arg3;
 Obj cc = co->args[4];
-pushCont(co, 11, _35clofun1013, 4, pat, expr, body, cc);
+pushCont(co, 11, _35clofun1009, 4, pat, expr, body, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4677,20 +4631,20 @@ if (True == _35reg291) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1013) { goto fail; }
+if (co->ctx.pc.func != _35clofun1009) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1013) { goto fail; }
+if (co->ctx.pc.func != _35clofun1009) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 } else {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1013) { goto fail; }
+if (co->ctx.pc.func != _35clofun1009) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -4698,14 +4652,14 @@ goto *jumpTable[co->ctx.pc.label];
 label14:
 {
 Obj x = __arg1;
-pushCont(co, 13, _35clofun1013, 1, x);
+pushCont(co, 13, _35clofun1009, 1, x);
 __nargs = 2;
 __arg0 = globalRef(intern("atom?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4718,7 +4672,7 @@ __arg1 = _35val320;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4744,7 +4698,7 @@ Obj _35reg317 = primCons(intern("if"), _35reg316);
 __nargs = 2;
 __arg1 = _35reg317;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1013) { goto fail; }
+if (co->ctx.pc.func != _35clofun1009) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg318 = primCar(pat);
@@ -4759,7 +4713,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -4768,12 +4722,12 @@ __arg1 = makeString1("no cond match");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 } else {
-pushCont(co, 15, _35clofun1013, 0);
+pushCont(co, 15, _35clofun1009, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("str"));
 __arg1 = makeString1("match fail ");
@@ -4781,7 +4735,7 @@ __arg2 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4799,7 +4753,7 @@ if (True == _35reg293) {
 __nargs = 2;
 __arg1 = body;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1013) { goto fail; }
+if (co->ctx.pc.func != _35clofun1009) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg294 = primCons(expr, Nil);
@@ -4813,7 +4767,7 @@ Obj _35reg301 = primCons(intern("if"), _35reg300);
 __nargs = 2;
 __arg1 = _35reg301;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1013) { goto fail; }
+if (co->ctx.pc.func != _35clofun1009) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 } else {
@@ -4826,17 +4780,17 @@ Obj _35reg306 = primCons(intern("let"), _35reg305);
 __nargs = 2;
 __arg1 = _35reg306;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1013) { goto fail; }
+if (co->ctx.pc.func != _35clofun1009) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 16, _35clofun1013, 4, expr, body, cc, pat);
+pushCont(co, 16, _35clofun1009, 4, expr, body, cc, pat);
 __nargs = 2;
 __arg0 = globalRef(intern("pair?"));
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4848,15 +4802,15 @@ Obj pat = __arg1;
 Obj expr = __arg2;
 Obj body = __arg3;
 Obj cc = co->args[4];
-Obj literal_63 = makeNative(14, _35clofun1013, 1, 0);
-pushCont(co, 17, _35clofun1013, 4, expr, body, cc, pat);
+Obj literal_63 = makeNative(14, _35clofun1009, 1, 0);
+pushCont(co, 17, _35clofun1009, 4, expr, body, cc, pat);
 __nargs = 2;
 __arg0 = literal_63;
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4873,7 +4827,7 @@ Obj _35reg333 = primCons(intern("if"), _35reg332);
 __nargs = 2;
 __arg1 = _35reg333;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1013) { goto fail; }
+if (co->ctx.pc.func != _35clofun1009) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -4882,14 +4836,14 @@ label20:
 Obj _35val327 = __arg1;
 Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 19, _35clofun1013, 2, cc, _35val327);
+pushCont(co, 19, _35clofun1009, 2, cc, _35val327);
 __nargs = 2;
 __arg0 = globalRef(intern("caddr"));
 __arg1 = action;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4902,7 +4856,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1012(struct Cora* co){
+void _35clofun1008(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -4923,7 +4877,7 @@ __arg1 = _35reg176;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4940,7 +4894,7 @@ Obj _35reg190 = primCons(intern("if"), _35reg189);
 __nargs = 2;
 __arg1 = _35reg190;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -4949,14 +4903,14 @@ label2:
 Obj _35val184 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg183= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun1012, 2, _35val184, _35reg183);
+pushCont(co, 1, _35clofun1008, 2, _35val184, _35reg183);
 __nargs = 2;
 __arg0 = globalRef(intern("cddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4966,14 +4920,14 @@ Obj _35val182 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj curr = _35val182;
 Obj _35reg183 = primCar(curr);
-pushCont(co, 2, _35clofun1012, 2, exp, _35reg183);
+pushCont(co, 2, _35clofun1008, 2, exp, _35reg183);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = curr;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4988,17 +4942,17 @@ Obj _35reg181 = primCons(intern("error"), _35reg180);
 __nargs = 2;
 __arg1 = _35reg181;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 3, _35clofun1012, 1, exp);
+pushCont(co, 3, _35clofun1008, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5013,7 +4967,7 @@ if (True == _35reg197) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg198 = primCar(l);
@@ -5024,7 +4978,7 @@ Obj _35reg202 = primCons(intern("if"), _35reg201);
 __nargs = 2;
 __arg1 = _35reg202;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -5037,7 +4991,7 @@ if (True == _35reg192) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg193 = primCar(l);
@@ -5046,18 +5000,18 @@ if (True == _35reg194) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg195 = primCdr(l);
-pushCont(co, 5, _35clofun1012, 1, l);
+pushCont(co, 5, _35clofun1008, 1, l);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.rewrite-or"));
 __arg1 = _35reg195;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5073,7 +5027,7 @@ __arg1 = _35reg204;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5087,7 +5041,7 @@ if (True == _35reg211) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg212 = primCar(l);
@@ -5098,7 +5052,7 @@ Obj _35reg216 = primCons(intern("if"), _35reg215);
 __nargs = 2;
 __arg1 = _35reg216;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -5111,7 +5065,7 @@ if (True == _35reg206) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg207 = primCar(l);
@@ -5120,18 +5074,18 @@ if (True == _35reg208) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg209 = primCdr(l);
-pushCont(co, 8, _35clofun1012, 1, l);
+pushCont(co, 8, _35clofun1008, 1, l);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.rewrite-and"));
 __arg1 = _35reg209;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5147,7 +5101,7 @@ __arg1 = _35reg218;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5159,7 +5113,7 @@ if (True == _35reg220) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg221 = primEQ(x, False);
@@ -5167,13 +5121,13 @@ if (True == _35reg221) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -5189,7 +5143,7 @@ Obj _35reg231 = primCons(intern("cons"), _35reg230);
 __nargs = 2;
 __arg1 = _35reg231;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5202,19 +5156,19 @@ Obj _35reg225 = primCar(pat);
 __nargs = 2;
 __arg1 = _35reg225;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg226 = primCar(pat);
 Obj _35reg227 = primCdr(pat);
-pushCont(co, 12, _35clofun1012, 1, _35reg226);
+pushCont(co, 12, _35clofun1008, 1, _35reg226);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.rcons1"));
 __arg1 = _35reg227;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5223,14 +5177,14 @@ label14:
 {
 Obj pat = __arg1;
 Obj _35reg223 = primCdr(pat);
-pushCont(co, 13, _35clofun1012, 1, pat);
+pushCont(co, 13, _35clofun1008, 1, pat);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
 __arg1 = _35reg223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5244,7 +5198,7 @@ __arg1 = _35reg233;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5263,7 +5217,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5276,7 +5230,7 @@ Obj x= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e2 = _35val241;
-pushCont(co, 16, _35clofun1012, 3, x, e1, cc);
+pushCont(co, 16, _35clofun1008, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init.match1"));
 __arg1 = y;
@@ -5286,7 +5240,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5299,14 +5253,14 @@ Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj e1 = _35val240;
-pushCont(co, 17, _35clofun1012, 5, y, body, x, e1, cc);
+pushCont(co, 17, _35clofun1008, 5, y, body, x, e1, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("caddr"));
 __arg1 = expr;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5323,7 +5277,7 @@ Obj _35reg255 = primCons(intern("if"), _35reg254);
 __nargs = 2;
 __arg1 = _35reg255;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1008) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5334,7 +5288,7 @@ Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg246= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg244= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun1012, 2, cc, _35reg244);
+pushCont(co, 19, _35clofun1008, 2, cc, _35reg244);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init.match1"));
 __arg1 = x;
@@ -5344,7 +5298,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5357,7 +5311,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1011(struct Cora* co){
+void _35clofun1007(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -5372,14 +5326,14 @@ label0:
 {
 Obj _35val119 = __arg1;
 Obj _35val118= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 20, _35clofun1010, 1, _35val118);
+pushCont(co, 20, _35clofun1006, 1, _35val118);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.macroexpand-boot"));
 __arg1 = _35val119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5387,14 +5341,14 @@ label1:
 {
 Obj _35val118 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun1011, 1, _35val118);
+pushCont(co, 0, _35clofun1007, 1, _35val118);
 __nargs = 2;
 __arg0 = globalRef(intern("caddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5410,7 +5364,7 @@ __arg2 = exp1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -5419,7 +5373,7 @@ __arg1 = exp1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5429,12 +5383,12 @@ label3:
 Obj _35val127 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 2;
-__arg0 = makeNative(2, _35clofun1011, 1, 1, exp);
+__arg0 = makeNative(2, _35clofun1007, 1, 1, exp);
 __arg1 = _35val127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5450,20 +5404,20 @@ Obj _35reg115 = primCdr(exp);
 __nargs = 2;
 __arg1 = _35reg115;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1011) { goto fail; }
+if (co->ctx.pc.func != _35clofun1007) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg116 = primCar(exp);
 Obj _35reg117 = primEQ(_35reg116, intern("lambda"));
 if (True == _35reg117) {
-pushCont(co, 1, _35clofun1011, 1, exp);
+pushCont(co, 1, _35clofun1007, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg124 = primCar(exp);
@@ -5472,17 +5426,17 @@ if (True == _35reg125) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1011) { goto fail; }
+if (co->ctx.pc.func != _35clofun1007) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 3, _35clofun1011, 1, exp);
+pushCont(co, 3, _35clofun1007, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.macroexpand1"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5491,7 +5445,7 @@ goto *jumpTable[ps.label];
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1011) { goto fail; }
+if (co->ctx.pc.func != _35clofun1007) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -5509,7 +5463,7 @@ Obj _35reg139 = primCons(intern("cora/init.add-to-*macros*"), _35reg138);
 __nargs = 2;
 __arg1 = _35reg139;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1011) { goto fail; }
+if (co->ctx.pc.func != _35clofun1007) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5518,14 +5472,14 @@ label6:
 Obj _35val133 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg132= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun1011, 2, _35val133, _35reg132);
+pushCont(co, 5, _35clofun1007, 2, _35val133, _35reg132);
 __nargs = 2;
 __arg0 = globalRef(intern("cdddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5535,28 +5489,28 @@ Obj _35val130 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg131 = primCons(_35val130, Nil);
 Obj _35reg132 = primCons(intern("quote"), _35reg131);
-pushCont(co, 6, _35clofun1011, 2, exp, _35reg132);
+pushCont(co, 6, _35clofun1007, 2, exp, _35reg132);
 __nargs = 2;
 __arg0 = globalRef(intern("caddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
 Obj exp = __arg1;
-pushCont(co, 7, _35clofun1011, 1, exp);
+pushCont(co, 7, _35clofun1007, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5570,7 +5524,7 @@ __arg1 = _35reg142;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5588,7 +5542,7 @@ Obj _35reg154 = primCons(intern("set"), _35reg153);
 __nargs = 2;
 __arg1 = _35reg154;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1011) { goto fail; }
+if (co->ctx.pc.func != _35clofun1007) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5597,14 +5551,14 @@ label11:
 Obj _35val147 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg146= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun1011, 2, _35val147, _35reg146);
+pushCont(co, 10, _35clofun1007, 2, _35val147, _35reg146);
 __nargs = 2;
 __arg0 = globalRef(intern("cadddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5614,28 +5568,28 @@ Obj _35val144 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg145 = primCons(_35val144, Nil);
 Obj _35reg146 = primCons(intern("quote"), _35reg145);
-pushCont(co, 11, _35clofun1011, 2, exp, _35reg146);
+pushCont(co, 11, _35clofun1007, 2, exp, _35reg146);
 __nargs = 2;
 __arg0 = globalRef(intern("caddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
 Obj exp = __arg1;
-pushCont(co, 12, _35clofun1011, 1, exp);
+pushCont(co, 12, _35clofun1007, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5651,7 +5605,7 @@ if (True == _35reg158) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1011) { goto fail; }
+if (co->ctx.pc.func != _35clofun1007) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg159 = primCdr(l);
@@ -5662,14 +5616,14 @@ __arg2 = _35reg159;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1011) { goto fail; }
+if (co->ctx.pc.func != _35clofun1007) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -5682,7 +5636,7 @@ Obj _35reg162 = primNot(_35reg161);
 __nargs = 2;
 __arg1 = _35reg162;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1011) { goto fail; }
+if (co->ctx.pc.func != _35clofun1007) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5698,7 +5652,7 @@ Obj _35reg174 = primCons(intern("let"), _35reg173);
 __nargs = 2;
 __arg1 = _35reg174;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1011) { goto fail; }
+if (co->ctx.pc.func != _35clofun1007) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5707,14 +5661,14 @@ label17:
 Obj _35val169 = __arg1;
 Obj _35val168= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg167= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 16, _35clofun1011, 2, _35val168, _35reg167);
+pushCont(co, 16, _35clofun1007, 2, _35val168, _35reg167);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init.rewrite-let"));
 __arg1 = _35val169;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5723,14 +5677,14 @@ label18:
 Obj _35val168 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg167= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 17, _35clofun1011, 2, _35val168, _35reg167);
+pushCont(co, 17, _35clofun1007, 2, _35val168, _35reg167);
 __nargs = 2;
 __arg0 = globalRef(intern("cddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5743,18 +5697,18 @@ Obj _35reg166 = primCar(exp);
 __nargs = 2;
 __arg1 = _35reg166;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1011) { goto fail; }
+if (co->ctx.pc.func != _35clofun1007) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg167 = primCar(exp);
-pushCont(co, 18, _35clofun1011, 2, exp, _35reg167);
+pushCont(co, 18, _35clofun1007, 2, exp, _35reg167);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5763,14 +5717,14 @@ label20:
 {
 Obj exp = __arg1;
 Obj _35reg164 = primCdr(exp);
-pushCont(co, 19, _35clofun1011, 1, exp);
+pushCont(co, 19, _35clofun1007, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
 __arg1 = _35reg164;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5783,7 +5737,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1010(struct Cora* co){
+void _35clofun1006(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -5801,7 +5755,7 @@ Obj _35reg38 = primEQ(x, Nil);
 __nargs = 2;
 __arg1 = _35reg38;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5813,7 +5767,7 @@ Obj _35reg41 = primCar(_35reg40);
 __nargs = 2;
 __arg1 = _35reg41;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5825,7 +5779,7 @@ Obj _35reg44 = primCar(_35reg43);
 __nargs = 2;
 __arg1 = _35reg44;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5837,7 +5791,7 @@ Obj _35reg47 = primCdr(_35reg46);
 __nargs = 2;
 __arg1 = _35reg47;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5849,7 +5803,7 @@ Obj _35reg50 = primCdr(_35reg49);
 __nargs = 2;
 __arg1 = _35reg50;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5862,7 +5816,7 @@ Obj _35reg54 = primCar(_35reg53);
 __nargs = 2;
 __arg1 = _35reg54;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5876,7 +5830,7 @@ Obj _35reg59 = primCar(_35reg58);
 __nargs = 2;
 __arg1 = _35reg59;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5889,7 +5843,7 @@ Obj _35reg63 = primCdr(_35reg62);
 __nargs = 2;
 __arg1 = _35reg63;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5903,7 +5857,7 @@ Obj _35reg71 = primCons(intern("cons"), _35reg70);
 __nargs = 2;
 __arg1 = _35reg71;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5914,20 +5868,20 @@ Obj _35reg65 = primIsCons(exp);
 if (True == _35reg65) {
 Obj _35reg66 = primCar(exp);
 Obj _35reg67 = primCdr(exp);
-pushCont(co, 8, _35clofun1010, 1, _35reg66);
+pushCont(co, 8, _35clofun1006, 1, _35reg66);
 __nargs = 2;
 __arg0 = globalRef(intern("rcons"));
 __arg1 = _35reg67;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -5939,7 +5893,7 @@ Obj _35reg73 = primIsCons(x);
 __nargs = 2;
 __arg1 = _35reg73;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5959,13 +5913,13 @@ __arg2 = _35reg78;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = res;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -5986,7 +5940,7 @@ __arg3 = _35reg86;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5998,14 +5952,14 @@ Obj l = __arg3;
 Obj _35reg82 = primIsCons(l);
 if (True == _35reg82) {
 Obj _35reg83 = primCar(l);
-pushCont(co, 12, _35clofun1010, 3, res, l, f);
+pushCont(co, 12, _35clofun1006, 3, res, l, f);
 __nargs = 2;
 __arg0 = f;
 __arg1 = _35reg83;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -6014,7 +5968,7 @@ __arg1 = res;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -6031,7 +5985,7 @@ __arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6042,7 +5996,7 @@ Obj _35reg92 = primCons(globalRef(intern("*protect-symbol*")), x);
 __nargs = 2;
 __arg1 = _35reg92;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -6056,7 +6010,7 @@ Obj _35reg96 = primSet(intern("*macros*"), _35reg95);
 __nargs = 2;
 __arg1 = _35reg96;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -6077,7 +6031,7 @@ __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg104 = primCdr(closureRef(co, 1));
@@ -6088,7 +6042,7 @@ __arg2 = _35reg104;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -6100,7 +6054,7 @@ __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg106 = primCdr(closureRef(co, 1));
@@ -6111,7 +6065,7 @@ __arg2 = _35reg106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -6124,7 +6078,7 @@ __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg108 = primCdr(closureRef(co, 1));
@@ -6135,7 +6089,7 @@ __arg2 = _35reg108;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -6150,17 +6104,17 @@ if (True == _35reg98) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg109 = primCar(macros);
 __nargs = 2;
-__arg0 = makeNative(17, _35clofun1010, 1, 2, exp, macros);
+__arg0 = makeNative(17, _35clofun1006, 1, 2, exp, macros);
 __arg1 = _35reg109;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -6175,7 +6129,7 @@ __arg2 = globalRef(intern("*macros*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6189,7 +6143,7 @@ Obj _35reg123 = primCons(intern("lambda"), _35reg122);
 __nargs = 2;
 __arg1 = _35reg123;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1010) { goto fail; }
+if (co->ctx.pc.func != _35clofun1006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 

--- a/init.cora
+++ b/init.cora
@@ -372,8 +372,3 @@
       
 (defmacro backquote (exp)
   (.rewrite-backquote (cadr exp)))
-
-;; the pseudo type checker, overloaded later.
-(defun typechecker (filename pkg)
-  ['succ 'fake])
-

--- a/lib/infer.cora
+++ b/lib/infer.cora
@@ -248,18 +248,10 @@
 ;;   'reverse-h '((list 1) -> ((list 1) -> (list 1))))
 ;;  ())
 
-(func .declare-or-deftype
-  ['declare . l] => true
-  ['deftype . l] => true
-  _ => false)
-
-(defun .check-file (from pkg-str)
- (let sexp (read-file-as-sexp from pkg-str)
-  (let sexp1 (match sexp
-			  ['begin . more] ['begin . (filter (lambda (x) (not (.declare-or-deftype x))) more)]
-			  x x)
-   (let input (macroexpand sexp1)
-	 (.check-type input (tvar) () ())))))
+(defun .enable (on)
+	(if on
+		(set '.*typecheck* true)
+		(set '.*typecheck* false)))
 
 (declare 'car (let a (tvar) b (tvar) [a '-> b]))
 (declare 'cons [(tvar) '-> [(tvar) '-> (tvar)]])
@@ -276,10 +268,3 @@
 (declare '*type-env* ['list ['tuple 'symbol (tvar)]])
 (declare 'error [(tvar) '-> (tvar)])
 (declare 'import `(string -> ,(tvar)))
-
-(set '.pseudo-typechecker typechecker)
-
-(defun typecheck (enable)
- (if enable
-  (set 'typechecker .check-file)
-  (set 'typechecker .pseudo-typechecker)))

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -498,7 +498,6 @@
    bc)))
 
 (func .handle-import-eagerly
-      ['begin . remain] => (.handle-import-eagerly remain)
       [['import pkg] . remain] => (begin
 				   (import pkg)
 				   ;; (io.display "import ==")
@@ -507,16 +506,37 @@
 				   (.handle-import-eagerly remain))
       _ => ())
 
+(func .split-type-and-code
+	[] type code k => (k (reverse type) (reverse code))
+ 	[[':type . exp] . more] type code k => (.split-type-and-code more (cons ['begin . exp] type) code k)
+ 	[[':declare . exp] . more] type code k => (.split-type-and-code more (cons ['declare . exp] type) code k)
+ 	[exp . more] type code k => (.split-type-and-code more
+  				(cons ['cora/lib/infer.check-type ['macroexpand (cons 'backquote (cons exp ()))] ['tvar] () ()] type)
+  				(cons exp code) k))
+
+(set 'cora/lib/infer.*typecheck* false)
+
+(defun .preprocess (sexp)
+ (let sexp1 (if (and (pair? sexp) (= 'begin (car sexp)))
+			 (cdr sexp)
+			 (cons sexp ()))
+	(begin
+		(.handle-import-eagerly sexp1)
+		(.split-type-and-code sexp1 () ()
+			(lambda (type code)
+				(if cora/lib/infer.*typecheck*
+					(cons 'begin (append type code))
+					(cons 'begin code)))))))
+
 (defun .compile-to-c (from to pkg-str)
   (let sexp (read-file-as-sexp from pkg-str)
-       (begin
-	(.handle-import-eagerly sexp)
-	(let input (macroexpand sexp)
-	     (let bc (.compile input)
-		  (let stream (io.open-output-file to)
-		       (begin
-			(.generate-c stream bc)
-			(io.close-output-file stream))))))))
+			(let sexp1 (.preprocess sexp)
+					(let input (macroexpand sexp1)
+						 (let bc (.compile input)
+						  (let stream (io.open-output-file to)
+							   (begin
+							(.generate-c stream bc)
+							(io.close-output-file stream))))))))
 
 
 ;; ============== utilities of eval0 ==========

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -586,31 +586,14 @@ builtinLoad(struct Cora *co) {
 				return;
 		}
 
-		Obj defTypeChecker = globalRef(intern("typechecker"));
-
 		/* co->args[0] = globalRef(intern("load-so"));  */
 		snprintf(buf, BUFSIZE, "/tmp/cora-xxx-%d.so", cfileidx);
 		str tmpSoFile = cstr(buf);
 		co->nargs = 3;
 		co->args[1] = makeString(tmpSoFile.str, tmpSoFile.len);
 		co->args[2] = pkg;
-		trampoline(co, 0, builtinLoadSo);
-		res = co->args[1];
-
-		// The source file may specify the typecheck.
-		// type check for it if the checker is available.
-		co->nargs = 3;
-		co->args[0] = globalRef(intern("typechecker"));
-		co->args[1] = filePath;
-		co->args[2] = pkg;
-		trampoline(co, 0, coraDispatch);
-		Obj tmp = co->args[1];
-		if (!iscons(tmp) || car(tmp) != intern("succ")) {
-				printf("type check for %s error\n", toCStr(stringStr(filePath)));
-		}
-
-		primSet(intern("typechecker"), defTypeChecker);
-		coraReturn(co, res);
+		co->ctx.pc.func = builtinLoadSo;
+		return;
 }
 
 void

--- a/toc.c
+++ b/toc.c
@@ -2,29 +2,30 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun2869(struct Cora* co);
-void _35clofun2868(struct Cora* co);
-void _35clofun2867(struct Cora* co);
-void _35clofun2866(struct Cora* co);
-void _35clofun2865(struct Cora* co);
-void _35clofun2864(struct Cora* co);
-void _35clofun2863(struct Cora* co);
-void _35clofun2862(struct Cora* co);
-void _35clofun2861(struct Cora* co);
-void _35clofun2860(struct Cora* co);
-void _35clofun2859(struct Cora* co);
-void _35clofun2858(struct Cora* co);
-void _35clofun2857(struct Cora* co);
-void _35clofun2856(struct Cora* co);
-void _35clofun2855(struct Cora* co);
-void _35clofun2854(struct Cora* co);
-void _35clofun2853(struct Cora* co);
-void _35clofun2852(struct Cora* co);
-void _35clofun2851(struct Cora* co);
-void _35clofun2850(struct Cora* co);
-void _35clofun2849(struct Cora* co);
-void _35clofun2848(struct Cora* co);
-void _35clofun2847(struct Cora* co);
+void _35clofun2944(struct Cora* co);
+void _35clofun2943(struct Cora* co);
+void _35clofun2942(struct Cora* co);
+void _35clofun2941(struct Cora* co);
+void _35clofun2940(struct Cora* co);
+void _35clofun2939(struct Cora* co);
+void _35clofun2938(struct Cora* co);
+void _35clofun2937(struct Cora* co);
+void _35clofun2936(struct Cora* co);
+void _35clofun2935(struct Cora* co);
+void _35clofun2934(struct Cora* co);
+void _35clofun2933(struct Cora* co);
+void _35clofun2932(struct Cora* co);
+void _35clofun2931(struct Cora* co);
+void _35clofun2930(struct Cora* co);
+void _35clofun2929(struct Cora* co);
+void _35clofun2928(struct Cora* co);
+void _35clofun2927(struct Cora* co);
+void _35clofun2926(struct Cora* co);
+void _35clofun2925(struct Cora* co);
+void _35clofun2924(struct Cora* co);
+void _35clofun2923(struct Cora* co);
+void _35clofun2922(struct Cora* co);
+void _35clofun2921(struct Cora* co);
 
 
 void entry(struct Cora* co){
@@ -40,7 +41,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-pushCont(co, 3, _35clofun2869, 0);
+pushCont(co, 8, _35clofun2944, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("import"));
 __arg1 = makeString1("cora/lib/toc/internal");
@@ -60,210 +61,509 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2869(struct Cora* co){
+void _35clofun2944(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
+Obj _35val2919 = __arg1;
+Obj _35val2917= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("apply"));
+__arg1 = _35val2917;
+__arg2 = _35val2919;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2917 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2918 = primCdr(exp);
+pushCont(co, 0, _35clofun2944, 1, _35val2917);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = globalRef(intern("cora/lib/toc.eval0"));
+__arg2 = _35reg2918;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val2905 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val2905) {
+if (True == True) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2944) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg2906 = primIsCons(exp);
+if (True == _35reg2906) {
+Obj _35reg2907 = primCar(exp);
+Obj _35reg2908 = primEQ(_35reg2907, intern("quote"));
+if (True == _35reg2908) {
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2909 = primCar(exp);
+pushCont(co, 20, _35clofun2943, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.eval0"));
+__arg1 = _35reg2909;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+if (True == False) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2944) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg2913 = primIsCons(exp);
+if (True == _35reg2913) {
+Obj _35reg2914 = primCar(exp);
+Obj _35reg2915 = primEQ(_35reg2914, intern("quote"));
+if (True == _35reg2915) {
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2916 = primCar(exp);
+pushCont(co, 1, _35clofun2944, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.eval0"));
+__arg1 = _35reg2916;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+}
+
+label3:
+{
+Obj _35val2897 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val2897) {
+if (True == True) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2944) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg2898 = primIsCons(exp);
+if (True == _35reg2898) {
+Obj _35reg2899 = primCar(exp);
+Obj _35reg2900 = primEQ(_35reg2899, intern("quote"));
+if (True == _35reg2900) {
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2901 = primCar(exp);
+pushCont(co, 18, _35clofun2943, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.eval0"));
+__arg1 = _35reg2901;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+pushCont(co, 2, _35clofun2944, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("null?"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val2881 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val2881) {
+if (True == True) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2944) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg2882 = primIsCons(exp);
+if (True == _35reg2882) {
+Obj _35reg2883 = primCar(exp);
+Obj _35reg2884 = primEQ(_35reg2883, intern("quote"));
+if (True == _35reg2884) {
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2885 = primCar(exp);
+pushCont(co, 14, _35clofun2943, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.eval0"));
+__arg1 = _35reg2885;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+Obj _35reg2889 = primIsString(exp);
+if (True == _35reg2889) {
+if (True == True) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2944) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg2890 = primIsCons(exp);
+if (True == _35reg2890) {
+Obj _35reg2891 = primCar(exp);
+Obj _35reg2892 = primEQ(_35reg2891, intern("quote"));
+if (True == _35reg2892) {
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2893 = primCar(exp);
+pushCont(co, 16, _35clofun2943, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.eval0"));
+__arg1 = _35reg2893;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+pushCont(co, 3, _35clofun2944, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("boolean?"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label5:
+{
 Obj exp = __arg1;
-Obj _35reg2806 = primIsSymbol(exp);
-if (True == _35reg2806) {
+Obj _35reg2880 = primIsSymbol(exp);
+if (True == _35reg2880) {
 __nargs = 2;
 __arg0 = globalRef(intern("value"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2869) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 20, _35clofun2868, 1, exp);
+pushCont(co, 4, _35clofun2944, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("number?"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2869) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label1:
+label6:
 {
-Obj _35val2697 = __arg1;
-Obj _35reg2702 = primSet(intern("cora/lib/toc.compile"), makeNative(3, _35clofun2865, 1, 0));
-Obj _35reg2708 = primSet(intern("for-each"), makeNative(7, _35clofun2865, 2, 0));
-Obj _35reg2715 = primSet(intern("cora/lib/toc.generate-jumptable"), makeNative(11, _35clofun2865, 3, 0));
-Obj _35reg2736 = primSet(intern("cora/lib/toc.generate-toplevel-group"), makeNative(12, _35clofun2866, 2, 0));
-Obj _35reg2743 = primSet(intern("cora/lib/toc.generate-c"), makeNative(0, _35clofun2867, 2, 0));
-Obj _35reg2766 = primSet(intern("cora/lib/toc.handle-import-eagerly"), makeNative(5, _35clofun2867, 1, 0));
-Obj _35reg2773 = primSet(intern("cora/lib/toc.compile-to-c"), makeNative(12, _35clofun2867, 3, 0));
-Obj _35reg2775 = primSet(intern("set"), makeNative(13, _35clofun2867, 2, 0));
-Obj _35reg2777 = primSet(intern("car"), makeNative(14, _35clofun2867, 1, 0));
-Obj _35reg2779 = primSet(intern("cdr"), makeNative(15, _35clofun2867, 1, 0));
-Obj _35reg2781 = primSet(intern("cons"), makeNative(16, _35clofun2867, 2, 0));
-Obj _35reg2783 = primSet(intern("cons"), makeNative(17, _35clofun2867, 2, 0));
-Obj _35reg2785 = primSet(intern("+"), makeNative(18, _35clofun2867, 2, 0));
-Obj _35reg2787 = primSet(intern("-"), makeNative(19, _35clofun2867, 2, 0));
-Obj _35reg2789 = primSet(intern("*"), makeNative(20, _35clofun2867, 2, 0));
-Obj _35reg2791 = primSet(intern("/"), makeNative(0, _35clofun2868, 2, 0));
-Obj _35reg2793 = primSet(intern("="), makeNative(1, _35clofun2868, 2, 0));
-Obj _35reg2795 = primSet(intern(">"), makeNative(2, _35clofun2868, 2, 0));
-Obj _35reg2797 = primSet(intern("<"), makeNative(3, _35clofun2868, 2, 0));
-Obj _35reg2799 = primSet(intern("gensym"), makeNative(4, _35clofun2868, 1, 0));
-Obj _35reg2801 = primSet(intern("symbol?"), makeNative(5, _35clofun2868, 1, 0));
-Obj _35reg2803 = primSet(intern("not"), makeNative(6, _35clofun2868, 1, 0));
-Obj _35reg2805 = primSet(intern("string?"), makeNative(7, _35clofun2868, 1, 0));
-Obj _35reg2846 = primSet(intern("cora/lib/toc.eval0"), makeNative(0, _35clofun2869, 1, 0));
+Obj _35val2699 = __arg1;
+Obj _35reg2704 = primSet(intern("cora/lib/toc.compile"), makeNative(3, _35clofun2939, 1, 0));
+Obj _35reg2710 = primSet(intern("for-each"), makeNative(7, _35clofun2939, 2, 0));
+Obj _35reg2717 = primSet(intern("cora/lib/toc.generate-jumptable"), makeNative(11, _35clofun2939, 3, 0));
+Obj _35reg2738 = primSet(intern("cora/lib/toc.generate-toplevel-group"), makeNative(12, _35clofun2940, 2, 0));
+Obj _35reg2745 = primSet(intern("cora/lib/toc.generate-c"), makeNative(0, _35clofun2941, 2, 0));
+Obj _35reg2764 = primSet(intern("cora/lib/toc.handle-import-eagerly"), makeNative(4, _35clofun2941, 1, 0));
+Obj _35reg2805 = primSet(intern("cora/lib/toc.split-type-and-code"), makeNative(11, _35clofun2941, 4, 0));
+Obj _35reg2806 = primSet(intern("cora/lib/infer.*typecheck*"), False);
+Obj _35reg2840 = primSet(intern("cora/lib/toc.preprocess"), makeNative(10, _35clofun2942, 1, 0));
+Obj _35reg2847 = primSet(intern("cora/lib/toc.compile-to-c"), makeNative(17, _35clofun2942, 3, 0));
+Obj _35reg2849 = primSet(intern("set"), makeNative(18, _35clofun2942, 2, 0));
+Obj _35reg2851 = primSet(intern("car"), makeNative(19, _35clofun2942, 1, 0));
+Obj _35reg2853 = primSet(intern("cdr"), makeNative(20, _35clofun2942, 1, 0));
+Obj _35reg2855 = primSet(intern("cons"), makeNative(0, _35clofun2943, 2, 0));
+Obj _35reg2857 = primSet(intern("cons"), makeNative(1, _35clofun2943, 2, 0));
+Obj _35reg2859 = primSet(intern("+"), makeNative(2, _35clofun2943, 2, 0));
+Obj _35reg2861 = primSet(intern("-"), makeNative(3, _35clofun2943, 2, 0));
+Obj _35reg2863 = primSet(intern("*"), makeNative(4, _35clofun2943, 2, 0));
+Obj _35reg2865 = primSet(intern("/"), makeNative(5, _35clofun2943, 2, 0));
+Obj _35reg2867 = primSet(intern("="), makeNative(6, _35clofun2943, 2, 0));
+Obj _35reg2869 = primSet(intern(">"), makeNative(7, _35clofun2943, 2, 0));
+Obj _35reg2871 = primSet(intern("<"), makeNative(8, _35clofun2943, 2, 0));
+Obj _35reg2873 = primSet(intern("gensym"), makeNative(9, _35clofun2943, 1, 0));
+Obj _35reg2875 = primSet(intern("symbol?"), makeNative(10, _35clofun2943, 1, 0));
+Obj _35reg2877 = primSet(intern("not"), makeNative(11, _35clofun2943, 1, 0));
+Obj _35reg2879 = primSet(intern("string?"), makeNative(12, _35clofun2943, 1, 0));
+Obj _35reg2920 = primSet(intern("cora/lib/toc.eval0"), makeNative(5, _35clofun2944, 1, 0));
 __nargs = 2;
-__arg1 = _35reg2846;
+__arg1 = _35reg2920;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2869) { goto fail; }
+if (co->ctx.pc.func != _35clofun2944) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label2:
+label7:
 {
-Obj _35val1204 = __arg1;
-Obj _35reg1219 = primSet(intern("cora/lib/toc.assq"), makeNative(3, _35clofun2847, 2, 0));
-Obj _35reg1225 = primSet(intern("cora/lib/toc.foldl"), makeNative(7, _35clofun2847, 3, 0));
-Obj _35reg1235 = primSet(intern("cora/lib/toc.pos-in-list0"), makeNative(11, _35clofun2847, 3, 0));
-Obj _35reg1236 = primSet(intern("cora/lib/toc.index"), makeNative(12, _35clofun2847, 2, 0));
-Obj _35reg1243 = primSet(intern("cora/lib/toc.exist-in-env"), makeNative(16, _35clofun2847, 2, 0));
-Obj _35reg1244 = primCons(intern("primSet"), Nil);
-Obj _35reg1245 = primCons(makeNumber(2), _35reg1244);
-Obj _35reg1246 = primCons(intern("set"), _35reg1245);
-Obj _35reg1247 = primCons(intern("primCar"), Nil);
-Obj _35reg1248 = primCons(makeNumber(1), _35reg1247);
-Obj _35reg1249 = primCons(intern("car"), _35reg1248);
-Obj _35reg1250 = primCons(intern("primCdr"), Nil);
-Obj _35reg1251 = primCons(makeNumber(1), _35reg1250);
-Obj _35reg1252 = primCons(intern("cdr"), _35reg1251);
-Obj _35reg1253 = primCons(intern("primCons"), Nil);
-Obj _35reg1254 = primCons(makeNumber(2), _35reg1253);
-Obj _35reg1255 = primCons(intern("cons"), _35reg1254);
-Obj _35reg1256 = primCons(intern("primIsCons"), Nil);
-Obj _35reg1257 = primCons(makeNumber(1), _35reg1256);
-Obj _35reg1258 = primCons(intern("cons?"), _35reg1257);
-Obj _35reg1259 = primCons(intern("primAdd"), Nil);
-Obj _35reg1260 = primCons(makeNumber(2), _35reg1259);
-Obj _35reg1261 = primCons(intern("+"), _35reg1260);
-Obj _35reg1262 = primCons(intern("primSub"), Nil);
-Obj _35reg1263 = primCons(makeNumber(2), _35reg1262);
-Obj _35reg1264 = primCons(intern("-"), _35reg1263);
-Obj _35reg1265 = primCons(intern("primMul"), Nil);
-Obj _35reg1266 = primCons(makeNumber(2), _35reg1265);
-Obj _35reg1267 = primCons(intern("*"), _35reg1266);
-Obj _35reg1268 = primCons(intern("primDiv"), Nil);
-Obj _35reg1269 = primCons(makeNumber(2), _35reg1268);
-Obj _35reg1270 = primCons(intern("/"), _35reg1269);
-Obj _35reg1271 = primCons(intern("primEQ"), Nil);
-Obj _35reg1272 = primCons(makeNumber(2), _35reg1271);
-Obj _35reg1273 = primCons(intern("="), _35reg1272);
-Obj _35reg1274 = primCons(intern("primGT"), Nil);
-Obj _35reg1275 = primCons(makeNumber(2), _35reg1274);
-Obj _35reg1276 = primCons(intern(">"), _35reg1275);
-Obj _35reg1277 = primCons(intern("primLT"), Nil);
-Obj _35reg1278 = primCons(makeNumber(2), _35reg1277);
-Obj _35reg1279 = primCons(intern("<"), _35reg1278);
-Obj _35reg1280 = primCons(intern("primGenSym"), Nil);
-Obj _35reg1281 = primCons(makeNumber(1), _35reg1280);
-Obj _35reg1282 = primCons(intern("gensym"), _35reg1281);
-Obj _35reg1283 = primCons(intern("primIsSymbol"), Nil);
-Obj _35reg1284 = primCons(makeNumber(1), _35reg1283);
-Obj _35reg1285 = primCons(intern("symbol?"), _35reg1284);
-Obj _35reg1286 = primCons(intern("primNot"), Nil);
-Obj _35reg1287 = primCons(makeNumber(1), _35reg1286);
-Obj _35reg1288 = primCons(intern("not"), _35reg1287);
-Obj _35reg1289 = primCons(intern("primIsNumber"), Nil);
-Obj _35reg1290 = primCons(makeNumber(1), _35reg1289);
-Obj _35reg1291 = primCons(intern("integer?"), _35reg1290);
-Obj _35reg1292 = primCons(intern("primIsString"), Nil);
-Obj _35reg1293 = primCons(makeNumber(1), _35reg1292);
-Obj _35reg1294 = primCons(intern("string?"), _35reg1293);
-Obj _35reg1295 = primCons(_35reg1294, Nil);
-Obj _35reg1296 = primCons(_35reg1291, _35reg1295);
-Obj _35reg1297 = primCons(_35reg1288, _35reg1296);
-Obj _35reg1298 = primCons(_35reg1285, _35reg1297);
-Obj _35reg1299 = primCons(_35reg1282, _35reg1298);
-Obj _35reg1300 = primCons(_35reg1279, _35reg1299);
-Obj _35reg1301 = primCons(_35reg1276, _35reg1300);
-Obj _35reg1302 = primCons(_35reg1273, _35reg1301);
-Obj _35reg1303 = primCons(_35reg1270, _35reg1302);
-Obj _35reg1304 = primCons(_35reg1267, _35reg1303);
-Obj _35reg1305 = primCons(_35reg1264, _35reg1304);
-Obj _35reg1306 = primCons(_35reg1261, _35reg1305);
-Obj _35reg1307 = primCons(_35reg1258, _35reg1306);
-Obj _35reg1308 = primCons(_35reg1255, _35reg1307);
-Obj _35reg1309 = primCons(_35reg1252, _35reg1308);
-Obj _35reg1310 = primCons(_35reg1249, _35reg1309);
-Obj _35reg1311 = primCons(_35reg1246, _35reg1310);
-Obj _35reg1312 = primSet(intern("cora/lib/toc.*builtin-prims*"), _35reg1311);
-Obj _35reg1316 = primSet(intern("builtin?"), makeNative(19, _35clofun2847, 1, 0));
-Obj _35reg1319 = primSet(intern("cora/lib/toc.builtin->name"), makeNative(1, _35clofun2848, 1, 0));
-Obj _35reg1322 = primSet(intern("cora/lib/toc.builtin->args"), makeNative(4, _35clofun2848, 1, 0));
-Obj _35reg1327 = primSet(intern("cora/lib/toc.temp-list"), makeNative(7, _35clofun2848, 2, 0));
-Obj _35reg1463 = primSet(intern("cora/lib/toc.parse"), makeNative(16, _35clofun2849, 2, 0));
-Obj _35reg1474 = primSet(intern("cora/lib/toc.union"), makeNative(1, _35clofun2850, 2, 0));
-Obj _35reg1485 = primSet(intern("cora/lib/toc.diff"), makeNative(7, _35clofun2850, 2, 0));
-Obj _35reg1536 = primSet(intern("cora/lib/toc.convert-protect?"), makeNative(14, _35clofun2850, 1, 0));
-Obj _35reg1711 = primSet(intern("cora/lib/toc.free-vars"), makeNative(16, _35clofun2851, 1, 0));
-Obj _35reg1784 = primSet(intern("cora/lib/toc.closure-convert"), makeNative(10, _35clofun2852, 2, 0));
-Obj _35reg1787 = primSet(intern("cora/lib/toc.id"), makeNative(11, _35clofun2852, 1, 0));
-Obj _35reg1924 = primSet(intern("cora/lib/toc.tailify"), makeNative(8, _35clofun2853, 2, 0));
-Obj _35reg1971 = primSet(intern("cora/lib/toc.tailify-list"), makeNative(18, _35clofun2853, 3, 0));
-Obj _35reg2050 = primSet(intern("cora/lib/toc.explicit-stack"), makeNative(15, _35clofun2854, 2, 0));
-Obj _35reg2226 = primSet(intern("cora/lib/toc.collect-lambda"), makeNative(8, _35clofun2856, 2, 0));
-Obj _35reg2239 = primSet(intern("cora/lib/toc.append-result"), makeNative(14, _35clofun2856, 5, 0));
-Obj _35reg2246 = primSet(intern("cora/lib/toc.wrap-var"), makeNative(16, _35clofun2856, 2, 0));
-Obj _35reg2266 = primSet(intern("cora/lib/toc.generate-call-list"), makeNative(9, _35clofun2857, 4, 0));
-Obj _35reg2533 = primSet(intern("cora/lib/toc.generate-inst"), makeNative(10, _35clofun2861, 4, 0));
-Obj _35reg2556 = primSet(intern("cora/lib/toc.generate-cont"), makeNative(2, _35clofun2862, 3, 0));
-Obj _35reg2565 = primSet(intern("cora/lib/toc.generate-inst-list-h"), makeNative(8, _35clofun2862, 5, 0));
-Obj _35reg2566 = primSet(intern("cora/lib/toc.generate-inst-list"), makeNative(9, _35clofun2862, 4, 0));
-Obj _35reg2571 = primSet(intern("cora/lib/toc.code-gen-func-declare"), makeNative(13, _35clofun2862, 2, 0));
-Obj _35reg2579 = primSet(intern("cora/lib/toc.local-from-params"), makeNative(20, _35clofun2862, 3, 0));
-Obj _35reg2584 = primSet(intern("cora/lib/toc.local-from-cont"), makeNative(4, _35clofun2863, 3, 0));
-Obj _35reg2591 = primSet(intern("cora/lib/toc.generate-call-args-reverse"), makeNative(8, _35clofun2863, 4, 0));
-Obj _35reg2653 = primSet(intern("cora/lib/toc.code-gen-toplevel"), makeNative(19, _35clofun2863, 2, 0));
-Obj _35reg2654 = primSet(intern("cora/lib/toc.parse-pass"), makeNative(20, _35clofun2863, 1, 0));
-Obj _35reg2655 = primSet(intern("cora/lib/toc.closure-convert-pass"), makeNative(0, _35clofun2864, 1, 0));
-Obj _35reg2656 = primSet(intern("cora/lib/toc.tailify-pass"), makeNative(1, _35clofun2864, 1, 0));
-Obj _35reg2657 = primSet(intern("cora/lib/toc.explicit-stack-pass"), makeNative(2, _35clofun2864, 1, 0));
-Obj _35reg2687 = primSet(intern("cora/lib/toc.collect-lambda-pass"), makeNative(13, _35clofun2864, 1, 0));
-Obj _35reg2694 = primSet(intern("cora/lib/toc.rewrite-->macro"), makeNative(16, _35clofun2864, 2, 0));
-pushCont(co, 1, _35clofun2869, 0);
+Obj _35val1206 = __arg1;
+Obj _35reg1221 = primSet(intern("cora/lib/toc.assq"), makeNative(3, _35clofun2921, 2, 0));
+Obj _35reg1227 = primSet(intern("cora/lib/toc.foldl"), makeNative(7, _35clofun2921, 3, 0));
+Obj _35reg1237 = primSet(intern("cora/lib/toc.pos-in-list0"), makeNative(11, _35clofun2921, 3, 0));
+Obj _35reg1238 = primSet(intern("cora/lib/toc.index"), makeNative(12, _35clofun2921, 2, 0));
+Obj _35reg1245 = primSet(intern("cora/lib/toc.exist-in-env"), makeNative(16, _35clofun2921, 2, 0));
+Obj _35reg1246 = primCons(intern("primSet"), Nil);
+Obj _35reg1247 = primCons(makeNumber(2), _35reg1246);
+Obj _35reg1248 = primCons(intern("set"), _35reg1247);
+Obj _35reg1249 = primCons(intern("primCar"), Nil);
+Obj _35reg1250 = primCons(makeNumber(1), _35reg1249);
+Obj _35reg1251 = primCons(intern("car"), _35reg1250);
+Obj _35reg1252 = primCons(intern("primCdr"), Nil);
+Obj _35reg1253 = primCons(makeNumber(1), _35reg1252);
+Obj _35reg1254 = primCons(intern("cdr"), _35reg1253);
+Obj _35reg1255 = primCons(intern("primCons"), Nil);
+Obj _35reg1256 = primCons(makeNumber(2), _35reg1255);
+Obj _35reg1257 = primCons(intern("cons"), _35reg1256);
+Obj _35reg1258 = primCons(intern("primIsCons"), Nil);
+Obj _35reg1259 = primCons(makeNumber(1), _35reg1258);
+Obj _35reg1260 = primCons(intern("cons?"), _35reg1259);
+Obj _35reg1261 = primCons(intern("primAdd"), Nil);
+Obj _35reg1262 = primCons(makeNumber(2), _35reg1261);
+Obj _35reg1263 = primCons(intern("+"), _35reg1262);
+Obj _35reg1264 = primCons(intern("primSub"), Nil);
+Obj _35reg1265 = primCons(makeNumber(2), _35reg1264);
+Obj _35reg1266 = primCons(intern("-"), _35reg1265);
+Obj _35reg1267 = primCons(intern("primMul"), Nil);
+Obj _35reg1268 = primCons(makeNumber(2), _35reg1267);
+Obj _35reg1269 = primCons(intern("*"), _35reg1268);
+Obj _35reg1270 = primCons(intern("primDiv"), Nil);
+Obj _35reg1271 = primCons(makeNumber(2), _35reg1270);
+Obj _35reg1272 = primCons(intern("/"), _35reg1271);
+Obj _35reg1273 = primCons(intern("primEQ"), Nil);
+Obj _35reg1274 = primCons(makeNumber(2), _35reg1273);
+Obj _35reg1275 = primCons(intern("="), _35reg1274);
+Obj _35reg1276 = primCons(intern("primGT"), Nil);
+Obj _35reg1277 = primCons(makeNumber(2), _35reg1276);
+Obj _35reg1278 = primCons(intern(">"), _35reg1277);
+Obj _35reg1279 = primCons(intern("primLT"), Nil);
+Obj _35reg1280 = primCons(makeNumber(2), _35reg1279);
+Obj _35reg1281 = primCons(intern("<"), _35reg1280);
+Obj _35reg1282 = primCons(intern("primGenSym"), Nil);
+Obj _35reg1283 = primCons(makeNumber(1), _35reg1282);
+Obj _35reg1284 = primCons(intern("gensym"), _35reg1283);
+Obj _35reg1285 = primCons(intern("primIsSymbol"), Nil);
+Obj _35reg1286 = primCons(makeNumber(1), _35reg1285);
+Obj _35reg1287 = primCons(intern("symbol?"), _35reg1286);
+Obj _35reg1288 = primCons(intern("primNot"), Nil);
+Obj _35reg1289 = primCons(makeNumber(1), _35reg1288);
+Obj _35reg1290 = primCons(intern("not"), _35reg1289);
+Obj _35reg1291 = primCons(intern("primIsNumber"), Nil);
+Obj _35reg1292 = primCons(makeNumber(1), _35reg1291);
+Obj _35reg1293 = primCons(intern("integer?"), _35reg1292);
+Obj _35reg1294 = primCons(intern("primIsString"), Nil);
+Obj _35reg1295 = primCons(makeNumber(1), _35reg1294);
+Obj _35reg1296 = primCons(intern("string?"), _35reg1295);
+Obj _35reg1297 = primCons(_35reg1296, Nil);
+Obj _35reg1298 = primCons(_35reg1293, _35reg1297);
+Obj _35reg1299 = primCons(_35reg1290, _35reg1298);
+Obj _35reg1300 = primCons(_35reg1287, _35reg1299);
+Obj _35reg1301 = primCons(_35reg1284, _35reg1300);
+Obj _35reg1302 = primCons(_35reg1281, _35reg1301);
+Obj _35reg1303 = primCons(_35reg1278, _35reg1302);
+Obj _35reg1304 = primCons(_35reg1275, _35reg1303);
+Obj _35reg1305 = primCons(_35reg1272, _35reg1304);
+Obj _35reg1306 = primCons(_35reg1269, _35reg1305);
+Obj _35reg1307 = primCons(_35reg1266, _35reg1306);
+Obj _35reg1308 = primCons(_35reg1263, _35reg1307);
+Obj _35reg1309 = primCons(_35reg1260, _35reg1308);
+Obj _35reg1310 = primCons(_35reg1257, _35reg1309);
+Obj _35reg1311 = primCons(_35reg1254, _35reg1310);
+Obj _35reg1312 = primCons(_35reg1251, _35reg1311);
+Obj _35reg1313 = primCons(_35reg1248, _35reg1312);
+Obj _35reg1314 = primSet(intern("cora/lib/toc.*builtin-prims*"), _35reg1313);
+Obj _35reg1318 = primSet(intern("builtin?"), makeNative(19, _35clofun2921, 1, 0));
+Obj _35reg1321 = primSet(intern("cora/lib/toc.builtin->name"), makeNative(1, _35clofun2922, 1, 0));
+Obj _35reg1324 = primSet(intern("cora/lib/toc.builtin->args"), makeNative(4, _35clofun2922, 1, 0));
+Obj _35reg1329 = primSet(intern("cora/lib/toc.temp-list"), makeNative(7, _35clofun2922, 2, 0));
+Obj _35reg1465 = primSet(intern("cora/lib/toc.parse"), makeNative(16, _35clofun2923, 2, 0));
+Obj _35reg1476 = primSet(intern("cora/lib/toc.union"), makeNative(1, _35clofun2924, 2, 0));
+Obj _35reg1487 = primSet(intern("cora/lib/toc.diff"), makeNative(7, _35clofun2924, 2, 0));
+Obj _35reg1538 = primSet(intern("cora/lib/toc.convert-protect?"), makeNative(14, _35clofun2924, 1, 0));
+Obj _35reg1713 = primSet(intern("cora/lib/toc.free-vars"), makeNative(16, _35clofun2925, 1, 0));
+Obj _35reg1786 = primSet(intern("cora/lib/toc.closure-convert"), makeNative(10, _35clofun2926, 2, 0));
+Obj _35reg1789 = primSet(intern("cora/lib/toc.id"), makeNative(11, _35clofun2926, 1, 0));
+Obj _35reg1926 = primSet(intern("cora/lib/toc.tailify"), makeNative(8, _35clofun2927, 2, 0));
+Obj _35reg1973 = primSet(intern("cora/lib/toc.tailify-list"), makeNative(18, _35clofun2927, 3, 0));
+Obj _35reg2052 = primSet(intern("cora/lib/toc.explicit-stack"), makeNative(15, _35clofun2928, 2, 0));
+Obj _35reg2228 = primSet(intern("cora/lib/toc.collect-lambda"), makeNative(8, _35clofun2930, 2, 0));
+Obj _35reg2241 = primSet(intern("cora/lib/toc.append-result"), makeNative(14, _35clofun2930, 5, 0));
+Obj _35reg2248 = primSet(intern("cora/lib/toc.wrap-var"), makeNative(16, _35clofun2930, 2, 0));
+Obj _35reg2268 = primSet(intern("cora/lib/toc.generate-call-list"), makeNative(9, _35clofun2931, 4, 0));
+Obj _35reg2535 = primSet(intern("cora/lib/toc.generate-inst"), makeNative(10, _35clofun2935, 4, 0));
+Obj _35reg2558 = primSet(intern("cora/lib/toc.generate-cont"), makeNative(2, _35clofun2936, 3, 0));
+Obj _35reg2567 = primSet(intern("cora/lib/toc.generate-inst-list-h"), makeNative(8, _35clofun2936, 5, 0));
+Obj _35reg2568 = primSet(intern("cora/lib/toc.generate-inst-list"), makeNative(9, _35clofun2936, 4, 0));
+Obj _35reg2573 = primSet(intern("cora/lib/toc.code-gen-func-declare"), makeNative(13, _35clofun2936, 2, 0));
+Obj _35reg2581 = primSet(intern("cora/lib/toc.local-from-params"), makeNative(20, _35clofun2936, 3, 0));
+Obj _35reg2586 = primSet(intern("cora/lib/toc.local-from-cont"), makeNative(4, _35clofun2937, 3, 0));
+Obj _35reg2593 = primSet(intern("cora/lib/toc.generate-call-args-reverse"), makeNative(8, _35clofun2937, 4, 0));
+Obj _35reg2655 = primSet(intern("cora/lib/toc.code-gen-toplevel"), makeNative(19, _35clofun2937, 2, 0));
+Obj _35reg2656 = primSet(intern("cora/lib/toc.parse-pass"), makeNative(20, _35clofun2937, 1, 0));
+Obj _35reg2657 = primSet(intern("cora/lib/toc.closure-convert-pass"), makeNative(0, _35clofun2938, 1, 0));
+Obj _35reg2658 = primSet(intern("cora/lib/toc.tailify-pass"), makeNative(1, _35clofun2938, 1, 0));
+Obj _35reg2659 = primSet(intern("cora/lib/toc.explicit-stack-pass"), makeNative(2, _35clofun2938, 1, 0));
+Obj _35reg2689 = primSet(intern("cora/lib/toc.collect-lambda-pass"), makeNative(13, _35clofun2938, 1, 0));
+Obj _35reg2696 = primSet(intern("cora/lib/toc.rewrite-->macro"), makeNative(16, _35clofun2938, 2, 0));
+pushCont(co, 6, _35clofun2944, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init.add-to-*macros*"));
 __arg1 = intern("->");
-__arg2 = makeNative(19, _35clofun2864, 1, 0);
+__arg2 = makeNative(19, _35clofun2938, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2869) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label8:
 {
-Obj _35val1203 = __arg1;
-pushCont(co, 2, _35clofun2869, 0);
+Obj _35val1205 = __arg1;
+pushCont(co, 7, _35clofun2944, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("import"));
 __arg1 = makeString1("cora/lib/io");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2869) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2944) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -276,7 +576,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2868(struct Cora* co){
+void _35clofun2943(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -289,518 +589,282 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35tmp1192 = __arg1;
-Obj _35tmp1191 = __arg2;
-Obj _35reg2790 = primDiv(_35tmp1192, _35tmp1191);
+Obj _35tmp1184 = __arg1;
+Obj _35tmp1183 = __arg2;
+Obj _35reg2854 = primCons(_35tmp1184, _35tmp1183);
 __nargs = 2;
-__arg1 = _35reg2790;
+__arg1 = _35reg2854;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj _35tmp1194 = __arg1;
-Obj _35tmp1193 = __arg2;
-Obj _35reg2792 = primEQ(_35tmp1194, _35tmp1193);
+Obj _35tmp1186 = __arg1;
+Obj _35tmp1185 = __arg2;
+Obj _35reg2856 = primCons(_35tmp1186, _35tmp1185);
 __nargs = 2;
-__arg1 = _35reg2792;
+__arg1 = _35reg2856;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35tmp1196 = __arg1;
-Obj _35tmp1195 = __arg2;
-Obj _35reg2794 = primGT(_35tmp1196, _35tmp1195);
+Obj _35tmp1188 = __arg1;
+Obj _35tmp1187 = __arg2;
+Obj _35reg2858 = primAdd(_35tmp1188, _35tmp1187);
 __nargs = 2;
-__arg1 = _35reg2794;
+__arg1 = _35reg2858;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label3:
 {
-Obj _35tmp1198 = __arg1;
-Obj _35tmp1197 = __arg2;
-Obj _35reg2796 = primLT(_35tmp1198, _35tmp1197);
+Obj _35tmp1190 = __arg1;
+Obj _35tmp1189 = __arg2;
+Obj _35reg2860 = primSub(_35tmp1190, _35tmp1189);
 __nargs = 2;
-__arg1 = _35reg2796;
+__arg1 = _35reg2860;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label4:
 {
-Obj _35tmp1199 = __arg1;
-Obj _35reg2798 = primGenSym(_35tmp1199);
+Obj _35tmp1192 = __arg1;
+Obj _35tmp1191 = __arg2;
+Obj _35reg2862 = primMul(_35tmp1192, _35tmp1191);
 __nargs = 2;
-__arg1 = _35reg2798;
+__arg1 = _35reg2862;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label5:
 {
-Obj _35tmp1200 = __arg1;
-Obj _35reg2800 = primIsSymbol(_35tmp1200);
+Obj _35tmp1194 = __arg1;
+Obj _35tmp1193 = __arg2;
+Obj _35reg2864 = primDiv(_35tmp1194, _35tmp1193);
 __nargs = 2;
-__arg1 = _35reg2800;
+__arg1 = _35reg2864;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label6:
 {
-Obj _35tmp1201 = __arg1;
-Obj _35reg2802 = primNot(_35tmp1201);
+Obj _35tmp1196 = __arg1;
+Obj _35tmp1195 = __arg2;
+Obj _35reg2866 = primEQ(_35tmp1196, _35tmp1195);
 __nargs = 2;
-__arg1 = _35reg2802;
+__arg1 = _35reg2866;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label7:
 {
-Obj _35tmp1202 = __arg1;
-Obj _35reg2804 = primIsString(_35tmp1202);
+Obj _35tmp1198 = __arg1;
+Obj _35tmp1197 = __arg2;
+Obj _35reg2868 = primGT(_35tmp1198, _35tmp1197);
 __nargs = 2;
-__arg1 = _35reg2804;
+__arg1 = _35reg2868;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label8:
 {
-Obj _35val2814 = __arg1;
-Obj _35val2812= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("apply"));
-__arg1 = _35val2812;
-__arg2 = _35val2814;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj _35tmp1200 = __arg1;
+Obj _35tmp1199 = __arg2;
+Obj _35reg2870 = primLT(_35tmp1200, _35tmp1199);
+__nargs = 2;
+__arg1 = _35reg2870;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label9:
 {
-Obj _35val2812 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2813 = primCdr(exp);
-pushCont(co, 8, _35clofun2868, 1, _35val2812);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = globalRef(intern("cora/lib/toc.eval0"));
-__arg2 = _35reg2813;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj _35tmp1201 = __arg1;
+Obj _35reg2872 = primGenSym(_35tmp1201);
+__nargs = 2;
+__arg1 = _35reg2872;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label10:
 {
-Obj _35val2822 = __arg1;
-Obj _35val2820= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("apply"));
-__arg1 = _35val2820;
-__arg2 = _35val2822;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj _35tmp1202 = __arg1;
+Obj _35reg2874 = primIsSymbol(_35tmp1202);
+__nargs = 2;
+__arg1 = _35reg2874;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label11:
 {
-Obj _35val2820 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2821 = primCdr(exp);
-pushCont(co, 10, _35clofun2868, 1, _35val2820);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = globalRef(intern("cora/lib/toc.eval0"));
-__arg2 = _35reg2821;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj _35tmp1203 = __arg1;
+Obj _35reg2876 = primNot(_35tmp1203);
+__nargs = 2;
+__arg1 = _35reg2876;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label12:
 {
-Obj _35val2830 = __arg1;
-Obj _35val2828= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("apply"));
-__arg1 = _35val2828;
-__arg2 = _35val2830;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj _35tmp1204 = __arg1;
+Obj _35reg2878 = primIsString(_35tmp1204);
+__nargs = 2;
+__arg1 = _35reg2878;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2943) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label13:
 {
-Obj _35val2828 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2829 = primCdr(exp);
-pushCont(co, 12, _35clofun2868, 1, _35val2828);
+Obj _35val2888 = __arg1;
+Obj _35val2886= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = globalRef(intern("cora/lib/toc.eval0"));
-__arg2 = _35reg2829;
+__arg0 = globalRef(intern("apply"));
+__arg1 = _35val2886;
+__arg2 = _35val2888;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2943) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2838 = __arg1;
-Obj _35val2836= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2886 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2887 = primCdr(exp);
+pushCont(co, 13, _35clofun2943, 1, _35val2886);
 __nargs = 3;
-__arg0 = globalRef(intern("apply"));
-__arg1 = _35val2836;
-__arg2 = _35val2838;
+__arg0 = globalRef(intern("map"));
+__arg1 = globalRef(intern("cora/lib/toc.eval0"));
+__arg2 = _35reg2887;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2943) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val2836 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2837 = primCdr(exp);
-pushCont(co, 14, _35clofun2868, 1, _35val2836);
+Obj _35val2896 = __arg1;
+Obj _35val2894= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = globalRef(intern("cora/lib/toc.eval0"));
-__arg2 = _35reg2837;
+__arg0 = globalRef(intern("apply"));
+__arg1 = _35val2894;
+__arg2 = _35val2896;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2943) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val2845 = __arg1;
-Obj _35val2843= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2894 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2895 = primCdr(exp);
+pushCont(co, 15, _35clofun2943, 1, _35val2894);
 __nargs = 3;
-__arg0 = globalRef(intern("apply"));
-__arg1 = _35val2843;
-__arg2 = _35val2845;
+__arg0 = globalRef(intern("map"));
+__arg1 = globalRef(intern("cora/lib/toc.eval0"));
+__arg2 = _35reg2895;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2943) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val2843 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2844 = primCdr(exp);
-pushCont(co, 16, _35clofun2868, 1, _35val2843);
+Obj _35val2904 = __arg1;
+Obj _35val2902= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = globalRef(intern("cora/lib/toc.eval0"));
-__arg2 = _35reg2844;
+__arg0 = globalRef(intern("apply"));
+__arg1 = _35val2902;
+__arg2 = _35val2904;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2943) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2831 = __arg1;
+Obj _35val2902 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val2831) {
-if (True == True) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg2832 = primIsCons(exp);
-if (True == _35reg2832) {
-Obj _35reg2833 = primCar(exp);
-Obj _35reg2834 = primEQ(_35reg2833, intern("quote"));
-if (True == _35reg2834) {
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
+Obj _35reg2903 = primCdr(exp);
+pushCont(co, 17, _35clofun2943, 1, _35val2902);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = globalRef(intern("cora/lib/toc.eval0"));
+__arg2 = _35reg2903;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2943) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj _35reg2835 = primCar(exp);
-pushCont(co, 15, _35clofun2868, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.eval0"));
-__arg1 = _35reg2835;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeString1("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-if (True == False) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg2839 = primIsCons(exp);
-if (True == _35reg2839) {
-Obj _35reg2840 = primCar(exp);
-Obj _35reg2841 = primEQ(_35reg2840, intern("quote"));
-if (True == _35reg2841) {
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2842 = primCar(exp);
-pushCont(co, 17, _35clofun2868, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.eval0"));
-__arg1 = _35reg2842;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeString1("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
 }
 
 label19:
 {
-Obj _35val2823 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val2823) {
-if (True == True) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg2824 = primIsCons(exp);
-if (True == _35reg2824) {
-Obj _35reg2825 = primCar(exp);
-Obj _35reg2826 = primEQ(_35reg2825, intern("quote"));
-if (True == _35reg2826) {
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
+Obj _35val2912 = __arg1;
+Obj _35val2910= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("apply"));
+__arg1 = _35val2910;
+__arg2 = _35val2912;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2943) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj _35reg2827 = primCar(exp);
-pushCont(co, 13, _35clofun2868, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.eval0"));
-__arg1 = _35reg2827;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeString1("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-pushCont(co, 18, _35clofun2868, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("null?"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label20:
 {
-Obj _35val2807 = __arg1;
+Obj _35val2910 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val2807) {
-if (True == True) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg2808 = primIsCons(exp);
-if (True == _35reg2808) {
-Obj _35reg2809 = primCar(exp);
-Obj _35reg2810 = primEQ(_35reg2809, intern("quote"));
-if (True == _35reg2810) {
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
+Obj _35reg2911 = primCdr(exp);
+pushCont(co, 19, _35clofun2943, 1, _35val2910);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = globalRef(intern("cora/lib/toc.eval0"));
+__arg2 = _35reg2911;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2943) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj _35reg2811 = primCar(exp);
-pushCont(co, 9, _35clofun2868, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.eval0"));
-__arg1 = _35reg2811;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeString1("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-Obj _35reg2815 = primIsString(exp);
-if (True == _35reg2815) {
-if (True == True) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2868) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg2816 = primIsCons(exp);
-if (True == _35reg2816) {
-Obj _35reg2817 = primCar(exp);
-Obj _35reg2818 = primEQ(_35reg2817, intern("quote"));
-if (True == _35reg2818) {
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2819 = primCar(exp);
-pushCont(co, 11, _35clofun2868, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.eval0"));
-__arg1 = _35reg2819;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeString1("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-pushCont(co, 19, _35clofun2868, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("boolean?"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2868) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
 }
 
 fail:
@@ -812,7 +876,435 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2867(struct Cora* co){
+void _35clofun2942(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2827 = __arg1;
+Obj _35reg2828 = primCons(intern("begin"), _35val2827);
+__nargs = 2;
+__arg1 = _35reg2828;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2942) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label1:
+{
+Obj type = __arg1;
+Obj code = __arg2;
+if (True == globalRef(intern("cora/lib/infer.*typecheck*"))) {
+pushCont(co, 0, _35clofun2942, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("append"));
+__arg1 = type;
+__arg2 = code;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2829 = primCons(intern("begin"), code);
+__nargs = 2;
+__arg1 = _35reg2829;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2942) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label2:
+{
+Obj _35val2826 = __arg1;
+Obj sexp1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc.split-type-and-code"));
+__arg1 = sexp1;
+__arg2 = Nil;
+__arg3 = Nil;
+co->args[4] = makeNative(1, _35clofun2942, 2, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2832 = __arg1;
+Obj _35reg2833 = primCons(intern("begin"), _35val2832);
+__nargs = 2;
+__arg1 = _35reg2833;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2942) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
+{
+Obj type = __arg1;
+Obj code = __arg2;
+if (True == globalRef(intern("cora/lib/infer.*typecheck*"))) {
+pushCont(co, 3, _35clofun2942, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("append"));
+__arg1 = type;
+__arg2 = code;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2834 = primCons(intern("begin"), code);
+__nargs = 2;
+__arg1 = _35reg2834;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2942) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label5:
+{
+Obj _35val2831 = __arg1;
+Obj sexp1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc.split-type-and-code"));
+__arg1 = sexp1;
+__arg2 = Nil;
+__arg3 = Nil;
+co->args[4] = makeNative(4, _35clofun2942, 2, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label6:
+{
+Obj _35val2837 = __arg1;
+Obj _35reg2838 = primCons(intern("begin"), _35val2837);
+__nargs = 2;
+__arg1 = _35reg2838;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2942) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label7:
+{
+Obj type = __arg1;
+Obj code = __arg2;
+if (True == globalRef(intern("cora/lib/infer.*typecheck*"))) {
+pushCont(co, 6, _35clofun2942, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("append"));
+__arg1 = type;
+__arg2 = code;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2839 = primCons(intern("begin"), code);
+__nargs = 2;
+__arg1 = _35reg2839;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2942) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label8:
+{
+Obj _35val2836 = __arg1;
+Obj sexp1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc.split-type-and-code"));
+__arg1 = sexp1;
+__arg2 = Nil;
+__arg3 = Nil;
+co->args[4] = makeNative(7, _35clofun2942, 2, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label9:
+{
+Obj _35val2807 = __arg1;
+Obj sexp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val2807) {
+Obj _35reg2808 = primCar(sexp);
+Obj _35reg2809 = primEQ(intern("begin"), _35reg2808);
+if (True == _35reg2809) {
+if (True == True) {
+Obj _35reg2810 = primCdr(sexp);
+Obj sexp1 = _35reg2810;
+pushCont(co, 14, _35clofun2941, 1, sexp1);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.handle-import-eagerly"));
+__arg1 = sexp1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2815 = primCons(sexp, Nil);
+Obj sexp1 = _35reg2815;
+pushCont(co, 17, _35clofun2941, 1, sexp1);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.handle-import-eagerly"));
+__arg1 = sexp1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+Obj _35reg2820 = primCdr(sexp);
+Obj sexp1 = _35reg2820;
+pushCont(co, 20, _35clofun2941, 1, sexp1);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.handle-import-eagerly"));
+__arg1 = sexp1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2825 = primCons(sexp, Nil);
+Obj sexp1 = _35reg2825;
+pushCont(co, 2, _35clofun2942, 1, sexp1);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.handle-import-eagerly"));
+__arg1 = sexp1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+if (True == False) {
+Obj _35reg2830 = primCdr(sexp);
+Obj sexp1 = _35reg2830;
+pushCont(co, 5, _35clofun2942, 1, sexp1);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.handle-import-eagerly"));
+__arg1 = sexp1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2835 = primCons(sexp, Nil);
+Obj sexp1 = _35reg2835;
+pushCont(co, 8, _35clofun2942, 1, sexp1);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.handle-import-eagerly"));
+__arg1 = sexp1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label10:
+{
+Obj sexp = __arg1;
+pushCont(co, 9, _35clofun2942, 1, sexp);
+__nargs = 2;
+__arg0 = globalRef(intern("pair?"));
+__arg1 = sexp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label11:
+{
+Obj _35val2846 = __arg1;
+Obj stream= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/io.close-output-file"));
+__arg1 = stream;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label12:
+{
+Obj _35val2845 = __arg1;
+Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj stream = _35val2845;
+pushCont(co, 11, _35clofun2942, 1, stream);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.generate-c"));
+__arg1 = stream;
+__arg2 = bc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label13:
+{
+Obj _35val2844 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj bc = _35val2844;
+pushCont(co, 12, _35clofun2942, 1, bc);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/io.open-output-file"));
+__arg1 = to;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label14:
+{
+Obj _35val2843 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj input = _35val2843;
+pushCont(co, 13, _35clofun2942, 1, to);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.compile"));
+__arg1 = input;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label15:
+{
+Obj _35val2842 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj sexp1 = _35val2842;
+pushCont(co, 14, _35clofun2942, 1, to);
+__nargs = 2;
+__arg0 = globalRef(intern("macroexpand"));
+__arg1 = sexp1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label16:
+{
+Obj _35val2841 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj sexp = _35val2841;
+pushCont(co, 15, _35clofun2942, 1, to);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.preprocess"));
+__arg1 = sexp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label17:
+{
+Obj from = __arg1;
+Obj to = __arg2;
+Obj pkg_45str = __arg3;
+pushCont(co, 16, _35clofun2942, 1, to);
+__nargs = 3;
+__arg0 = globalRef(intern("read-file-as-sexp"));
+__arg1 = from;
+__arg2 = pkg_45str;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2942) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label18:
+{
+Obj _35tmp1180 = __arg1;
+Obj _35tmp1179 = __arg2;
+Obj _35reg2848 = primSet(_35tmp1180, _35tmp1179);
+__nargs = 2;
+__arg1 = _35reg2848;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2942) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label19:
+{
+Obj _35tmp1181 = __arg1;
+Obj _35reg2850 = primCar(_35tmp1181);
+__nargs = 2;
+__arg1 = _35reg2850;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2942) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label20:
+{
+Obj _35tmp1182 = __arg1;
+Obj _35reg2852 = primCdr(_35tmp1182);
+__nargs = 2;
+__arg1 = _35reg2852;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2942) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void _35clofun2941(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -827,7 +1319,7 @@ label0:
 {
 Obj to = __arg1;
 Obj bc = __arg2;
-pushCont(co, 20, _35clofun2866, 2, to, bc);
+pushCont(co, 20, _35clofun2940, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -835,7 +1327,7 @@ __arg2 = makeString1("#include \"types.h\"\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -847,24 +1339,24 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35cc1176 = makeNative(1, _35clofun2867, 0, 0);
+Obj _35cc1170 = makeNative(1, _35clofun2941, 0, 0);
 Obj __ = closureRef(co, 0);
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2867) { goto fail; }
+if (co->ctx.pc.func != _35clofun2941) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label3:
 {
-Obj _35val2761 = __arg1;
+Obj _35val2763 = __arg1;
 Obj remain= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.handle-import-eagerly"));
@@ -872,336 +1364,497 @@ __arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35cc1175 = makeNative(2, _35clofun2867, 0, 1, closureRef(co, 0));
-Obj _35reg2744 = primIsCons(closureRef(co, 0));
-if (True == _35reg2744) {
-Obj _35reg2745 = primCar(closureRef(co, 0));
-Obj _35reg2746 = primIsCons(_35reg2745);
+Obj _35p1168 = __arg1;
+Obj _35cc1169 = makeNative(2, _35clofun2941, 0, 1, _35p1168);
+Obj _35reg2746 = primIsCons(_35p1168);
 if (True == _35reg2746) {
-Obj _35reg2747 = primCar(closureRef(co, 0));
-Obj _35reg2748 = primCar(_35reg2747);
-Obj _35reg2749 = primEQ(intern("import"), _35reg2748);
-if (True == _35reg2749) {
-Obj _35reg2750 = primCar(closureRef(co, 0));
-Obj _35reg2751 = primCdr(_35reg2750);
-Obj _35reg2752 = primIsCons(_35reg2751);
-if (True == _35reg2752) {
-Obj _35reg2753 = primCar(closureRef(co, 0));
-Obj _35reg2754 = primCdr(_35reg2753);
-Obj _35reg2755 = primCar(_35reg2754);
-Obj pkg = _35reg2755;
-Obj _35reg2756 = primCar(closureRef(co, 0));
-Obj _35reg2757 = primCdr(_35reg2756);
-Obj _35reg2758 = primCdr(_35reg2757);
-Obj _35reg2759 = primEQ(Nil, _35reg2758);
-if (True == _35reg2759) {
-Obj _35reg2760 = primCdr(closureRef(co, 0));
-Obj remain = _35reg2760;
-pushCont(co, 3, _35clofun2867, 1, remain);
+Obj _35reg2747 = primCar(_35p1168);
+Obj _35reg2748 = primIsCons(_35reg2747);
+if (True == _35reg2748) {
+Obj _35reg2749 = primCar(_35p1168);
+Obj _35reg2750 = primCar(_35reg2749);
+Obj _35reg2751 = primEQ(intern("import"), _35reg2750);
+if (True == _35reg2751) {
+Obj _35reg2752 = primCar(_35p1168);
+Obj _35reg2753 = primCdr(_35reg2752);
+Obj _35reg2754 = primIsCons(_35reg2753);
+if (True == _35reg2754) {
+Obj _35reg2755 = primCar(_35p1168);
+Obj _35reg2756 = primCdr(_35reg2755);
+Obj _35reg2757 = primCar(_35reg2756);
+Obj pkg = _35reg2757;
+Obj _35reg2758 = primCar(_35p1168);
+Obj _35reg2759 = primCdr(_35reg2758);
+Obj _35reg2760 = primCdr(_35reg2759);
+Obj _35reg2761 = primEQ(Nil, _35reg2760);
+if (True == _35reg2761) {
+Obj _35reg2762 = primCdr(_35p1168);
+Obj remain = _35reg2762;
+pushCont(co, 3, _35clofun2941, 1, remain);
 __nargs = 2;
 __arg0 = globalRef(intern("import"));
 __arg1 = pkg;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1175;
+__arg0 = _35cc1169;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1175;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1175;
+__arg0 = _35cc1169;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1175;
+__arg0 = _35cc1169;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1175;
+__arg0 = _35cc1169;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1169;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35p1173 = __arg1;
-Obj _35cc1174 = makeNative(4, _35clofun2867, 0, 1, _35p1173);
-Obj _35reg2762 = primIsCons(_35p1173);
-if (True == _35reg2762) {
-Obj _35reg2763 = primCar(_35p1173);
-Obj _35reg2764 = primEQ(intern("begin"), _35reg2763);
-if (True == _35reg2764) {
-Obj _35reg2765 = primCdr(_35p1173);
-Obj remain = _35reg2765;
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.handle-import-eagerly"));
-__arg1 = remain;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1174;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1174;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label6:
 {
-Obj _35val2772 = __arg1;
-Obj stream= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/io.close-output-file"));
-__arg1 = stream;
+Obj _35cc1178 = makeNative(5, _35clofun2941, 0, 0);
+Obj _35reg2765 = primIsCons(closureRef(co, 0));
+if (True == _35reg2765) {
+Obj _35reg2766 = primCar(closureRef(co, 0));
+Obj exp = _35reg2766;
+Obj _35reg2767 = primCdr(closureRef(co, 0));
+Obj more = _35reg2767;
+Obj type = closureRef(co, 1);
+Obj code = closureRef(co, 2);
+Obj k = closureRef(co, 3);
+Obj _35reg2768 = primCons(exp, Nil);
+Obj _35reg2769 = primCons(intern("backquote"), _35reg2768);
+Obj _35reg2770 = primCons(_35reg2769, Nil);
+Obj _35reg2771 = primCons(intern("macroexpand"), _35reg2770);
+Obj _35reg2772 = primCons(intern("tvar"), Nil);
+Obj _35reg2773 = primCons(Nil, Nil);
+Obj _35reg2774 = primCons(Nil, _35reg2773);
+Obj _35reg2775 = primCons(_35reg2772, _35reg2774);
+Obj _35reg2776 = primCons(_35reg2771, _35reg2775);
+Obj _35reg2777 = primCons(intern("cora/lib/infer.check-type"), _35reg2776);
+Obj _35reg2778 = primCons(_35reg2777, type);
+Obj _35reg2779 = primCons(exp, code);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc.split-type-and-code"));
+__arg1 = more;
+__arg2 = _35reg2778;
+__arg3 = _35reg2779;
+co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1178;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label7:
 {
-Obj _35val2771 = __arg1;
-Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stream = _35val2771;
-pushCont(co, 6, _35clofun2867, 1, stream);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.generate-c"));
-__arg1 = stream;
-__arg2 = bc;
+Obj _35cc1177 = makeNative(6, _35clofun2941, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35reg2780 = primIsCons(closureRef(co, 0));
+if (True == _35reg2780) {
+Obj _35reg2781 = primCar(closureRef(co, 0));
+Obj _35reg2782 = primIsCons(_35reg2781);
+if (True == _35reg2782) {
+Obj _35reg2783 = primCar(closureRef(co, 0));
+Obj _35reg2784 = primCar(_35reg2783);
+Obj _35reg2785 = primEQ(intern(":declare"), _35reg2784);
+if (True == _35reg2785) {
+Obj _35reg2786 = primCar(closureRef(co, 0));
+Obj _35reg2787 = primCdr(_35reg2786);
+Obj exp = _35reg2787;
+Obj _35reg2788 = primCdr(closureRef(co, 0));
+Obj more = _35reg2788;
+Obj type = closureRef(co, 1);
+Obj code = closureRef(co, 2);
+Obj k = closureRef(co, 3);
+Obj _35reg2789 = primCons(intern("declare"), exp);
+Obj _35reg2790 = primCons(_35reg2789, type);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc.split-type-and-code"));
+__arg1 = more;
+__arg2 = _35reg2790;
+__arg3 = code;
+co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1177;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1177;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1177;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label8:
 {
-Obj _35val2770 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc = _35val2770;
-pushCont(co, 7, _35clofun2867, 1, bc);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/io.open-output-file"));
-__arg1 = to;
+Obj _35cc1176 = makeNative(7, _35clofun2941, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35reg2791 = primIsCons(closureRef(co, 0));
+if (True == _35reg2791) {
+Obj _35reg2792 = primCar(closureRef(co, 0));
+Obj _35reg2793 = primIsCons(_35reg2792);
+if (True == _35reg2793) {
+Obj _35reg2794 = primCar(closureRef(co, 0));
+Obj _35reg2795 = primCar(_35reg2794);
+Obj _35reg2796 = primEQ(intern(":type"), _35reg2795);
+if (True == _35reg2796) {
+Obj _35reg2797 = primCar(closureRef(co, 0));
+Obj _35reg2798 = primCdr(_35reg2797);
+Obj exp = _35reg2798;
+Obj _35reg2799 = primCdr(closureRef(co, 0));
+Obj more = _35reg2799;
+Obj type = closureRef(co, 1);
+Obj code = closureRef(co, 2);
+Obj k = closureRef(co, 3);
+Obj _35reg2800 = primCons(intern("begin"), exp);
+Obj _35reg2801 = primCons(_35reg2800, type);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc.split-type-and-code"));
+__arg1 = more;
+__arg2 = _35reg2801;
+__arg3 = code;
+co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1176;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1176;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1176;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label9:
 {
-Obj _35val2769 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj input = _35val2769;
-pushCont(co, 8, _35clofun2867, 1, to);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.compile"));
-__arg1 = input;
+Obj _35val2804 = __arg1;
+Obj k= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2803= co->ctx.stk.stack[co->ctx.stk.base + 1];
+__nargs = 3;
+__arg0 = k;
+__arg1 = _35val2803;
+__arg2 = _35val2804;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val2768 = __arg1;
-Obj sexp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun2867, 1, to);
+Obj _35val2803 = __arg1;
+Obj code= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj k= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 9, _35clofun2941, 2, k, _35val2803);
 __nargs = 2;
-__arg0 = globalRef(intern("macroexpand"));
-__arg1 = sexp;
+__arg0 = globalRef(intern("reverse"));
+__arg1 = code;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val2767 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj sexp = _35val2767;
-pushCont(co, 10, _35clofun2867, 2, sexp, to);
+Obj _35p1171 = __arg1;
+Obj _35p1172 = __arg2;
+Obj _35p1173 = __arg3;
+Obj _35p1174 = co->args[4];
+Obj _35cc1175 = makeNative(8, _35clofun2941, 0, 4, _35p1171, _35p1172, _35p1173, _35p1174);
+Obj _35reg2802 = primEQ(Nil, _35p1171);
+if (True == _35reg2802) {
+Obj type = _35p1172;
+Obj code = _35p1173;
+Obj k = _35p1174;
+pushCont(co, 10, _35clofun2941, 2, code, k);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.handle-import-eagerly"));
-__arg1 = sexp;
+__arg0 = globalRef(intern("reverse"));
+__arg1 = type;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1175;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label12:
 {
-Obj from = __arg1;
-Obj to = __arg2;
-Obj pkg_45str = __arg3;
-pushCont(co, 11, _35clofun2867, 1, to);
-__nargs = 3;
-__arg0 = globalRef(intern("read-file-as-sexp"));
-__arg1 = from;
-__arg2 = pkg_45str;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2867) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj _35val2812 = __arg1;
+Obj _35reg2813 = primCons(intern("begin"), _35val2812);
+__nargs = 2;
+__arg1 = _35reg2813;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2941) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label13:
 {
-Obj _35tmp1178 = __arg1;
-Obj _35tmp1177 = __arg2;
-Obj _35reg2774 = primSet(_35tmp1178, _35tmp1177);
+Obj type = __arg1;
+Obj code = __arg2;
+if (True == globalRef(intern("cora/lib/infer.*typecheck*"))) {
+pushCont(co, 12, _35clofun2941, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("append"));
+__arg1 = type;
+__arg2 = code;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2814 = primCons(intern("begin"), code);
 __nargs = 2;
-__arg1 = _35reg2774;
+__arg1 = _35reg2814;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2867) { goto fail; }
+if (co->ctx.pc.func != _35clofun2941) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
+}
 }
 
 label14:
 {
-Obj _35tmp1179 = __arg1;
-Obj _35reg2776 = primCar(_35tmp1179);
-__nargs = 2;
-__arg1 = _35reg2776;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2867) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val2811 = __arg1;
+Obj sexp1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc.split-type-and-code"));
+__arg1 = sexp1;
+__arg2 = Nil;
+__arg3 = Nil;
+co->args[4] = makeNative(13, _35clofun2941, 2, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35tmp1180 = __arg1;
-Obj _35reg2778 = primCdr(_35tmp1180);
+Obj _35val2817 = __arg1;
+Obj _35reg2818 = primCons(intern("begin"), _35val2817);
 __nargs = 2;
-__arg1 = _35reg2778;
+__arg1 = _35reg2818;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2867) { goto fail; }
+if (co->ctx.pc.func != _35clofun2941) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label16:
 {
-Obj _35tmp1182 = __arg1;
-Obj _35tmp1181 = __arg2;
-Obj _35reg2780 = primCons(_35tmp1182, _35tmp1181);
+Obj type = __arg1;
+Obj code = __arg2;
+if (True == globalRef(intern("cora/lib/infer.*typecheck*"))) {
+pushCont(co, 15, _35clofun2941, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("append"));
+__arg1 = type;
+__arg2 = code;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2819 = primCons(intern("begin"), code);
 __nargs = 2;
-__arg1 = _35reg2780;
+__arg1 = _35reg2819;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2867) { goto fail; }
+if (co->ctx.pc.func != _35clofun2941) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
+}
 }
 
 label17:
 {
-Obj _35tmp1184 = __arg1;
-Obj _35tmp1183 = __arg2;
-Obj _35reg2782 = primCons(_35tmp1184, _35tmp1183);
-__nargs = 2;
-__arg1 = _35reg2782;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2867) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val2816 = __arg1;
+Obj sexp1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc.split-type-and-code"));
+__arg1 = sexp1;
+__arg2 = Nil;
+__arg3 = Nil;
+co->args[4] = makeNative(16, _35clofun2941, 2, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35tmp1186 = __arg1;
-Obj _35tmp1185 = __arg2;
-Obj _35reg2784 = primAdd(_35tmp1186, _35tmp1185);
+Obj _35val2822 = __arg1;
+Obj _35reg2823 = primCons(intern("begin"), _35val2822);
 __nargs = 2;
-__arg1 = _35reg2784;
+__arg1 = _35reg2823;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2867) { goto fail; }
+if (co->ctx.pc.func != _35clofun2941) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label19:
 {
-Obj _35tmp1188 = __arg1;
-Obj _35tmp1187 = __arg2;
-Obj _35reg2786 = primSub(_35tmp1188, _35tmp1187);
+Obj type = __arg1;
+Obj code = __arg2;
+if (True == globalRef(intern("cora/lib/infer.*typecheck*"))) {
+pushCont(co, 18, _35clofun2941, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("append"));
+__arg1 = type;
+__arg2 = code;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2824 = primCons(intern("begin"), code);
 __nargs = 2;
-__arg1 = _35reg2786;
+__arg1 = _35reg2824;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2867) { goto fail; }
+if (co->ctx.pc.func != _35clofun2941) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
+}
 }
 
 label20:
 {
-Obj _35tmp1190 = __arg1;
-Obj _35tmp1189 = __arg2;
-Obj _35reg2788 = primMul(_35tmp1190, _35tmp1189);
-__nargs = 2;
-__arg1 = _35reg2788;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2867) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val2821 = __arg1;
+Obj sexp1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc.split-type-and-code"));
+__arg1 = sexp1;
+__arg2 = Nil;
+__arg3 = Nil;
+co->args[4] = makeNative(19, _35clofun2941, 2, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2941) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 fail:
@@ -1213,7 +1866,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2866(struct Cora* co){
+void _35clofun2940(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -1226,10 +1879,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2727 = __arg1;
+Obj _35val2729 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 20, _35clofun2865, 2, group, to);
+pushCont(co, 20, _35clofun2939, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1237,16 +1890,16 @@ __arg2 = makeString1("goto *jumpTable[co->ctx.pc.label];\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2726 = __arg1;
+Obj _35val2728 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2866, 2, group, to);
+pushCont(co, 0, _35clofun2940, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1254,50 +1907,50 @@ __arg2 = makeString1("};\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val2725 = __arg1;
+Obj _35val2727 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun2866, 2, group, to);
+pushCont(co, 1, _35clofun2940, 2, group, to);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc.generate-jumptable"));
 __arg1 = to;
 __arg2 = makeNumber(0);
-__arg3 = _35val2725;
+__arg3 = _35val2727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2724 = __arg1;
+Obj _35val2726 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun2866, 2, group, to);
+pushCont(co, 2, _35clofun2940, 2, group, to);
 __nargs = 2;
 __arg0 = globalRef(intern("length"));
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val2723 = __arg1;
+Obj _35val2725 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 3, _35clofun2866, 2, group, to);
+pushCont(co, 3, _35clofun2940, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1305,16 +1958,16 @@ __arg2 = makeString1("static void* jumpTable[] = {");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val2722 = __arg1;
+Obj _35val2724 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun2866, 2, group, to);
+pushCont(co, 4, _35clofun2940, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1322,16 +1975,16 @@ __arg2 = makeString1("Obj __arg3 = co->args[3];\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val2721 = __arg1;
+Obj _35val2723 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun2866, 2, group, to);
+pushCont(co, 5, _35clofun2940, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1339,16 +1992,16 @@ __arg2 = makeString1("Obj __arg2 = co->args[2];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val2720 = __arg1;
+Obj _35val2722 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 6, _35clofun2866, 2, group, to);
+pushCont(co, 6, _35clofun2940, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1356,16 +2009,16 @@ __arg2 = makeString1("Obj __arg1 = co->args[1];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val2719 = __arg1;
+Obj _35val2721 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun2866, 2, group, to);
+pushCont(co, 7, _35clofun2940, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1373,16 +2026,16 @@ __arg2 = makeString1("Obj __arg0 = co->args[0];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val2718 = __arg1;
+Obj _35val2720 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun2866, 2, group, to);
+pushCont(co, 8, _35clofun2940, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1390,16 +2043,16 @@ __arg2 = makeString1("int __nargs = co->nargs;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val2717 = __arg1;
+Obj _35val2719 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun2866, 2, group, to);
+pushCont(co, 9, _35clofun2940, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1407,24 +2060,24 @@ __arg2 = makeString1("{\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val2716 = __arg1;
+Obj _35val2718 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun2866, 2, group, to);
+pushCont(co, 10, _35clofun2940, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.code-gen-func-declare"));
 __arg1 = to;
-__arg2 = _35val2716;
+__arg2 = _35val2718;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1432,20 +2085,20 @@ label12:
 {
 Obj to = __arg1;
 Obj group = __arg2;
-pushCont(co, 11, _35clofun2866, 2, group, to);
+pushCont(co, 11, _35clofun2940, 2, group, to);
 __nargs = 2;
 __arg0 = globalRef(intern("caar"));
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val2740 = __arg1;
+Obj _35val2742 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = closureRef(co, 0);
@@ -1453,36 +2106,36 @@ __arg2 = makeString1(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2739 = __arg1;
-pushCont(co, 13, _35clofun2866, 0);
+Obj _35val2741 = __arg1;
+pushCont(co, 13, _35clofun2940, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.code-gen-func-declare"));
 __arg1 = closureRef(co, 0);
-__arg2 = _35val2739;
+__arg2 = _35val2741;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
 Obj group = __arg1;
-pushCont(co, 14, _35clofun2866, 0);
+pushCont(co, 14, _35clofun2940, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("caar"));
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1496,32 +2149,32 @@ __arg2 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val2742 = __arg1;
+Obj _35val2744 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 3;
 __arg0 = globalRef(intern("for-each"));
-__arg1 = makeNative(16, _35clofun2866, 1, 1, to);
+__arg1 = makeNative(16, _35clofun2940, 1, 1, to);
 __arg2 = bc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2741 = __arg1;
+Obj _35val2743 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 17, _35clofun2866, 2, to, bc);
+pushCont(co, 17, _35clofun2940, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1529,33 +2182,33 @@ __arg2 = makeString1("\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val2738 = __arg1;
+Obj _35val2740 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 18, _35clofun2866, 2, to, bc);
+pushCont(co, 18, _35clofun2940, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("for-each"));
-__arg1 = makeNative(15, _35clofun2866, 1, 1, to);
+__arg1 = makeNative(15, _35clofun2940, 1, 1, to);
 __arg2 = bc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val2737 = __arg1;
+Obj _35val2739 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 19, _35clofun2866, 2, to, bc);
+pushCont(co, 19, _35clofun2940, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1563,7 +2216,7 @@ __arg2 = makeString1("#include \"runtime.h\"\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2866) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2940) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1576,7 +2229,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2865(struct Cora* co){
+void _35clofun2939(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -1589,57 +2242,57 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2700 = __arg1;
-pushCont(co, 20, _35clofun2864, 0);
+Obj _35val2702 = __arg1;
+pushCont(co, 20, _35clofun2938, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.explicit-stack-pass"));
-__arg1 = _35val2700;
+__arg1 = _35val2702;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2699 = __arg1;
-pushCont(co, 0, _35clofun2865, 0);
+Obj _35val2701 = __arg1;
+pushCont(co, 0, _35clofun2939, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.tailify-pass"));
-__arg1 = _35val2699;
+__arg1 = _35val2701;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val2698 = __arg1;
-pushCont(co, 1, _35clofun2865, 0);
+Obj _35val2700 = __arg1;
+pushCont(co, 1, _35clofun2939, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.closure-convert-pass"));
-__arg1 = _35val2698;
+__arg1 = _35val2700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
 Obj exp = __arg1;
-pushCont(co, 2, _35clofun2865, 0);
+pushCont(co, 2, _35clofun2939, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.parse-pass"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1651,13 +2304,13 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val2706 = __arg1;
+Obj _35val2708 = __arg1;
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 3;
@@ -1667,67 +2320,67 @@ __arg2 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc1172 = makeNative(4, _35clofun2865, 0, 0);
+Obj _35cc1167 = makeNative(4, _35clofun2939, 0, 0);
 Obj fn = closureRef(co, 0);
-Obj _35reg2703 = primIsCons(closureRef(co, 1));
-if (True == _35reg2703) {
-Obj _35reg2704 = primCar(closureRef(co, 1));
-Obj x = _35reg2704;
-Obj _35reg2705 = primCdr(closureRef(co, 1));
-Obj y = _35reg2705;
-pushCont(co, 5, _35clofun2865, 2, fn, y);
+Obj _35reg2705 = primIsCons(closureRef(co, 1));
+if (True == _35reg2705) {
+Obj _35reg2706 = primCar(closureRef(co, 1));
+Obj x = _35reg2706;
+Obj _35reg2707 = primCdr(closureRef(co, 1));
+Obj y = _35reg2707;
+pushCont(co, 5, _35clofun2939, 2, fn, y);
 __nargs = 2;
 __arg0 = fn;
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1172;
+__arg0 = _35cc1167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35p1169 = __arg1;
-Obj _35p1170 = __arg2;
-Obj _35cc1171 = makeNative(6, _35clofun2865, 0, 2, _35p1169, _35p1170);
-Obj fn = _35p1169;
-Obj _35reg2707 = primEQ(Nil, _35p1170);
-if (True == _35reg2707) {
+Obj _35p1164 = __arg1;
+Obj _35p1165 = __arg2;
+Obj _35cc1166 = makeNative(6, _35clofun2939, 0, 2, _35p1164, _35p1165);
+Obj fn = _35p1164;
+Obj _35reg2709 = primEQ(Nil, _35p1165);
+if (True == _35reg2709) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2865) { goto fail; }
+if (co->ctx.pc.func != _35clofun2939) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1171;
+__arg0 = _35cc1166;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35val2710 = __arg1;
+Obj _35val2712 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj n= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -1738,36 +2391,36 @@ __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val2713 = __arg1;
+Obj _35val2715 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj n= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2714 = primAdd(i, makeNumber(1));
+Obj _35reg2716 = primAdd(i, makeNumber(1));
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc.generate-jumptable"));
 __arg1 = to;
-__arg2 = _35reg2714;
+__arg2 = _35reg2716;
 __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val2712 = __arg1;
+Obj _35val2714 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj n= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 9, _35clofun2865, 3, i, to, n);
+pushCont(co, 9, _35clofun2939, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = to;
@@ -1775,7 +2428,7 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1784,9 +2437,9 @@ label11:
 Obj to = __arg1;
 Obj i = __arg2;
 Obj n = __arg3;
-Obj _35reg2709 = primEQ(i, makeNumber(0));
-if (True == _35reg2709) {
-pushCont(co, 8, _35clofun2865, 2, to, n);
+Obj _35reg2711 = primEQ(i, makeNumber(0));
+if (True == _35reg2711) {
+pushCont(co, 8, _35clofun2939, 2, to, n);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1794,12 +2447,12 @@ __arg2 = makeString1("&&label0");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2711 = primLT(i, n);
-if (True == _35reg2711) {
-pushCont(co, 10, _35clofun2865, 3, i, to, n);
+Obj _35reg2713 = primLT(i, n);
+if (True == _35reg2713) {
+pushCont(co, 10, _35clofun2939, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1807,13 +2460,13 @@ __arg2 = makeString1(", &&label");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2865) { goto fail; }
+if (co->ctx.pc.func != _35clofun2939) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -1829,13 +2482,13 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val2735 = __arg1;
+Obj _35val2737 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -1844,15 +2497,15 @@ __arg2 = makeString1("\n}\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2734 = __arg1;
+Obj _35val2736 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 13, _35clofun2865, 1, to);
+pushCont(co, 13, _35clofun2939, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1860,15 +2513,15 @@ __arg2 = makeString1("co->args[3] = __arg3;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val2733 = __arg1;
+Obj _35val2735 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 14, _35clofun2865, 1, to);
+pushCont(co, 14, _35clofun2939, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1876,15 +2529,15 @@ __arg2 = makeString1("co->args[2] = __arg2;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val2732 = __arg1;
+Obj _35val2734 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 15, _35clofun2865, 1, to);
+pushCont(co, 15, _35clofun2939, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1892,15 +2545,15 @@ __arg2 = makeString1("co->args[1] = __arg1;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val2731 = __arg1;
+Obj _35val2733 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 16, _35clofun2865, 1, to);
+pushCont(co, 16, _35clofun2939, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1908,15 +2561,15 @@ __arg2 = makeString1("co->args[0] = __arg0;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2730 = __arg1;
+Obj _35val2732 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 17, _35clofun2865, 1, to);
+pushCont(co, 17, _35clofun2939, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1924,15 +2577,15 @@ __arg2 = makeString1("co->nargs = __nargs;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val2729 = __arg1;
+Obj _35val2731 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 18, _35clofun2865, 1, to);
+pushCont(co, 18, _35clofun2939, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = to;
@@ -1940,24 +2593,24 @@ __arg2 = makeString1("fail:\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val2728 = __arg1;
+Obj _35val2730 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 19, _35clofun2865, 1, to);
+pushCont(co, 19, _35clofun2939, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("for-each"));
-__arg1 = makeNative(12, _35clofun2865, 1, 1, to);
+__arg1 = makeNative(12, _35clofun2939, 1, 1, to);
 __arg2 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2865) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2939) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1970,7 +2623,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2864(struct Cora* co){
+void _35clofun2938(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -1991,7 +2644,7 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2005,7 +2658,7 @@ __arg2 = globalRef(intern("cora/lib/toc.id"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2019,60 +2672,60 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2665 = __arg1;
+Obj _35val2667 = __arg1;
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj res = _35val2665;
-Obj _35reg2666 = primCons(intern("entry"), makeNumber(0));
-Obj _35reg2667 = primCons(e1, Nil);
-Obj _35reg2668 = primCons(Nil, _35reg2667);
-Obj _35reg2669 = primCons(Nil, _35reg2668);
-Obj _35reg2670 = primCons(intern("lambda"), _35reg2669);
-Obj _35reg2671 = primCons(_35reg2670, Nil);
-Obj _35reg2672 = primCons(_35reg2666, _35reg2671);
+Obj res = _35val2667;
+Obj _35reg2668 = primCons(intern("entry"), makeNumber(0));
+Obj _35reg2669 = primCons(e1, Nil);
+Obj _35reg2670 = primCons(Nil, _35reg2669);
+Obj _35reg2671 = primCons(Nil, _35reg2670);
+Obj _35reg2672 = primCons(intern("lambda"), _35reg2671);
 Obj _35reg2673 = primCons(_35reg2672, Nil);
-Obj _35reg2674 = primCons(_35reg2673, res);
+Obj _35reg2674 = primCons(_35reg2668, _35reg2673);
+Obj _35reg2675 = primCons(_35reg2674, Nil);
+Obj _35reg2676 = primCons(_35reg2675, res);
 __nargs = 2;
-__arg1 = _35reg2674;
+__arg1 = _35reg2676;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2864) { goto fail; }
+if (co->ctx.pc.func != _35clofun2938) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label4:
 {
-Obj _35val2676 = __arg1;
-Obj _35val2675= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2678 = __arg1;
+Obj _35val2677= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2677 = primCons(_35val2675, _35val2676);
-Obj res = _35reg2677;
-Obj _35reg2678 = primCons(intern("entry"), makeNumber(0));
-Obj _35reg2679 = primCons(e1, Nil);
-Obj _35reg2680 = primCons(Nil, _35reg2679);
-Obj _35reg2681 = primCons(Nil, _35reg2680);
-Obj _35reg2682 = primCons(intern("lambda"), _35reg2681);
-Obj _35reg2683 = primCons(_35reg2682, Nil);
-Obj _35reg2684 = primCons(_35reg2678, _35reg2683);
+Obj _35reg2679 = primCons(_35val2677, _35val2678);
+Obj res = _35reg2679;
+Obj _35reg2680 = primCons(intern("entry"), makeNumber(0));
+Obj _35reg2681 = primCons(e1, Nil);
+Obj _35reg2682 = primCons(Nil, _35reg2681);
+Obj _35reg2683 = primCons(Nil, _35reg2682);
+Obj _35reg2684 = primCons(intern("lambda"), _35reg2683);
 Obj _35reg2685 = primCons(_35reg2684, Nil);
-Obj _35reg2686 = primCons(_35reg2685, res);
+Obj _35reg2686 = primCons(_35reg2680, _35reg2685);
+Obj _35reg2687 = primCons(_35reg2686, Nil);
+Obj _35reg2688 = primCons(_35reg2687, res);
 __nargs = 2;
-__arg1 = _35reg2686;
+__arg1 = _35reg2688;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2864) { goto fail; }
+if (co->ctx.pc.func != _35clofun2938) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label5:
 {
-Obj _35val2675 = __arg1;
+Obj _35val2677 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun2864, 2, _35val2675, e1);
+pushCont(co, 4, _35clofun2938, 2, _35val2677, e1);
 __nargs = 3;
 __arg0 = globalRef(intern("vector-ref"));
 __arg1 = v;
@@ -2080,18 +2733,18 @@ __arg2 = makeNumber(2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val2664 = __arg1;
+Obj _35val2666 = __arg1;
 Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val2664) {
-pushCont(co, 3, _35clofun2864, 1, e1);
+if (True == _35val2666) {
+pushCont(co, 3, _35clofun2938, 1, e1);
 __nargs = 3;
 __arg0 = globalRef(intern("vector-ref"));
 __arg1 = v;
@@ -2099,44 +2752,44 @@ __arg2 = makeNumber(2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 5, _35clofun2864, 2, v, e1);
+pushCont(co, 5, _35clofun2938, 2, v, e1);
 __nargs = 2;
 __arg0 = globalRef(intern("reverse"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35val2663 = __arg1;
+Obj _35val2665 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cur = _35val2663;
-pushCont(co, 6, _35clofun2864, 3, cur, v, e1);
+Obj cur = _35val2665;
+pushCont(co, 6, _35clofun2938, 3, cur, v, e1);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val2662 = __arg1;
+Obj _35val2664 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj e1 = _35val2662;
-pushCont(co, 7, _35clofun2864, 2, v, e1);
+Obj e1 = _35val2664;
+pushCont(co, 7, _35clofun2938, 2, v, e1);
 __nargs = 3;
 __arg0 = globalRef(intern("vector-ref"));
 __arg1 = v;
@@ -2144,16 +2797,16 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val2661 = __arg1;
+Obj _35val2663 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun2864, 1, v);
+pushCont(co, 8, _35clofun2938, 1, v);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.collect-lambda"));
 __arg1 = v;
@@ -2161,16 +2814,16 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val2660 = __arg1;
+Obj _35val2662 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun2864, 2, exp, v);
+pushCont(co, 9, _35clofun2938, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(intern("vector-set!"));
 __arg1 = v;
@@ -2179,16 +2832,16 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val2659 = __arg1;
+Obj _35val2661 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun2864, 2, exp, v);
+pushCont(co, 10, _35clofun2938, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(intern("vector-set!"));
 __arg1 = v;
@@ -2197,16 +2850,16 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val2658 = __arg1;
+Obj _35val2660 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v = _35val2658;
-pushCont(co, 11, _35clofun2864, 2, exp, v);
+Obj v = _35val2660;
+pushCont(co, 11, _35clofun2938, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(intern("vector-set!"));
 __arg1 = v;
@@ -2215,21 +2868,21 @@ __arg3 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
 Obj exp = __arg1;
-pushCont(co, 12, _35clofun2864, 1, exp);
+pushCont(co, 12, _35clofun2938, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("vector"));
 __arg1 = makeNumber(3);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2241,71 +2894,71 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35cc1168 = makeNative(14, _35clofun2864, 0, 0);
+Obj _35cc1163 = makeNative(14, _35clofun2938, 0, 0);
 Obj obj = closureRef(co, 0);
-Obj _35reg2688 = primIsCons(closureRef(co, 1));
-if (True == _35reg2688) {
-Obj _35reg2689 = primCar(closureRef(co, 1));
-Obj hd = _35reg2689;
-Obj _35reg2690 = primCdr(closureRef(co, 1));
-Obj more = _35reg2690;
-Obj _35reg2691 = primCons(obj, Nil);
-Obj _35reg2692 = primCons(hd, _35reg2691);
+Obj _35reg2690 = primIsCons(closureRef(co, 1));
+if (True == _35reg2690) {
+Obj _35reg2691 = primCar(closureRef(co, 1));
+Obj hd = _35reg2691;
+Obj _35reg2692 = primCdr(closureRef(co, 1));
+Obj more = _35reg2692;
+Obj _35reg2693 = primCons(obj, Nil);
+Obj _35reg2694 = primCons(hd, _35reg2693);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.rewrite-->macro"));
-__arg1 = _35reg2692;
+__arg1 = _35reg2694;
 __arg2 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1168;
+__arg0 = _35cc1163;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label16:
 {
-Obj _35p1165 = __arg1;
-Obj _35p1166 = __arg2;
-Obj _35cc1167 = makeNative(15, _35clofun2864, 0, 2, _35p1165, _35p1166);
-Obj obj = _35p1165;
-Obj _35reg2693 = primEQ(Nil, _35p1166);
-if (True == _35reg2693) {
+Obj _35p1160 = __arg1;
+Obj _35p1161 = __arg2;
+Obj _35cc1162 = makeNative(15, _35clofun2938, 0, 2, _35p1160, _35p1161);
+Obj obj = _35p1160;
+Obj _35reg2695 = primEQ(Nil, _35p1161);
+if (True == _35reg2695) {
 __nargs = 2;
 __arg1 = obj;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2864) { goto fail; }
+if (co->ctx.pc.func != _35clofun2938) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1167;
+__arg0 = _35cc1162;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label17:
 {
-Obj _35val2696 = __arg1;
+Obj _35val2698 = __arg1;
 Obj obj= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fns = _35val2696;
+Obj fns = _35val2698;
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.rewrite-->macro"));
 __arg1 = obj;
@@ -2313,50 +2966,50 @@ __arg2 = fns;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2695 = __arg1;
+Obj _35val2697 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj obj = _35val2695;
-pushCont(co, 17, _35clofun2864, 1, obj);
+Obj obj = _35val2697;
+pushCont(co, 17, _35clofun2938, 1, obj);
 __nargs = 2;
 __arg0 = globalRef(intern("cddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
 Obj exp = __arg1;
-pushCont(co, 18, _35clofun2864, 1, exp);
+pushCont(co, 18, _35clofun2938, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val2701 = __arg1;
+Obj _35val2703 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.collect-lambda-pass"));
-__arg1 = _35val2701;
+__arg1 = _35val2703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2864) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2938) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2369,7 +3022,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2863(struct Cora* co){
+void _35clofun2937(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -2382,7 +3035,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2583 = __arg1;
+Obj _35val2585 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -2391,16 +3044,16 @@ __arg2 = makeString1("];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2582 = __arg1;
+Obj _35val2584 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2863, 1, w);
+pushCont(co, 0, _35clofun2937, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
@@ -2408,16 +3061,16 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val2581 = __arg1;
+Obj _35val2583 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun2863, 2, i, w);
+pushCont(co, 1, _35clofun2937, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -2425,17 +3078,17 @@ __arg2 = makeString1("= co->ctx.stk.stack[co->ctx.stk.base + ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2580 = __arg1;
+Obj _35val2582 = __arg1;
 Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 2, _35clofun2863, 2, i, w);
+pushCont(co, 2, _35clofun2937, 2, i, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
 __arg1 = intern("ignore");
@@ -2445,7 +3098,7 @@ co->args[4] = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2454,7 +3107,7 @@ label4:
 Obj w = __arg1;
 Obj i = __arg2;
 Obj var = __arg3;
-pushCont(co, 3, _35clofun2863, 3, var, i, w);
+pushCont(co, 3, _35clofun2937, 3, var, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -2462,7 +3115,7 @@ __arg2 = makeString1("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2474,44 +3127,44 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val2588 = __arg1;
+Obj _35val2590 = __arg1;
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2589 = primAdd(idx, makeNumber(1));
+Obj _35reg2591 = primAdd(idx, makeNumber(1));
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-call-args-reverse"));
 __arg1 = fn;
 __arg2 = w;
-__arg3 = _35reg2589;
+__arg3 = _35reg2591;
 co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35cc1160 = makeNative(5, _35clofun2863, 0, 0);
+Obj _35cc1155 = makeNative(5, _35clofun2937, 0, 0);
 Obj fn = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj idx = closureRef(co, 2);
-Obj _35reg2585 = primIsCons(closureRef(co, 3));
-if (True == _35reg2585) {
-Obj _35reg2586 = primCar(closureRef(co, 3));
-Obj a = _35reg2586;
-Obj _35reg2587 = primCdr(closureRef(co, 3));
-Obj b = _35reg2587;
-pushCont(co, 6, _35clofun2863, 4, idx, fn, w, b);
+Obj _35reg2587 = primIsCons(closureRef(co, 3));
+if (True == _35reg2587) {
+Obj _35reg2588 = primCar(closureRef(co, 3));
+Obj a = _35reg2588;
+Obj _35reg2589 = primCdr(closureRef(co, 3));
+Obj b = _35reg2589;
+pushCont(co, 6, _35clofun2937, 4, idx, fn, w, b);
 __nargs = 4;
 __arg0 = fn;
 __arg1 = w;
@@ -2520,43 +3173,43 @@ __arg3 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1160;
+__arg0 = _35cc1155;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35p1155 = __arg1;
-Obj _35p1156 = __arg2;
-Obj _35p1157 = __arg3;
-Obj _35p1158 = co->args[4];
-Obj _35cc1159 = makeNative(7, _35clofun2863, 0, 4, _35p1155, _35p1156, _35p1157, _35p1158);
-Obj fn = _35p1155;
-Obj w = _35p1156;
-Obj idx = _35p1157;
-Obj _35reg2590 = primEQ(Nil, _35p1158);
-if (True == _35reg2590) {
+Obj _35p1150 = __arg1;
+Obj _35p1151 = __arg2;
+Obj _35p1152 = __arg3;
+Obj _35p1153 = co->args[4];
+Obj _35cc1154 = makeNative(7, _35clofun2937, 0, 4, _35p1150, _35p1151, _35p1152, _35p1153);
+Obj fn = _35p1150;
+Obj w = _35p1151;
+Obj idx = _35p1152;
+Obj _35reg2592 = primEQ(Nil, _35p1153);
+if (True == _35reg2592) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2863) { goto fail; }
+if (co->ctx.pc.func != _35clofun2937) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1159;
+__arg0 = _35cc1154;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2569,57 +3222,57 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val2593 = __arg1;
+Obj _35val2595 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io.display"));
 __arg1 = makeString1("\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val2592 = __arg1;
+Obj _35val2594 = __arg1;
 Obj other= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 10, _35clofun2863, 0);
+pushCont(co, 10, _35clofun2937, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io.display"));
 __arg1 = other;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35cc1164 = makeNative(9, _35clofun2863, 0, 0);
+Obj _35cc1159 = makeNative(9, _35clofun2937, 0, 0);
 Obj w = closureRef(co, 0);
 Obj other = closureRef(co, 1);
-pushCont(co, 11, _35clofun2863, 1, other);
+pushCont(co, 11, _35clofun2937, 1, other);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io.display"));
 __arg1 = makeString1("wrong format of toplevel\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val2652 = __arg1;
+Obj _35val2654 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -2628,41 +3281,41 @@ __arg2 = makeString1("}\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2650 = __arg1;
+Obj _35val2652 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2651 = primCar(label);
-pushCont(co, 13, _35clofun2863, 1, w);
+Obj _35reg2653 = primCar(label);
+pushCont(co, 13, _35clofun2937, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
-__arg1 = _35reg2651;
+__arg1 = _35reg2653;
 __arg2 = params;
 __arg3 = w;
 co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val2649 = __arg1;
+Obj _35val2651 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 14, _35clofun2863, 4, label, params, body, w);
+pushCont(co, 14, _35clofun2937, 4, label, params, body, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-call-args-reverse"));
 __arg1 = globalRef(intern("cora/lib/toc.local-from-cont"));
@@ -2672,19 +3325,19 @@ co->args[4] = actives;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val2648 = __arg1;
+Obj _35val2650 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 15, _35clofun2863, 5, actives, label, params, body, w);
+pushCont(co, 15, _35clofun2937, 5, actives, label, params, body, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-call-args-reverse"));
 __arg1 = globalRef(intern("cora/lib/toc.local-from-params"));
@@ -2694,19 +3347,19 @@ co->args[4] = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val2647 = __arg1;
+Obj _35val2649 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 16, _35clofun2863, 5, actives, label, params, body, w);
+pushCont(co, 16, _35clofun2937, 5, actives, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -2714,102 +3367,102 @@ __arg2 = makeString1(":\n{\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2645 = __arg1;
+Obj _35val2647 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2646 = primCdr(label);
-pushCont(co, 17, _35clofun2863, 5, actives, label, params, body, w);
+Obj _35reg2648 = primCdr(label);
+pushCont(co, 17, _35clofun2937, 5, actives, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
-__arg2 = _35reg2646;
+__arg2 = _35reg2648;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35p1161 = __arg1;
-Obj _35p1162 = __arg2;
-Obj _35cc1163 = makeNative(12, _35clofun2863, 0, 2, _35p1161, _35p1162);
-Obj w = _35p1161;
-Obj _35reg2594 = primIsCons(_35p1162);
-if (True == _35reg2594) {
-Obj _35reg2595 = primCar(_35p1162);
-Obj label = _35reg2595;
-Obj _35reg2596 = primCdr(_35p1162);
-Obj _35reg2597 = primIsCons(_35reg2596);
-if (True == _35reg2597) {
-Obj _35reg2598 = primCdr(_35p1162);
-Obj _35reg2599 = primCar(_35reg2598);
-Obj _35reg2600 = primIsCons(_35reg2599);
-if (True == _35reg2600) {
-Obj _35reg2601 = primCdr(_35p1162);
-Obj _35reg2602 = primCar(_35reg2601);
-Obj _35reg2603 = primCar(_35reg2602);
-Obj _35reg2604 = primEQ(intern("lambda"), _35reg2603);
-if (True == _35reg2604) {
-Obj _35reg2605 = primCdr(_35p1162);
-Obj _35reg2606 = primCar(_35reg2605);
-Obj _35reg2607 = primCdr(_35reg2606);
-Obj _35reg2608 = primIsCons(_35reg2607);
-if (True == _35reg2608) {
-Obj _35reg2609 = primCdr(_35p1162);
-Obj _35reg2610 = primCar(_35reg2609);
-Obj _35reg2611 = primCdr(_35reg2610);
+Obj _35p1156 = __arg1;
+Obj _35p1157 = __arg2;
+Obj _35cc1158 = makeNative(12, _35clofun2937, 0, 2, _35p1156, _35p1157);
+Obj w = _35p1156;
+Obj _35reg2596 = primIsCons(_35p1157);
+if (True == _35reg2596) {
+Obj _35reg2597 = primCar(_35p1157);
+Obj label = _35reg2597;
+Obj _35reg2598 = primCdr(_35p1157);
+Obj _35reg2599 = primIsCons(_35reg2598);
+if (True == _35reg2599) {
+Obj _35reg2600 = primCdr(_35p1157);
+Obj _35reg2601 = primCar(_35reg2600);
+Obj _35reg2602 = primIsCons(_35reg2601);
+if (True == _35reg2602) {
+Obj _35reg2603 = primCdr(_35p1157);
+Obj _35reg2604 = primCar(_35reg2603);
+Obj _35reg2605 = primCar(_35reg2604);
+Obj _35reg2606 = primEQ(intern("lambda"), _35reg2605);
+if (True == _35reg2606) {
+Obj _35reg2607 = primCdr(_35p1157);
+Obj _35reg2608 = primCar(_35reg2607);
+Obj _35reg2609 = primCdr(_35reg2608);
+Obj _35reg2610 = primIsCons(_35reg2609);
+if (True == _35reg2610) {
+Obj _35reg2611 = primCdr(_35p1157);
 Obj _35reg2612 = primCar(_35reg2611);
-Obj params = _35reg2612;
-Obj _35reg2613 = primCdr(_35p1162);
+Obj _35reg2613 = primCdr(_35reg2612);
 Obj _35reg2614 = primCar(_35reg2613);
-Obj _35reg2615 = primCdr(_35reg2614);
-Obj _35reg2616 = primCdr(_35reg2615);
-Obj _35reg2617 = primIsCons(_35reg2616);
-if (True == _35reg2617) {
-Obj _35reg2618 = primCdr(_35p1162);
-Obj _35reg2619 = primCar(_35reg2618);
-Obj _35reg2620 = primCdr(_35reg2619);
-Obj _35reg2621 = primCdr(_35reg2620);
-Obj _35reg2622 = primCar(_35reg2621);
-Obj actives = _35reg2622;
-Obj _35reg2623 = primCdr(_35p1162);
+Obj params = _35reg2614;
+Obj _35reg2615 = primCdr(_35p1157);
+Obj _35reg2616 = primCar(_35reg2615);
+Obj _35reg2617 = primCdr(_35reg2616);
+Obj _35reg2618 = primCdr(_35reg2617);
+Obj _35reg2619 = primIsCons(_35reg2618);
+if (True == _35reg2619) {
+Obj _35reg2620 = primCdr(_35p1157);
+Obj _35reg2621 = primCar(_35reg2620);
+Obj _35reg2622 = primCdr(_35reg2621);
+Obj _35reg2623 = primCdr(_35reg2622);
 Obj _35reg2624 = primCar(_35reg2623);
-Obj _35reg2625 = primCdr(_35reg2624);
-Obj _35reg2626 = primCdr(_35reg2625);
+Obj actives = _35reg2624;
+Obj _35reg2625 = primCdr(_35p1157);
+Obj _35reg2626 = primCar(_35reg2625);
 Obj _35reg2627 = primCdr(_35reg2626);
-Obj _35reg2628 = primIsCons(_35reg2627);
-if (True == _35reg2628) {
-Obj _35reg2629 = primCdr(_35p1162);
-Obj _35reg2630 = primCar(_35reg2629);
-Obj _35reg2631 = primCdr(_35reg2630);
-Obj _35reg2632 = primCdr(_35reg2631);
+Obj _35reg2628 = primCdr(_35reg2627);
+Obj _35reg2629 = primCdr(_35reg2628);
+Obj _35reg2630 = primIsCons(_35reg2629);
+if (True == _35reg2630) {
+Obj _35reg2631 = primCdr(_35p1157);
+Obj _35reg2632 = primCar(_35reg2631);
 Obj _35reg2633 = primCdr(_35reg2632);
-Obj _35reg2634 = primCar(_35reg2633);
-Obj body = _35reg2634;
-Obj _35reg2635 = primCdr(_35p1162);
+Obj _35reg2634 = primCdr(_35reg2633);
+Obj _35reg2635 = primCdr(_35reg2634);
 Obj _35reg2636 = primCar(_35reg2635);
-Obj _35reg2637 = primCdr(_35reg2636);
-Obj _35reg2638 = primCdr(_35reg2637);
+Obj body = _35reg2636;
+Obj _35reg2637 = primCdr(_35p1157);
+Obj _35reg2638 = primCar(_35reg2637);
 Obj _35reg2639 = primCdr(_35reg2638);
 Obj _35reg2640 = primCdr(_35reg2639);
-Obj _35reg2641 = primEQ(Nil, _35reg2640);
-if (True == _35reg2641) {
-Obj _35reg2642 = primCdr(_35p1162);
-Obj _35reg2643 = primCdr(_35reg2642);
-Obj _35reg2644 = primEQ(Nil, _35reg2643);
-if (True == _35reg2644) {
-pushCont(co, 18, _35clofun2863, 5, actives, label, params, body, w);
+Obj _35reg2641 = primCdr(_35reg2640);
+Obj _35reg2642 = primCdr(_35reg2641);
+Obj _35reg2643 = primEQ(Nil, _35reg2642);
+if (True == _35reg2643) {
+Obj _35reg2644 = primCdr(_35p1157);
+Obj _35reg2645 = primCdr(_35reg2644);
+Obj _35reg2646 = primEQ(Nil, _35reg2645);
+if (True == _35reg2646) {
+pushCont(co, 18, _35clofun2937, 5, actives, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -2817,87 +3470,87 @@ __arg2 = makeString1("label");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1163;
+__arg0 = _35cc1158;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1163;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1163;
+__arg0 = _35cc1158;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1163;
+__arg0 = _35cc1158;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1163;
+__arg0 = _35cc1158;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1163;
+__arg0 = _35cc1158;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1163;
+__arg0 = _35cc1158;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1163;
+__arg0 = _35cc1158;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1163;
+__arg0 = _35cc1158;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1158;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2912,7 +3565,7 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2863) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2937) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2925,7 +3578,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2862(struct Cora* co){
+void _35clofun2936(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -2938,12 +3591,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2545 = __arg1;
+Obj _35val2547 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 20, _35clofun2861, 4, label, self, stacks, w);
+pushCont(co, 20, _35clofun2935, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -2951,53 +3604,53 @@ __arg2 = makeString1(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2543 = __arg1;
+Obj _35val2545 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2544 = primCdr(label);
-pushCont(co, 0, _35clofun2862, 4, label, self, stacks, w);
+Obj _35reg2546 = primCdr(label);
+pushCont(co, 0, _35clofun2936, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
-__arg2 = _35reg2544;
+__arg2 = _35reg2546;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35p1144 = __arg1;
-Obj _35p1145 = __arg2;
-Obj _35p1146 = __arg3;
-Obj _35cc1147 = makeNative(11, _35clofun2861, 0, 0);
-Obj self = _35p1144;
-Obj w = _35p1145;
-Obj _35reg2534 = primIsCons(_35p1146);
-if (True == _35reg2534) {
-Obj _35reg2535 = primCar(_35p1146);
-Obj _35reg2536 = primEQ(intern("%continuation"), _35reg2535);
+Obj _35p1139 = __arg1;
+Obj _35p1140 = __arg2;
+Obj _35p1141 = __arg3;
+Obj _35cc1142 = makeNative(11, _35clofun2935, 0, 0);
+Obj self = _35p1139;
+Obj w = _35p1140;
+Obj _35reg2536 = primIsCons(_35p1141);
 if (True == _35reg2536) {
-Obj _35reg2537 = primCdr(_35p1146);
-Obj _35reg2538 = primIsCons(_35reg2537);
+Obj _35reg2537 = primCar(_35p1141);
+Obj _35reg2538 = primEQ(intern("%continuation"), _35reg2537);
 if (True == _35reg2538) {
-Obj _35reg2539 = primCdr(_35p1146);
-Obj _35reg2540 = primCar(_35reg2539);
-Obj label = _35reg2540;
-Obj _35reg2541 = primCdr(_35p1146);
-Obj _35reg2542 = primCdr(_35reg2541);
-Obj stacks = _35reg2542;
-pushCont(co, 1, _35clofun2862, 4, label, self, stacks, w);
+Obj _35reg2539 = primCdr(_35p1141);
+Obj _35reg2540 = primIsCons(_35reg2539);
+if (True == _35reg2540) {
+Obj _35reg2541 = primCdr(_35p1141);
+Obj _35reg2542 = primCar(_35reg2541);
+Obj label = _35reg2542;
+Obj _35reg2543 = primCdr(_35p1141);
+Obj _35reg2544 = primCdr(_35reg2543);
+Obj stacks = _35reg2544;
+pushCont(co, 1, _35clofun2936, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -3005,33 +3658,33 @@ __arg2 = makeString1("pushCont(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1147;
+__arg0 = _35cc1142;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1147;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1147;
+__arg0 = _35cc1142;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1142;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3044,13 +3697,13 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val2563 = __arg1;
+Obj _35val2565 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -3066,21 +3719,21 @@ co->args[5] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val2561 = __arg1;
+Obj _35val2563 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2562 = primNot(_35val2561);
-if (True == _35reg2562) {
-pushCont(co, 4, _35clofun2862, 5, self, env, fn, w, b);
+Obj _35reg2564 = primNot(_35val2563);
+if (True == _35reg2564) {
+pushCont(co, 4, _35clofun2936, 5, self, env, fn, w, b);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -3088,7 +3741,7 @@ __arg2 = makeString1(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
@@ -3102,44 +3755,44 @@ co->args[5] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label6:
 {
-Obj _35val2560 = __arg1;
+Obj _35val2562 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 5, _35clofun2862, 5, self, env, fn, w, b);
+pushCont(co, 5, _35clofun2936, 5, self, env, fn, w, b);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
 __arg1 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35cc1154 = makeNative(3, _35clofun2862, 0, 0);
+Obj _35cc1149 = makeNative(3, _35clofun2936, 0, 0);
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj fn = closureRef(co, 2);
 Obj w = closureRef(co, 3);
-Obj _35reg2557 = primIsCons(closureRef(co, 4));
-if (True == _35reg2557) {
-Obj _35reg2558 = primCar(closureRef(co, 4));
-Obj a = _35reg2558;
-Obj _35reg2559 = primCdr(closureRef(co, 4));
-Obj b = _35reg2559;
-pushCont(co, 6, _35clofun2862, 5, self, env, fn, w, b);
+Obj _35reg2559 = primIsCons(closureRef(co, 4));
+if (True == _35reg2559) {
+Obj _35reg2560 = primCar(closureRef(co, 4));
+Obj a = _35reg2560;
+Obj _35reg2561 = primCdr(closureRef(co, 4));
+Obj b = _35reg2561;
+pushCont(co, 6, _35clofun2936, 5, self, env, fn, w, b);
 __nargs = 5;
 __arg0 = fn;
 __arg1 = self;
@@ -3149,45 +3802,45 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1154;
+__arg0 = _35cc1149;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35p1148 = __arg1;
-Obj _35p1149 = __arg2;
-Obj _35p1150 = __arg3;
-Obj _35p1151 = co->args[4];
-Obj _35p1152 = co->args[5];
-Obj _35cc1153 = makeNative(7, _35clofun2862, 0, 5, _35p1148, _35p1149, _35p1150, _35p1151, _35p1152);
-Obj self = _35p1148;
-Obj env = _35p1149;
-Obj fn = _35p1150;
-Obj w = _35p1151;
-Obj _35reg2564 = primEQ(Nil, _35p1152);
-if (True == _35reg2564) {
+Obj _35p1143 = __arg1;
+Obj _35p1144 = __arg2;
+Obj _35p1145 = __arg3;
+Obj _35p1146 = co->args[4];
+Obj _35p1147 = co->args[5];
+Obj _35cc1148 = makeNative(7, _35clofun2936, 0, 5, _35p1143, _35p1144, _35p1145, _35p1146, _35p1147);
+Obj self = _35p1143;
+Obj env = _35p1144;
+Obj fn = _35p1145;
+Obj w = _35p1146;
+Obj _35reg2566 = primEQ(Nil, _35p1147);
+if (True == _35reg2566) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2862) { goto fail; }
+if (co->ctx.pc.func != _35clofun2936) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1153;
+__arg0 = _35cc1148;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3208,13 +3861,13 @@ co->args[5] = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val2570 = __arg1;
+Obj _35val2572 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3223,15 +3876,15 @@ __arg2 = makeString1(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val2569 = __arg1;
+Obj _35val2571 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 10, _35clofun2862, 1, w);
+pushCont(co, 10, _35clofun2936, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -3239,25 +3892,25 @@ __arg2 = makeString1("(struct Cora* co");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val2567 = __arg1;
+Obj _35val2569 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2568 = primCar(label);
-pushCont(co, 11, _35clofun2862, 1, w);
+Obj _35reg2570 = primCar(label);
+pushCont(co, 11, _35clofun2936, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 __arg1 = w;
-__arg2 = _35reg2568;
+__arg2 = _35reg2570;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3265,7 +3918,7 @@ label13:
 {
 Obj w = __arg1;
 Obj label = __arg2;
-pushCont(co, 12, _35clofun2862, 2, label, w);
+pushCont(co, 12, _35clofun2936, 2, label, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -3273,13 +3926,13 @@ __arg2 = makeString1("void ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2576 = __arg1;
+Obj _35val2578 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3288,16 +3941,16 @@ __arg2 = makeString1(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val2575 = __arg1;
+Obj _35val2577 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 14, _35clofun2862, 1, w);
+pushCont(co, 14, _35clofun2936, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
@@ -3305,13 +3958,13 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val2578 = __arg1;
+Obj _35val2580 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3320,16 +3973,16 @@ __arg2 = makeString1("];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val2577 = __arg1;
+Obj _35val2579 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 16, _35clofun2862, 1, w);
+pushCont(co, 16, _35clofun2936, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
@@ -3337,18 +3990,18 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2573 = __arg1;
+Obj _35val2575 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2574 = primLT(i, makeNumber(4));
-if (True == _35reg2574) {
-pushCont(co, 15, _35clofun2862, 2, i, w);
+Obj _35reg2576 = primLT(i, makeNumber(4));
+if (True == _35reg2576) {
+pushCont(co, 15, _35clofun2936, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -3356,10 +4009,10 @@ __arg2 = makeString1(" = __arg");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 17, _35clofun2862, 2, i, w);
+pushCont(co, 17, _35clofun2936, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -3367,18 +4020,18 @@ __arg2 = makeString1(" = co->args[");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label19:
 {
-Obj _35val2572 = __arg1;
+Obj _35val2574 = __arg1;
 Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 18, _35clofun2862, 2, i, w);
+pushCont(co, 18, _35clofun2936, 2, i, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
 __arg1 = intern("ignore");
@@ -3388,7 +4041,7 @@ co->args[4] = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3397,7 +4050,7 @@ label20:
 Obj w = __arg1;
 Obj i = __arg2;
 Obj var = __arg3;
-pushCont(co, 19, _35clofun2862, 3, var, i, w);
+pushCont(co, 19, _35clofun2936, 3, var, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -3405,7 +4058,7 @@ __arg2 = makeString1("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2862) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2936) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3418,7 +4071,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2861(struct Cora* co){
+void _35clofun2935(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -3431,7 +4084,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2506 = __arg1;
+Obj _35val2508 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3440,16 +4093,16 @@ __arg2 = makeString1(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2505 = __arg1;
+Obj _35val2507 = __arg1;
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2861, 1, w);
+pushCont(co, 0, _35clofun2935, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
@@ -3457,32 +4110,32 @@ __arg2 = idx;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35cc1133 = makeNative(20, _35clofun2860, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1128 = makeNative(20, _35clofun2934, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2495 = primIsCons(closureRef(co, 3));
-if (True == _35reg2495) {
-Obj _35reg2496 = primCar(closureRef(co, 3));
-Obj _35reg2497 = primEQ(intern("%stack-ref"), _35reg2496);
+Obj _35reg2497 = primIsCons(closureRef(co, 3));
 if (True == _35reg2497) {
-Obj _35reg2498 = primCdr(closureRef(co, 3));
-Obj _35reg2499 = primIsCons(_35reg2498);
+Obj _35reg2498 = primCar(closureRef(co, 3));
+Obj _35reg2499 = primEQ(intern("%stack-ref"), _35reg2498);
 if (True == _35reg2499) {
 Obj _35reg2500 = primCdr(closureRef(co, 3));
-Obj _35reg2501 = primCar(_35reg2500);
-Obj idx = _35reg2501;
+Obj _35reg2501 = primIsCons(_35reg2500);
+if (True == _35reg2501) {
 Obj _35reg2502 = primCdr(closureRef(co, 3));
-Obj _35reg2503 = primCdr(_35reg2502);
-Obj _35reg2504 = primEQ(Nil, _35reg2503);
-if (True == _35reg2504) {
-pushCont(co, 1, _35clofun2861, 2, idx, w);
+Obj _35reg2503 = primCar(_35reg2502);
+Obj idx = _35reg2503;
+Obj _35reg2504 = primCdr(closureRef(co, 3));
+Obj _35reg2505 = primCdr(_35reg2504);
+Obj _35reg2506 = primEQ(Nil, _35reg2505);
+if (True == _35reg2506) {
+pushCont(co, 1, _35clofun2935, 2, idx, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -3490,49 +4143,49 @@ __arg2 = makeString1("stackRef(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1133;
+__arg0 = _35cc1128;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1133;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1133;
+__arg0 = _35cc1128;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1133;
+__arg0 = _35cc1128;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1128;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35val2518 = __arg1;
+Obj _35val2520 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3541,16 +4194,16 @@ __arg2 = makeString1(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val2517 = __arg1;
+Obj _35val2519 = __arg1;
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 3, _35clofun2861, 1, w);
+pushCont(co, 3, _35clofun2935, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
@@ -3558,32 +4211,32 @@ __arg2 = idx;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35cc1132 = makeNative(2, _35clofun2861, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1127 = makeNative(2, _35clofun2935, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2507 = primIsCons(closureRef(co, 3));
-if (True == _35reg2507) {
-Obj _35reg2508 = primCar(closureRef(co, 3));
-Obj _35reg2509 = primEQ(intern("%closure-ref"), _35reg2508);
+Obj _35reg2509 = primIsCons(closureRef(co, 3));
 if (True == _35reg2509) {
-Obj _35reg2510 = primCdr(closureRef(co, 3));
-Obj _35reg2511 = primIsCons(_35reg2510);
+Obj _35reg2510 = primCar(closureRef(co, 3));
+Obj _35reg2511 = primEQ(intern("%closure-ref"), _35reg2510);
 if (True == _35reg2511) {
 Obj _35reg2512 = primCdr(closureRef(co, 3));
-Obj _35reg2513 = primCar(_35reg2512);
-Obj idx = _35reg2513;
+Obj _35reg2513 = primIsCons(_35reg2512);
+if (True == _35reg2513) {
 Obj _35reg2514 = primCdr(closureRef(co, 3));
-Obj _35reg2515 = primCdr(_35reg2514);
-Obj _35reg2516 = primEQ(Nil, _35reg2515);
-if (True == _35reg2516) {
-pushCont(co, 4, _35clofun2861, 2, idx, w);
+Obj _35reg2515 = primCar(_35reg2514);
+Obj idx = _35reg2515;
+Obj _35reg2516 = primCdr(closureRef(co, 3));
+Obj _35reg2517 = primCdr(_35reg2516);
+Obj _35reg2518 = primEQ(Nil, _35reg2517);
+if (True == _35reg2518) {
+pushCont(co, 4, _35clofun2935, 2, idx, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -3591,49 +4244,49 @@ __arg2 = makeString1("closureRef(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1132;
+__arg0 = _35cc1127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1132;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1132;
+__arg0 = _35cc1127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1132;
+__arg0 = _35cc1127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label6:
 {
-Obj _35val2531 = __arg1;
+Obj _35val2533 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3642,64 +4295,64 @@ __arg2 = makeString1("\"))");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val2530 = __arg1;
+Obj _35val2532 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 6, _35clofun2861, 1, w);
+pushCont(co, 6, _35clofun2935, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
-__arg2 = _35val2530;
+__arg2 = _35val2532;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val2529 = __arg1;
+Obj _35val2531 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun2861, 1, w);
+pushCont(co, 7, _35clofun2935, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("symbol->string"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35cc1131 = makeNative(5, _35clofun2861, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1126 = makeNative(5, _35clofun2935, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2519 = primIsCons(closureRef(co, 3));
-if (True == _35reg2519) {
-Obj _35reg2520 = primCar(closureRef(co, 3));
-Obj _35reg2521 = primEQ(intern("%global"), _35reg2520);
+Obj _35reg2521 = primIsCons(closureRef(co, 3));
 if (True == _35reg2521) {
-Obj _35reg2522 = primCdr(closureRef(co, 3));
-Obj _35reg2523 = primIsCons(_35reg2522);
+Obj _35reg2522 = primCar(closureRef(co, 3));
+Obj _35reg2523 = primEQ(intern("%global"), _35reg2522);
 if (True == _35reg2523) {
 Obj _35reg2524 = primCdr(closureRef(co, 3));
-Obj _35reg2525 = primCar(_35reg2524);
-Obj x = _35reg2525;
+Obj _35reg2525 = primIsCons(_35reg2524);
+if (True == _35reg2525) {
 Obj _35reg2526 = primCdr(closureRef(co, 3));
-Obj _35reg2527 = primCdr(_35reg2526);
-Obj _35reg2528 = primEQ(Nil, _35reg2527);
-if (True == _35reg2528) {
-pushCont(co, 8, _35clofun2861, 2, x, w);
+Obj _35reg2527 = primCar(_35reg2526);
+Obj x = _35reg2527;
+Obj _35reg2528 = primCdr(closureRef(co, 3));
+Obj _35reg2529 = primCdr(_35reg2528);
+Obj _35reg2530 = primEQ(Nil, _35reg2529);
+if (True == _35reg2530) {
+pushCont(co, 8, _35clofun2935, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -3707,59 +4360,59 @@ __arg2 = makeString1("globalRef(intern(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1131;
+__arg0 = _35cc1126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1131;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1131;
+__arg0 = _35cc1126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1131;
+__arg0 = _35cc1126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1126;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35p1126 = __arg1;
-Obj _35p1127 = __arg2;
-Obj _35p1128 = __arg3;
-Obj _35p1129 = co->args[4];
-Obj _35cc1130 = makeNative(9, _35clofun2861, 0, 4, _35p1126, _35p1127, _35p1128, _35p1129);
-Obj self = _35p1126;
-Obj env = _35p1127;
-Obj w = _35p1128;
-Obj x = _35p1129;
-Obj _35reg2532 = primIsSymbol(x);
-if (True == _35reg2532) {
+Obj _35p1121 = __arg1;
+Obj _35p1122 = __arg2;
+Obj _35p1123 = __arg3;
+Obj _35p1124 = co->args[4];
+Obj _35cc1125 = makeNative(9, _35clofun2935, 0, 4, _35p1121, _35p1122, _35p1123, _35p1124);
+Obj self = _35p1121;
+Obj env = _35p1122;
+Obj w = _35p1123;
+Obj x = _35p1124;
+Obj _35reg2534 = primIsSymbol(x);
+if (True == _35reg2534) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 __arg1 = w;
@@ -3767,15 +4420,15 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1130;
+__arg0 = _35cc1125;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3788,13 +4441,13 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val2554 = __arg1;
+Obj _35val2556 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
@@ -3805,14 +4458,14 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
 Obj x = __arg1;
-pushCont(co, 12, _35clofun2861, 1, x);
+pushCont(co, 12, _35clofun2935, 1, x);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = closureRef(co, 1);
@@ -3820,13 +4473,13 @@ __arg2 = makeString1(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2555 = __arg1;
+Obj _35val2557 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -3835,27 +4488,27 @@ __arg2 = makeString1(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val2552 = __arg1;
+Obj _35val2554 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2553 = primNot(_35val2552);
-if (True == _35reg2553) {
-pushCont(co, 14, _35clofun2861, 1, w);
+Obj _35reg2555 = primNot(_35val2554);
+if (True == _35reg2555) {
+pushCont(co, 14, _35clofun2935, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("for-each"));
-__arg1 = makeNative(13, _35clofun2861, 1, 2, self, w);
+__arg1 = makeNative(13, _35clofun2935, 1, 2, self, w);
 __arg2 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
@@ -3866,70 +4519,70 @@ __arg2 = makeString1(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label16:
 {
-Obj _35val2551 = __arg1;
+Obj _35val2553 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 15, _35clofun2861, 3, self, stacks, w);
+pushCont(co, 15, _35clofun2935, 3, self, stacks, w);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
 __arg1 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val2550 = __arg1;
+Obj _35val2552 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 16, _35clofun2861, 3, self, stacks, w);
+pushCont(co, 16, _35clofun2935, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
-__arg2 = _35val2550;
+__arg2 = _35val2552;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2549 = __arg1;
+Obj _35val2551 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 17, _35clofun2861, 3, self, stacks, w);
+pushCont(co, 17, _35clofun2935, 3, self, stacks, w);
 __nargs = 2;
 __arg0 = globalRef(intern("length"));
 __arg1 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val2548 = __arg1;
+Obj _35val2550 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 18, _35clofun2861, 3, self, stacks, w);
+pushCont(co, 18, _35clofun2935, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -3937,27 +4590,27 @@ __arg2 = makeString1(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val2546 = __arg1;
+Obj _35val2548 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2547 = primCar(label);
-pushCont(co, 19, _35clofun2861, 3, self, stacks, w);
+Obj _35reg2549 = primCar(label);
+pushCont(co, 19, _35clofun2935, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 __arg1 = w;
-__arg2 = _35reg2547;
+__arg2 = _35reg2549;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2861) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2935) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3970,7 +4623,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2860(struct Cora* co){
+void _35clofun2934(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -3983,35 +4636,35 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2464 = __arg1;
+Obj _35val2466 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2465 = primCons(a, env);
+Obj _35reg2467 = primCons(a, env);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
 __arg1 = self;
-__arg2 = _35reg2465;
+__arg2 = _35reg2467;
 __arg3 = w;
 co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2463 = __arg1;
+Obj _35val2465 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun2860, 5, a, env, self, w, c);
+pushCont(co, 0, _35clofun2934, 5, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4019,11 +4672,55 @@ __arg2 = makeString1(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
+{
+Obj _35val2464 = __arg1;
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 1, _35clofun2934, 5, a, env, self, w, c);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2463 = __arg1;
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 2, _35clofun2934, 6, b, a, env, self, w, c);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
+__arg1 = w;
+__arg2 = makeString1(" = ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
 {
 Obj _35val2462 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
@@ -4032,7 +4729,70 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 1, _35clofun2860, 5, a, env, self, w, c);
+pushCont(co, 3, _35clofun2934, 6, b, a, env, self, w, c);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal.generate-sym"));
+__arg1 = w;
+__arg2 = a;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val2471 = __arg1;
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj _35reg2472 = primCons(a, env);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
+__arg1 = self;
+__arg2 = _35reg2472;
+__arg3 = w;
+co->args[4] = c;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label6:
+{
+Obj _35val2470 = __arg1;
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 5, _35clofun2934, 5, a, env, self, w, c);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
+__arg1 = w;
+__arg2 = makeString1(";\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label7:
+{
+Obj _35val2469 = __arg1;
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 6, _35clofun2934, 5, a, env, self, w, c);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
 __arg1 = self;
@@ -4042,20 +4802,20 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label8:
 {
-Obj _35val2461 = __arg1;
+Obj _35val2468 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 2, _35clofun2860, 6, b, a, env, self, w, c);
+pushCont(co, 7, _35clofun2934, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4063,11 +4823,11 @@ __arg2 = makeString1(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label4:
+label9:
 {
 Obj _35val2460 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
@@ -4076,117 +4836,10 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 3, _35clofun2860, 6, b, a, env, self, w, c);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal.generate-sym"));
-__arg1 = w;
-__arg2 = a;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35val2469 = __arg1;
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2470 = primCons(a, env);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
-__arg1 = self;
-__arg2 = _35reg2470;
-__arg3 = w;
-co->args[4] = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val2468 = __arg1;
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 5, _35clofun2860, 5, a, env, self, w, c);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
-__arg1 = w;
-__arg2 = makeString1(";\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val2467 = __arg1;
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 6, _35clofun2860, 5, a, env, self, w, c);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35val2466 = __arg1;
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 7, _35clofun2860, 6, b, a, env, self, w, c);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
-__arg1 = w;
-__arg2 = makeString1(" = ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val2458 = __arg1;
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj idx = _35val2458;
-Obj _35reg2459 = primLT(idx, makeNumber(0));
-if (True == _35reg2459) {
-pushCont(co, 4, _35clofun2860, 6, b, a, env, self, w, c);
+Obj idx = _35val2460;
+Obj _35reg2461 = primLT(idx, makeNumber(0));
+if (True == _35reg2461) {
+pushCont(co, 4, _35clofun2934, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4194,11 +4847,11 @@ __arg2 = makeString1("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
-pushCont(co, 8, _35clofun2860, 6, b, a, env, self, w, c);
+pushCont(co, 8, _35clofun2934, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 __arg1 = w;
@@ -4206,53 +4859,53 @@ __arg2 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35cc1135 = makeNative(20, _35clofun2859, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1130 = makeNative(20, _35clofun2933, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2432 = primIsCons(closureRef(co, 3));
-if (True == _35reg2432) {
-Obj _35reg2433 = primCar(closureRef(co, 3));
-Obj _35reg2434 = primEQ(intern("let"), _35reg2433);
+Obj _35reg2434 = primIsCons(closureRef(co, 3));
 if (True == _35reg2434) {
-Obj _35reg2435 = primCdr(closureRef(co, 3));
-Obj _35reg2436 = primIsCons(_35reg2435);
+Obj _35reg2435 = primCar(closureRef(co, 3));
+Obj _35reg2436 = primEQ(intern("let"), _35reg2435);
 if (True == _35reg2436) {
 Obj _35reg2437 = primCdr(closureRef(co, 3));
-Obj _35reg2438 = primCar(_35reg2437);
-Obj a = _35reg2438;
+Obj _35reg2438 = primIsCons(_35reg2437);
+if (True == _35reg2438) {
 Obj _35reg2439 = primCdr(closureRef(co, 3));
-Obj _35reg2440 = primCdr(_35reg2439);
-Obj _35reg2441 = primIsCons(_35reg2440);
-if (True == _35reg2441) {
-Obj _35reg2442 = primCdr(closureRef(co, 3));
-Obj _35reg2443 = primCdr(_35reg2442);
-Obj _35reg2444 = primCar(_35reg2443);
-Obj b = _35reg2444;
-Obj _35reg2445 = primCdr(closureRef(co, 3));
-Obj _35reg2446 = primCdr(_35reg2445);
-Obj _35reg2447 = primCdr(_35reg2446);
-Obj _35reg2448 = primIsCons(_35reg2447);
-if (True == _35reg2448) {
-Obj _35reg2449 = primCdr(closureRef(co, 3));
-Obj _35reg2450 = primCdr(_35reg2449);
-Obj _35reg2451 = primCdr(_35reg2450);
-Obj _35reg2452 = primCar(_35reg2451);
-Obj c = _35reg2452;
-Obj _35reg2453 = primCdr(closureRef(co, 3));
-Obj _35reg2454 = primCdr(_35reg2453);
-Obj _35reg2455 = primCdr(_35reg2454);
+Obj _35reg2440 = primCar(_35reg2439);
+Obj a = _35reg2440;
+Obj _35reg2441 = primCdr(closureRef(co, 3));
+Obj _35reg2442 = primCdr(_35reg2441);
+Obj _35reg2443 = primIsCons(_35reg2442);
+if (True == _35reg2443) {
+Obj _35reg2444 = primCdr(closureRef(co, 3));
+Obj _35reg2445 = primCdr(_35reg2444);
+Obj _35reg2446 = primCar(_35reg2445);
+Obj b = _35reg2446;
+Obj _35reg2447 = primCdr(closureRef(co, 3));
+Obj _35reg2448 = primCdr(_35reg2447);
+Obj _35reg2449 = primCdr(_35reg2448);
+Obj _35reg2450 = primIsCons(_35reg2449);
+if (True == _35reg2450) {
+Obj _35reg2451 = primCdr(closureRef(co, 3));
+Obj _35reg2452 = primCdr(_35reg2451);
+Obj _35reg2453 = primCdr(_35reg2452);
+Obj _35reg2454 = primCar(_35reg2453);
+Obj c = _35reg2454;
+Obj _35reg2455 = primCdr(closureRef(co, 3));
 Obj _35reg2456 = primCdr(_35reg2455);
-Obj _35reg2457 = primEQ(Nil, _35reg2456);
-if (True == _35reg2457) {
-pushCont(co, 9, _35clofun2860, 6, b, a, env, self, w, c);
+Obj _35reg2457 = primCdr(_35reg2456);
+Obj _35reg2458 = primCdr(_35reg2457);
+Obj _35reg2459 = primEQ(Nil, _35reg2458);
+if (True == _35reg2459) {
+pushCont(co, 9, _35clofun2934, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.index"));
 __arg1 = a;
@@ -4260,67 +4913,67 @@ __arg2 = env;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1135;
+__arg0 = _35cc1130;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1135;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1135;
+__arg0 = _35cc1130;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1135;
+__arg0 = _35cc1130;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1135;
+__arg0 = _35cc1130;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1135;
+__arg0 = _35cc1130;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1130;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35val2484 = __arg1;
+Obj _35val2486 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -4329,45 +4982,45 @@ __arg2 = makeString1("\")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val2483 = __arg1;
+Obj _35val2485 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 11, _35clofun2860, 1, w);
+pushCont(co, 11, _35clofun2934, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
-__arg2 = _35val2483;
+__arg2 = _35val2485;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val2482 = __arg1;
+Obj _35val2484 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun2860, 1, w);
+pushCont(co, 12, _35clofun2934, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("symbol->string"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2487 = __arg1;
+Obj _35val2489 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -4376,16 +5029,16 @@ __arg2 = makeString1(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val2486 = __arg1;
+Obj _35val2488 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 14, _35clofun2860, 1, w);
+pushCont(co, 14, _35clofun2934, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
@@ -4393,13 +5046,13 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val2491 = __arg1;
+Obj _35val2493 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -4408,49 +5061,49 @@ __arg2 = makeString1("\")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val2490 = __arg1;
+Obj _35val2492 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 16, _35clofun2860, 1, w);
+pushCont(co, 16, _35clofun2934, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
-__arg2 = _35val2490;
+__arg2 = _35val2492;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2489 = __arg1;
+Obj _35val2491 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 17, _35clofun2860, 1, w);
+pushCont(co, 17, _35clofun2934, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc/internal.escape-str"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val2485 = __arg1;
+Obj _35val2487 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2485) {
-pushCont(co, 15, _35clofun2860, 2, x, w);
+if (True == _35val2487) {
+pushCont(co, 15, _35clofun2934, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4458,12 +5111,12 @@ __arg2 = makeString1("makeNumber(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2488 = primIsString(x);
-if (True == _35reg2488) {
-pushCont(co, 18, _35clofun2860, 2, x, w);
+Obj _35reg2490 = primIsString(x);
+if (True == _35reg2490) {
+pushCont(co, 18, _35clofun2934, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4471,11 +5124,11 @@ __arg2 = makeString1("makeString1(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2492 = primEQ(x, Nil);
-if (True == _35reg2492) {
+Obj _35reg2494 = primEQ(x, Nil);
+if (True == _35reg2494) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4483,11 +5136,11 @@ __arg2 = makeString1("Nil");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2493 = primEQ(x, True);
-if (True == _35reg2493) {
+Obj _35reg2495 = primEQ(x, True);
+if (True == _35reg2495) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4495,11 +5148,11 @@ __arg2 = makeString1("True");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2494 = primEQ(x, False);
-if (True == _35reg2494) {
+Obj _35reg2496 = primEQ(x, False);
+if (True == _35reg2496) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4507,7 +5160,7 @@ __arg2 = makeString1("False");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -4516,7 +5169,7 @@ __arg1 = makeString1("no cond match");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4527,28 +5180,28 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj _35cc1134 = makeNative(10, _35clofun2860, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1129 = makeNative(10, _35clofun2934, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2471 = primIsCons(closureRef(co, 3));
-if (True == _35reg2471) {
-Obj _35reg2472 = primCar(closureRef(co, 3));
-Obj _35reg2473 = primEQ(intern("%const"), _35reg2472);
+Obj _35reg2473 = primIsCons(closureRef(co, 3));
 if (True == _35reg2473) {
-Obj _35reg2474 = primCdr(closureRef(co, 3));
-Obj _35reg2475 = primIsCons(_35reg2474);
+Obj _35reg2474 = primCar(closureRef(co, 3));
+Obj _35reg2475 = primEQ(intern("%const"), _35reg2474);
 if (True == _35reg2475) {
 Obj _35reg2476 = primCdr(closureRef(co, 3));
-Obj _35reg2477 = primCar(_35reg2476);
-Obj x = _35reg2477;
+Obj _35reg2477 = primIsCons(_35reg2476);
+if (True == _35reg2477) {
 Obj _35reg2478 = primCdr(closureRef(co, 3));
-Obj _35reg2479 = primCdr(_35reg2478);
-Obj _35reg2480 = primEQ(Nil, _35reg2479);
-if (True == _35reg2480) {
-Obj _35reg2481 = primIsSymbol(x);
-if (True == _35reg2481) {
-pushCont(co, 13, _35clofun2860, 2, x, w);
+Obj _35reg2479 = primCar(_35reg2478);
+Obj x = _35reg2479;
+Obj _35reg2480 = primCdr(closureRef(co, 3));
+Obj _35reg2481 = primCdr(_35reg2480);
+Obj _35reg2482 = primEQ(Nil, _35reg2481);
+if (True == _35reg2482) {
+Obj _35reg2483 = primIsSymbol(x);
+if (True == _35reg2483) {
+pushCont(co, 13, _35clofun2934, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4556,53 +5209,53 @@ __arg2 = makeString1("intern(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 19, _35clofun2860, 2, x, w);
+pushCont(co, 19, _35clofun2934, 2, x, w);
 __nargs = 2;
 __arg0 = globalRef(intern("number?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1134;
+__arg0 = _35cc1129;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1134;
+__arg0 = _35cc1129;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1134;
+__arg0 = _35cc1129;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1134;
+__arg0 = _35cc1129;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2860) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2934) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4616,7 +5269,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2859(struct Cora* co){
+void _35clofun2933(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -4629,49 +5282,49 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2373 = __arg1;
+Obj _35val2375 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 20, _35clofun2858, 4, self, env, frees, w);
+pushCont(co, 20, _35clofun2932, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
-__arg2 = _35val2373;
+__arg2 = _35val2375;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2372 = __arg1;
+Obj _35val2374 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun2859, 4, self, env, frees, w);
+pushCont(co, 0, _35clofun2933, 4, self, env, frees, w);
 __nargs = 2;
 __arg0 = globalRef(intern("length"));
 __arg1 = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val2371 = __arg1;
+Obj _35val2373 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 1, _35clofun2859, 4, self, env, frees, w);
+pushCont(co, 1, _35clofun2933, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4679,19 +5332,19 @@ __arg2 = makeString1(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2370 = __arg1;
+Obj _35val2372 = __arg1;
 Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 2, _35clofun2859, 4, self, env, frees, w);
+pushCont(co, 2, _35clofun2933, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
@@ -4699,19 +5352,19 @@ __arg2 = nargs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val2369 = __arg1;
+Obj _35val2371 = __arg1;
 Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 3, _35clofun2859, 5, nargs, self, env, frees, w);
+pushCont(co, 3, _35clofun2933, 5, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4719,33 +5372,54 @@ __arg2 = makeString1(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val2367 = __arg1;
+Obj _35val2369 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj _35reg2368 = primCar(label);
-pushCont(co, 4, _35clofun2859, 5, nargs, self, env, frees, w);
+Obj _35reg2370 = primCar(label);
+pushCont(co, 4, _35clofun2933, 5, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 __arg1 = w;
-__arg2 = _35reg2368;
+__arg2 = _35reg2370;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
+{
+Obj _35val2368 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 5, _35clofun2933, 6, label, nargs, self, env, frees, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
+__arg1 = w;
+__arg2 = makeString1(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label7:
 {
 Obj _35val2366 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
@@ -4754,70 +5428,49 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 5, _35clofun2859, 6, label, nargs, self, env, frees, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
-__arg1 = w;
-__arg2 = makeString1(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val2364 = __arg1;
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj _35reg2365 = primCdr(label);
-pushCont(co, 6, _35clofun2859, 6, label, nargs, self, env, frees, w);
+Obj _35reg2367 = primCdr(label);
+pushCont(co, 6, _35clofun2933, 6, label, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
-__arg2 = _35reg2365;
+__arg2 = _35reg2367;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35cc1138 = makeNative(16, _35clofun2858, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1133 = makeNative(16, _35clofun2932, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2348 = primIsCons(closureRef(co, 3));
-if (True == _35reg2348) {
-Obj _35reg2349 = primCar(closureRef(co, 3));
-Obj _35reg2350 = primEQ(intern("%closure"), _35reg2349);
+Obj _35reg2350 = primIsCons(closureRef(co, 3));
 if (True == _35reg2350) {
-Obj _35reg2351 = primCdr(closureRef(co, 3));
-Obj _35reg2352 = primIsCons(_35reg2351);
+Obj _35reg2351 = primCar(closureRef(co, 3));
+Obj _35reg2352 = primEQ(intern("%closure"), _35reg2351);
 if (True == _35reg2352) {
 Obj _35reg2353 = primCdr(closureRef(co, 3));
-Obj _35reg2354 = primCar(_35reg2353);
-Obj label = _35reg2354;
+Obj _35reg2354 = primIsCons(_35reg2353);
+if (True == _35reg2354) {
 Obj _35reg2355 = primCdr(closureRef(co, 3));
-Obj _35reg2356 = primCdr(_35reg2355);
-Obj _35reg2357 = primIsCons(_35reg2356);
-if (True == _35reg2357) {
-Obj _35reg2358 = primCdr(closureRef(co, 3));
-Obj _35reg2359 = primCdr(_35reg2358);
-Obj _35reg2360 = primCar(_35reg2359);
-Obj nargs = _35reg2360;
-Obj _35reg2361 = primCdr(closureRef(co, 3));
-Obj _35reg2362 = primCdr(_35reg2361);
-Obj _35reg2363 = primCdr(_35reg2362);
-Obj frees = _35reg2363;
-pushCont(co, 7, _35clofun2859, 6, label, nargs, self, env, frees, w);
+Obj _35reg2356 = primCar(_35reg2355);
+Obj label = _35reg2356;
+Obj _35reg2357 = primCdr(closureRef(co, 3));
+Obj _35reg2358 = primCdr(_35reg2357);
+Obj _35reg2359 = primIsCons(_35reg2358);
+if (True == _35reg2359) {
+Obj _35reg2360 = primCdr(closureRef(co, 3));
+Obj _35reg2361 = primCdr(_35reg2360);
+Obj _35reg2362 = primCar(_35reg2361);
+Obj nargs = _35reg2362;
+Obj _35reg2363 = primCdr(closureRef(co, 3));
+Obj _35reg2364 = primCdr(_35reg2363);
+Obj _35reg2365 = primCdr(_35reg2364);
+Obj frees = _35reg2365;
+pushCont(co, 7, _35clofun2933, 6, label, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4825,49 +5478,49 @@ __arg2 = makeString1("makeNative(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1138;
+__arg0 = _35cc1133;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1138;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1138;
+__arg0 = _35cc1133;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1138;
+__arg0 = _35cc1133;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1133;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label9:
 {
-Obj _35val2410 = __arg1;
+Obj _35val2412 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -4876,18 +5529,18 @@ __arg2 = makeString1("}\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val2409 = __arg1;
+Obj _35val2411 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 9, _35clofun2859, 1, w);
+pushCont(co, 9, _35clofun2933, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
 __arg1 = self;
@@ -4897,18 +5550,18 @@ co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val2408 = __arg1;
+Obj _35val2410 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 10, _35clofun2859, 4, self, env, c, w);
+pushCont(co, 10, _35clofun2933, 4, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4916,19 +5569,19 @@ __arg2 = makeString1("} else {\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val2407 = __arg1;
+Obj _35val2409 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 11, _35clofun2859, 4, self, env, c, w);
+pushCont(co, 11, _35clofun2933, 4, self, env, c, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
 __arg1 = self;
@@ -4938,19 +5591,19 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val2406 = __arg1;
+Obj _35val2408 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 12, _35clofun2859, 5, b, self, env, c, w);
+pushCont(co, 12, _35clofun2933, 5, b, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -4958,20 +5611,20 @@ __arg2 = makeString1(") {\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2405 = __arg1;
+Obj _35val2407 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 13, _35clofun2859, 5, b, self, env, c, w);
+pushCont(co, 13, _35clofun2933, 5, b, self, env, c, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
 __arg1 = self;
@@ -4981,52 +5634,52 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35cc1137 = makeNative(8, _35clofun2859, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1132 = makeNative(8, _35clofun2933, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2379 = primIsCons(closureRef(co, 3));
-if (True == _35reg2379) {
-Obj _35reg2380 = primCar(closureRef(co, 3));
-Obj _35reg2381 = primEQ(intern("if"), _35reg2380);
+Obj _35reg2381 = primIsCons(closureRef(co, 3));
 if (True == _35reg2381) {
-Obj _35reg2382 = primCdr(closureRef(co, 3));
-Obj _35reg2383 = primIsCons(_35reg2382);
+Obj _35reg2382 = primCar(closureRef(co, 3));
+Obj _35reg2383 = primEQ(intern("if"), _35reg2382);
 if (True == _35reg2383) {
 Obj _35reg2384 = primCdr(closureRef(co, 3));
-Obj _35reg2385 = primCar(_35reg2384);
-Obj a = _35reg2385;
+Obj _35reg2385 = primIsCons(_35reg2384);
+if (True == _35reg2385) {
 Obj _35reg2386 = primCdr(closureRef(co, 3));
-Obj _35reg2387 = primCdr(_35reg2386);
-Obj _35reg2388 = primIsCons(_35reg2387);
-if (True == _35reg2388) {
-Obj _35reg2389 = primCdr(closureRef(co, 3));
-Obj _35reg2390 = primCdr(_35reg2389);
-Obj _35reg2391 = primCar(_35reg2390);
-Obj b = _35reg2391;
-Obj _35reg2392 = primCdr(closureRef(co, 3));
-Obj _35reg2393 = primCdr(_35reg2392);
-Obj _35reg2394 = primCdr(_35reg2393);
-Obj _35reg2395 = primIsCons(_35reg2394);
-if (True == _35reg2395) {
-Obj _35reg2396 = primCdr(closureRef(co, 3));
-Obj _35reg2397 = primCdr(_35reg2396);
-Obj _35reg2398 = primCdr(_35reg2397);
-Obj _35reg2399 = primCar(_35reg2398);
-Obj c = _35reg2399;
-Obj _35reg2400 = primCdr(closureRef(co, 3));
-Obj _35reg2401 = primCdr(_35reg2400);
-Obj _35reg2402 = primCdr(_35reg2401);
+Obj _35reg2387 = primCar(_35reg2386);
+Obj a = _35reg2387;
+Obj _35reg2388 = primCdr(closureRef(co, 3));
+Obj _35reg2389 = primCdr(_35reg2388);
+Obj _35reg2390 = primIsCons(_35reg2389);
+if (True == _35reg2390) {
+Obj _35reg2391 = primCdr(closureRef(co, 3));
+Obj _35reg2392 = primCdr(_35reg2391);
+Obj _35reg2393 = primCar(_35reg2392);
+Obj b = _35reg2393;
+Obj _35reg2394 = primCdr(closureRef(co, 3));
+Obj _35reg2395 = primCdr(_35reg2394);
+Obj _35reg2396 = primCdr(_35reg2395);
+Obj _35reg2397 = primIsCons(_35reg2396);
+if (True == _35reg2397) {
+Obj _35reg2398 = primCdr(closureRef(co, 3));
+Obj _35reg2399 = primCdr(_35reg2398);
+Obj _35reg2400 = primCdr(_35reg2399);
+Obj _35reg2401 = primCar(_35reg2400);
+Obj c = _35reg2401;
+Obj _35reg2402 = primCdr(closureRef(co, 3));
 Obj _35reg2403 = primCdr(_35reg2402);
-Obj _35reg2404 = primEQ(Nil, _35reg2403);
-if (True == _35reg2404) {
-pushCont(co, 14, _35clofun2859, 6, a, b, self, env, c, w);
+Obj _35reg2404 = primCdr(_35reg2403);
+Obj _35reg2405 = primCdr(_35reg2404);
+Obj _35reg2406 = primEQ(Nil, _35reg2405);
+if (True == _35reg2406) {
+pushCont(co, 14, _35clofun2933, 6, a, b, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -5034,67 +5687,67 @@ __arg2 = makeString1("if (True == ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1137;
+__arg0 = _35cc1132;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1137;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1137;
+__arg0 = _35cc1132;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1137;
+__arg0 = _35cc1132;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1137;
+__arg0 = _35cc1132;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1137;
+__arg0 = _35cc1132;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1132;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label16:
 {
-Obj _35val2431 = __arg1;
+Obj _35val2433 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -5103,18 +5756,18 @@ __arg2 = makeString1(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val2430 = __arg1;
+Obj _35val2432 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 16, _35clofun2859, 1, w);
+pushCont(co, 16, _35clofun2933, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst-list"));
 __arg1 = self;
@@ -5124,18 +5777,18 @@ co->args[4] = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2429 = __arg1;
+Obj _35val2431 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 17, _35clofun2859, 4, self, env, args, w);
+pushCont(co, 17, _35clofun2933, 4, self, env, args, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -5143,111 +5796,111 @@ __arg2 = makeString1("(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val2428 = __arg1;
+Obj _35val2430 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun2859, 4, self, env, args, w);
+pushCont(co, 18, _35clofun2933, 4, self, env, args, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 __arg1 = w;
-__arg2 = _35val2428;
+__arg2 = _35val2430;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35cc1136 = makeNative(15, _35clofun2859, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1131 = makeNative(15, _35clofun2933, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2411 = primIsCons(closureRef(co, 3));
-if (True == _35reg2411) {
-Obj _35reg2412 = primCar(closureRef(co, 3));
-Obj _35reg2413 = primIsCons(_35reg2412);
+Obj _35reg2413 = primIsCons(closureRef(co, 3));
 if (True == _35reg2413) {
 Obj _35reg2414 = primCar(closureRef(co, 3));
-Obj _35reg2415 = primCar(_35reg2414);
-Obj _35reg2416 = primEQ(intern("%builtin"), _35reg2415);
-if (True == _35reg2416) {
-Obj _35reg2417 = primCar(closureRef(co, 3));
-Obj _35reg2418 = primCdr(_35reg2417);
-Obj _35reg2419 = primIsCons(_35reg2418);
-if (True == _35reg2419) {
-Obj _35reg2420 = primCar(closureRef(co, 3));
-Obj _35reg2421 = primCdr(_35reg2420);
-Obj _35reg2422 = primCar(_35reg2421);
-Obj f = _35reg2422;
-Obj _35reg2423 = primCar(closureRef(co, 3));
-Obj _35reg2424 = primCdr(_35reg2423);
-Obj _35reg2425 = primCdr(_35reg2424);
-Obj _35reg2426 = primEQ(Nil, _35reg2425);
-if (True == _35reg2426) {
-Obj _35reg2427 = primCdr(closureRef(co, 3));
-Obj args = _35reg2427;
-pushCont(co, 19, _35clofun2859, 4, self, env, args, w);
+Obj _35reg2415 = primIsCons(_35reg2414);
+if (True == _35reg2415) {
+Obj _35reg2416 = primCar(closureRef(co, 3));
+Obj _35reg2417 = primCar(_35reg2416);
+Obj _35reg2418 = primEQ(intern("%builtin"), _35reg2417);
+if (True == _35reg2418) {
+Obj _35reg2419 = primCar(closureRef(co, 3));
+Obj _35reg2420 = primCdr(_35reg2419);
+Obj _35reg2421 = primIsCons(_35reg2420);
+if (True == _35reg2421) {
+Obj _35reg2422 = primCar(closureRef(co, 3));
+Obj _35reg2423 = primCdr(_35reg2422);
+Obj _35reg2424 = primCar(_35reg2423);
+Obj f = _35reg2424;
+Obj _35reg2425 = primCar(closureRef(co, 3));
+Obj _35reg2426 = primCdr(_35reg2425);
+Obj _35reg2427 = primCdr(_35reg2426);
+Obj _35reg2428 = primEQ(Nil, _35reg2427);
+if (True == _35reg2428) {
+Obj _35reg2429 = primCdr(closureRef(co, 3));
+Obj args = _35reg2429;
+pushCont(co, 19, _35clofun2933, 4, self, env, args, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.builtin->name"));
 __arg1 = f;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1136;
+__arg0 = _35cc1131;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1136;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1136;
+__arg0 = _35cc1131;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1136;
+__arg0 = _35cc1131;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1136;
+__arg0 = _35cc1131;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2859) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1131;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2933) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5261,7 +5914,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2858(struct Cora* co){
+void _35clofun2932(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -5274,35 +5927,35 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2270 = __arg1;
+Obj _35val2272 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 20, _35clofun2857, 4, f, args, self, w);
+pushCont(co, 20, _35clofun2931, 4, f, args, self, w);
 __nargs = 2;
 __arg0 = globalRef(intern("length"));
 __arg1 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35cc1143 = makeNative(10, _35clofun2857, 0, 0);
+Obj _35cc1138 = makeNative(10, _35clofun2931, 0, 0);
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2267 = primIsCons(closureRef(co, 3));
-if (True == _35reg2267) {
-Obj _35reg2268 = primCar(closureRef(co, 3));
-Obj f = _35reg2268;
-Obj _35reg2269 = primCdr(closureRef(co, 3));
-Obj args = _35reg2269;
-pushCont(co, 0, _35clofun2858, 4, f, args, self, w);
+Obj _35reg2269 = primIsCons(closureRef(co, 3));
+if (True == _35reg2269) {
+Obj _35reg2270 = primCar(closureRef(co, 3));
+Obj f = _35reg2270;
+Obj _35reg2271 = primCdr(closureRef(co, 3));
+Obj args = _35reg2271;
+pushCont(co, 0, _35clofun2932, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -5310,22 +5963,22 @@ __arg2 = makeString1("__nargs = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1143;
+__arg0 = _35cc1138;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label2:
 {
-Obj _35val2300 = __arg1;
+Obj _35val2302 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -5339,41 +5992,41 @@ co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc1142 = makeNative(1, _35clofun2858, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1137 = makeNative(1, _35clofun2932, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2283 = primIsCons(closureRef(co, 3));
-if (True == _35reg2283) {
-Obj _35reg2284 = primCar(closureRef(co, 3));
-Obj _35reg2285 = primEQ(intern("call"), _35reg2284);
+Obj _35reg2285 = primIsCons(closureRef(co, 3));
 if (True == _35reg2285) {
-Obj _35reg2286 = primCdr(closureRef(co, 3));
-Obj _35reg2287 = primIsCons(_35reg2286);
+Obj _35reg2286 = primCar(closureRef(co, 3));
+Obj _35reg2287 = primEQ(intern("call"), _35reg2286);
 if (True == _35reg2287) {
 Obj _35reg2288 = primCdr(closureRef(co, 3));
-Obj _35reg2289 = primCar(_35reg2288);
-Obj exp = _35reg2289;
+Obj _35reg2289 = primIsCons(_35reg2288);
+if (True == _35reg2289) {
 Obj _35reg2290 = primCdr(closureRef(co, 3));
-Obj _35reg2291 = primCdr(_35reg2290);
-Obj _35reg2292 = primIsCons(_35reg2291);
-if (True == _35reg2292) {
-Obj _35reg2293 = primCdr(closureRef(co, 3));
-Obj _35reg2294 = primCdr(_35reg2293);
-Obj _35reg2295 = primCar(_35reg2294);
-Obj cont = _35reg2295;
-Obj _35reg2296 = primCdr(closureRef(co, 3));
-Obj _35reg2297 = primCdr(_35reg2296);
-Obj _35reg2298 = primCdr(_35reg2297);
-Obj _35reg2299 = primEQ(Nil, _35reg2298);
-if (True == _35reg2299) {
-pushCont(co, 2, _35clofun2858, 4, self, env, w, exp);
+Obj _35reg2291 = primCar(_35reg2290);
+Obj exp = _35reg2291;
+Obj _35reg2292 = primCdr(closureRef(co, 3));
+Obj _35reg2293 = primCdr(_35reg2292);
+Obj _35reg2294 = primIsCons(_35reg2293);
+if (True == _35reg2294) {
+Obj _35reg2295 = primCdr(closureRef(co, 3));
+Obj _35reg2296 = primCdr(_35reg2295);
+Obj _35reg2297 = primCar(_35reg2296);
+Obj cont = _35reg2297;
+Obj _35reg2298 = primCdr(closureRef(co, 3));
+Obj _35reg2299 = primCdr(_35reg2298);
+Obj _35reg2300 = primCdr(_35reg2299);
+Obj _35reg2301 = primEQ(Nil, _35reg2300);
+if (True == _35reg2301) {
+pushCont(co, 2, _35clofun2932, 4, self, env, w, exp);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc.generate-cont"));
 __arg1 = self;
@@ -5382,76 +6035,76 @@ __arg3 = cont;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1142;
+__arg0 = _35cc1137;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1142;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1142;
+__arg0 = _35cc1137;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1142;
+__arg0 = _35cc1137;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1142;
+__arg0 = _35cc1137;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1137;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35cc1141 = makeNative(3, _35clofun2858, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1136 = makeNative(3, _35clofun2932, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2301 = primIsCons(closureRef(co, 3));
-if (True == _35reg2301) {
-Obj _35reg2302 = primCar(closureRef(co, 3));
-Obj _35reg2303 = primEQ(intern("tailcall"), _35reg2302);
+Obj _35reg2303 = primIsCons(closureRef(co, 3));
 if (True == _35reg2303) {
-Obj _35reg2304 = primCdr(closureRef(co, 3));
-Obj _35reg2305 = primIsCons(_35reg2304);
+Obj _35reg2304 = primCar(closureRef(co, 3));
+Obj _35reg2305 = primEQ(intern("tailcall"), _35reg2304);
 if (True == _35reg2305) {
 Obj _35reg2306 = primCdr(closureRef(co, 3));
-Obj _35reg2307 = primCar(_35reg2306);
-Obj exp = _35reg2307;
+Obj _35reg2307 = primIsCons(_35reg2306);
+if (True == _35reg2307) {
 Obj _35reg2308 = primCdr(closureRef(co, 3));
-Obj _35reg2309 = primCdr(_35reg2308);
-Obj _35reg2310 = primEQ(Nil, _35reg2309);
-if (True == _35reg2310) {
+Obj _35reg2309 = primCar(_35reg2308);
+Obj exp = _35reg2309;
+Obj _35reg2310 = primCdr(closureRef(co, 3));
+Obj _35reg2311 = primCdr(_35reg2310);
+Obj _35reg2312 = primEQ(Nil, _35reg2311);
+if (True == _35reg2312) {
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
 __arg1 = self;
@@ -5461,49 +6114,49 @@ co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1141;
+__arg0 = _35cc1136;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1141;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1141;
+__arg0 = _35cc1136;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1141;
+__arg0 = _35cc1136;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1136;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35val2328 = __arg1;
+Obj _35val2330 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -5512,15 +6165,15 @@ __arg2 = makeString1("goto *jumpTable[co->ctx.pc.label];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val2327 = __arg1;
+Obj _35val2329 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 5, _35clofun2858, 1, w);
+pushCont(co, 5, _35clofun2932, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -5528,16 +6181,16 @@ __arg2 = makeString1(") { goto fail; }\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val2326 = __arg1;
+Obj _35val2328 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 6, _35clofun2858, 1, w);
+pushCont(co, 6, _35clofun2932, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 __arg1 = w;
@@ -5545,16 +6198,16 @@ __arg2 = self;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val2325 = __arg1;
+Obj _35val2327 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun2858, 2, self, w);
+pushCont(co, 7, _35clofun2932, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -5562,16 +6215,16 @@ __arg2 = makeString1("if (co->ctx.pc.func != ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val2324 = __arg1;
+Obj _35val2326 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun2858, 2, self, w);
+pushCont(co, 8, _35clofun2932, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -5579,16 +6232,16 @@ __arg2 = makeString1("co->ctx = co->callstack.data[--co->callstack.len];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val2323 = __arg1;
+Obj _35val2325 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun2858, 2, self, w);
+pushCont(co, 9, _35clofun2932, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -5596,18 +6249,18 @@ __arg2 = makeString1(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val2322 = __arg1;
+Obj _35val2324 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 10, _35clofun2858, 2, self, w);
+pushCont(co, 10, _35clofun2932, 2, self, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
 __arg1 = self;
@@ -5617,18 +6270,18 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val2321 = __arg1;
+Obj _35val2323 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 11, _35clofun2858, 4, env, x, self, w);
+pushCont(co, 11, _35clofun2932, 4, env, x, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -5636,32 +6289,32 @@ __arg2 = makeString1("__arg1 = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35cc1140 = makeNative(4, _35clofun2858, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1135 = makeNative(4, _35clofun2932, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2311 = primIsCons(closureRef(co, 3));
-if (True == _35reg2311) {
-Obj _35reg2312 = primCar(closureRef(co, 3));
-Obj _35reg2313 = primEQ(intern("return"), _35reg2312);
+Obj _35reg2313 = primIsCons(closureRef(co, 3));
 if (True == _35reg2313) {
-Obj _35reg2314 = primCdr(closureRef(co, 3));
-Obj _35reg2315 = primIsCons(_35reg2314);
+Obj _35reg2314 = primCar(closureRef(co, 3));
+Obj _35reg2315 = primEQ(intern("return"), _35reg2314);
 if (True == _35reg2315) {
 Obj _35reg2316 = primCdr(closureRef(co, 3));
-Obj _35reg2317 = primCar(_35reg2316);
-Obj x = _35reg2317;
+Obj _35reg2317 = primIsCons(_35reg2316);
+if (True == _35reg2317) {
 Obj _35reg2318 = primCdr(closureRef(co, 3));
-Obj _35reg2319 = primCdr(_35reg2318);
-Obj _35reg2320 = primEQ(Nil, _35reg2319);
-if (True == _35reg2320) {
-pushCont(co, 12, _35clofun2858, 4, env, x, self, w);
+Obj _35reg2319 = primCar(_35reg2318);
+Obj x = _35reg2319;
+Obj _35reg2320 = primCdr(closureRef(co, 3));
+Obj _35reg2321 = primCdr(_35reg2320);
+Obj _35reg2322 = primEQ(Nil, _35reg2321);
+if (True == _35reg2322) {
+pushCont(co, 12, _35clofun2932, 4, env, x, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -5669,49 +6322,49 @@ __arg2 = makeString1("__nargs = 2;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1140;
+__arg0 = _35cc1135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1140;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1140;
+__arg0 = _35cc1135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1140;
+__arg0 = _35cc1135;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1135;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label14:
 {
-Obj _35val2347 = __arg1;
+Obj _35val2349 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -5725,18 +6378,18 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val2346 = __arg1;
+Obj _35val2348 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 14, _35clofun2858, 4, self, env, w, b);
+pushCont(co, 14, _35clofun2932, 4, self, env, w, b);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -5744,41 +6397,41 @@ __arg2 = makeString1(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35cc1139 = makeNative(13, _35clofun2858, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1134 = makeNative(13, _35clofun2932, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2329 = primIsCons(closureRef(co, 3));
-if (True == _35reg2329) {
-Obj _35reg2330 = primCar(closureRef(co, 3));
-Obj _35reg2331 = primEQ(intern("do"), _35reg2330);
+Obj _35reg2331 = primIsCons(closureRef(co, 3));
 if (True == _35reg2331) {
-Obj _35reg2332 = primCdr(closureRef(co, 3));
-Obj _35reg2333 = primIsCons(_35reg2332);
+Obj _35reg2332 = primCar(closureRef(co, 3));
+Obj _35reg2333 = primEQ(intern("do"), _35reg2332);
 if (True == _35reg2333) {
 Obj _35reg2334 = primCdr(closureRef(co, 3));
-Obj _35reg2335 = primCar(_35reg2334);
-Obj a = _35reg2335;
+Obj _35reg2335 = primIsCons(_35reg2334);
+if (True == _35reg2335) {
 Obj _35reg2336 = primCdr(closureRef(co, 3));
-Obj _35reg2337 = primCdr(_35reg2336);
-Obj _35reg2338 = primIsCons(_35reg2337);
-if (True == _35reg2338) {
-Obj _35reg2339 = primCdr(closureRef(co, 3));
-Obj _35reg2340 = primCdr(_35reg2339);
-Obj _35reg2341 = primCar(_35reg2340);
-Obj b = _35reg2341;
-Obj _35reg2342 = primCdr(closureRef(co, 3));
-Obj _35reg2343 = primCdr(_35reg2342);
-Obj _35reg2344 = primCdr(_35reg2343);
-Obj _35reg2345 = primEQ(Nil, _35reg2344);
-if (True == _35reg2345) {
-pushCont(co, 15, _35clofun2858, 4, self, env, w, b);
+Obj _35reg2337 = primCar(_35reg2336);
+Obj a = _35reg2337;
+Obj _35reg2338 = primCdr(closureRef(co, 3));
+Obj _35reg2339 = primCdr(_35reg2338);
+Obj _35reg2340 = primIsCons(_35reg2339);
+if (True == _35reg2340) {
+Obj _35reg2341 = primCdr(closureRef(co, 3));
+Obj _35reg2342 = primCdr(_35reg2341);
+Obj _35reg2343 = primCar(_35reg2342);
+Obj b = _35reg2343;
+Obj _35reg2344 = primCdr(closureRef(co, 3));
+Obj _35reg2345 = primCdr(_35reg2344);
+Obj _35reg2346 = primCdr(_35reg2345);
+Obj _35reg2347 = primEQ(Nil, _35reg2346);
+if (True == _35reg2347) {
+pushCont(co, 15, _35clofun2932, 4, self, env, w, b);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
 __arg1 = self;
@@ -5788,58 +6441,58 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1139;
+__arg0 = _35cc1134;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1139;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1139;
+__arg0 = _35cc1134;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1139;
+__arg0 = _35cc1134;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1139;
+__arg0 = _35cc1134;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1134;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label17:
 {
-Obj _35val2378 = __arg1;
+Obj _35val2380 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -5848,18 +6501,18 @@ __arg2 = makeString1(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2377 = __arg1;
+Obj _35val2379 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 17, _35clofun2858, 1, w);
+pushCont(co, 17, _35clofun2932, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst-list"));
 __arg1 = self;
@@ -5869,20 +6522,20 @@ co->args[4] = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val2375 = __arg1;
+Obj _35val2377 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2376 = primNot(_35val2375);
-if (True == _35reg2376) {
-pushCont(co, 18, _35clofun2858, 4, self, env, frees, w);
+Obj _35reg2378 = primNot(_35val2377);
+if (True == _35reg2378) {
+pushCont(co, 18, _35clofun2932, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -5890,7 +6543,7 @@ __arg2 = makeString1(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
@@ -5901,26 +6554,26 @@ __arg2 = makeString1(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label20:
 {
-Obj _35val2374 = __arg1;
+Obj _35val2376 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun2858, 4, self, env, frees, w);
+pushCont(co, 19, _35clofun2932, 4, self, env, frees, w);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
 __arg1 = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2858) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2932) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5933,7 +6586,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2857(struct Cora* co){
+void _35clofun2931(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -5946,13 +6599,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2253 = __arg1;
+Obj _35val2255 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 20, _35clofun2856, 5, x, i, self, w, more);
+pushCont(co, 20, _35clofun2930, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -5960,19 +6613,19 @@ __arg2 = makeString1(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2252 = __arg1;
+Obj _35val2254 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun2857, 5, x, i, self, w, more);
+pushCont(co, 0, _35clofun2931, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
@@ -5980,39 +6633,39 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val2263 = __arg1;
+Obj _35val2265 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2264 = primAdd(i, makeNumber(1));
+Obj _35reg2266 = primAdd(i, makeNumber(1));
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-call-list"));
 __arg1 = self;
 __arg2 = w;
-__arg3 = _35reg2264;
+__arg3 = _35reg2266;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2262 = __arg1;
+Obj _35val2264 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 2, _35clofun2857, 4, i, self, w, more);
+pushCont(co, 2, _35clofun2931, 4, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -6020,19 +6673,19 @@ __arg2 = makeString1(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val2261 = __arg1;
+Obj _35val2263 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 3, _35clofun2857, 4, i, self, w, more);
+pushCont(co, 3, _35clofun2931, 4, i, self, w, more);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
 __arg1 = self;
@@ -6042,19 +6695,19 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val2260 = __arg1;
+Obj _35val2262 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 4, _35clofun2857, 5, x, i, self, w, more);
+pushCont(co, 4, _35clofun2931, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -6062,19 +6715,19 @@ __arg2 = makeString1(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val2259 = __arg1;
+Obj _35val2261 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 5, _35clofun2857, 5, x, i, self, w, more);
+pushCont(co, 5, _35clofun2931, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -6082,19 +6735,19 @@ __arg2 = makeString1("]");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val2258 = __arg1;
+Obj _35val2260 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 6, _35clofun2857, 5, x, i, self, w, more);
+pushCont(co, 6, _35clofun2931, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
@@ -6102,26 +6755,26 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35cc1125 = makeNative(17, _35clofun2856, 0, 0);
+Obj _35cc1120 = makeNative(17, _35clofun2930, 0, 0);
 Obj self = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj i = closureRef(co, 2);
-Obj _35reg2247 = primIsCons(closureRef(co, 3));
-if (True == _35reg2247) {
-Obj _35reg2248 = primCar(closureRef(co, 3));
-Obj x = _35reg2248;
-Obj _35reg2249 = primCdr(closureRef(co, 3));
-Obj more = _35reg2249;
-Obj _35reg2250 = primGT(i, makeNumber(3));
-Obj _35reg2251 = primNot(_35reg2250);
-if (True == _35reg2251) {
-pushCont(co, 1, _35clofun2857, 5, x, i, self, w, more);
+Obj _35reg2249 = primIsCons(closureRef(co, 3));
+if (True == _35reg2249) {
+Obj _35reg2250 = primCar(closureRef(co, 3));
+Obj x = _35reg2250;
+Obj _35reg2251 = primCdr(closureRef(co, 3));
+Obj more = _35reg2251;
+Obj _35reg2252 = primGT(i, makeNumber(3));
+Obj _35reg2253 = primNot(_35reg2252);
+if (True == _35reg2253) {
+pushCont(co, 1, _35clofun2931, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -6129,10 +6782,10 @@ __arg2 = makeString1("__arg");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 7, _35clofun2857, 5, x, i, self, w, more);
+pushCont(co, 7, _35clofun2931, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -6140,44 +6793,44 @@ __arg2 = makeString1("co->args[");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1125;
+__arg0 = _35cc1120;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label9:
 {
-Obj _35p1120 = __arg1;
-Obj _35p1121 = __arg2;
-Obj _35p1122 = __arg3;
-Obj _35p1123 = co->args[4];
-Obj _35cc1124 = makeNative(8, _35clofun2857, 0, 4, _35p1120, _35p1121, _35p1122, _35p1123);
-Obj self = _35p1120;
-Obj w = _35p1121;
-Obj i = _35p1122;
-Obj _35reg2265 = primEQ(Nil, _35p1123);
-if (True == _35reg2265) {
+Obj _35p1115 = __arg1;
+Obj _35p1116 = __arg2;
+Obj _35p1117 = __arg3;
+Obj _35p1118 = co->args[4];
+Obj _35cc1119 = makeNative(8, _35clofun2931, 0, 4, _35p1115, _35p1116, _35p1117, _35p1118);
+Obj self = _35p1115;
+Obj w = _35p1116;
+Obj i = _35p1117;
+Obj _35reg2267 = primEQ(Nil, _35p1118);
+if (True == _35reg2267) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2857) { goto fail; }
+if (co->ctx.pc.func != _35clofun2931) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1124;
+__arg0 = _35cc1119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -6190,13 +6843,13 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val2282 = __arg1;
+Obj _35val2284 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
@@ -6205,15 +6858,15 @@ __arg2 = makeString1("goto *jumpTable[ps.label];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val2281 = __arg1;
+Obj _35val2283 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 11, _35clofun2857, 1, w);
+pushCont(co, 11, _35clofun2931, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -6221,16 +6874,16 @@ __arg2 = makeString1(") { co->ctx.pc = ps; goto fail; };\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val2280 = __arg1;
+Obj _35val2282 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun2857, 1, w);
+pushCont(co, 12, _35clofun2931, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-sym"));
 __arg1 = w;
@@ -6238,16 +6891,16 @@ __arg2 = self;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2279 = __arg1;
+Obj _35val2281 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 13, _35clofun2857, 2, self, w);
+pushCont(co, 13, _35clofun2931, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -6255,16 +6908,16 @@ __arg2 = makeString1("if (ps.func != ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val2278 = __arg1;
+Obj _35val2280 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 14, _35clofun2857, 2, self, w);
+pushCont(co, 14, _35clofun2931, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -6272,16 +6925,16 @@ __arg2 = makeString1("if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) {
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val2277 = __arg1;
+Obj _35val2279 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 15, _35clofun2857, 2, self, w);
+pushCont(co, 15, _35clofun2931, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -6289,16 +6942,16 @@ __arg2 = makeString1("struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n"
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val2276 = __arg1;
+Obj _35val2278 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 16, _35clofun2857, 2, self, w);
+pushCont(co, 16, _35clofun2931, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -6306,40 +6959,40 @@ __arg2 = makeString1("co->ctx.frees = __arg0;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2274 = __arg1;
+Obj _35val2276 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2275 = primCons(f, args);
-pushCont(co, 17, _35clofun2857, 2, self, w);
+Obj _35reg2277 = primCons(f, args);
+pushCont(co, 17, _35clofun2931, 2, self, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-call-list"));
 __arg1 = self;
 __arg2 = w;
 __arg3 = makeNumber(0);
-co->args[4] = _35reg2275;
+co->args[4] = _35reg2277;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val2273 = __arg1;
+Obj _35val2275 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun2857, 4, f, args, self, w);
+pushCont(co, 18, _35clofun2931, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -6347,27 +7000,27 @@ __arg2 = makeString1(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val2271 = __arg1;
+Obj _35val2273 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2272 = primAdd(makeNumber(1), _35val2271);
-pushCont(co, 19, _35clofun2857, 4, f, args, self, w);
+Obj _35reg2274 = primAdd(makeNumber(1), _35val2273);
+pushCont(co, 19, _35clofun2931, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-num"));
 __arg1 = w;
-__arg2 = _35reg2272;
+__arg2 = _35reg2274;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2857) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2931) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6380,7 +7033,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2856(struct Cora* co){
+void _35clofun2930(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -6393,77 +7046,77 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2201 = __arg1;
+Obj _35val2203 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2202 = primCons(name, idx);
-Obj _35reg2203 = primCons(_35reg2202, fvs);
-Obj _35reg2204 = primCons(clo_45or_45cont, _35reg2203);
+Obj _35reg2204 = primCons(name, idx);
+Obj _35reg2205 = primCons(_35reg2204, fvs);
+Obj _35reg2206 = primCons(clo_45or_45cont, _35reg2205);
 __nargs = 2;
-__arg1 = _35reg2204;
+__arg1 = _35reg2206;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2856) { goto fail; }
+if (co->ctx.pc.func != _35clofun2930) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj _35val2214 = __arg1;
+Obj _35val2216 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2213= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2215= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2215 = primCons(_35val2214, fvs);
-Obj _35reg2216 = primCons(_35reg2213, _35reg2215);
-Obj _35reg2217 = primCons(clo_45or_45cont, _35reg2216);
+Obj _35reg2217 = primCons(_35val2216, fvs);
+Obj _35reg2218 = primCons(_35reg2215, _35reg2217);
+Obj _35reg2219 = primCons(clo_45or_45cont, _35reg2218);
 __nargs = 2;
-__arg1 = _35reg2217;
+__arg1 = _35reg2219;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2856) { goto fail; }
+if (co->ctx.pc.func != _35clofun2930) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val2212 = __arg1;
+Obj _35val2214 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2213 = primCons(name, idx);
-pushCont(co, 1, _35clofun2856, 3, fvs, _35reg2213, clo_45or_45cont);
+Obj _35reg2215 = primCons(name, idx);
+pushCont(co, 1, _35clofun2930, 3, fvs, _35reg2215, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2222 = __arg1;
+Obj _35val2224 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2223 = primCons(name, idx);
-Obj _35reg2224 = primCons(_35reg2223, fvs);
-Obj _35reg2225 = primCons(clo_45or_45cont, _35reg2224);
+Obj _35reg2225 = primCons(name, idx);
+Obj _35reg2226 = primCons(_35reg2225, fvs);
+Obj _35reg2227 = primCons(clo_45or_45cont, _35reg2226);
 __nargs = 2;
-__arg1 = _35reg2225;
+__arg1 = _35reg2227;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2856) { goto fail; }
+if (co->ctx.pc.func != _35clofun2930) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label4:
 {
-Obj _35val2205 = __arg1;
+Obj _35val2207 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -6471,123 +7124,123 @@ Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 5];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 6];
-Obj _35reg2206 = primCar(_35val2205);
-Obj name = _35reg2206;
-Obj _35reg2207 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2207) {
-Obj _35reg2208 = primCons(body1, Nil);
-Obj _35reg2209 = primCons(Nil, _35reg2208);
-Obj _35reg2210 = primCons(params, _35reg2209);
-Obj _35reg2211 = primCons(intern("lambda"), _35reg2210);
-pushCont(co, 2, _35clofun2856, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj _35reg2208 = primCar(_35val2207);
+Obj name = _35reg2208;
+Obj _35reg2209 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2209) {
+Obj _35reg2210 = primCons(body1, Nil);
+Obj _35reg2211 = primCons(Nil, _35reg2210);
+Obj _35reg2212 = primCons(params, _35reg2211);
+Obj _35reg2213 = primCons(intern("lambda"), _35reg2212);
+pushCont(co, 2, _35clofun2930, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc.append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2211;
+co->args[5] = _35reg2213;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2218 = primCons(body1, Nil);
-Obj _35reg2219 = primCons(fvs, _35reg2218);
-Obj _35reg2220 = primCons(params, _35reg2219);
-Obj _35reg2221 = primCons(intern("lambda"), _35reg2220);
-pushCont(co, 3, _35clofun2856, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg2220 = primCons(body1, Nil);
+Obj _35reg2221 = primCons(fvs, _35reg2220);
+Obj _35reg2222 = primCons(params, _35reg2221);
+Obj _35reg2223 = primCons(intern("lambda"), _35reg2222);
+pushCont(co, 3, _35clofun2930, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc.append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2221;
+co->args[5] = _35reg2223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35val2183 = __arg1;
+Obj _35val2185 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj cur = _35val2183;
-Obj _35reg2184 = primEQ(idx, makeNumber(0));
-if (True == _35reg2184) {
-Obj _35reg2185 = primGenSym(intern("clofun"));
-Obj name = _35reg2185;
-Obj _35reg2186 = primEQ(clo_45or_45cont, intern("%closure"));
+Obj cur = _35val2185;
+Obj _35reg2186 = primEQ(idx, makeNumber(0));
 if (True == _35reg2186) {
-Obj _35reg2187 = primCons(body1, Nil);
-Obj _35reg2188 = primCons(Nil, _35reg2187);
-Obj _35reg2189 = primCons(params, _35reg2188);
-Obj _35reg2190 = primCons(intern("lambda"), _35reg2189);
-pushCont(co, 20, _35clofun2855, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj _35reg2187 = primGenSym(intern("clofun"));
+Obj name = _35reg2187;
+Obj _35reg2188 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2188) {
+Obj _35reg2189 = primCons(body1, Nil);
+Obj _35reg2190 = primCons(Nil, _35reg2189);
+Obj _35reg2191 = primCons(params, _35reg2190);
+Obj _35reg2192 = primCons(intern("lambda"), _35reg2191);
+pushCont(co, 20, _35clofun2929, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc.append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2190;
+co->args[5] = _35reg2192;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2197 = primCons(body1, Nil);
-Obj _35reg2198 = primCons(fvs, _35reg2197);
-Obj _35reg2199 = primCons(params, _35reg2198);
-Obj _35reg2200 = primCons(intern("lambda"), _35reg2199);
-pushCont(co, 0, _35clofun2856, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg2199 = primCons(body1, Nil);
+Obj _35reg2200 = primCons(fvs, _35reg2199);
+Obj _35reg2201 = primCons(params, _35reg2200);
+Obj _35reg2202 = primCons(intern("lambda"), _35reg2201);
+pushCont(co, 0, _35clofun2930, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc.append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2200;
+co->args[5] = _35reg2202;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 4, _35clofun2856, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
+pushCont(co, 4, _35clofun2930, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("caar"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label6:
 {
-Obj _35val2182 = __arg1;
+Obj _35val2184 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val2182;
-pushCont(co, 5, _35clofun2856, 6, body1, params, v, idx, fvs, clo_45or_45cont);
+Obj idx = _35val2184;
+pushCont(co, 5, _35clofun2930, 6, body1, params, v, idx, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("vector-ref"));
 __arg1 = v;
@@ -6595,19 +7248,19 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val2181 = __arg1;
+Obj _35val2183 = __arg1;
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj body1 = _35val2181;
-pushCont(co, 6, _35clofun2856, 5, body1, params, v, fvs, clo_45or_45cont);
+Obj body1 = _35val2183;
+pushCont(co, 6, _35clofun2930, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("vector-ref"));
 __arg1 = v;
@@ -6615,68 +7268,68 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35p1115 = __arg1;
-Obj _35p1116 = __arg2;
-Obj _35cc1117 = makeNative(19, _35clofun2854, 0, 2, _35p1115, _35p1116);
-Obj v = _35p1115;
-Obj _35reg2052 = primIsCons(_35p1116);
-if (True == _35reg2052) {
-Obj _35reg2053 = primCar(_35p1116);
-Obj clo_45or_45cont = _35reg2053;
-Obj _35reg2054 = primCdr(_35p1116);
-Obj _35reg2055 = primIsCons(_35reg2054);
-if (True == _35reg2055) {
-Obj _35reg2056 = primCdr(_35p1116);
-Obj _35reg2057 = primCar(_35reg2056);
-Obj _35reg2058 = primIsCons(_35reg2057);
-if (True == _35reg2058) {
-Obj _35reg2059 = primCdr(_35p1116);
-Obj _35reg2060 = primCar(_35reg2059);
-Obj _35reg2061 = primCar(_35reg2060);
-Obj _35reg2062 = primEQ(intern("lambda"), _35reg2061);
-if (True == _35reg2062) {
-Obj _35reg2063 = primCdr(_35p1116);
-Obj _35reg2064 = primCar(_35reg2063);
-Obj _35reg2065 = primCdr(_35reg2064);
-Obj _35reg2066 = primIsCons(_35reg2065);
-if (True == _35reg2066) {
-Obj _35reg2067 = primCdr(_35p1116);
-Obj _35reg2068 = primCar(_35reg2067);
-Obj _35reg2069 = primCdr(_35reg2068);
+Obj _35p1110 = __arg1;
+Obj _35p1111 = __arg2;
+Obj _35cc1112 = makeNative(19, _35clofun2928, 0, 2, _35p1110, _35p1111);
+Obj v = _35p1110;
+Obj _35reg2054 = primIsCons(_35p1111);
+if (True == _35reg2054) {
+Obj _35reg2055 = primCar(_35p1111);
+Obj clo_45or_45cont = _35reg2055;
+Obj _35reg2056 = primCdr(_35p1111);
+Obj _35reg2057 = primIsCons(_35reg2056);
+if (True == _35reg2057) {
+Obj _35reg2058 = primCdr(_35p1111);
+Obj _35reg2059 = primCar(_35reg2058);
+Obj _35reg2060 = primIsCons(_35reg2059);
+if (True == _35reg2060) {
+Obj _35reg2061 = primCdr(_35p1111);
+Obj _35reg2062 = primCar(_35reg2061);
+Obj _35reg2063 = primCar(_35reg2062);
+Obj _35reg2064 = primEQ(intern("lambda"), _35reg2063);
+if (True == _35reg2064) {
+Obj _35reg2065 = primCdr(_35p1111);
+Obj _35reg2066 = primCar(_35reg2065);
+Obj _35reg2067 = primCdr(_35reg2066);
+Obj _35reg2068 = primIsCons(_35reg2067);
+if (True == _35reg2068) {
+Obj _35reg2069 = primCdr(_35p1111);
 Obj _35reg2070 = primCar(_35reg2069);
-Obj params = _35reg2070;
-Obj _35reg2071 = primCdr(_35p1116);
+Obj _35reg2071 = primCdr(_35reg2070);
 Obj _35reg2072 = primCar(_35reg2071);
-Obj _35reg2073 = primCdr(_35reg2072);
-Obj _35reg2074 = primCdr(_35reg2073);
-Obj _35reg2075 = primIsCons(_35reg2074);
-if (True == _35reg2075) {
-Obj _35reg2076 = primCdr(_35p1116);
-Obj _35reg2077 = primCar(_35reg2076);
-Obj _35reg2078 = primCdr(_35reg2077);
-Obj _35reg2079 = primCdr(_35reg2078);
-Obj _35reg2080 = primCar(_35reg2079);
-Obj body = _35reg2080;
-Obj _35reg2081 = primCdr(_35p1116);
+Obj params = _35reg2072;
+Obj _35reg2073 = primCdr(_35p1111);
+Obj _35reg2074 = primCar(_35reg2073);
+Obj _35reg2075 = primCdr(_35reg2074);
+Obj _35reg2076 = primCdr(_35reg2075);
+Obj _35reg2077 = primIsCons(_35reg2076);
+if (True == _35reg2077) {
+Obj _35reg2078 = primCdr(_35p1111);
+Obj _35reg2079 = primCar(_35reg2078);
+Obj _35reg2080 = primCdr(_35reg2079);
+Obj _35reg2081 = primCdr(_35reg2080);
 Obj _35reg2082 = primCar(_35reg2081);
-Obj _35reg2083 = primCdr(_35reg2082);
-Obj _35reg2084 = primCdr(_35reg2083);
+Obj body = _35reg2082;
+Obj _35reg2083 = primCdr(_35p1111);
+Obj _35reg2084 = primCar(_35reg2083);
 Obj _35reg2085 = primCdr(_35reg2084);
-Obj _35reg2086 = primEQ(Nil, _35reg2085);
-if (True == _35reg2086) {
-Obj _35reg2087 = primCdr(_35p1116);
-Obj _35reg2088 = primCdr(_35reg2087);
-Obj fvs = _35reg2088;
-Obj _35reg2089 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2089) {
+Obj _35reg2086 = primCdr(_35reg2085);
+Obj _35reg2087 = primCdr(_35reg2086);
+Obj _35reg2088 = primEQ(Nil, _35reg2087);
+if (True == _35reg2088) {
+Obj _35reg2089 = primCdr(_35p1111);
+Obj _35reg2090 = primCdr(_35reg2089);
+Obj fvs = _35reg2090;
+Obj _35reg2091 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2091) {
 if (True == True) {
-pushCont(co, 8, _35clofun2855, 4, params, v, fvs, clo_45or_45cont);
+pushCont(co, 8, _35clofun2929, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.collect-lambda"));
 __arg1 = v;
@@ -6684,22 +7337,22 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1117;
+__arg0 = _35cc1112;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj _35reg2135 = primEQ(clo_45or_45cont, intern("%continuation"));
-if (True == _35reg2135) {
+Obj _35reg2137 = primEQ(clo_45or_45cont, intern("%continuation"));
+if (True == _35reg2137) {
 if (True == True) {
-pushCont(co, 18, _35clofun2855, 4, params, v, fvs, clo_45or_45cont);
+pushCont(co, 18, _35clofun2929, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.collect-lambda"));
 __arg1 = v;
@@ -6707,20 +7360,20 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1117;
+__arg0 = _35cc1112;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-pushCont(co, 7, _35clofun2856, 4, params, v, fvs, clo_45or_45cont);
+pushCont(co, 7, _35clofun2930, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.collect-lambda"));
 __arg1 = v;
@@ -6728,87 +7381,87 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1117;
+__arg0 = _35cc1112;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1117;
+__arg0 = _35cc1112;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1117;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1117;
+__arg0 = _35cc1112;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1117;
+__arg0 = _35cc1112;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1117;
+__arg0 = _35cc1112;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1117;
+__arg0 = _35cc1112;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1117;
+__arg0 = _35cc1112;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1112;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label9:
 {
-Obj _35val2233 = __arg1;
+Obj _35val2235 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -6819,51 +7472,51 @@ __arg3 = cur1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val2237 = __arg1;
+Obj _35val2239 = __arg1;
 Obj res= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2238 = primCons(_35val2237, res);
+Obj _35reg2240 = primCons(_35val2239, res);
 __nargs = 4;
 __arg0 = globalRef(intern("vector-set!"));
 __arg1 = v;
 __arg2 = makeNumber(2);
-__arg3 = _35reg2238;
+__arg3 = _35reg2240;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val2236 = __arg1;
+Obj _35val2238 = __arg1;
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj res = _35val2236;
-pushCont(co, 10, _35clofun2856, 2, res, v);
+Obj res = _35val2238;
+pushCont(co, 10, _35clofun2930, 2, res, v);
 __nargs = 2;
 __arg0 = globalRef(intern("reverse"));
 __arg1 = cur1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val2235 = __arg1;
+Obj _35val2237 = __arg1;
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun2856, 2, cur1, v);
+pushCont(co, 11, _35clofun2930, 2, cur1, v);
 __nargs = 3;
 __arg0 = globalRef(intern("vector-ref"));
 __arg1 = v;
@@ -6871,16 +7524,16 @@ __arg2 = makeNumber(2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val2234 = __arg1;
+Obj _35val2236 = __arg1;
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun2856, 2, cur1, v);
+pushCont(co, 12, _35clofun2930, 2, cur1, v);
 __nargs = 4;
 __arg0 = globalRef(intern("vector-set!"));
 __arg1 = v;
@@ -6889,7 +7542,7 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6900,27 +7553,27 @@ Obj idx = __arg2;
 Obj cur = __arg3;
 Obj name = co->args[4];
 Obj val = co->args[5];
-Obj _35reg2227 = primCons(name, idx);
-Obj _35reg2228 = primCons(val, Nil);
-Obj _35reg2229 = primCons(_35reg2227, _35reg2228);
-Obj _35reg2230 = primCons(_35reg2229, cur);
-Obj cur1 = _35reg2230;
-Obj _35reg2231 = primLT(idx, makeNumber(20));
-if (True == _35reg2231) {
-Obj _35reg2232 = primAdd(idx, makeNumber(1));
-pushCont(co, 9, _35clofun2856, 2, v, cur1);
+Obj _35reg2229 = primCons(name, idx);
+Obj _35reg2230 = primCons(val, Nil);
+Obj _35reg2231 = primCons(_35reg2229, _35reg2230);
+Obj _35reg2232 = primCons(_35reg2231, cur);
+Obj cur1 = _35reg2232;
+Obj _35reg2233 = primLT(idx, makeNumber(20));
+if (True == _35reg2233) {
+Obj _35reg2234 = primAdd(idx, makeNumber(1));
+pushCont(co, 9, _35clofun2930, 2, v, cur1);
 __nargs = 4;
 __arg0 = globalRef(intern("vector-set!"));
 __arg1 = v;
 __arg2 = makeNumber(0);
-__arg3 = _35reg2232;
+__arg3 = _35reg2234;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 13, _35clofun2856, 2, cur1, v);
+pushCont(co, 13, _35clofun2930, 2, cur1, v);
 __nargs = 4;
 __arg0 = globalRef(intern("vector-set!"));
 __arg1 = v;
@@ -6929,24 +7582,24 @@ __arg3 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label15:
 {
-Obj _35val2241 = __arg1;
+Obj _35val2243 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj tmp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2242 = primCons(_35val2241, Nil);
-Obj _35reg2243 = primCons(x, _35reg2242);
-Obj _35reg2244 = primCons(tmp, _35reg2243);
-Obj _35reg2245 = primCons(intern("let"), _35reg2244);
+Obj _35reg2244 = primCons(_35val2243, Nil);
+Obj _35reg2245 = primCons(x, _35reg2244);
+Obj _35reg2246 = primCons(tmp, _35reg2245);
+Obj _35reg2247 = primCons(intern("let"), _35reg2246);
 __nargs = 2;
-__arg1 = _35reg2245;
+__arg1 = _35reg2247;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2856) { goto fail; }
+if (co->ctx.pc.func != _35clofun2930) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -6954,16 +7607,16 @@ label16:
 {
 Obj x = __arg1;
 Obj k = __arg2;
-Obj _35reg2240 = primGenSym(intern("reg"));
-Obj tmp = _35reg2240;
-pushCont(co, 15, _35clofun2856, 2, x, tmp);
+Obj _35reg2242 = primGenSym(intern("reg"));
+Obj tmp = _35reg2242;
+pushCont(co, 15, _35clofun2930, 2, x, tmp);
 __nargs = 2;
 __arg0 = k;
 __arg1 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6975,39 +7628,39 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2256 = __arg1;
+Obj _35val2258 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2257 = primAdd(i, makeNumber(1));
+Obj _35reg2259 = primAdd(i, makeNumber(1));
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-call-list"));
 __arg1 = self;
 __arg2 = w;
-__arg3 = _35reg2257;
+__arg3 = _35reg2259;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val2255 = __arg1;
+Obj _35val2257 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun2856, 4, i, self, w, more);
+pushCont(co, 18, _35clofun2930, 4, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal.generate-str"));
 __arg1 = w;
@@ -7015,19 +7668,19 @@ __arg2 = makeString1(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val2254 = __arg1;
+Obj _35val2256 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 19, _35clofun2856, 4, i, self, w, more);
+pushCont(co, 19, _35clofun2930, 4, i, self, w, more);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc.generate-inst"));
 __arg1 = self;
@@ -7037,7 +7690,7 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2856) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2930) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7050,7 +7703,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2855(struct Cora* co){
+void _35clofun2929(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -7063,97 +7716,97 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2100 = __arg1;
+Obj _35val2102 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2101 = primCons(name, idx);
-pushCont(co, 20, _35clofun2854, 3, fvs, _35reg2101, clo_45or_45cont);
+Obj _35reg2103 = primCons(name, idx);
+pushCont(co, 20, _35clofun2928, 3, fvs, _35reg2103, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2110 = __arg1;
+Obj _35val2112 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2111 = primCons(name, idx);
-Obj _35reg2112 = primCons(_35reg2111, fvs);
-Obj _35reg2113 = primCons(clo_45or_45cont, _35reg2112);
+Obj _35reg2113 = primCons(name, idx);
+Obj _35reg2114 = primCons(_35reg2113, fvs);
+Obj _35reg2115 = primCons(clo_45or_45cont, _35reg2114);
 __nargs = 2;
-__arg1 = _35reg2113;
+__arg1 = _35reg2115;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2855) { goto fail; }
+if (co->ctx.pc.func != _35clofun2929) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val2123 = __arg1;
+Obj _35val2125 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2122= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2124= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2124 = primCons(_35val2123, fvs);
-Obj _35reg2125 = primCons(_35reg2122, _35reg2124);
-Obj _35reg2126 = primCons(clo_45or_45cont, _35reg2125);
+Obj _35reg2126 = primCons(_35val2125, fvs);
+Obj _35reg2127 = primCons(_35reg2124, _35reg2126);
+Obj _35reg2128 = primCons(clo_45or_45cont, _35reg2127);
 __nargs = 2;
-__arg1 = _35reg2126;
+__arg1 = _35reg2128;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2855) { goto fail; }
+if (co->ctx.pc.func != _35clofun2929) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label3:
 {
-Obj _35val2121 = __arg1;
+Obj _35val2123 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2122 = primCons(name, idx);
-pushCont(co, 2, _35clofun2855, 3, fvs, _35reg2122, clo_45or_45cont);
+Obj _35reg2124 = primCons(name, idx);
+pushCont(co, 2, _35clofun2929, 3, fvs, _35reg2124, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val2131 = __arg1;
+Obj _35val2133 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2132 = primCons(name, idx);
-Obj _35reg2133 = primCons(_35reg2132, fvs);
-Obj _35reg2134 = primCons(clo_45or_45cont, _35reg2133);
+Obj _35reg2134 = primCons(name, idx);
+Obj _35reg2135 = primCons(_35reg2134, fvs);
+Obj _35reg2136 = primCons(clo_45or_45cont, _35reg2135);
 __nargs = 2;
-__arg1 = _35reg2134;
+__arg1 = _35reg2136;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2855) { goto fail; }
+if (co->ctx.pc.func != _35clofun2929) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label5:
 {
-Obj _35val2114 = __arg1;
+Obj _35val2116 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -7161,123 +7814,123 @@ Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 5];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 6];
-Obj _35reg2115 = primCar(_35val2114);
-Obj name = _35reg2115;
-Obj _35reg2116 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2116) {
-Obj _35reg2117 = primCons(body1, Nil);
-Obj _35reg2118 = primCons(Nil, _35reg2117);
-Obj _35reg2119 = primCons(params, _35reg2118);
-Obj _35reg2120 = primCons(intern("lambda"), _35reg2119);
-pushCont(co, 3, _35clofun2855, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj _35reg2117 = primCar(_35val2116);
+Obj name = _35reg2117;
+Obj _35reg2118 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2118) {
+Obj _35reg2119 = primCons(body1, Nil);
+Obj _35reg2120 = primCons(Nil, _35reg2119);
+Obj _35reg2121 = primCons(params, _35reg2120);
+Obj _35reg2122 = primCons(intern("lambda"), _35reg2121);
+pushCont(co, 3, _35clofun2929, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc.append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2120;
+co->args[5] = _35reg2122;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2127 = primCons(body1, Nil);
-Obj _35reg2128 = primCons(fvs, _35reg2127);
-Obj _35reg2129 = primCons(params, _35reg2128);
-Obj _35reg2130 = primCons(intern("lambda"), _35reg2129);
-pushCont(co, 4, _35clofun2855, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg2129 = primCons(body1, Nil);
+Obj _35reg2130 = primCons(fvs, _35reg2129);
+Obj _35reg2131 = primCons(params, _35reg2130);
+Obj _35reg2132 = primCons(intern("lambda"), _35reg2131);
+pushCont(co, 4, _35clofun2929, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc.append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2130;
+co->args[5] = _35reg2132;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label6:
 {
-Obj _35val2092 = __arg1;
+Obj _35val2094 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj cur = _35val2092;
-Obj _35reg2093 = primEQ(idx, makeNumber(0));
-if (True == _35reg2093) {
-Obj _35reg2094 = primGenSym(intern("clofun"));
-Obj name = _35reg2094;
-Obj _35reg2095 = primEQ(clo_45or_45cont, intern("%closure"));
+Obj cur = _35val2094;
+Obj _35reg2095 = primEQ(idx, makeNumber(0));
 if (True == _35reg2095) {
-Obj _35reg2096 = primCons(body1, Nil);
-Obj _35reg2097 = primCons(Nil, _35reg2096);
-Obj _35reg2098 = primCons(params, _35reg2097);
-Obj _35reg2099 = primCons(intern("lambda"), _35reg2098);
-pushCont(co, 0, _35clofun2855, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj _35reg2096 = primGenSym(intern("clofun"));
+Obj name = _35reg2096;
+Obj _35reg2097 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2097) {
+Obj _35reg2098 = primCons(body1, Nil);
+Obj _35reg2099 = primCons(Nil, _35reg2098);
+Obj _35reg2100 = primCons(params, _35reg2099);
+Obj _35reg2101 = primCons(intern("lambda"), _35reg2100);
+pushCont(co, 0, _35clofun2929, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc.append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2099;
+co->args[5] = _35reg2101;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2106 = primCons(body1, Nil);
-Obj _35reg2107 = primCons(fvs, _35reg2106);
-Obj _35reg2108 = primCons(params, _35reg2107);
-Obj _35reg2109 = primCons(intern("lambda"), _35reg2108);
-pushCont(co, 1, _35clofun2855, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg2108 = primCons(body1, Nil);
+Obj _35reg2109 = primCons(fvs, _35reg2108);
+Obj _35reg2110 = primCons(params, _35reg2109);
+Obj _35reg2111 = primCons(intern("lambda"), _35reg2110);
+pushCont(co, 1, _35clofun2929, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc.append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2109;
+co->args[5] = _35reg2111;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 5, _35clofun2855, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
+pushCont(co, 5, _35clofun2929, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("caar"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35val2091 = __arg1;
+Obj _35val2093 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val2091;
-pushCont(co, 6, _35clofun2855, 6, body1, params, v, idx, fvs, clo_45or_45cont);
+Obj idx = _35val2093;
+pushCont(co, 6, _35clofun2929, 6, body1, params, v, idx, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("vector-ref"));
 __arg1 = v;
@@ -7285,19 +7938,19 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val2090 = __arg1;
+Obj _35val2092 = __arg1;
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj body1 = _35val2090;
-pushCont(co, 7, _35clofun2855, 5, body1, params, v, fvs, clo_45or_45cont);
+Obj body1 = _35val2092;
+pushCont(co, 7, _35clofun2929, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("vector-ref"));
 __arg1 = v;
@@ -7305,119 +7958,119 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val2148 = __arg1;
+Obj _35val2150 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2147= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2149= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2149 = primCons(_35val2148, fvs);
-Obj _35reg2150 = primCons(_35reg2147, _35reg2149);
-Obj _35reg2151 = primCons(clo_45or_45cont, _35reg2150);
+Obj _35reg2151 = primCons(_35val2150, fvs);
+Obj _35reg2152 = primCons(_35reg2149, _35reg2151);
+Obj _35reg2153 = primCons(clo_45or_45cont, _35reg2152);
 __nargs = 2;
-__arg1 = _35reg2151;
+__arg1 = _35reg2153;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2855) { goto fail; }
+if (co->ctx.pc.func != _35clofun2929) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label10:
 {
-Obj _35val2146 = __arg1;
+Obj _35val2148 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2147 = primCons(name, idx);
-pushCont(co, 9, _35clofun2855, 3, fvs, _35reg2147, clo_45or_45cont);
+Obj _35reg2149 = primCons(name, idx);
+pushCont(co, 9, _35clofun2929, 3, fvs, _35reg2149, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val2156 = __arg1;
+Obj _35val2158 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2157 = primCons(name, idx);
-Obj _35reg2158 = primCons(_35reg2157, fvs);
-Obj _35reg2159 = primCons(clo_45or_45cont, _35reg2158);
+Obj _35reg2159 = primCons(name, idx);
+Obj _35reg2160 = primCons(_35reg2159, fvs);
+Obj _35reg2161 = primCons(clo_45or_45cont, _35reg2160);
 __nargs = 2;
-__arg1 = _35reg2159;
+__arg1 = _35reg2161;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2855) { goto fail; }
+if (co->ctx.pc.func != _35clofun2929) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label12:
 {
-Obj _35val2169 = __arg1;
+Obj _35val2171 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2168= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2170= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2170 = primCons(_35val2169, fvs);
-Obj _35reg2171 = primCons(_35reg2168, _35reg2170);
-Obj _35reg2172 = primCons(clo_45or_45cont, _35reg2171);
+Obj _35reg2172 = primCons(_35val2171, fvs);
+Obj _35reg2173 = primCons(_35reg2170, _35reg2172);
+Obj _35reg2174 = primCons(clo_45or_45cont, _35reg2173);
 __nargs = 2;
-__arg1 = _35reg2172;
+__arg1 = _35reg2174;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2855) { goto fail; }
+if (co->ctx.pc.func != _35clofun2929) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label13:
 {
-Obj _35val2167 = __arg1;
+Obj _35val2169 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2168 = primCons(name, idx);
-pushCont(co, 12, _35clofun2855, 3, fvs, _35reg2168, clo_45or_45cont);
+Obj _35reg2170 = primCons(name, idx);
+pushCont(co, 12, _35clofun2929, 3, fvs, _35reg2170, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2177 = __arg1;
+Obj _35val2179 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2178 = primCons(name, idx);
-Obj _35reg2179 = primCons(_35reg2178, fvs);
-Obj _35reg2180 = primCons(clo_45or_45cont, _35reg2179);
+Obj _35reg2180 = primCons(name, idx);
+Obj _35reg2181 = primCons(_35reg2180, fvs);
+Obj _35reg2182 = primCons(clo_45or_45cont, _35reg2181);
 __nargs = 2;
-__arg1 = _35reg2180;
+__arg1 = _35reg2182;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2855) { goto fail; }
+if (co->ctx.pc.func != _35clofun2929) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label15:
 {
-Obj _35val2160 = __arg1;
+Obj _35val2162 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -7425,123 +8078,123 @@ Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 5];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 6];
-Obj _35reg2161 = primCar(_35val2160);
-Obj name = _35reg2161;
-Obj _35reg2162 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2162) {
-Obj _35reg2163 = primCons(body1, Nil);
-Obj _35reg2164 = primCons(Nil, _35reg2163);
-Obj _35reg2165 = primCons(params, _35reg2164);
-Obj _35reg2166 = primCons(intern("lambda"), _35reg2165);
-pushCont(co, 13, _35clofun2855, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj _35reg2163 = primCar(_35val2162);
+Obj name = _35reg2163;
+Obj _35reg2164 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2164) {
+Obj _35reg2165 = primCons(body1, Nil);
+Obj _35reg2166 = primCons(Nil, _35reg2165);
+Obj _35reg2167 = primCons(params, _35reg2166);
+Obj _35reg2168 = primCons(intern("lambda"), _35reg2167);
+pushCont(co, 13, _35clofun2929, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc.append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2166;
+co->args[5] = _35reg2168;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2173 = primCons(body1, Nil);
-Obj _35reg2174 = primCons(fvs, _35reg2173);
-Obj _35reg2175 = primCons(params, _35reg2174);
-Obj _35reg2176 = primCons(intern("lambda"), _35reg2175);
-pushCont(co, 14, _35clofun2855, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg2175 = primCons(body1, Nil);
+Obj _35reg2176 = primCons(fvs, _35reg2175);
+Obj _35reg2177 = primCons(params, _35reg2176);
+Obj _35reg2178 = primCons(intern("lambda"), _35reg2177);
+pushCont(co, 14, _35clofun2929, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc.append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2176;
+co->args[5] = _35reg2178;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label16:
 {
-Obj _35val2138 = __arg1;
+Obj _35val2140 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj cur = _35val2138;
-Obj _35reg2139 = primEQ(idx, makeNumber(0));
-if (True == _35reg2139) {
-Obj _35reg2140 = primGenSym(intern("clofun"));
-Obj name = _35reg2140;
-Obj _35reg2141 = primEQ(clo_45or_45cont, intern("%closure"));
+Obj cur = _35val2140;
+Obj _35reg2141 = primEQ(idx, makeNumber(0));
 if (True == _35reg2141) {
-Obj _35reg2142 = primCons(body1, Nil);
-Obj _35reg2143 = primCons(Nil, _35reg2142);
-Obj _35reg2144 = primCons(params, _35reg2143);
-Obj _35reg2145 = primCons(intern("lambda"), _35reg2144);
-pushCont(co, 10, _35clofun2855, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj _35reg2142 = primGenSym(intern("clofun"));
+Obj name = _35reg2142;
+Obj _35reg2143 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2143) {
+Obj _35reg2144 = primCons(body1, Nil);
+Obj _35reg2145 = primCons(Nil, _35reg2144);
+Obj _35reg2146 = primCons(params, _35reg2145);
+Obj _35reg2147 = primCons(intern("lambda"), _35reg2146);
+pushCont(co, 10, _35clofun2929, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc.append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2145;
+co->args[5] = _35reg2147;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2152 = primCons(body1, Nil);
-Obj _35reg2153 = primCons(fvs, _35reg2152);
-Obj _35reg2154 = primCons(params, _35reg2153);
-Obj _35reg2155 = primCons(intern("lambda"), _35reg2154);
-pushCont(co, 11, _35clofun2855, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg2154 = primCons(body1, Nil);
+Obj _35reg2155 = primCons(fvs, _35reg2154);
+Obj _35reg2156 = primCons(params, _35reg2155);
+Obj _35reg2157 = primCons(intern("lambda"), _35reg2156);
+pushCont(co, 11, _35clofun2929, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc.append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2155;
+co->args[5] = _35reg2157;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 15, _35clofun2855, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
+pushCont(co, 15, _35clofun2929, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("caar"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label17:
 {
-Obj _35val2137 = __arg1;
+Obj _35val2139 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val2137;
-pushCont(co, 16, _35clofun2855, 6, body1, params, v, idx, fvs, clo_45or_45cont);
+Obj idx = _35val2139;
+pushCont(co, 16, _35clofun2929, 6, body1, params, v, idx, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("vector-ref"));
 __arg1 = v;
@@ -7549,19 +8202,19 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2136 = __arg1;
+Obj _35val2138 = __arg1;
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj body1 = _35val2136;
-pushCont(co, 17, _35clofun2855, 5, body1, params, v, fvs, clo_45or_45cont);
+Obj body1 = _35val2138;
+pushCont(co, 17, _35clofun2929, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("vector-ref"));
 __arg1 = v;
@@ -7569,43 +8222,43 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val2193 = __arg1;
+Obj _35val2195 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2192= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2194= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2194 = primCons(_35val2193, fvs);
-Obj _35reg2195 = primCons(_35reg2192, _35reg2194);
-Obj _35reg2196 = primCons(clo_45or_45cont, _35reg2195);
+Obj _35reg2196 = primCons(_35val2195, fvs);
+Obj _35reg2197 = primCons(_35reg2194, _35reg2196);
+Obj _35reg2198 = primCons(clo_45or_45cont, _35reg2197);
 __nargs = 2;
-__arg1 = _35reg2196;
+__arg1 = _35reg2198;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2855) { goto fail; }
+if (co->ctx.pc.func != _35clofun2929) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label20:
 {
-Obj _35val2191 = __arg1;
+Obj _35val2193 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2192 = primCons(name, idx);
-pushCont(co, 19, _35clofun2855, 3, fvs, _35reg2192, clo_45or_45cont);
+Obj _35reg2194 = primCons(name, idx);
+pushCont(co, 19, _35clofun2929, 3, fvs, _35reg2194, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2855) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2929) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7618,7 +8271,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2854(struct Cora* co){
+void _35clofun2928(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -7631,54 +8284,54 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1114 = makeNative(19, _35clofun2853, 0, 0);
+Obj _35cc1109 = makeNative(19, _35clofun2927, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj _35reg1972 = primIsCons(closureRef(co, 1));
-if (True == _35reg1972) {
-Obj _35reg1973 = primCar(closureRef(co, 1));
-Obj f = _35reg1973;
-Obj _35reg1974 = primCdr(closureRef(co, 1));
-Obj args = _35reg1974;
-pushCont(co, 20, _35clofun2853, 2, f, args);
+Obj _35reg1974 = primIsCons(closureRef(co, 1));
+if (True == _35reg1974) {
+Obj _35reg1975 = primCar(closureRef(co, 1));
+Obj f = _35reg1975;
+Obj _35reg1976 = primCdr(closureRef(co, 1));
+Obj args = _35reg1976;
+pushCont(co, 20, _35clofun2927, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.explicit-stack"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1114;
+__arg0 = _35cc1109;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35val1996 = __arg1;
-Obj _35val1995= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1997 = primCons(_35val1996, Nil);
-Obj _35reg1998 = primCons(_35val1995, _35reg1997);
-Obj _35reg1999 = primCons(intern("call"), _35reg1998);
+Obj _35val1998 = __arg1;
+Obj _35val1997= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1999 = primCons(_35val1998, Nil);
+Obj _35reg2000 = primCons(_35val1997, _35reg1999);
+Obj _35reg2001 = primCons(intern("call"), _35reg2000);
 __nargs = 2;
-__arg1 = _35reg1999;
+__arg1 = _35reg2001;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2854) { goto fail; }
+if (co->ctx.pc.func != _35clofun2928) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val1995 = __arg1;
+Obj _35val1997 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun2854, 1, _35val1995);
+pushCont(co, 1, _35clofun2928, 1, _35val1997);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.explicit-stack"));
 __arg1 = fvs;
@@ -7686,137 +8339,137 @@ __arg2 = cont;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val1994 = __arg1;
+Obj _35val1996 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 2, _35clofun2854, 2, fvs, cont);
+pushCont(co, 2, _35clofun2928, 2, fvs, cont);
 __nargs = 3;
 __arg0 = globalRef(intern("map"));
-__arg1 = _35val1994;
+__arg1 = _35val1996;
 __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35cc1113 = makeNative(0, _35clofun2854, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1108 = makeNative(0, _35clofun2928, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg1977 = primIsCons(closureRef(co, 1));
-if (True == _35reg1977) {
-Obj _35reg1978 = primCar(closureRef(co, 1));
-Obj _35reg1979 = primEQ(intern("call"), _35reg1978);
+Obj _35reg1979 = primIsCons(closureRef(co, 1));
 if (True == _35reg1979) {
-Obj _35reg1980 = primCdr(closureRef(co, 1));
-Obj _35reg1981 = primIsCons(_35reg1980);
+Obj _35reg1980 = primCar(closureRef(co, 1));
+Obj _35reg1981 = primEQ(intern("call"), _35reg1980);
 if (True == _35reg1981) {
 Obj _35reg1982 = primCdr(closureRef(co, 1));
-Obj _35reg1983 = primCar(_35reg1982);
-Obj exp = _35reg1983;
+Obj _35reg1983 = primIsCons(_35reg1982);
+if (True == _35reg1983) {
 Obj _35reg1984 = primCdr(closureRef(co, 1));
-Obj _35reg1985 = primCdr(_35reg1984);
-Obj _35reg1986 = primIsCons(_35reg1985);
-if (True == _35reg1986) {
-Obj _35reg1987 = primCdr(closureRef(co, 1));
-Obj _35reg1988 = primCdr(_35reg1987);
-Obj _35reg1989 = primCar(_35reg1988);
-Obj cont = _35reg1989;
-Obj _35reg1990 = primCdr(closureRef(co, 1));
-Obj _35reg1991 = primCdr(_35reg1990);
-Obj _35reg1992 = primCdr(_35reg1991);
-Obj _35reg1993 = primEQ(Nil, _35reg1992);
-if (True == _35reg1993) {
-pushCont(co, 3, _35clofun2854, 3, exp, fvs, cont);
+Obj _35reg1985 = primCar(_35reg1984);
+Obj exp = _35reg1985;
+Obj _35reg1986 = primCdr(closureRef(co, 1));
+Obj _35reg1987 = primCdr(_35reg1986);
+Obj _35reg1988 = primIsCons(_35reg1987);
+if (True == _35reg1988) {
+Obj _35reg1989 = primCdr(closureRef(co, 1));
+Obj _35reg1990 = primCdr(_35reg1989);
+Obj _35reg1991 = primCar(_35reg1990);
+Obj cont = _35reg1991;
+Obj _35reg1992 = primCdr(closureRef(co, 1));
+Obj _35reg1993 = primCdr(_35reg1992);
+Obj _35reg1994 = primCdr(_35reg1993);
+Obj _35reg1995 = primEQ(Nil, _35reg1994);
+if (True == _35reg1995) {
+pushCont(co, 3, _35clofun2928, 3, exp, fvs, cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.explicit-stack"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1113;
+__arg0 = _35cc1108;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1113;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1113;
+__arg0 = _35cc1108;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1113;
+__arg0 = _35cc1108;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1113;
+__arg0 = _35cc1108;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1108;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35val2021 = __arg1;
+Obj _35val2023 = __arg1;
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fvs2= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2022 = primCons(_35val2021, Nil);
-Obj _35reg2023 = primCons(val, _35reg2022);
-Obj _35reg2024 = primCons(intern("lambda"), _35reg2023);
-Obj _35reg2025 = primCons(_35reg2024, fvs2);
-Obj _35reg2026 = primCons(intern("%continuation"), _35reg2025);
+Obj _35reg2024 = primCons(_35val2023, Nil);
+Obj _35reg2025 = primCons(val, _35reg2024);
+Obj _35reg2026 = primCons(intern("lambda"), _35reg2025);
+Obj _35reg2027 = primCons(_35reg2026, fvs2);
+Obj _35reg2028 = primCons(intern("%continuation"), _35reg2027);
 __nargs = 2;
-__arg1 = _35reg2026;
+__arg1 = _35reg2028;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2854) { goto fail; }
+if (co->ctx.pc.func != _35clofun2928) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label6:
 {
-Obj _35val2020 = __arg1;
+Obj _35val2022 = __arg1;
 Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs2 = _35val2020;
-pushCont(co, 5, _35clofun2854, 2, val, fvs2);
+Obj fvs2 = _35val2022;
+pushCont(co, 5, _35clofun2928, 2, val, fvs2);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.explicit-stack"));
 __arg1 = fvs1;
@@ -7824,191 +8477,191 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val2019 = __arg1;
+Obj _35val2021 = __arg1;
 Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 6, _35clofun2854, 3, fvs1, body, val);
+pushCont(co, 6, _35clofun2928, 3, fvs1, body, val);
 __nargs = 3;
 __arg0 = globalRef(intern("map"));
-__arg1 = _35val2019;
+__arg1 = _35val2021;
 __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val2018 = __arg1;
+Obj _35val2020 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs1 = _35val2018;
-pushCont(co, 7, _35clofun2854, 3, fvs1, body, val);
+Obj fvs1 = _35val2020;
+pushCont(co, 7, _35clofun2928, 3, fvs1, body, val);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.explicit-stack"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val2017 = __arg1;
+Obj _35val2019 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 8, _35clofun2854, 3, fvs, body, val);
+pushCont(co, 8, _35clofun2928, 3, fvs, body, val);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.diff"));
-__arg1 = _35val2017;
+__arg1 = _35val2019;
 __arg2 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35cc1112 = makeNative(4, _35clofun2854, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1107 = makeNative(4, _35clofun2928, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2000 = primIsCons(closureRef(co, 1));
-if (True == _35reg2000) {
-Obj _35reg2001 = primCar(closureRef(co, 1));
-Obj _35reg2002 = primEQ(intern("continuation"), _35reg2001);
+Obj _35reg2002 = primIsCons(closureRef(co, 1));
 if (True == _35reg2002) {
-Obj _35reg2003 = primCdr(closureRef(co, 1));
-Obj _35reg2004 = primIsCons(_35reg2003);
+Obj _35reg2003 = primCar(closureRef(co, 1));
+Obj _35reg2004 = primEQ(intern("continuation"), _35reg2003);
 if (True == _35reg2004) {
 Obj _35reg2005 = primCdr(closureRef(co, 1));
-Obj _35reg2006 = primCar(_35reg2005);
-Obj val = _35reg2006;
+Obj _35reg2006 = primIsCons(_35reg2005);
+if (True == _35reg2006) {
 Obj _35reg2007 = primCdr(closureRef(co, 1));
-Obj _35reg2008 = primCdr(_35reg2007);
-Obj _35reg2009 = primIsCons(_35reg2008);
-if (True == _35reg2009) {
-Obj _35reg2010 = primCdr(closureRef(co, 1));
-Obj _35reg2011 = primCdr(_35reg2010);
-Obj _35reg2012 = primCar(_35reg2011);
-Obj body = _35reg2012;
-Obj _35reg2013 = primCdr(closureRef(co, 1));
-Obj _35reg2014 = primCdr(_35reg2013);
-Obj _35reg2015 = primCdr(_35reg2014);
-Obj _35reg2016 = primEQ(Nil, _35reg2015);
-if (True == _35reg2016) {
-pushCont(co, 9, _35clofun2854, 3, fvs, body, val);
+Obj _35reg2008 = primCar(_35reg2007);
+Obj val = _35reg2008;
+Obj _35reg2009 = primCdr(closureRef(co, 1));
+Obj _35reg2010 = primCdr(_35reg2009);
+Obj _35reg2011 = primIsCons(_35reg2010);
+if (True == _35reg2011) {
+Obj _35reg2012 = primCdr(closureRef(co, 1));
+Obj _35reg2013 = primCdr(_35reg2012);
+Obj _35reg2014 = primCar(_35reg2013);
+Obj body = _35reg2014;
+Obj _35reg2015 = primCdr(closureRef(co, 1));
+Obj _35reg2016 = primCdr(_35reg2015);
+Obj _35reg2017 = primCdr(_35reg2016);
+Obj _35reg2018 = primEQ(Nil, _35reg2017);
+if (True == _35reg2018) {
+pushCont(co, 9, _35clofun2928, 3, fvs, body, val);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.free-vars"));
 __arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1112;
+__arg0 = _35cc1107;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1112;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1112;
+__arg0 = _35cc1107;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1112;
+__arg0 = _35cc1107;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1112;
+__arg0 = _35cc1107;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1107;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35val2044 = __arg1;
+Obj _35val2046 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2045 = primCons(_35val2044, Nil);
-Obj _35reg2046 = primCons(args, _35reg2045);
-Obj _35reg2047 = primCons(intern("lambda"), _35reg2046);
+Obj _35reg2047 = primCons(_35val2046, Nil);
+Obj _35reg2048 = primCons(args, _35reg2047);
+Obj _35reg2049 = primCons(intern("lambda"), _35reg2048);
 __nargs = 2;
-__arg1 = _35reg2047;
+__arg1 = _35reg2049;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2854) { goto fail; }
+if (co->ctx.pc.func != _35clofun2928) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label12:
 {
-Obj _35cc1111 = makeNative(10, _35clofun2854, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1106 = makeNative(10, _35clofun2928, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2027 = primIsCons(closureRef(co, 1));
-if (True == _35reg2027) {
-Obj _35reg2028 = primCar(closureRef(co, 1));
-Obj _35reg2029 = primEQ(intern("lambda"), _35reg2028);
+Obj _35reg2029 = primIsCons(closureRef(co, 1));
 if (True == _35reg2029) {
-Obj _35reg2030 = primCdr(closureRef(co, 1));
-Obj _35reg2031 = primIsCons(_35reg2030);
+Obj _35reg2030 = primCar(closureRef(co, 1));
+Obj _35reg2031 = primEQ(intern("lambda"), _35reg2030);
 if (True == _35reg2031) {
 Obj _35reg2032 = primCdr(closureRef(co, 1));
-Obj _35reg2033 = primCar(_35reg2032);
-Obj args = _35reg2033;
+Obj _35reg2033 = primIsCons(_35reg2032);
+if (True == _35reg2033) {
 Obj _35reg2034 = primCdr(closureRef(co, 1));
-Obj _35reg2035 = primCdr(_35reg2034);
-Obj _35reg2036 = primIsCons(_35reg2035);
-if (True == _35reg2036) {
-Obj _35reg2037 = primCdr(closureRef(co, 1));
-Obj _35reg2038 = primCdr(_35reg2037);
-Obj _35reg2039 = primCar(_35reg2038);
-Obj body = _35reg2039;
-Obj _35reg2040 = primCdr(closureRef(co, 1));
-Obj _35reg2041 = primCdr(_35reg2040);
-Obj _35reg2042 = primCdr(_35reg2041);
-Obj _35reg2043 = primEQ(Nil, _35reg2042);
-if (True == _35reg2043) {
-pushCont(co, 11, _35clofun2854, 1, args);
+Obj _35reg2035 = primCar(_35reg2034);
+Obj args = _35reg2035;
+Obj _35reg2036 = primCdr(closureRef(co, 1));
+Obj _35reg2037 = primCdr(_35reg2036);
+Obj _35reg2038 = primIsCons(_35reg2037);
+if (True == _35reg2038) {
+Obj _35reg2039 = primCdr(closureRef(co, 1));
+Obj _35reg2040 = primCdr(_35reg2039);
+Obj _35reg2041 = primCar(_35reg2040);
+Obj body = _35reg2041;
+Obj _35reg2042 = primCdr(closureRef(co, 1));
+Obj _35reg2043 = primCdr(_35reg2042);
+Obj _35reg2044 = primCdr(_35reg2043);
+Obj _35reg2045 = primEQ(Nil, _35reg2044);
+if (True == _35reg2045) {
+pushCont(co, 11, _35clofun2928, 1, args);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.explicit-stack"));
 __arg1 = fvs;
@@ -8016,115 +8669,115 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1111;
+__arg0 = _35cc1106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1111;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1111;
+__arg0 = _35cc1106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1111;
+__arg0 = _35cc1106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1111;
+__arg0 = _35cc1106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1106;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label13:
 {
-Obj _35cc1110 = makeNative(12, _35clofun2854, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1105 = makeNative(12, _35clofun2928, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj _35reg2048 = primIsSymbol(var);
-if (True == _35reg2048) {
+Obj _35reg2050 = primIsSymbol(var);
+if (True == _35reg2050) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2854) { goto fail; }
+if (co->ctx.pc.func != _35clofun2928) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1110;
+__arg0 = _35cc1105;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label14:
 {
-Obj _35val2049 = __arg1;
+Obj _35val2051 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1109= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2049) {
+Obj _35cc1104= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val2051) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2854) { goto fail; }
+if (co->ctx.pc.func != _35clofun2928) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1109;
+__arg0 = _35cc1104;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label15:
 {
-Obj _35p1107 = __arg1;
-Obj _35p1108 = __arg2;
-Obj _35cc1109 = makeNative(13, _35clofun2854, 0, 2, _35p1107, _35p1108);
-Obj __ = _35p1107;
-Obj x = _35p1108;
-pushCont(co, 14, _35clofun2854, 2, x, _35cc1109);
+Obj _35p1102 = __arg1;
+Obj _35p1103 = __arg2;
+Obj _35cc1104 = makeNative(13, _35clofun2928, 0, 2, _35p1102, _35p1103);
+Obj __ = _35p1102;
+Obj x = _35p1103;
+pushCont(co, 14, _35clofun2928, 2, x, _35cc1104);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8136,19 +8789,19 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35cc1119 = makeNative(16, _35clofun2854, 0, 0);
+Obj _35cc1114 = makeNative(16, _35clofun2928, 0, 0);
 Obj v = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2854) { goto fail; }
+if (co->ctx.pc.func != _35clofun2928) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -8162,50 +8815,50 @@ __arg2 = e;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35cc1118 = makeNative(17, _35clofun2854, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1113 = makeNative(17, _35clofun2928, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj v = closureRef(co, 0);
 Obj f_45args = closureRef(co, 1);
-Obj _35reg2051 = primIsCons(f_45args);
-if (True == _35reg2051) {
+Obj _35reg2053 = primIsCons(f_45args);
+if (True == _35reg2053) {
 __nargs = 3;
 __arg0 = globalRef(intern("map"));
-__arg1 = makeNative(18, _35clofun2854, 1, 1, v);
+__arg1 = makeNative(18, _35clofun2928, 1, 1, v);
 __arg2 = f_45args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1118;
+__arg0 = _35cc1113;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2854) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2928) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label20:
 {
-Obj _35val2102 = __arg1;
+Obj _35val2104 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2101= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2103= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2103 = primCons(_35val2102, fvs);
-Obj _35reg2104 = primCons(_35reg2101, _35reg2103);
-Obj _35reg2105 = primCons(clo_45or_45cont, _35reg2104);
+Obj _35reg2105 = primCons(_35val2104, fvs);
+Obj _35reg2106 = primCons(_35reg2103, _35reg2105);
+Obj _35reg2107 = primCons(clo_45or_45cont, _35reg2106);
 __nargs = 2;
-__arg1 = _35reg2105;
+__arg1 = _35reg2107;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2854) { goto fail; }
+if (co->ctx.pc.func != _35clofun2928) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -8218,7 +8871,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2853(struct Cora* co){
+void _35clofun2927(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -8231,109 +8884,109 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1098 = makeNative(18, _35clofun2852, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1867 = primIsCons(closureRef(co, 0));
-if (True == _35reg1867) {
-Obj _35reg1868 = primCar(closureRef(co, 0));
-Obj _35reg1869 = primEQ(intern("do"), _35reg1868);
+Obj _35cc1093 = makeNative(18, _35clofun2926, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1869 = primIsCons(closureRef(co, 0));
 if (True == _35reg1869) {
-Obj _35reg1870 = primCdr(closureRef(co, 0));
-Obj _35reg1871 = primIsCons(_35reg1870);
+Obj _35reg1870 = primCar(closureRef(co, 0));
+Obj _35reg1871 = primEQ(intern("do"), _35reg1870);
 if (True == _35reg1871) {
 Obj _35reg1872 = primCdr(closureRef(co, 0));
-Obj _35reg1873 = primCar(_35reg1872);
-Obj a = _35reg1873;
+Obj _35reg1873 = primIsCons(_35reg1872);
+if (True == _35reg1873) {
 Obj _35reg1874 = primCdr(closureRef(co, 0));
-Obj _35reg1875 = primCdr(_35reg1874);
-Obj _35reg1876 = primIsCons(_35reg1875);
-if (True == _35reg1876) {
-Obj _35reg1877 = primCdr(closureRef(co, 0));
-Obj _35reg1878 = primCdr(_35reg1877);
-Obj _35reg1879 = primCar(_35reg1878);
-Obj b = _35reg1879;
-Obj _35reg1880 = primCdr(closureRef(co, 0));
-Obj _35reg1881 = primCdr(_35reg1880);
-Obj _35reg1882 = primCdr(_35reg1881);
-Obj _35reg1883 = primEQ(Nil, _35reg1882);
-if (True == _35reg1883) {
+Obj _35reg1875 = primCar(_35reg1874);
+Obj a = _35reg1875;
+Obj _35reg1876 = primCdr(closureRef(co, 0));
+Obj _35reg1877 = primCdr(_35reg1876);
+Obj _35reg1878 = primIsCons(_35reg1877);
+if (True == _35reg1878) {
+Obj _35reg1879 = primCdr(closureRef(co, 0));
+Obj _35reg1880 = primCdr(_35reg1879);
+Obj _35reg1881 = primCar(_35reg1880);
+Obj b = _35reg1881;
+Obj _35reg1882 = primCdr(closureRef(co, 0));
+Obj _35reg1883 = primCdr(_35reg1882);
+Obj _35reg1884 = primCdr(_35reg1883);
+Obj _35reg1885 = primEQ(Nil, _35reg1884);
+if (True == _35reg1885) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.tailify"));
 __arg1 = a;
-__arg2 = makeNative(20, _35clofun2852, 1, 2, b, next);
+__arg2 = makeNative(20, _35clofun2926, 1, 2, b, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1098;
+__arg0 = _35cc1093;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1098;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1098;
+__arg0 = _35cc1093;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1098;
+__arg0 = _35cc1093;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1098;
+__arg0 = _35cc1093;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1093;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35val1916 = __arg1;
-Obj _35val1915= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val1918 = __arg1;
+Obj _35val1917= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1917 = primCons(_35val1916, Nil);
-Obj _35reg1918 = primCons(_35val1915, _35reg1917);
-Obj _35reg1919 = primCons(ra, _35reg1918);
-Obj _35reg1920 = primCons(intern("if"), _35reg1919);
+Obj _35reg1919 = primCons(_35val1918, Nil);
+Obj _35reg1920 = primCons(_35val1917, _35reg1919);
+Obj _35reg1921 = primCons(ra, _35reg1920);
+Obj _35reg1922 = primCons(intern("if"), _35reg1921);
 __nargs = 2;
-__arg1 = _35reg1920;
+__arg1 = _35reg1922;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2853) { goto fail; }
+if (co->ctx.pc.func != _35clofun2927) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val1915 = __arg1;
+Obj _35val1917 = __arg1;
 Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 1, _35clofun2853, 2, _35val1915, ra);
+pushCont(co, 1, _35clofun2927, 2, _35val1917, ra);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.tailify"));
 __arg1 = closureRef(co, 1);
@@ -8341,14 +8994,14 @@ __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
 Obj ra = __arg1;
-pushCont(co, 2, _35clofun2853, 1, ra);
+pushCont(co, 2, _35clofun2927, 1, ra);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.tailify"));
 __arg1 = closureRef(co, 0);
@@ -8356,2163 +9009,57 @@ __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35cc1097 = makeNative(0, _35clofun2853, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1889 = primIsCons(closureRef(co, 0));
-if (True == _35reg1889) {
-Obj _35reg1890 = primCar(closureRef(co, 0));
-Obj _35reg1891 = primEQ(intern("if"), _35reg1890);
+Obj _35cc1092 = makeNative(0, _35clofun2927, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1891 = primIsCons(closureRef(co, 0));
 if (True == _35reg1891) {
-Obj _35reg1892 = primCdr(closureRef(co, 0));
-Obj _35reg1893 = primIsCons(_35reg1892);
+Obj _35reg1892 = primCar(closureRef(co, 0));
+Obj _35reg1893 = primEQ(intern("if"), _35reg1892);
 if (True == _35reg1893) {
 Obj _35reg1894 = primCdr(closureRef(co, 0));
-Obj _35reg1895 = primCar(_35reg1894);
-Obj a = _35reg1895;
+Obj _35reg1895 = primIsCons(_35reg1894);
+if (True == _35reg1895) {
 Obj _35reg1896 = primCdr(closureRef(co, 0));
-Obj _35reg1897 = primCdr(_35reg1896);
-Obj _35reg1898 = primIsCons(_35reg1897);
-if (True == _35reg1898) {
-Obj _35reg1899 = primCdr(closureRef(co, 0));
-Obj _35reg1900 = primCdr(_35reg1899);
-Obj _35reg1901 = primCar(_35reg1900);
-Obj b = _35reg1901;
-Obj _35reg1902 = primCdr(closureRef(co, 0));
-Obj _35reg1903 = primCdr(_35reg1902);
-Obj _35reg1904 = primCdr(_35reg1903);
-Obj _35reg1905 = primIsCons(_35reg1904);
-if (True == _35reg1905) {
-Obj _35reg1906 = primCdr(closureRef(co, 0));
-Obj _35reg1907 = primCdr(_35reg1906);
-Obj _35reg1908 = primCdr(_35reg1907);
-Obj _35reg1909 = primCar(_35reg1908);
-Obj c = _35reg1909;
-Obj _35reg1910 = primCdr(closureRef(co, 0));
-Obj _35reg1911 = primCdr(_35reg1910);
-Obj _35reg1912 = primCdr(_35reg1911);
+Obj _35reg1897 = primCar(_35reg1896);
+Obj a = _35reg1897;
+Obj _35reg1898 = primCdr(closureRef(co, 0));
+Obj _35reg1899 = primCdr(_35reg1898);
+Obj _35reg1900 = primIsCons(_35reg1899);
+if (True == _35reg1900) {
+Obj _35reg1901 = primCdr(closureRef(co, 0));
+Obj _35reg1902 = primCdr(_35reg1901);
+Obj _35reg1903 = primCar(_35reg1902);
+Obj b = _35reg1903;
+Obj _35reg1904 = primCdr(closureRef(co, 0));
+Obj _35reg1905 = primCdr(_35reg1904);
+Obj _35reg1906 = primCdr(_35reg1905);
+Obj _35reg1907 = primIsCons(_35reg1906);
+if (True == _35reg1907) {
+Obj _35reg1908 = primCdr(closureRef(co, 0));
+Obj _35reg1909 = primCdr(_35reg1908);
+Obj _35reg1910 = primCdr(_35reg1909);
+Obj _35reg1911 = primCar(_35reg1910);
+Obj c = _35reg1911;
+Obj _35reg1912 = primCdr(closureRef(co, 0));
 Obj _35reg1913 = primCdr(_35reg1912);
-Obj _35reg1914 = primEQ(Nil, _35reg1913);
-if (True == _35reg1914) {
+Obj _35reg1914 = primCdr(_35reg1913);
+Obj _35reg1915 = primCdr(_35reg1914);
+Obj _35reg1916 = primEQ(Nil, _35reg1915);
+if (True == _35reg1916) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.tailify"));
 __arg1 = a;
-__arg2 = makeNative(3, _35clofun2853, 1, 3, b, c, next);
+__arg2 = makeNative(3, _35clofun2927, 1, 3, b, c, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1097;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1097;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1097;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1097;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1097;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1097;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label5:
-{
-Obj _35val1921 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1096= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1921) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2853) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1096;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label6:
-{
-Obj _35cc1096 = makeNative(4, _35clofun2853, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x = closureRef(co, 0);
-Obj __ = closureRef(co, 1);
-pushCont(co, 5, _35clofun2853, 2, x, _35cc1096);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.convert-protect?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val1923 = __arg1;
-Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc1095= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1923) {
-if (True == True) {
-__nargs = 2;
-__arg0 = next;
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1095;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-__nargs = 2;
-__arg0 = next;
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1095;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label8:
-{
-Obj _35p1093 = __arg1;
-Obj _35p1094 = __arg2;
-Obj _35cc1095 = makeNative(6, _35clofun2853, 0, 2, _35p1093, _35p1094);
-Obj x = _35p1093;
-Obj next = _35p1094;
-Obj _35reg1922 = primIsSymbol(x);
-if (True == _35reg1922) {
-if (True == True) {
-__nargs = 2;
-__arg0 = next;
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1095;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 7, _35clofun2853, 3, next, x, _35cc1095);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.convert-protect?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label9:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeString1("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj hd1 = __arg1;
-Obj _35reg1928 = primCons(hd1, closureRef(co, 1));
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc.tailify-list"));
-__arg1 = closureRef(co, 0);
-__arg2 = _35reg1928;
-__arg3 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35cc1106 = makeNative(9, _35clofun2853, 0, 0);
-Obj _35reg1925 = primIsCons(closureRef(co, 0));
-if (True == _35reg1925) {
-Obj _35reg1926 = primCar(closureRef(co, 0));
-Obj hd = _35reg1926;
-Obj _35reg1927 = primCdr(closureRef(co, 0));
-Obj tl = _35reg1927;
-Obj ls = closureRef(co, 1);
-Obj next = closureRef(co, 2);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.tailify"));
-__arg1 = hd;
-__arg2 = makeNative(10, _35clofun2853, 1, 3, tl, ls, next);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1106;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35val1940 = __arg1;
-Obj _35reg1939= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1941 = primCons(_35val1940, Nil);
-Obj _35reg1942 = primCons(_35reg1939, _35reg1941);
-Obj _35reg1943 = primCons(intern("continuation"), _35reg1942);
-Obj _35reg1944 = primCons(_35reg1943, Nil);
-Obj _35reg1945 = primCons(exp, _35reg1944);
-Obj _35reg1946 = primCons(intern("call"), _35reg1945);
-__nargs = 2;
-__arg1 = _35reg1946;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2853) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label13:
-{
-Obj _35val1952 = __arg1;
-Obj _35reg1951= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1953 = primCons(_35val1952, Nil);
-Obj _35reg1954 = primCons(_35reg1951, _35reg1953);
-Obj _35reg1955 = primCons(intern("continuation"), _35reg1954);
-Obj _35reg1956 = primCons(_35reg1955, Nil);
-Obj _35reg1957 = primCons(exp, _35reg1956);
-Obj _35reg1958 = primCons(intern("call"), _35reg1957);
-__nargs = 2;
-__arg1 = _35reg1958;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2853) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label14:
-{
-Obj _35val1933 = __arg1;
-Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1934 = primEQ(_35val1933, intern("%builtin"));
-if (True == _35reg1934) {
-if (True == True) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.wrap-var"));
-__arg1 = exp;
-__arg2 = next;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1935 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
-if (True == _35reg1935) {
-Obj _35reg1936 = primCons(exp, Nil);
-Obj _35reg1937 = primCons(intern("tailcall"), _35reg1936);
-__nargs = 2;
-__arg1 = _35reg1937;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2853) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg1938 = primGenSym(intern("val"));
-Obj val = _35reg1938;
-Obj _35reg1939 = primCons(val, Nil);
-pushCont(co, 12, _35clofun2853, 2, _35reg1939, exp);
-__nargs = 2;
-__arg0 = next;
-__arg1 = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-if (True == False) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.wrap-var"));
-__arg1 = exp;
-__arg2 = next;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1947 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
-if (True == _35reg1947) {
-Obj _35reg1948 = primCons(exp, Nil);
-Obj _35reg1949 = primCons(intern("tailcall"), _35reg1948);
-__nargs = 2;
-__arg1 = _35reg1949;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2853) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg1950 = primGenSym(intern("val"));
-Obj val = _35reg1950;
-Obj _35reg1951 = primCons(val, Nil);
-pushCont(co, 13, _35clofun2853, 2, _35reg1951, exp);
-__nargs = 2;
-__arg0 = next;
-__arg1 = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-}
-
-label15:
-{
-Obj _35val1964 = __arg1;
-Obj _35reg1963= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1965 = primCons(_35val1964, Nil);
-Obj _35reg1966 = primCons(_35reg1963, _35reg1965);
-Obj _35reg1967 = primCons(intern("continuation"), _35reg1966);
-Obj _35reg1968 = primCons(_35reg1967, Nil);
-Obj _35reg1969 = primCons(exp, _35reg1968);
-Obj _35reg1970 = primCons(intern("call"), _35reg1969);
-__nargs = 2;
-__arg1 = _35reg1970;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2853) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label16:
-{
-Obj _35val1932 = __arg1;
-Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1932) {
-pushCont(co, 14, _35clofun2853, 2, next, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("caar"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-if (True == False) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.wrap-var"));
-__arg1 = exp;
-__arg2 = next;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1959 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
-if (True == _35reg1959) {
-Obj _35reg1960 = primCons(exp, Nil);
-Obj _35reg1961 = primCons(intern("tailcall"), _35reg1960);
-__nargs = 2;
-__arg1 = _35reg1961;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2853) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg1962 = primGenSym(intern("val"));
-Obj val = _35reg1962;
-Obj _35reg1963 = primCons(val, Nil);
-pushCont(co, 15, _35clofun2853, 2, _35reg1963, exp);
-__nargs = 2;
-__arg0 = next;
-__arg1 = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-}
-
-label17:
-{
-Obj _35val1930 = __arg1;
-Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp = _35val1930;
-Obj _35reg1931 = primCar(exp);
-pushCont(co, 16, _35clofun2853, 2, next, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("pair?"));
-__arg1 = _35reg1931;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35p1102 = __arg1;
-Obj _35p1103 = __arg2;
-Obj _35p1104 = __arg3;
-Obj _35cc1105 = makeNative(11, _35clofun2853, 0, 3, _35p1102, _35p1103, _35p1104);
-Obj _35reg1929 = primEQ(Nil, _35p1102);
-if (True == _35reg1929) {
-Obj ls = _35p1103;
-Obj next = _35p1104;
-pushCont(co, 17, _35clofun2853, 1, next);
-__nargs = 2;
-__arg0 = globalRef(intern("reverse"));
-__arg1 = ls;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1105;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label19:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeString1("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val1975 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1976 = primCons(f, args);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = _35val1975;
-__arg2 = _35reg1976;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2853) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-fail:
-co->nargs = __nargs;
-co->args[0] = __arg0;
-co->args[1] = __arg1;
-co->args[2] = __arg2;
-co->args[3] = __arg3;
-
-}
-
-void _35clofun2852(struct Cora* co){
-int __nargs = co->nargs;
-Obj __arg0 = co->args[0];
-Obj __arg1 = co->args[1];
-Obj __arg2 = co->args[2];
-Obj __arg3 = co->args[3];
-
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
-
-goto *jumpTable[co->ctx.pc.label];
-
-label0:
-{
-Obj _35val1743 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 20, _35clofun2851, 2, _35val1743, a);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.closure-convert"));
-__arg1 = fvs;
-__arg2 = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35cc1091 = makeNative(19, _35clofun2851, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg1717 = primIsCons(closureRef(co, 1));
-if (True == _35reg1717) {
-Obj _35reg1718 = primCar(closureRef(co, 1));
-Obj _35reg1719 = primEQ(intern("let"), _35reg1718);
-if (True == _35reg1719) {
-Obj _35reg1720 = primCdr(closureRef(co, 1));
-Obj _35reg1721 = primIsCons(_35reg1720);
-if (True == _35reg1721) {
-Obj _35reg1722 = primCdr(closureRef(co, 1));
-Obj _35reg1723 = primCar(_35reg1722);
-Obj a = _35reg1723;
-Obj _35reg1724 = primCdr(closureRef(co, 1));
-Obj _35reg1725 = primCdr(_35reg1724);
-Obj _35reg1726 = primIsCons(_35reg1725);
-if (True == _35reg1726) {
-Obj _35reg1727 = primCdr(closureRef(co, 1));
-Obj _35reg1728 = primCdr(_35reg1727);
-Obj _35reg1729 = primCar(_35reg1728);
-Obj b = _35reg1729;
-Obj _35reg1730 = primCdr(closureRef(co, 1));
-Obj _35reg1731 = primCdr(_35reg1730);
-Obj _35reg1732 = primCdr(_35reg1731);
-Obj _35reg1733 = primIsCons(_35reg1732);
-if (True == _35reg1733) {
-Obj _35reg1734 = primCdr(closureRef(co, 1));
-Obj _35reg1735 = primCdr(_35reg1734);
-Obj _35reg1736 = primCdr(_35reg1735);
-Obj _35reg1737 = primCar(_35reg1736);
-Obj c = _35reg1737;
-Obj _35reg1738 = primCdr(closureRef(co, 1));
-Obj _35reg1739 = primCdr(_35reg1738);
-Obj _35reg1740 = primCdr(_35reg1739);
-Obj _35reg1741 = primCdr(_35reg1740);
-Obj _35reg1742 = primEQ(Nil, _35reg1741);
-if (True == _35reg1742) {
-pushCont(co, 0, _35clofun2852, 3, fvs, c, a);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.closure-convert"));
-__arg1 = fvs;
-__arg2 = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1091;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1091;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1091;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1091;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1091;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1091;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label2:
-{
-Obj _35val1775 = __arg1;
-Obj _35reg1773= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1776 = primCons(_35reg1773, _35val1775);
-Obj _35reg1777 = primCons(intern("%closure"), _35reg1776);
-__nargs = 2;
-__arg1 = _35reg1777;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2852) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label3:
-{
-Obj _35val1774 = __arg1;
-Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1773= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun2852, 1, _35reg1773);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = _35val1774;
-__arg2 = fvs1;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj _35val1770 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1771 = primCons(_35val1770, Nil);
-Obj _35reg1772 = primCons(args, _35reg1771);
-Obj _35reg1773 = primCons(intern("lambda"), _35reg1772);
-pushCont(co, 3, _35clofun2852, 2, fvs1, _35reg1773);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.closure-convert"));
-__arg1 = fvs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35val1769 = __arg1;
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs1 = _35val1769;
-pushCont(co, 4, _35clofun2852, 3, args, fvs, fvs1);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.closure-convert"));
-__arg1 = fvs1;
-__arg2 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35cc1090 = makeNative(1, _35clofun2852, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg1749 = primIsCons(closureRef(co, 1));
-if (True == _35reg1749) {
-Obj _35reg1750 = primCar(closureRef(co, 1));
-Obj _35reg1751 = primEQ(intern("lambda"), _35reg1750);
-if (True == _35reg1751) {
-Obj _35reg1752 = primCdr(closureRef(co, 1));
-Obj _35reg1753 = primIsCons(_35reg1752);
-if (True == _35reg1753) {
-Obj _35reg1754 = primCdr(closureRef(co, 1));
-Obj _35reg1755 = primCar(_35reg1754);
-Obj args = _35reg1755;
-Obj _35reg1756 = primCdr(closureRef(co, 1));
-Obj _35reg1757 = primCdr(_35reg1756);
-Obj _35reg1758 = primIsCons(_35reg1757);
-if (True == _35reg1758) {
-Obj _35reg1759 = primCdr(closureRef(co, 1));
-Obj _35reg1760 = primCdr(_35reg1759);
-Obj _35reg1761 = primCar(_35reg1760);
-Obj body = _35reg1761;
-Obj _35reg1762 = primCdr(closureRef(co, 1));
-Obj _35reg1763 = primCdr(_35reg1762);
-Obj _35reg1764 = primCdr(_35reg1763);
-Obj _35reg1765 = primEQ(Nil, _35reg1764);
-if (True == _35reg1765) {
-Obj _35reg1766 = primCons(body, Nil);
-Obj _35reg1767 = primCons(args, _35reg1766);
-Obj _35reg1768 = primCons(intern("lambda"), _35reg1767);
-pushCont(co, 5, _35clofun2852, 3, body, args, fvs);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
-__arg1 = _35reg1768;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1090;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1090;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1090;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1090;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1090;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label7:
-{
-Obj _35val1779 = __arg1;
-Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj pos = _35val1779;
-Obj _35reg1780 = primEQ(makeNumber(-1), pos);
-if (True == _35reg1780) {
-__nargs = 2;
-__arg1 = var;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2852) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg1781 = primCons(pos, Nil);
-Obj _35reg1782 = primCons(intern("%closure-ref"), _35reg1781);
-__nargs = 2;
-__arg1 = _35reg1782;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2852) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label8:
-{
-Obj _35cc1089 = makeNative(6, _35clofun2852, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj var = closureRef(co, 1);
-Obj _35reg1778 = primIsSymbol(var);
-if (True == _35reg1778) {
-pushCont(co, 7, _35clofun2852, 1, var);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.index"));
-__arg1 = var;
-__arg2 = fvs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1089;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label9:
-{
-Obj _35val1783 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1088= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1783) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2852) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1088;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj _35p1086 = __arg1;
-Obj _35p1087 = __arg2;
-Obj _35cc1088 = makeNative(8, _35clofun2852, 0, 2, _35p1086, _35p1087);
-Obj __ = _35p1086;
-Obj x = _35p1087;
-pushCont(co, 9, _35clofun2852, 2, x, _35cc1088);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.convert-protect?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj x = __arg1;
-Obj _35reg1785 = primCons(x, Nil);
-Obj _35reg1786 = primCons(intern("return"), _35reg1785);
-__nargs = 2;
-__arg1 = _35reg1786;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2852) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label12:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeString1("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35cc1101 = makeNative(12, _35clofun2852, 0, 0);
-Obj _35reg1788 = primIsCons(closureRef(co, 0));
-if (True == _35reg1788) {
-Obj _35reg1789 = primCar(closureRef(co, 0));
-Obj f = _35reg1789;
-Obj _35reg1790 = primCdr(closureRef(co, 0));
-Obj args = _35reg1790;
-Obj next = closureRef(co, 1);
-Obj _35reg1791 = primCons(f, args);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc.tailify-list"));
-__arg1 = _35reg1791;
-__arg2 = Nil;
-__arg3 = next;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1101;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label14:
-{
-Obj _35val1830 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj next= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1831 = primCons(_35val1830, Nil);
-Obj _35reg1832 = primCons(args, _35reg1831);
-Obj _35reg1833 = primCons(intern("lambda"), _35reg1832);
-Obj _35reg1834 = primCons(_35reg1833, frees);
-Obj _35reg1835 = primCons(intern("%closure"), _35reg1834);
-__nargs = 2;
-__arg0 = next;
-__arg1 = _35reg1835;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35cc1100 = makeNative(13, _35clofun2852, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1792 = primIsCons(closureRef(co, 0));
-if (True == _35reg1792) {
-Obj _35reg1793 = primCar(closureRef(co, 0));
-Obj _35reg1794 = primEQ(intern("%closure"), _35reg1793);
-if (True == _35reg1794) {
-Obj _35reg1795 = primCdr(closureRef(co, 0));
-Obj _35reg1796 = primIsCons(_35reg1795);
-if (True == _35reg1796) {
-Obj _35reg1797 = primCdr(closureRef(co, 0));
-Obj _35reg1798 = primCar(_35reg1797);
-Obj _35reg1799 = primIsCons(_35reg1798);
-if (True == _35reg1799) {
-Obj _35reg1800 = primCdr(closureRef(co, 0));
-Obj _35reg1801 = primCar(_35reg1800);
-Obj _35reg1802 = primCar(_35reg1801);
-Obj _35reg1803 = primEQ(intern("lambda"), _35reg1802);
-if (True == _35reg1803) {
-Obj _35reg1804 = primCdr(closureRef(co, 0));
-Obj _35reg1805 = primCar(_35reg1804);
-Obj _35reg1806 = primCdr(_35reg1805);
-Obj _35reg1807 = primIsCons(_35reg1806);
-if (True == _35reg1807) {
-Obj _35reg1808 = primCdr(closureRef(co, 0));
-Obj _35reg1809 = primCar(_35reg1808);
-Obj _35reg1810 = primCdr(_35reg1809);
-Obj _35reg1811 = primCar(_35reg1810);
-Obj args = _35reg1811;
-Obj _35reg1812 = primCdr(closureRef(co, 0));
-Obj _35reg1813 = primCar(_35reg1812);
-Obj _35reg1814 = primCdr(_35reg1813);
-Obj _35reg1815 = primCdr(_35reg1814);
-Obj _35reg1816 = primIsCons(_35reg1815);
-if (True == _35reg1816) {
-Obj _35reg1817 = primCdr(closureRef(co, 0));
-Obj _35reg1818 = primCar(_35reg1817);
-Obj _35reg1819 = primCdr(_35reg1818);
-Obj _35reg1820 = primCdr(_35reg1819);
-Obj _35reg1821 = primCar(_35reg1820);
-Obj body = _35reg1821;
-Obj _35reg1822 = primCdr(closureRef(co, 0));
-Obj _35reg1823 = primCar(_35reg1822);
-Obj _35reg1824 = primCdr(_35reg1823);
-Obj _35reg1825 = primCdr(_35reg1824);
-Obj _35reg1826 = primCdr(_35reg1825);
-Obj _35reg1827 = primEQ(Nil, _35reg1826);
-if (True == _35reg1827) {
-Obj _35reg1828 = primCdr(closureRef(co, 0));
-Obj _35reg1829 = primCdr(_35reg1828);
-Obj frees = _35reg1829;
-Obj next = closureRef(co, 1);
-pushCont(co, 14, _35clofun2852, 3, args, frees, next);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.tailify"));
-__arg1 = body;
-__arg2 = globalRef(intern("cora/lib/toc.id"));
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1100;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1100;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1100;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1100;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1100;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1100;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1100;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1100;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label16:
-{
-Obj _35val1862 = __arg1;
-Obj rb= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1863 = primCons(_35val1862, Nil);
-Obj _35reg1864 = primCons(rb, _35reg1863);
-Obj _35reg1865 = primCons(closureRef(co, 0), _35reg1864);
-Obj _35reg1866 = primCons(intern("let"), _35reg1865);
-__nargs = 2;
-__arg1 = _35reg1866;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2852) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label17:
-{
-Obj rb = __arg1;
-pushCont(co, 16, _35clofun2852, 1, rb);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.tailify"));
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35cc1099 = makeNative(15, _35clofun2852, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1836 = primIsCons(closureRef(co, 0));
-if (True == _35reg1836) {
-Obj _35reg1837 = primCar(closureRef(co, 0));
-Obj _35reg1838 = primEQ(intern("let"), _35reg1837);
-if (True == _35reg1838) {
-Obj _35reg1839 = primCdr(closureRef(co, 0));
-Obj _35reg1840 = primIsCons(_35reg1839);
-if (True == _35reg1840) {
-Obj _35reg1841 = primCdr(closureRef(co, 0));
-Obj _35reg1842 = primCar(_35reg1841);
-Obj a = _35reg1842;
-Obj _35reg1843 = primCdr(closureRef(co, 0));
-Obj _35reg1844 = primCdr(_35reg1843);
-Obj _35reg1845 = primIsCons(_35reg1844);
-if (True == _35reg1845) {
-Obj _35reg1846 = primCdr(closureRef(co, 0));
-Obj _35reg1847 = primCdr(_35reg1846);
-Obj _35reg1848 = primCar(_35reg1847);
-Obj b = _35reg1848;
-Obj _35reg1849 = primCdr(closureRef(co, 0));
-Obj _35reg1850 = primCdr(_35reg1849);
-Obj _35reg1851 = primCdr(_35reg1850);
-Obj _35reg1852 = primIsCons(_35reg1851);
-if (True == _35reg1852) {
-Obj _35reg1853 = primCdr(closureRef(co, 0));
-Obj _35reg1854 = primCdr(_35reg1853);
-Obj _35reg1855 = primCdr(_35reg1854);
-Obj _35reg1856 = primCar(_35reg1855);
-Obj c = _35reg1856;
-Obj _35reg1857 = primCdr(closureRef(co, 0));
-Obj _35reg1858 = primCdr(_35reg1857);
-Obj _35reg1859 = primCdr(_35reg1858);
-Obj _35reg1860 = primCdr(_35reg1859);
-Obj _35reg1861 = primEQ(Nil, _35reg1860);
-if (True == _35reg1861) {
-Obj next = closureRef(co, 1);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.tailify"));
-__arg1 = b;
-__arg2 = makeNative(17, _35clofun2852, 1, 3, a, c, next);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1099;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1099;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1099;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1099;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1099;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1099;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label19:
-{
-Obj _35val1885 = __arg1;
-Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1886 = primCons(_35val1885, Nil);
-Obj _35reg1887 = primCons(ra, _35reg1886);
-Obj _35reg1888 = primCons(intern("do"), _35reg1887);
-__nargs = 2;
-__arg1 = _35reg1888;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2852) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label20:
-{
-Obj ra = __arg1;
-Obj _35reg1884 = primIsSymbol(ra);
-if (True == _35reg1884) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.tailify"));
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 19, _35clofun2852, 1, ra);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.tailify"));
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2852) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-fail:
-co->nargs = __nargs;
-co->args[0] = __arg0;
-co->args[1] = __arg1;
-co->args[2] = __arg2;
-co->args[3] = __arg3;
-
-}
-
-void _35clofun2851(struct Cora* co){
-int __nargs = co->nargs;
-Obj __arg0 = co->args[0];
-Obj __arg1 = co->args[1];
-Obj __arg2 = co->args[2];
-Obj __arg3 = co->args[3];
-
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
-
-goto *jumpTable[co->ctx.pc.label];
-
-label0:
-{
-Obj _35val1589 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc.foldl"));
-__arg1 = globalRef(intern("cora/lib/toc.union"));
-__arg2 = Nil;
-__arg3 = _35val1589;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35cc1082 = makeNative(20, _35clofun2850, 0, 1, closureRef(co, 0));
-Obj _35reg1570 = primIsCons(closureRef(co, 0));
-if (True == _35reg1570) {
-Obj _35reg1571 = primCar(closureRef(co, 0));
-Obj _35reg1572 = primEQ(intern("call"), _35reg1571);
-if (True == _35reg1572) {
-Obj _35reg1573 = primCdr(closureRef(co, 0));
-Obj _35reg1574 = primIsCons(_35reg1573);
-if (True == _35reg1574) {
-Obj _35reg1575 = primCdr(closureRef(co, 0));
-Obj _35reg1576 = primCar(_35reg1575);
-Obj exp = _35reg1576;
-Obj _35reg1577 = primCdr(closureRef(co, 0));
-Obj _35reg1578 = primCdr(_35reg1577);
-Obj _35reg1579 = primIsCons(_35reg1578);
-if (True == _35reg1579) {
-Obj _35reg1580 = primCdr(closureRef(co, 0));
-Obj _35reg1581 = primCdr(_35reg1580);
-Obj _35reg1582 = primCar(_35reg1581);
-Obj cont = _35reg1582;
-Obj _35reg1583 = primCdr(closureRef(co, 0));
-Obj _35reg1584 = primCdr(_35reg1583);
-Obj _35reg1585 = primCdr(_35reg1584);
-Obj _35reg1586 = primEQ(Nil, _35reg1585);
-if (True == _35reg1586) {
-Obj _35reg1587 = primCons(cont, Nil);
-Obj _35reg1588 = primCons(exp, _35reg1587);
-pushCont(co, 0, _35clofun2851, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = globalRef(intern("cora/lib/toc.free-vars"));
-__arg2 = _35reg1588;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1082;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1082;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1082;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1082;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1082;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label2:
-{
-Obj _35cc1081 = makeNative(1, _35clofun2851, 0, 1, closureRef(co, 0));
-Obj _35reg1590 = primIsCons(closureRef(co, 0));
-if (True == _35reg1590) {
-Obj _35reg1591 = primCar(closureRef(co, 0));
-Obj _35reg1592 = primEQ(intern("return"), _35reg1591);
-if (True == _35reg1592) {
-Obj _35reg1593 = primCdr(closureRef(co, 0));
-Obj _35reg1594 = primIsCons(_35reg1593);
-if (True == _35reg1594) {
-Obj _35reg1595 = primCdr(closureRef(co, 0));
-Obj _35reg1596 = primCar(_35reg1595);
-Obj x = _35reg1596;
-Obj _35reg1597 = primCdr(closureRef(co, 0));
-Obj _35reg1598 = primCdr(_35reg1597);
-Obj _35reg1599 = primEQ(Nil, _35reg1598);
-if (True == _35reg1599) {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1081;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1081;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1081;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1081;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label3:
-{
-Obj _35cc1080 = makeNative(2, _35clofun2851, 0, 1, closureRef(co, 0));
-Obj _35reg1600 = primIsCons(closureRef(co, 0));
-if (True == _35reg1600) {
-Obj _35reg1601 = primCar(closureRef(co, 0));
-Obj _35reg1602 = primEQ(intern("%closure"), _35reg1601);
-if (True == _35reg1602) {
-Obj _35reg1603 = primCdr(closureRef(co, 0));
-Obj _35reg1604 = primIsCons(_35reg1603);
-if (True == _35reg1604) {
-Obj _35reg1605 = primCdr(closureRef(co, 0));
-Obj _35reg1606 = primCar(_35reg1605);
-Obj lam = _35reg1606;
-Obj _35reg1607 = primCdr(closureRef(co, 0));
-Obj _35reg1608 = primCdr(_35reg1607);
-Obj more = _35reg1608;
-Obj _35reg1609 = primCons(lam, more);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
-__arg1 = _35reg1609;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1080;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1080;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1080;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label4:
-{
-Obj _35val1639 = __arg1;
-Obj _35val1636= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.union"));
-__arg1 = _35val1636;
-__arg2 = _35val1639;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35val1637 = __arg1;
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val1636= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1638 = primCons(a, Nil);
-pushCont(co, 4, _35clofun2851, 1, _35val1636);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.diff"));
-__arg1 = _35val1637;
-__arg2 = _35reg1638;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val1636 = __arg1;
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun2851, 2, a, _35val1636);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
-__arg1 = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35cc1079 = makeNative(3, _35clofun2851, 0, 1, closureRef(co, 0));
-Obj _35reg1610 = primIsCons(closureRef(co, 0));
-if (True == _35reg1610) {
-Obj _35reg1611 = primCar(closureRef(co, 0));
-Obj _35reg1612 = primEQ(intern("let"), _35reg1611);
-if (True == _35reg1612) {
-Obj _35reg1613 = primCdr(closureRef(co, 0));
-Obj _35reg1614 = primIsCons(_35reg1613);
-if (True == _35reg1614) {
-Obj _35reg1615 = primCdr(closureRef(co, 0));
-Obj _35reg1616 = primCar(_35reg1615);
-Obj a = _35reg1616;
-Obj _35reg1617 = primCdr(closureRef(co, 0));
-Obj _35reg1618 = primCdr(_35reg1617);
-Obj _35reg1619 = primIsCons(_35reg1618);
-if (True == _35reg1619) {
-Obj _35reg1620 = primCdr(closureRef(co, 0));
-Obj _35reg1621 = primCdr(_35reg1620);
-Obj _35reg1622 = primCar(_35reg1621);
-Obj b = _35reg1622;
-Obj _35reg1623 = primCdr(closureRef(co, 0));
-Obj _35reg1624 = primCdr(_35reg1623);
-Obj _35reg1625 = primCdr(_35reg1624);
-Obj _35reg1626 = primIsCons(_35reg1625);
-if (True == _35reg1626) {
-Obj _35reg1627 = primCdr(closureRef(co, 0));
-Obj _35reg1628 = primCdr(_35reg1627);
-Obj _35reg1629 = primCdr(_35reg1628);
-Obj _35reg1630 = primCar(_35reg1629);
-Obj c = _35reg1630;
-Obj _35reg1631 = primCdr(closureRef(co, 0));
-Obj _35reg1632 = primCdr(_35reg1631);
-Obj _35reg1633 = primCdr(_35reg1632);
-Obj _35reg1634 = primCdr(_35reg1633);
-Obj _35reg1635 = primEQ(Nil, _35reg1634);
-if (True == _35reg1635) {
-pushCont(co, 6, _35clofun2851, 2, c, a);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
-__arg1 = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1079;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-Obj _35val1659 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc.foldl"));
-__arg1 = globalRef(intern("cora/lib/toc.union"));
-__arg2 = Nil;
-__arg3 = _35val1659;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35cc1078 = makeNative(7, _35clofun2851, 0, 1, closureRef(co, 0));
-Obj _35reg1640 = primIsCons(closureRef(co, 0));
-if (True == _35reg1640) {
-Obj _35reg1641 = primCar(closureRef(co, 0));
-Obj _35reg1642 = primEQ(intern("do"), _35reg1641);
-if (True == _35reg1642) {
-Obj _35reg1643 = primCdr(closureRef(co, 0));
-Obj _35reg1644 = primIsCons(_35reg1643);
-if (True == _35reg1644) {
-Obj _35reg1645 = primCdr(closureRef(co, 0));
-Obj _35reg1646 = primCar(_35reg1645);
-Obj x = _35reg1646;
-Obj _35reg1647 = primCdr(closureRef(co, 0));
-Obj _35reg1648 = primCdr(_35reg1647);
-Obj _35reg1649 = primIsCons(_35reg1648);
-if (True == _35reg1649) {
-Obj _35reg1650 = primCdr(closureRef(co, 0));
-Obj _35reg1651 = primCdr(_35reg1650);
-Obj _35reg1652 = primCar(_35reg1651);
-Obj y = _35reg1652;
-Obj _35reg1653 = primCdr(closureRef(co, 0));
-Obj _35reg1654 = primCdr(_35reg1653);
-Obj _35reg1655 = primCdr(_35reg1654);
-Obj _35reg1656 = primEQ(Nil, _35reg1655);
-if (True == _35reg1656) {
-Obj _35reg1657 = primCons(y, Nil);
-Obj _35reg1658 = primCons(x, _35reg1657);
-pushCont(co, 8, _35clofun2851, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = globalRef(intern("cora/lib/toc.free-vars"));
-__arg2 = _35reg1658;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1078;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1078;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1078;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1078;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1078;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj _35val1689 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc.foldl"));
-__arg1 = globalRef(intern("cora/lib/toc.union"));
-__arg2 = Nil;
-__arg3 = _35val1689;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35cc1077 = makeNative(9, _35clofun2851, 0, 1, closureRef(co, 0));
-Obj _35reg1660 = primIsCons(closureRef(co, 0));
-if (True == _35reg1660) {
-Obj _35reg1661 = primCar(closureRef(co, 0));
-Obj _35reg1662 = primEQ(intern("if"), _35reg1661);
-if (True == _35reg1662) {
-Obj _35reg1663 = primCdr(closureRef(co, 0));
-Obj _35reg1664 = primIsCons(_35reg1663);
-if (True == _35reg1664) {
-Obj _35reg1665 = primCdr(closureRef(co, 0));
-Obj _35reg1666 = primCar(_35reg1665);
-Obj x = _35reg1666;
-Obj _35reg1667 = primCdr(closureRef(co, 0));
-Obj _35reg1668 = primCdr(_35reg1667);
-Obj _35reg1669 = primIsCons(_35reg1668);
-if (True == _35reg1669) {
-Obj _35reg1670 = primCdr(closureRef(co, 0));
-Obj _35reg1671 = primCdr(_35reg1670);
-Obj _35reg1672 = primCar(_35reg1671);
-Obj y = _35reg1672;
-Obj _35reg1673 = primCdr(closureRef(co, 0));
-Obj _35reg1674 = primCdr(_35reg1673);
-Obj _35reg1675 = primCdr(_35reg1674);
-Obj _35reg1676 = primIsCons(_35reg1675);
-if (True == _35reg1676) {
-Obj _35reg1677 = primCdr(closureRef(co, 0));
-Obj _35reg1678 = primCdr(_35reg1677);
-Obj _35reg1679 = primCdr(_35reg1678);
-Obj _35reg1680 = primCar(_35reg1679);
-Obj z = _35reg1680;
-Obj _35reg1681 = primCdr(closureRef(co, 0));
-Obj _35reg1682 = primCdr(_35reg1681);
-Obj _35reg1683 = primCdr(_35reg1682);
-Obj _35reg1684 = primCdr(_35reg1683);
-Obj _35reg1685 = primEQ(Nil, _35reg1684);
-if (True == _35reg1685) {
-Obj _35reg1686 = primCons(z, Nil);
-Obj _35reg1687 = primCons(y, _35reg1686);
-Obj _35reg1688 = primCons(x, _35reg1687);
-pushCont(co, 10, _35clofun2851, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = globalRef(intern("cora/lib/toc.free-vars"));
-__arg2 = _35reg1688;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1077;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1077;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1077;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1077;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1077;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1077;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35val1707 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.diff"));
-__arg1 = _35val1707;
-__arg2 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35cc1076 = makeNative(11, _35clofun2851, 0, 1, closureRef(co, 0));
-Obj _35reg1690 = primIsCons(closureRef(co, 0));
-if (True == _35reg1690) {
-Obj _35reg1691 = primCar(closureRef(co, 0));
-Obj _35reg1692 = primEQ(intern("lambda"), _35reg1691);
-if (True == _35reg1692) {
-Obj _35reg1693 = primCdr(closureRef(co, 0));
-Obj _35reg1694 = primIsCons(_35reg1693);
-if (True == _35reg1694) {
-Obj _35reg1695 = primCdr(closureRef(co, 0));
-Obj _35reg1696 = primCar(_35reg1695);
-Obj args = _35reg1696;
-Obj _35reg1697 = primCdr(closureRef(co, 0));
-Obj _35reg1698 = primCdr(_35reg1697);
-Obj _35reg1699 = primIsCons(_35reg1698);
-if (True == _35reg1699) {
-Obj _35reg1700 = primCdr(closureRef(co, 0));
-Obj _35reg1701 = primCdr(_35reg1700);
-Obj _35reg1702 = primCar(_35reg1701);
-Obj body = _35reg1702;
-Obj _35reg1703 = primCdr(closureRef(co, 0));
-Obj _35reg1704 = primCdr(_35reg1703);
-Obj _35reg1705 = primCdr(_35reg1704);
-Obj _35reg1706 = primEQ(Nil, _35reg1705);
-if (True == _35reg1706) {
-pushCont(co, 12, _35clofun2851, 1, args);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1076;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1076;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1076;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1076;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1076;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label14:
-{
-Obj _35cc1075 = makeNative(13, _35clofun2851, 0, 1, closureRef(co, 0));
-Obj x = closureRef(co, 0);
-Obj _35reg1708 = primIsSymbol(x);
-if (True == _35reg1708) {
-Obj _35reg1709 = primCons(x, Nil);
-__nargs = 2;
-__arg1 = _35reg1709;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2851) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1075;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj _35val1710 = __arg1;
-Obj _35cc1074= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1710) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2851) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1074;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label16:
-{
-Obj _35p1073 = __arg1;
-Obj _35cc1074 = makeNative(14, _35clofun2851, 0, 1, _35p1073);
-Obj x = _35p1073;
-pushCont(co, 15, _35clofun2851, 1, _35cc1074);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.convert-protect?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeString1("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val1715 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1716 = primCons(f, args);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = _35val1715;
-__arg2 = _35reg1716;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35cc1092 = makeNative(17, _35clofun2851, 0, 0);
-Obj fvs = closureRef(co, 0);
-Obj _35reg1712 = primIsCons(closureRef(co, 1));
-if (True == _35reg1712) {
-Obj _35reg1713 = primCar(closureRef(co, 1));
-Obj f = _35reg1713;
-Obj _35reg1714 = primCdr(closureRef(co, 1));
-Obj args = _35reg1714;
-pushCont(co, 18, _35clofun2851, 2, f, args);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.closure-convert"));
-__arg1 = fvs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -10520,25 +9067,503 @@ __arg0 = _35cc1092;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2851) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1092;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1092;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1092;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1092;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1092;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
+label5:
+{
+Obj _35val1923 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1091= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1923) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2927) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1091;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label6:
+{
+Obj _35cc1091 = makeNative(4, _35clofun2927, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x = closureRef(co, 0);
+Obj __ = closureRef(co, 1);
+pushCont(co, 5, _35clofun2927, 2, x, _35cc1091);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.convert-protect?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label7:
+{
+Obj _35val1925 = __arg1;
+Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc1090= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val1925) {
+if (True == True) {
+__nargs = 2;
+__arg0 = next;
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1090;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+__nargs = 2;
+__arg0 = next;
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1090;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label8:
+{
+Obj _35p1088 = __arg1;
+Obj _35p1089 = __arg2;
+Obj _35cc1090 = makeNative(6, _35clofun2927, 0, 2, _35p1088, _35p1089);
+Obj x = _35p1088;
+Obj next = _35p1089;
+Obj _35reg1924 = primIsSymbol(x);
+if (True == _35reg1924) {
+if (True == True) {
+__nargs = 2;
+__arg0 = next;
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1090;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+pushCont(co, 7, _35clofun2927, 3, next, x, _35cc1090);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.convert-protect?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label9:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label10:
+{
+Obj hd1 = __arg1;
+Obj _35reg1930 = primCons(hd1, closureRef(co, 1));
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc.tailify-list"));
+__arg1 = closureRef(co, 0);
+__arg2 = _35reg1930;
+__arg3 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label11:
+{
+Obj _35cc1101 = makeNative(9, _35clofun2927, 0, 0);
+Obj _35reg1927 = primIsCons(closureRef(co, 0));
+if (True == _35reg1927) {
+Obj _35reg1928 = primCar(closureRef(co, 0));
+Obj hd = _35reg1928;
+Obj _35reg1929 = primCdr(closureRef(co, 0));
+Obj tl = _35reg1929;
+Obj ls = closureRef(co, 1);
+Obj next = closureRef(co, 2);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.tailify"));
+__arg1 = hd;
+__arg2 = makeNative(10, _35clofun2927, 1, 3, tl, ls, next);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1101;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label12:
+{
+Obj _35val1942 = __arg1;
+Obj _35reg1941= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1943 = primCons(_35val1942, Nil);
+Obj _35reg1944 = primCons(_35reg1941, _35reg1943);
+Obj _35reg1945 = primCons(intern("continuation"), _35reg1944);
+Obj _35reg1946 = primCons(_35reg1945, Nil);
+Obj _35reg1947 = primCons(exp, _35reg1946);
+Obj _35reg1948 = primCons(intern("call"), _35reg1947);
+__nargs = 2;
+__arg1 = _35reg1948;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2927) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label13:
+{
+Obj _35val1954 = __arg1;
+Obj _35reg1953= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1955 = primCons(_35val1954, Nil);
+Obj _35reg1956 = primCons(_35reg1953, _35reg1955);
+Obj _35reg1957 = primCons(intern("continuation"), _35reg1956);
+Obj _35reg1958 = primCons(_35reg1957, Nil);
+Obj _35reg1959 = primCons(exp, _35reg1958);
+Obj _35reg1960 = primCons(intern("call"), _35reg1959);
+__nargs = 2;
+__arg1 = _35reg1960;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2927) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label14:
+{
+Obj _35val1935 = __arg1;
+Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1936 = primEQ(_35val1935, intern("%builtin"));
+if (True == _35reg1936) {
+if (True == True) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.wrap-var"));
+__arg1 = exp;
+__arg2 = next;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1937 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
+if (True == _35reg1937) {
+Obj _35reg1938 = primCons(exp, Nil);
+Obj _35reg1939 = primCons(intern("tailcall"), _35reg1938);
+__nargs = 2;
+__arg1 = _35reg1939;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2927) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg1940 = primGenSym(intern("val"));
+Obj val = _35reg1940;
+Obj _35reg1941 = primCons(val, Nil);
+pushCont(co, 12, _35clofun2927, 2, _35reg1941, exp);
+__nargs = 2;
+__arg0 = next;
+__arg1 = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+if (True == False) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.wrap-var"));
+__arg1 = exp;
+__arg2 = next;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1949 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
+if (True == _35reg1949) {
+Obj _35reg1950 = primCons(exp, Nil);
+Obj _35reg1951 = primCons(intern("tailcall"), _35reg1950);
+__nargs = 2;
+__arg1 = _35reg1951;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2927) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg1952 = primGenSym(intern("val"));
+Obj val = _35reg1952;
+Obj _35reg1953 = primCons(val, Nil);
+pushCont(co, 13, _35clofun2927, 2, _35reg1953, exp);
+__nargs = 2;
+__arg0 = next;
+__arg1 = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+}
+
+label15:
+{
+Obj _35val1966 = __arg1;
+Obj _35reg1965= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1967 = primCons(_35val1966, Nil);
+Obj _35reg1968 = primCons(_35reg1965, _35reg1967);
+Obj _35reg1969 = primCons(intern("continuation"), _35reg1968);
+Obj _35reg1970 = primCons(_35reg1969, Nil);
+Obj _35reg1971 = primCons(exp, _35reg1970);
+Obj _35reg1972 = primCons(intern("call"), _35reg1971);
+__nargs = 2;
+__arg1 = _35reg1972;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2927) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label16:
+{
+Obj _35val1934 = __arg1;
+Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1934) {
+pushCont(co, 14, _35clofun2927, 2, next, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("caar"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+if (True == False) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.wrap-var"));
+__arg1 = exp;
+__arg2 = next;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1961 = primEQ(next, globalRef(intern("cora/lib/toc.id")));
+if (True == _35reg1961) {
+Obj _35reg1962 = primCons(exp, Nil);
+Obj _35reg1963 = primCons(intern("tailcall"), _35reg1962);
+__nargs = 2;
+__arg1 = _35reg1963;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2927) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg1964 = primGenSym(intern("val"));
+Obj val = _35reg1964;
+Obj _35reg1965 = primCons(val, Nil);
+pushCont(co, 15, _35clofun2927, 2, _35reg1965, exp);
+__nargs = 2;
+__arg0 = next;
+__arg1 = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+}
+
+label17:
+{
+Obj _35val1932 = __arg1;
+Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp = _35val1932;
+Obj _35reg1933 = primCar(exp);
+pushCont(co, 16, _35clofun2927, 2, next, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("pair?"));
+__arg1 = _35reg1933;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label18:
+{
+Obj _35p1097 = __arg1;
+Obj _35p1098 = __arg2;
+Obj _35p1099 = __arg3;
+Obj _35cc1100 = makeNative(11, _35clofun2927, 0, 3, _35p1097, _35p1098, _35p1099);
+Obj _35reg1931 = primEQ(Nil, _35p1097);
+if (True == _35reg1931) {
+Obj ls = _35p1098;
+Obj next = _35p1099;
+pushCont(co, 17, _35clofun2927, 1, next);
+__nargs = 2;
+__arg0 = globalRef(intern("reverse"));
+__arg1 = ls;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1100;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label19:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
 label20:
 {
-Obj _35val1744 = __arg1;
-Obj _35val1743= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1745 = primCons(_35val1744, Nil);
-Obj _35reg1746 = primCons(_35val1743, _35reg1745);
-Obj _35reg1747 = primCons(a, _35reg1746);
-Obj _35reg1748 = primCons(intern("let"), _35reg1747);
-__nargs = 2;
-__arg1 = _35reg1748;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2851) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val1977 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1978 = primCons(f, args);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = _35val1977;
+__arg2 = _35reg1978;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2927) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 fail:
@@ -10550,7 +9575,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2850(struct Cora* co){
+void _35clofun2926(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -10563,571 +9588,235 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1059 = makeNative(19, _35clofun2849, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1469 = primIsCons(closureRef(co, 0));
-if (True == _35reg1469) {
-Obj _35reg1470 = primCar(closureRef(co, 0));
-Obj x = _35reg1470;
-Obj _35reg1471 = primCdr(closureRef(co, 0));
-Obj y = _35reg1471;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 20, _35clofun2849, 3, y, s2, _35cc1059);
+Obj _35val1745 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 20, _35clofun2925, 2, _35val1745, a);
 __nargs = 3;
-__arg0 = globalRef(intern("elem?"));
-__arg1 = x;
-__arg2 = s2;
+__arg0 = globalRef(intern("cora/lib/toc.closure-convert"));
+__arg1 = fvs;
+__arg2 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1059;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label1:
 {
-Obj _35p1056 = __arg1;
-Obj _35p1057 = __arg2;
-Obj _35cc1058 = makeNative(0, _35clofun2850, 0, 2, _35p1056, _35p1057);
-Obj _35reg1473 = primEQ(Nil, _35p1056);
-if (True == _35reg1473) {
-Obj s2 = _35p1057;
-__nargs = 2;
-__arg1 = s2;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2850) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1058;
+Obj _35cc1086 = makeNative(19, _35clofun2925, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj _35reg1719 = primIsCons(closureRef(co, 1));
+if (True == _35reg1719) {
+Obj _35reg1720 = primCar(closureRef(co, 1));
+Obj _35reg1721 = primEQ(intern("let"), _35reg1720);
+if (True == _35reg1721) {
+Obj _35reg1722 = primCdr(closureRef(co, 1));
+Obj _35reg1723 = primIsCons(_35reg1722);
+if (True == _35reg1723) {
+Obj _35reg1724 = primCdr(closureRef(co, 1));
+Obj _35reg1725 = primCar(_35reg1724);
+Obj a = _35reg1725;
+Obj _35reg1726 = primCdr(closureRef(co, 1));
+Obj _35reg1727 = primCdr(_35reg1726);
+Obj _35reg1728 = primIsCons(_35reg1727);
+if (True == _35reg1728) {
+Obj _35reg1729 = primCdr(closureRef(co, 1));
+Obj _35reg1730 = primCdr(_35reg1729);
+Obj _35reg1731 = primCar(_35reg1730);
+Obj b = _35reg1731;
+Obj _35reg1732 = primCdr(closureRef(co, 1));
+Obj _35reg1733 = primCdr(_35reg1732);
+Obj _35reg1734 = primCdr(_35reg1733);
+Obj _35reg1735 = primIsCons(_35reg1734);
+if (True == _35reg1735) {
+Obj _35reg1736 = primCdr(closureRef(co, 1));
+Obj _35reg1737 = primCdr(_35reg1736);
+Obj _35reg1738 = primCdr(_35reg1737);
+Obj _35reg1739 = primCar(_35reg1738);
+Obj c = _35reg1739;
+Obj _35reg1740 = primCdr(closureRef(co, 1));
+Obj _35reg1741 = primCdr(_35reg1740);
+Obj _35reg1742 = primCdr(_35reg1741);
+Obj _35reg1743 = primCdr(_35reg1742);
+Obj _35reg1744 = primEQ(Nil, _35reg1743);
+if (True == _35reg1744) {
+pushCont(co, 0, _35clofun2926, 3, fvs, c, a);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.closure-convert"));
+__arg1 = fvs;
+__arg2 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1086;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1086;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1086;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1086;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1086;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1086;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label2:
 {
+Obj _35val1777 = __arg1;
+Obj _35reg1775= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1778 = primCons(_35reg1775, _35val1777);
+Obj _35reg1779 = primCons(intern("%closure"), _35reg1778);
 __nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeString1("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = _35reg1779;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2926) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label3:
 {
-Obj _35val1478 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1479 = primCons(x, _35val1478);
-__nargs = 2;
-__arg1 = _35reg1479;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2850) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val1776 = __arg1;
+Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1775= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 2, _35clofun2926, 1, _35reg1775);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = _35val1776;
+__arg2 = fvs1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35cc1065 = makeNative(2, _35clofun2850, 0, 0);
-Obj _35reg1475 = primIsCons(closureRef(co, 0));
-if (True == _35reg1475) {
-Obj _35reg1476 = primCar(closureRef(co, 0));
-Obj x = _35reg1476;
-Obj _35reg1477 = primCdr(closureRef(co, 0));
-Obj y = _35reg1477;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 3, _35clofun2850, 1, x);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.diff"));
-__arg1 = y;
-__arg2 = s2;
+Obj _35val1772 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg1773 = primCons(_35val1772, Nil);
+Obj _35reg1774 = primCons(args, _35reg1773);
+Obj _35reg1775 = primCons(intern("lambda"), _35reg1774);
+pushCont(co, 3, _35clofun2926, 2, fvs1, _35reg1775);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.closure-convert"));
+__arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1065;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label5:
 {
-Obj _35val1483 = __arg1;
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc1064= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1483) {
+Obj _35val1771 = __arg1;
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj fvs1 = _35val1771;
+pushCont(co, 4, _35clofun2926, 3, args, fvs, fvs1);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.diff"));
-__arg1 = y;
-__arg2 = s2;
+__arg0 = globalRef(intern("cora/lib/toc.closure-convert"));
+__arg1 = fvs1;
+__arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1064;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label6:
 {
-Obj _35cc1064 = makeNative(4, _35clofun2850, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1480 = primIsCons(closureRef(co, 0));
-if (True == _35reg1480) {
-Obj _35reg1481 = primCar(closureRef(co, 0));
-Obj x = _35reg1481;
-Obj _35reg1482 = primCdr(closureRef(co, 0));
-Obj y = _35reg1482;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 5, _35clofun2850, 3, y, s2, _35cc1064);
-__nargs = 3;
-__arg0 = globalRef(intern("elem?"));
-__arg1 = x;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1064;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label7:
-{
-Obj _35p1061 = __arg1;
-Obj _35p1062 = __arg2;
-Obj _35cc1063 = makeNative(6, _35clofun2850, 0, 2, _35p1061, _35p1062);
-Obj _35reg1484 = primEQ(Nil, _35p1061);
-if (True == _35reg1484) {
-Obj __ = _35p1062;
+Obj _35cc1085 = makeNative(1, _35clofun2926, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj _35reg1751 = primIsCons(closureRef(co, 1));
+if (True == _35reg1751) {
+Obj _35reg1752 = primCar(closureRef(co, 1));
+Obj _35reg1753 = primEQ(intern("lambda"), _35reg1752);
+if (True == _35reg1753) {
+Obj _35reg1754 = primCdr(closureRef(co, 1));
+Obj _35reg1755 = primIsCons(_35reg1754);
+if (True == _35reg1755) {
+Obj _35reg1756 = primCdr(closureRef(co, 1));
+Obj _35reg1757 = primCar(_35reg1756);
+Obj args = _35reg1757;
+Obj _35reg1758 = primCdr(closureRef(co, 1));
+Obj _35reg1759 = primCdr(_35reg1758);
+Obj _35reg1760 = primIsCons(_35reg1759);
+if (True == _35reg1760) {
+Obj _35reg1761 = primCdr(closureRef(co, 1));
+Obj _35reg1762 = primCdr(_35reg1761);
+Obj _35reg1763 = primCar(_35reg1762);
+Obj body = _35reg1763;
+Obj _35reg1764 = primCdr(closureRef(co, 1));
+Obj _35reg1765 = primCdr(_35reg1764);
+Obj _35reg1766 = primCdr(_35reg1765);
+Obj _35reg1767 = primEQ(Nil, _35reg1766);
+if (True == _35reg1767) {
+Obj _35reg1768 = primCons(body, Nil);
+Obj _35reg1769 = primCons(args, _35reg1768);
+Obj _35reg1770 = primCons(intern("lambda"), _35reg1769);
+pushCont(co, 5, _35clofun2926, 3, body, args, fvs);
 __nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2850) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1063;
+__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
+__arg1 = _35reg1770;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeString1("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35cc1072 = makeNative(8, _35clofun2850, 0, 0);
-Obj x = closureRef(co, 0);
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2850) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label10:
-{
-Obj _35cc1071 = makeNative(9, _35clofun2850, 0, 1, closureRef(co, 0));
-Obj _35reg1486 = primIsCons(closureRef(co, 0));
-if (True == _35reg1486) {
-Obj _35reg1487 = primCar(closureRef(co, 0));
-Obj _35reg1488 = primEQ(intern("%closure-ref"), _35reg1487);
-if (True == _35reg1488) {
-Obj _35reg1489 = primCdr(closureRef(co, 0));
-Obj _35reg1490 = primIsCons(_35reg1489);
-if (True == _35reg1490) {
-Obj _35reg1491 = primCdr(closureRef(co, 0));
-Obj _35reg1492 = primCar(_35reg1491);
-Obj __ = _35reg1492;
-Obj _35reg1493 = primCdr(closureRef(co, 0));
-Obj _35reg1494 = primCdr(_35reg1493);
-Obj _35reg1495 = primEQ(Nil, _35reg1494);
-if (True == _35reg1495) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2850) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1071;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1071;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1071;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1071;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label11:
-{
-Obj _35cc1070 = makeNative(10, _35clofun2850, 0, 1, closureRef(co, 0));
-Obj _35reg1496 = primIsCons(closureRef(co, 0));
-if (True == _35reg1496) {
-Obj _35reg1497 = primCar(closureRef(co, 0));
-Obj _35reg1498 = primEQ(intern("quote"), _35reg1497);
-if (True == _35reg1498) {
-Obj _35reg1499 = primCdr(closureRef(co, 0));
-Obj _35reg1500 = primIsCons(_35reg1499);
-if (True == _35reg1500) {
-Obj _35reg1501 = primCdr(closureRef(co, 0));
-Obj _35reg1502 = primCar(_35reg1501);
-Obj x = _35reg1502;
-Obj _35reg1503 = primCdr(closureRef(co, 0));
-Obj _35reg1504 = primCdr(_35reg1503);
-Obj _35reg1505 = primEQ(Nil, _35reg1504);
-if (True == _35reg1505) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2850) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1070;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1070;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1070;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1070;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35cc1069 = makeNative(11, _35clofun2850, 0, 1, closureRef(co, 0));
-Obj _35reg1506 = primIsCons(closureRef(co, 0));
-if (True == _35reg1506) {
-Obj _35reg1507 = primCar(closureRef(co, 0));
-Obj _35reg1508 = primEQ(intern("%builtin"), _35reg1507);
-if (True == _35reg1508) {
-Obj _35reg1509 = primCdr(closureRef(co, 0));
-Obj _35reg1510 = primIsCons(_35reg1509);
-if (True == _35reg1510) {
-Obj _35reg1511 = primCdr(closureRef(co, 0));
-Obj _35reg1512 = primCar(_35reg1511);
-Obj op = _35reg1512;
-Obj _35reg1513 = primCdr(closureRef(co, 0));
-Obj _35reg1514 = primCdr(_35reg1513);
-Obj _35reg1515 = primEQ(Nil, _35reg1514);
-if (True == _35reg1515) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2850) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1069;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1069;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1069;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1069;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
-{
-Obj _35cc1068 = makeNative(12, _35clofun2850, 0, 1, closureRef(co, 0));
-Obj _35reg1516 = primIsCons(closureRef(co, 0));
-if (True == _35reg1516) {
-Obj _35reg1517 = primCar(closureRef(co, 0));
-Obj _35reg1518 = primEQ(intern("%global"), _35reg1517);
-if (True == _35reg1518) {
-Obj _35reg1519 = primCdr(closureRef(co, 0));
-Obj _35reg1520 = primIsCons(_35reg1519);
-if (True == _35reg1520) {
-Obj _35reg1521 = primCdr(closureRef(co, 0));
-Obj _35reg1522 = primCar(_35reg1521);
-Obj x = _35reg1522;
-Obj _35reg1523 = primCdr(closureRef(co, 0));
-Obj _35reg1524 = primCdr(_35reg1523);
-Obj _35reg1525 = primEQ(Nil, _35reg1524);
-if (True == _35reg1525) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2850) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1068;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1068;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1068;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1068;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label14:
-{
-Obj _35p1066 = __arg1;
-Obj _35cc1067 = makeNative(13, _35clofun2850, 0, 1, _35p1066);
-Obj _35reg1526 = primIsCons(_35p1066);
-if (True == _35reg1526) {
-Obj _35reg1527 = primCar(_35p1066);
-Obj _35reg1528 = primEQ(intern("%const"), _35reg1527);
-if (True == _35reg1528) {
-Obj _35reg1529 = primCdr(_35p1066);
-Obj _35reg1530 = primIsCons(_35reg1529);
-if (True == _35reg1530) {
-Obj _35reg1531 = primCdr(_35p1066);
-Obj _35reg1532 = primCar(_35reg1531);
-Obj x = _35reg1532;
-Obj _35reg1533 = primCdr(_35p1066);
-Obj _35reg1534 = primCdr(_35reg1533);
-Obj _35reg1535 = primEQ(Nil, _35reg1534);
-if (True == _35reg1535) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2850) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1067;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1067;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1067;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1067;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeString1("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val1541 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc.foldl"));
-__arg1 = globalRef(intern("cora/lib/toc.union"));
-__arg2 = Nil;
-__arg3 = _35val1541;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35cc1085 = makeNative(15, _35clofun2850, 0, 0);
-Obj _35reg1537 = primIsCons(closureRef(co, 0));
-if (True == _35reg1537) {
-Obj _35reg1538 = primCar(closureRef(co, 0));
-Obj f = _35reg1538;
-Obj _35reg1539 = primCdr(closureRef(co, 0));
-Obj args = _35reg1539;
-Obj _35reg1540 = primCons(f, args);
-pushCont(co, 16, _35clofun2850, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = globalRef(intern("cora/lib/toc.free-vars"));
-__arg2 = _35reg1540;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -11135,169 +9824,524 @@ __arg0 = _35cc1085;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = _35cc1085;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1085;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1085;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1085;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label7:
+{
+Obj _35val1781 = __arg1;
+Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj pos = _35val1781;
+Obj _35reg1782 = primEQ(makeNumber(-1), pos);
+if (True == _35reg1782) {
+__nargs = 2;
+__arg1 = var;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2926) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg1783 = primCons(pos, Nil);
+Obj _35reg1784 = primCons(intern("%closure-ref"), _35reg1783);
+__nargs = 2;
+__arg1 = _35reg1784;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2926) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label8:
+{
+Obj _35cc1084 = makeNative(6, _35clofun2926, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj var = closureRef(co, 1);
+Obj _35reg1780 = primIsSymbol(var);
+if (True == _35reg1780) {
+pushCont(co, 7, _35clofun2926, 1, var);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.index"));
+__arg1 = var;
+__arg2 = fvs;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1084;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label9:
+{
+Obj _35val1785 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1083= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1785) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2926) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1083;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label10:
+{
+Obj _35p1081 = __arg1;
+Obj _35p1082 = __arg2;
+Obj _35cc1083 = makeNative(8, _35clofun2926, 0, 2, _35p1081, _35p1082);
+Obj __ = _35p1081;
+Obj x = _35p1082;
+pushCont(co, 9, _35clofun2926, 2, x, _35cc1083);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.convert-protect?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label11:
+{
+Obj x = __arg1;
+Obj _35reg1787 = primCons(x, Nil);
+Obj _35reg1788 = primCons(intern("return"), _35reg1787);
+__nargs = 2;
+__arg1 = _35reg1788;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2926) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label12:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label13:
+{
+Obj _35cc1096 = makeNative(12, _35clofun2926, 0, 0);
+Obj _35reg1790 = primIsCons(closureRef(co, 0));
+if (True == _35reg1790) {
+Obj _35reg1791 = primCar(closureRef(co, 0));
+Obj f = _35reg1791;
+Obj _35reg1792 = primCdr(closureRef(co, 0));
+Obj args = _35reg1792;
+Obj next = closureRef(co, 1);
+Obj _35reg1793 = primCons(f, args);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc.tailify-list"));
+__arg1 = _35reg1793;
+__arg2 = Nil;
+__arg3 = next;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1096;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label14:
+{
+Obj _35val1832 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj next= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg1833 = primCons(_35val1832, Nil);
+Obj _35reg1834 = primCons(args, _35reg1833);
+Obj _35reg1835 = primCons(intern("lambda"), _35reg1834);
+Obj _35reg1836 = primCons(_35reg1835, frees);
+Obj _35reg1837 = primCons(intern("%closure"), _35reg1836);
+__nargs = 2;
+__arg0 = next;
+__arg1 = _35reg1837;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label15:
+{
+Obj _35cc1095 = makeNative(13, _35clofun2926, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1794 = primIsCons(closureRef(co, 0));
+if (True == _35reg1794) {
+Obj _35reg1795 = primCar(closureRef(co, 0));
+Obj _35reg1796 = primEQ(intern("%closure"), _35reg1795);
+if (True == _35reg1796) {
+Obj _35reg1797 = primCdr(closureRef(co, 0));
+Obj _35reg1798 = primIsCons(_35reg1797);
+if (True == _35reg1798) {
+Obj _35reg1799 = primCdr(closureRef(co, 0));
+Obj _35reg1800 = primCar(_35reg1799);
+Obj _35reg1801 = primIsCons(_35reg1800);
+if (True == _35reg1801) {
+Obj _35reg1802 = primCdr(closureRef(co, 0));
+Obj _35reg1803 = primCar(_35reg1802);
+Obj _35reg1804 = primCar(_35reg1803);
+Obj _35reg1805 = primEQ(intern("lambda"), _35reg1804);
+if (True == _35reg1805) {
+Obj _35reg1806 = primCdr(closureRef(co, 0));
+Obj _35reg1807 = primCar(_35reg1806);
+Obj _35reg1808 = primCdr(_35reg1807);
+Obj _35reg1809 = primIsCons(_35reg1808);
+if (True == _35reg1809) {
+Obj _35reg1810 = primCdr(closureRef(co, 0));
+Obj _35reg1811 = primCar(_35reg1810);
+Obj _35reg1812 = primCdr(_35reg1811);
+Obj _35reg1813 = primCar(_35reg1812);
+Obj args = _35reg1813;
+Obj _35reg1814 = primCdr(closureRef(co, 0));
+Obj _35reg1815 = primCar(_35reg1814);
+Obj _35reg1816 = primCdr(_35reg1815);
+Obj _35reg1817 = primCdr(_35reg1816);
+Obj _35reg1818 = primIsCons(_35reg1817);
+if (True == _35reg1818) {
+Obj _35reg1819 = primCdr(closureRef(co, 0));
+Obj _35reg1820 = primCar(_35reg1819);
+Obj _35reg1821 = primCdr(_35reg1820);
+Obj _35reg1822 = primCdr(_35reg1821);
+Obj _35reg1823 = primCar(_35reg1822);
+Obj body = _35reg1823;
+Obj _35reg1824 = primCdr(closureRef(co, 0));
+Obj _35reg1825 = primCar(_35reg1824);
+Obj _35reg1826 = primCdr(_35reg1825);
+Obj _35reg1827 = primCdr(_35reg1826);
+Obj _35reg1828 = primCdr(_35reg1827);
+Obj _35reg1829 = primEQ(Nil, _35reg1828);
+if (True == _35reg1829) {
+Obj _35reg1830 = primCdr(closureRef(co, 0));
+Obj _35reg1831 = primCdr(_35reg1830);
+Obj frees = _35reg1831;
+Obj next = closureRef(co, 1);
+pushCont(co, 14, _35clofun2926, 3, args, frees, next);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.tailify"));
+__arg1 = body;
+__arg2 = globalRef(intern("cora/lib/toc.id"));
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1095;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label16:
+{
+Obj _35val1864 = __arg1;
+Obj rb= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1865 = primCons(_35val1864, Nil);
+Obj _35reg1866 = primCons(rb, _35reg1865);
+Obj _35reg1867 = primCons(closureRef(co, 0), _35reg1866);
+Obj _35reg1868 = primCons(intern("let"), _35reg1867);
+__nargs = 2;
+__arg1 = _35reg1868;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2926) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label17:
+{
+Obj rb = __arg1;
+pushCont(co, 16, _35clofun2926, 1, rb);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.tailify"));
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1559 = __arg1;
-Obj arg= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1094 = makeNative(15, _35clofun2926, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1838 = primIsCons(closureRef(co, 0));
+if (True == _35reg1838) {
+Obj _35reg1839 = primCar(closureRef(co, 0));
+Obj _35reg1840 = primEQ(intern("let"), _35reg1839);
+if (True == _35reg1840) {
+Obj _35reg1841 = primCdr(closureRef(co, 0));
+Obj _35reg1842 = primIsCons(_35reg1841);
+if (True == _35reg1842) {
+Obj _35reg1843 = primCdr(closureRef(co, 0));
+Obj _35reg1844 = primCar(_35reg1843);
+Obj a = _35reg1844;
+Obj _35reg1845 = primCdr(closureRef(co, 0));
+Obj _35reg1846 = primCdr(_35reg1845);
+Obj _35reg1847 = primIsCons(_35reg1846);
+if (True == _35reg1847) {
+Obj _35reg1848 = primCdr(closureRef(co, 0));
+Obj _35reg1849 = primCdr(_35reg1848);
+Obj _35reg1850 = primCar(_35reg1849);
+Obj b = _35reg1850;
+Obj _35reg1851 = primCdr(closureRef(co, 0));
+Obj _35reg1852 = primCdr(_35reg1851);
+Obj _35reg1853 = primCdr(_35reg1852);
+Obj _35reg1854 = primIsCons(_35reg1853);
+if (True == _35reg1854) {
+Obj _35reg1855 = primCdr(closureRef(co, 0));
+Obj _35reg1856 = primCdr(_35reg1855);
+Obj _35reg1857 = primCdr(_35reg1856);
+Obj _35reg1858 = primCar(_35reg1857);
+Obj c = _35reg1858;
+Obj _35reg1859 = primCdr(closureRef(co, 0));
+Obj _35reg1860 = primCdr(_35reg1859);
+Obj _35reg1861 = primCdr(_35reg1860);
+Obj _35reg1862 = primCdr(_35reg1861);
+Obj _35reg1863 = primEQ(Nil, _35reg1862);
+if (True == _35reg1863) {
+Obj next = closureRef(co, 1);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.diff"));
-__arg1 = _35val1559;
-__arg2 = arg;
+__arg0 = globalRef(intern("cora/lib/toc.tailify"));
+__arg1 = b;
+__arg2 = makeNative(17, _35clofun2926, 1, 3, a, c, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1094;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1094;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1094;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1094;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1094;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1094;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label19:
 {
-Obj _35cc1084 = makeNative(17, _35clofun2850, 0, 1, closureRef(co, 0));
-Obj _35reg1542 = primIsCons(closureRef(co, 0));
-if (True == _35reg1542) {
-Obj _35reg1543 = primCar(closureRef(co, 0));
-Obj _35reg1544 = primEQ(intern("continuation"), _35reg1543);
-if (True == _35reg1544) {
-Obj _35reg1545 = primCdr(closureRef(co, 0));
-Obj _35reg1546 = primIsCons(_35reg1545);
-if (True == _35reg1546) {
-Obj _35reg1547 = primCdr(closureRef(co, 0));
-Obj _35reg1548 = primCar(_35reg1547);
-Obj arg = _35reg1548;
-Obj _35reg1549 = primCdr(closureRef(co, 0));
-Obj _35reg1550 = primCdr(_35reg1549);
-Obj _35reg1551 = primIsCons(_35reg1550);
-if (True == _35reg1551) {
-Obj _35reg1552 = primCdr(closureRef(co, 0));
-Obj _35reg1553 = primCdr(_35reg1552);
-Obj _35reg1554 = primCar(_35reg1553);
-Obj body = _35reg1554;
-Obj _35reg1555 = primCdr(closureRef(co, 0));
-Obj _35reg1556 = primCdr(_35reg1555);
-Obj _35reg1557 = primCdr(_35reg1556);
-Obj _35reg1558 = primEQ(Nil, _35reg1557);
-if (True == _35reg1558) {
-pushCont(co, 18, _35clofun2850, 1, arg);
+Obj _35val1887 = __arg1;
+Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1888 = primCons(_35val1887, Nil);
+Obj _35reg1889 = primCons(ra, _35reg1888);
+Obj _35reg1890 = primCons(intern("do"), _35reg1889);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1084;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1084;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1084;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1084;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1084;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+__arg1 = _35reg1890;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2926) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label20:
 {
-Obj _35cc1083 = makeNative(19, _35clofun2850, 0, 1, closureRef(co, 0));
-Obj _35reg1560 = primIsCons(closureRef(co, 0));
-if (True == _35reg1560) {
-Obj _35reg1561 = primCar(closureRef(co, 0));
-Obj _35reg1562 = primEQ(intern("tailcall"), _35reg1561);
-if (True == _35reg1562) {
-Obj _35reg1563 = primCdr(closureRef(co, 0));
-Obj _35reg1564 = primIsCons(_35reg1563);
-if (True == _35reg1564) {
-Obj _35reg1565 = primCdr(closureRef(co, 0));
-Obj _35reg1566 = primCar(_35reg1565);
-Obj exp = _35reg1566;
-Obj _35reg1567 = primCdr(closureRef(co, 0));
-Obj _35reg1568 = primCdr(_35reg1567);
-Obj _35reg1569 = primEQ(Nil, _35reg1568);
-if (True == _35reg1569) {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
-__arg1 = exp;
+Obj ra = __arg1;
+Obj _35reg1886 = primIsSymbol(ra);
+if (True == _35reg1886) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.tailify"));
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 1;
-__arg0 = _35cc1083;
+pushCont(co, 19, _35clofun2926, 1, ra);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.tailify"));
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1083;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1083;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1083;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2850) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2926) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11311,7 +10355,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2849(struct Cora* co){
+void _35clofun2925(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -11324,673 +10368,754 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1053 = makeNative(18, _35clofun2848, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj env = closureRef(co, 0);
-Obj _35reg1349 = primIsCons(closureRef(co, 1));
-if (True == _35reg1349) {
-Obj _35reg1350 = primCar(closureRef(co, 1));
-Obj _35reg1351 = primEQ(intern("let"), _35reg1350);
-if (True == _35reg1351) {
-Obj _35reg1352 = primCdr(closureRef(co, 1));
-Obj _35reg1353 = primIsCons(_35reg1352);
-if (True == _35reg1353) {
-Obj _35reg1354 = primCdr(closureRef(co, 1));
-Obj _35reg1355 = primCar(_35reg1354);
-Obj a = _35reg1355;
-Obj _35reg1356 = primCdr(closureRef(co, 1));
-Obj _35reg1357 = primCdr(_35reg1356);
-Obj _35reg1358 = primIsCons(_35reg1357);
-if (True == _35reg1358) {
-Obj _35reg1359 = primCdr(closureRef(co, 1));
-Obj _35reg1360 = primCdr(_35reg1359);
-Obj _35reg1361 = primCar(_35reg1360);
-Obj b = _35reg1361;
-Obj _35reg1362 = primCdr(closureRef(co, 1));
-Obj _35reg1363 = primCdr(_35reg1362);
-Obj _35reg1364 = primCdr(_35reg1363);
-Obj _35reg1365 = primIsCons(_35reg1364);
-if (True == _35reg1365) {
-Obj _35reg1366 = primCdr(closureRef(co, 1));
-Obj _35reg1367 = primCdr(_35reg1366);
-Obj _35reg1368 = primCdr(_35reg1367);
-Obj _35reg1369 = primCar(_35reg1368);
-Obj c = _35reg1369;
-Obj _35reg1370 = primCdr(closureRef(co, 1));
-Obj _35reg1371 = primCdr(_35reg1370);
-Obj _35reg1372 = primCdr(_35reg1371);
-Obj _35reg1373 = primCdr(_35reg1372);
-Obj _35reg1374 = primEQ(Nil, _35reg1373);
-if (True == _35reg1374) {
-pushCont(co, 20, _35clofun2848, 3, env, c, a);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.parse"));
-__arg1 = env;
-__arg2 = b;
+Obj _35val1591 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc.foldl"));
+__arg1 = globalRef(intern("cora/lib/toc.union"));
+__arg2 = Nil;
+__arg3 = _35val1591;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1053;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1053;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1053;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1053;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1053;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1053;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label1:
 {
-Obj _35val1400 = __arg1;
-Obj _35val1399= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1401 = primCons(_35val1400, Nil);
-Obj _35reg1402 = primCons(_35val1399, _35reg1401);
-Obj _35reg1403 = primCons(intern("do"), _35reg1402);
-__nargs = 2;
-__arg1 = _35reg1403;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2849) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35cc1077 = makeNative(20, _35clofun2924, 0, 1, closureRef(co, 0));
+Obj _35reg1572 = primIsCons(closureRef(co, 0));
+if (True == _35reg1572) {
+Obj _35reg1573 = primCar(closureRef(co, 0));
+Obj _35reg1574 = primEQ(intern("call"), _35reg1573);
+if (True == _35reg1574) {
+Obj _35reg1575 = primCdr(closureRef(co, 0));
+Obj _35reg1576 = primIsCons(_35reg1575);
+if (True == _35reg1576) {
+Obj _35reg1577 = primCdr(closureRef(co, 0));
+Obj _35reg1578 = primCar(_35reg1577);
+Obj exp = _35reg1578;
+Obj _35reg1579 = primCdr(closureRef(co, 0));
+Obj _35reg1580 = primCdr(_35reg1579);
+Obj _35reg1581 = primIsCons(_35reg1580);
+if (True == _35reg1581) {
+Obj _35reg1582 = primCdr(closureRef(co, 0));
+Obj _35reg1583 = primCdr(_35reg1582);
+Obj _35reg1584 = primCar(_35reg1583);
+Obj cont = _35reg1584;
+Obj _35reg1585 = primCdr(closureRef(co, 0));
+Obj _35reg1586 = primCdr(_35reg1585);
+Obj _35reg1587 = primCdr(_35reg1586);
+Obj _35reg1588 = primEQ(Nil, _35reg1587);
+if (True == _35reg1588) {
+Obj _35reg1589 = primCons(cont, Nil);
+Obj _35reg1590 = primCons(exp, _35reg1589);
+pushCont(co, 0, _35clofun2925, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = globalRef(intern("cora/lib/toc.free-vars"));
+__arg2 = _35reg1590;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1077;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1077;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1077;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1077;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1077;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label2:
 {
-Obj _35val1399 = __arg1;
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun2849, 1, _35val1399);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.parse"));
-__arg1 = env;
-__arg2 = y;
+Obj _35cc1076 = makeNative(1, _35clofun2925, 0, 1, closureRef(co, 0));
+Obj _35reg1592 = primIsCons(closureRef(co, 0));
+if (True == _35reg1592) {
+Obj _35reg1593 = primCar(closureRef(co, 0));
+Obj _35reg1594 = primEQ(intern("return"), _35reg1593);
+if (True == _35reg1594) {
+Obj _35reg1595 = primCdr(closureRef(co, 0));
+Obj _35reg1596 = primIsCons(_35reg1595);
+if (True == _35reg1596) {
+Obj _35reg1597 = primCdr(closureRef(co, 0));
+Obj _35reg1598 = primCar(_35reg1597);
+Obj x = _35reg1598;
+Obj _35reg1599 = primCdr(closureRef(co, 0));
+Obj _35reg1600 = primCdr(_35reg1599);
+Obj _35reg1601 = primEQ(Nil, _35reg1600);
+if (True == _35reg1601) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1076;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1076;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1076;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1076;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label3:
 {
-Obj _35cc1052 = makeNative(0, _35clofun2849, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj env = closureRef(co, 0);
-Obj _35reg1382 = primIsCons(closureRef(co, 1));
-if (True == _35reg1382) {
-Obj _35reg1383 = primCar(closureRef(co, 1));
-Obj _35reg1384 = primEQ(intern("do"), _35reg1383);
-if (True == _35reg1384) {
-Obj _35reg1385 = primCdr(closureRef(co, 1));
-Obj _35reg1386 = primIsCons(_35reg1385);
-if (True == _35reg1386) {
-Obj _35reg1387 = primCdr(closureRef(co, 1));
-Obj _35reg1388 = primCar(_35reg1387);
-Obj x = _35reg1388;
-Obj _35reg1389 = primCdr(closureRef(co, 1));
-Obj _35reg1390 = primCdr(_35reg1389);
-Obj _35reg1391 = primIsCons(_35reg1390);
-if (True == _35reg1391) {
-Obj _35reg1392 = primCdr(closureRef(co, 1));
-Obj _35reg1393 = primCdr(_35reg1392);
-Obj _35reg1394 = primCar(_35reg1393);
-Obj y = _35reg1394;
-Obj _35reg1395 = primCdr(closureRef(co, 1));
-Obj _35reg1396 = primCdr(_35reg1395);
-Obj _35reg1397 = primCdr(_35reg1396);
-Obj _35reg1398 = primEQ(Nil, _35reg1397);
-if (True == _35reg1398) {
-pushCont(co, 2, _35clofun2849, 2, env, y);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.parse"));
-__arg1 = env;
-__arg2 = x;
+Obj _35cc1075 = makeNative(2, _35clofun2925, 0, 1, closureRef(co, 0));
+Obj _35reg1602 = primIsCons(closureRef(co, 0));
+if (True == _35reg1602) {
+Obj _35reg1603 = primCar(closureRef(co, 0));
+Obj _35reg1604 = primEQ(intern("%closure"), _35reg1603);
+if (True == _35reg1604) {
+Obj _35reg1605 = primCdr(closureRef(co, 0));
+Obj _35reg1606 = primIsCons(_35reg1605);
+if (True == _35reg1606) {
+Obj _35reg1607 = primCdr(closureRef(co, 0));
+Obj _35reg1608 = primCar(_35reg1607);
+Obj lam = _35reg1608;
+Obj _35reg1609 = primCdr(closureRef(co, 0));
+Obj _35reg1610 = primCdr(_35reg1609);
+Obj more = _35reg1610;
+Obj _35reg1611 = primCons(lam, more);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
+__arg1 = _35reg1611;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1052;
+__arg0 = _35cc1075;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1052;
+__arg0 = _35cc1075;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1052;
+__arg0 = _35cc1075;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1052;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1052;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35val1409 = __arg1;
-Obj _35reg1410 = primCons(intern("if"), _35val1409);
-__nargs = 2;
-__arg1 = _35reg1410;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2849) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val1641 = __arg1;
+Obj _35val1638= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.union"));
+__arg1 = _35val1638;
+__arg2 = _35val1641;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1408 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 4, _35clofun2849, 0);
+Obj _35val1639 = __arg1;
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val1638= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1640 = primCons(a, Nil);
+pushCont(co, 4, _35clofun2925, 1, _35val1638);
 __nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = _35val1408;
-__arg2 = args;
+__arg0 = globalRef(intern("cora/lib/toc.diff"));
+__arg1 = _35val1639;
+__arg2 = _35reg1640;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc1051 = makeNative(3, _35clofun2849, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj env = closureRef(co, 0);
-Obj _35reg1404 = primIsCons(closureRef(co, 1));
-if (True == _35reg1404) {
-Obj _35reg1405 = primCar(closureRef(co, 1));
-Obj _35reg1406 = primEQ(intern("if"), _35reg1405);
-if (True == _35reg1406) {
-Obj _35reg1407 = primCdr(closureRef(co, 1));
-Obj args = _35reg1407;
-pushCont(co, 5, _35clofun2849, 1, args);
+Obj _35val1638 = __arg1;
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 5, _35clofun2925, 2, a, _35val1638);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc.parse"));
-__arg1 = env;
+__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
+__arg1 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1051;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1051;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label7:
 {
-Obj _35val1429 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1430 = primCons(_35val1429, Nil);
-Obj _35reg1431 = primCons(args, _35reg1430);
-Obj _35reg1432 = primCons(intern("lambda"), _35reg1431);
+Obj _35cc1074 = makeNative(3, _35clofun2925, 0, 1, closureRef(co, 0));
+Obj _35reg1612 = primIsCons(closureRef(co, 0));
+if (True == _35reg1612) {
+Obj _35reg1613 = primCar(closureRef(co, 0));
+Obj _35reg1614 = primEQ(intern("let"), _35reg1613);
+if (True == _35reg1614) {
+Obj _35reg1615 = primCdr(closureRef(co, 0));
+Obj _35reg1616 = primIsCons(_35reg1615);
+if (True == _35reg1616) {
+Obj _35reg1617 = primCdr(closureRef(co, 0));
+Obj _35reg1618 = primCar(_35reg1617);
+Obj a = _35reg1618;
+Obj _35reg1619 = primCdr(closureRef(co, 0));
+Obj _35reg1620 = primCdr(_35reg1619);
+Obj _35reg1621 = primIsCons(_35reg1620);
+if (True == _35reg1621) {
+Obj _35reg1622 = primCdr(closureRef(co, 0));
+Obj _35reg1623 = primCdr(_35reg1622);
+Obj _35reg1624 = primCar(_35reg1623);
+Obj b = _35reg1624;
+Obj _35reg1625 = primCdr(closureRef(co, 0));
+Obj _35reg1626 = primCdr(_35reg1625);
+Obj _35reg1627 = primCdr(_35reg1626);
+Obj _35reg1628 = primIsCons(_35reg1627);
+if (True == _35reg1628) {
+Obj _35reg1629 = primCdr(closureRef(co, 0));
+Obj _35reg1630 = primCdr(_35reg1629);
+Obj _35reg1631 = primCdr(_35reg1630);
+Obj _35reg1632 = primCar(_35reg1631);
+Obj c = _35reg1632;
+Obj _35reg1633 = primCdr(closureRef(co, 0));
+Obj _35reg1634 = primCdr(_35reg1633);
+Obj _35reg1635 = primCdr(_35reg1634);
+Obj _35reg1636 = primCdr(_35reg1635);
+Obj _35reg1637 = primEQ(Nil, _35reg1636);
+if (True == _35reg1637) {
+pushCont(co, 6, _35clofun2925, 2, c, a);
 __nargs = 2;
-__arg1 = _35reg1432;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2849) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
+__arg1 = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1074;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1074;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1074;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1074;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1074;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1074;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label8:
 {
-Obj _35val1428 = __arg1;
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun2849, 1, args);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.parse"));
-__arg1 = _35val1428;
-__arg2 = body;
+Obj _35val1661 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc.foldl"));
+__arg1 = globalRef(intern("cora/lib/toc.union"));
+__arg2 = Nil;
+__arg3 = _35val1661;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35cc1050 = makeNative(6, _35clofun2849, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj env = closureRef(co, 0);
-Obj _35reg1411 = primIsCons(closureRef(co, 1));
-if (True == _35reg1411) {
-Obj _35reg1412 = primCar(closureRef(co, 1));
-Obj _35reg1413 = primEQ(intern("lambda"), _35reg1412);
-if (True == _35reg1413) {
-Obj _35reg1414 = primCdr(closureRef(co, 1));
-Obj _35reg1415 = primIsCons(_35reg1414);
-if (True == _35reg1415) {
-Obj _35reg1416 = primCdr(closureRef(co, 1));
-Obj _35reg1417 = primCar(_35reg1416);
-Obj args = _35reg1417;
-Obj _35reg1418 = primCdr(closureRef(co, 1));
-Obj _35reg1419 = primCdr(_35reg1418);
-Obj _35reg1420 = primIsCons(_35reg1419);
-if (True == _35reg1420) {
-Obj _35reg1421 = primCdr(closureRef(co, 1));
-Obj _35reg1422 = primCdr(_35reg1421);
-Obj _35reg1423 = primCar(_35reg1422);
-Obj body = _35reg1423;
-Obj _35reg1424 = primCdr(closureRef(co, 1));
-Obj _35reg1425 = primCdr(_35reg1424);
-Obj _35reg1426 = primCdr(_35reg1425);
-Obj _35reg1427 = primEQ(Nil, _35reg1426);
-if (True == _35reg1427) {
-pushCont(co, 8, _35clofun2849, 2, body, args);
+Obj _35cc1073 = makeNative(7, _35clofun2925, 0, 1, closureRef(co, 0));
+Obj _35reg1642 = primIsCons(closureRef(co, 0));
+if (True == _35reg1642) {
+Obj _35reg1643 = primCar(closureRef(co, 0));
+Obj _35reg1644 = primEQ(intern("do"), _35reg1643);
+if (True == _35reg1644) {
+Obj _35reg1645 = primCdr(closureRef(co, 0));
+Obj _35reg1646 = primIsCons(_35reg1645);
+if (True == _35reg1646) {
+Obj _35reg1647 = primCdr(closureRef(co, 0));
+Obj _35reg1648 = primCar(_35reg1647);
+Obj x = _35reg1648;
+Obj _35reg1649 = primCdr(closureRef(co, 0));
+Obj _35reg1650 = primCdr(_35reg1649);
+Obj _35reg1651 = primIsCons(_35reg1650);
+if (True == _35reg1651) {
+Obj _35reg1652 = primCdr(closureRef(co, 0));
+Obj _35reg1653 = primCdr(_35reg1652);
+Obj _35reg1654 = primCar(_35reg1653);
+Obj y = _35reg1654;
+Obj _35reg1655 = primCdr(closureRef(co, 0));
+Obj _35reg1656 = primCdr(_35reg1655);
+Obj _35reg1657 = primCdr(_35reg1656);
+Obj _35reg1658 = primEQ(Nil, _35reg1657);
+if (True == _35reg1658) {
+Obj _35reg1659 = primCons(y, Nil);
+Obj _35reg1660 = primCons(x, _35reg1659);
+pushCont(co, 8, _35clofun2925, 0);
 __nargs = 3;
-__arg0 = globalRef(intern("append"));
-__arg1 = args;
-__arg2 = env;
+__arg0 = globalRef(intern("map"));
+__arg1 = globalRef(intern("cora/lib/toc.free-vars"));
+__arg2 = _35reg1660;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1050;
+__arg0 = _35cc1073;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1050;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1050;
+__arg0 = _35cc1073;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1050;
+__arg0 = _35cc1073;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1050;
+__arg0 = _35cc1073;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1073;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35val1434 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1434) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2849) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg1435 = primCons(x, Nil);
-Obj _35reg1436 = primCons(intern("%global"), _35reg1435);
-__nargs = 2;
-__arg1 = _35reg1436;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2849) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
+Obj _35val1691 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc.foldl"));
+__arg1 = globalRef(intern("cora/lib/toc.union"));
+__arg2 = Nil;
+__arg3 = _35val1691;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35cc1049 = makeNative(9, _35clofun2849, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj env = closureRef(co, 0);
-Obj x = closureRef(co, 1);
-Obj _35reg1433 = primIsSymbol(x);
-if (True == _35reg1433) {
-pushCont(co, 10, _35clofun2849, 1, x);
+Obj _35cc1072 = makeNative(9, _35clofun2925, 0, 1, closureRef(co, 0));
+Obj _35reg1662 = primIsCons(closureRef(co, 0));
+if (True == _35reg1662) {
+Obj _35reg1663 = primCar(closureRef(co, 0));
+Obj _35reg1664 = primEQ(intern("if"), _35reg1663);
+if (True == _35reg1664) {
+Obj _35reg1665 = primCdr(closureRef(co, 0));
+Obj _35reg1666 = primIsCons(_35reg1665);
+if (True == _35reg1666) {
+Obj _35reg1667 = primCdr(closureRef(co, 0));
+Obj _35reg1668 = primCar(_35reg1667);
+Obj x = _35reg1668;
+Obj _35reg1669 = primCdr(closureRef(co, 0));
+Obj _35reg1670 = primCdr(_35reg1669);
+Obj _35reg1671 = primIsCons(_35reg1670);
+if (True == _35reg1671) {
+Obj _35reg1672 = primCdr(closureRef(co, 0));
+Obj _35reg1673 = primCdr(_35reg1672);
+Obj _35reg1674 = primCar(_35reg1673);
+Obj y = _35reg1674;
+Obj _35reg1675 = primCdr(closureRef(co, 0));
+Obj _35reg1676 = primCdr(_35reg1675);
+Obj _35reg1677 = primCdr(_35reg1676);
+Obj _35reg1678 = primIsCons(_35reg1677);
+if (True == _35reg1678) {
+Obj _35reg1679 = primCdr(closureRef(co, 0));
+Obj _35reg1680 = primCdr(_35reg1679);
+Obj _35reg1681 = primCdr(_35reg1680);
+Obj _35reg1682 = primCar(_35reg1681);
+Obj z = _35reg1682;
+Obj _35reg1683 = primCdr(closureRef(co, 0));
+Obj _35reg1684 = primCdr(_35reg1683);
+Obj _35reg1685 = primCdr(_35reg1684);
+Obj _35reg1686 = primCdr(_35reg1685);
+Obj _35reg1687 = primEQ(Nil, _35reg1686);
+if (True == _35reg1687) {
+Obj _35reg1688 = primCons(z, Nil);
+Obj _35reg1689 = primCons(y, _35reg1688);
+Obj _35reg1690 = primCons(x, _35reg1689);
+pushCont(co, 10, _35clofun2925, 0);
 __nargs = 3;
-__arg0 = globalRef(intern("elem?"));
-__arg1 = x;
-__arg2 = env;
+__arg0 = globalRef(intern("map"));
+__arg1 = globalRef(intern("cora/lib/toc.free-vars"));
+__arg2 = _35reg1690;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1049;
+__arg0 = _35cc1072;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1072;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1072;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1072;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1072;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1072;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj _35cc1048 = makeNative(11, _35clofun2849, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj __ = closureRef(co, 0);
-Obj _35reg1437 = primIsCons(closureRef(co, 1));
-if (True == _35reg1437) {
-Obj _35reg1438 = primCar(closureRef(co, 1));
-Obj _35reg1439 = primEQ(intern("quote"), _35reg1438);
-if (True == _35reg1439) {
-Obj _35reg1440 = primCdr(closureRef(co, 1));
-Obj _35reg1441 = primIsCons(_35reg1440);
-if (True == _35reg1441) {
-Obj _35reg1442 = primCdr(closureRef(co, 1));
-Obj _35reg1443 = primCar(_35reg1442);
-Obj x = _35reg1443;
-Obj _35reg1444 = primCdr(closureRef(co, 1));
-Obj _35reg1445 = primCdr(_35reg1444);
-Obj _35reg1446 = primEQ(Nil, _35reg1445);
-if (True == _35reg1446) {
-Obj _35reg1447 = primCons(x, Nil);
-Obj _35reg1448 = primCons(intern("%const"), _35reg1447);
-__nargs = 2;
-__arg1 = _35reg1448;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2849) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1048;
+Obj _35val1709 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.diff"));
+__arg1 = _35val1709;
+__arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1048;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1048;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1048;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label13:
 {
-Obj _35val1458 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1047= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1458) {
-if (True == True) {
-Obj _35reg1459 = primCons(x, Nil);
-Obj _35reg1460 = primCons(intern("%const"), _35reg1459);
+Obj _35cc1071 = makeNative(11, _35clofun2925, 0, 1, closureRef(co, 0));
+Obj _35reg1692 = primIsCons(closureRef(co, 0));
+if (True == _35reg1692) {
+Obj _35reg1693 = primCar(closureRef(co, 0));
+Obj _35reg1694 = primEQ(intern("lambda"), _35reg1693);
+if (True == _35reg1694) {
+Obj _35reg1695 = primCdr(closureRef(co, 0));
+Obj _35reg1696 = primIsCons(_35reg1695);
+if (True == _35reg1696) {
+Obj _35reg1697 = primCdr(closureRef(co, 0));
+Obj _35reg1698 = primCar(_35reg1697);
+Obj args = _35reg1698;
+Obj _35reg1699 = primCdr(closureRef(co, 0));
+Obj _35reg1700 = primCdr(_35reg1699);
+Obj _35reg1701 = primIsCons(_35reg1700);
+if (True == _35reg1701) {
+Obj _35reg1702 = primCdr(closureRef(co, 0));
+Obj _35reg1703 = primCdr(_35reg1702);
+Obj _35reg1704 = primCar(_35reg1703);
+Obj body = _35reg1704;
+Obj _35reg1705 = primCdr(closureRef(co, 0));
+Obj _35reg1706 = primCdr(_35reg1705);
+Obj _35reg1707 = primCdr(_35reg1706);
+Obj _35reg1708 = primEQ(Nil, _35reg1707);
+if (True == _35reg1708) {
+pushCont(co, 12, _35clofun2925, 1, args);
 __nargs = 2;
-__arg1 = _35reg1460;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2849) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1047;
+__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
+__arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-Obj _35reg1461 = primCons(x, Nil);
-Obj _35reg1462 = primCons(intern("%const"), _35reg1461);
-__nargs = 2;
-__arg1 = _35reg1462;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2849) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1047;
+__arg0 = _35cc1071;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = _35cc1071;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1071;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1071;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1071;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 }
 
 label14:
 {
-Obj _35val1455 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1047= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1455) {
-if (True == True) {
-Obj _35reg1456 = primCons(x, Nil);
-Obj _35reg1457 = primCons(intern("%const"), _35reg1456);
+Obj _35cc1070 = makeNative(13, _35clofun2925, 0, 1, closureRef(co, 0));
+Obj x = closureRef(co, 0);
+Obj _35reg1710 = primIsSymbol(x);
+if (True == _35reg1710) {
+Obj _35reg1711 = primCons(x, Nil);
 __nargs = 2;
-__arg1 = _35reg1457;
+__arg1 = _35reg1711;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2849) { goto fail; }
+if (co->ctx.pc.func != _35clofun2925) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1047;
+__arg0 = _35cc1070;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 13, _35clofun2849, 2, x, _35cc1047);
-__nargs = 2;
-__arg0 = globalRef(intern("null?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label15:
 {
-Obj _35val1449 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1047= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1449) {
-if (True == True) {
-Obj _35reg1450 = primCons(x, Nil);
-Obj _35reg1451 = primCons(intern("%const"), _35reg1450);
+Obj _35val1712 = __arg1;
+Obj _35cc1069= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1712) {
 __nargs = 2;
-__arg1 = _35reg1451;
+__arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2849) { goto fail; }
+if (co->ctx.pc.func != _35clofun2925) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1047;
+__arg0 = _35cc1069;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-Obj _35reg1452 = primIsString(x);
-if (True == _35reg1452) {
-if (True == True) {
-Obj _35reg1453 = primCons(x, Nil);
-Obj _35reg1454 = primCons(intern("%const"), _35reg1453);
-__nargs = 2;
-__arg1 = _35reg1454;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2849) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1047;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 14, _35clofun2849, 2, x, _35cc1047);
-__nargs = 2;
-__arg0 = globalRef(intern("boolean?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 }
 
 label16:
 {
-Obj _35p1045 = __arg1;
-Obj _35p1046 = __arg2;
-Obj _35cc1047 = makeNative(12, _35clofun2849, 0, 2, _35p1045, _35p1046);
-Obj __ = _35p1045;
-Obj x = _35p1046;
-pushCont(co, 15, _35clofun2849, 2, x, _35cc1047);
+Obj _35p1068 = __arg1;
+Obj _35cc1069 = makeNative(14, _35clofun2925, 0, 1, _35p1068);
+Obj x = _35p1068;
+pushCont(co, 15, _35clofun2925, 1, _35cc1069);
 __nargs = 2;
-__arg0 = globalRef(intern("number?"));
+__arg0 = globalRef(intern("cora/lib/toc.convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12002,41 +11127,191 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1467 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1468 = primCons(x, _35val1467);
-__nargs = 2;
-__arg1 = _35reg1468;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2849) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val1717 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1718 = primCons(f, args);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = _35val1717;
+__arg2 = _35reg1718;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35cc1060 = makeNative(17, _35clofun2849, 0, 0);
-Obj _35reg1464 = primIsCons(closureRef(co, 0));
-if (True == _35reg1464) {
-Obj _35reg1465 = primCar(closureRef(co, 0));
-Obj x = _35reg1465;
-Obj _35reg1466 = primCdr(closureRef(co, 0));
-Obj y = _35reg1466;
+Obj _35cc1087 = makeNative(17, _35clofun2925, 0, 0);
+Obj fvs = closureRef(co, 0);
+Obj _35reg1714 = primIsCons(closureRef(co, 1));
+if (True == _35reg1714) {
+Obj _35reg1715 = primCar(closureRef(co, 1));
+Obj f = _35reg1715;
+Obj _35reg1716 = primCdr(closureRef(co, 1));
+Obj args = _35reg1716;
+pushCont(co, 18, _35clofun2925, 2, f, args);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.closure-convert"));
+__arg1 = fvs;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1087;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2925) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label20:
+{
+Obj _35val1746 = __arg1;
+Obj _35val1745= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1747 = primCons(_35val1746, Nil);
+Obj _35reg1748 = primCons(_35val1745, _35reg1747);
+Obj _35reg1749 = primCons(a, _35reg1748);
+Obj _35reg1750 = primCons(intern("let"), _35reg1749);
+__nargs = 2;
+__arg1 = _35reg1750;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2925) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void _35clofun2924(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc1054 = makeNative(19, _35clofun2923, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1471 = primIsCons(closureRef(co, 0));
+if (True == _35reg1471) {
+Obj _35reg1472 = primCar(closureRef(co, 0));
+Obj x = _35reg1472;
+Obj _35reg1473 = primCdr(closureRef(co, 0));
+Obj y = _35reg1473;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 18, _35clofun2849, 1, x);
+pushCont(co, 20, _35clofun2923, 3, y, s2, _35cc1054);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.union"));
+__arg0 = globalRef(intern("elem?"));
+__arg1 = x;
+__arg2 = s2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1054;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35p1051 = __arg1;
+Obj _35p1052 = __arg2;
+Obj _35cc1053 = makeNative(0, _35clofun2924, 0, 2, _35p1051, _35p1052);
+Obj _35reg1475 = primEQ(Nil, _35p1051);
+if (True == _35reg1475) {
+Obj s2 = _35p1052;
+__nargs = 2;
+__arg1 = s2;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2924) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1053;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val1480 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1481 = primCons(x, _35val1480);
+__nargs = 2;
+__arg1 = _35reg1481;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2924) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
+{
+Obj _35cc1060 = makeNative(2, _35clofun2924, 0, 0);
+Obj _35reg1477 = primIsCons(closureRef(co, 0));
+if (True == _35reg1477) {
+Obj _35reg1478 = primCar(closureRef(co, 0));
+Obj x = _35reg1478;
+Obj _35reg1479 = primCdr(closureRef(co, 0));
+Obj y = _35reg1479;
+Obj s2 = closureRef(co, 1);
+pushCont(co, 3, _35clofun2924, 1, x);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.diff"));
 __arg1 = y;
 __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12044,26 +11319,26 @@ __arg0 = _35cc1060;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label20:
+label5:
 {
-Obj _35val1472 = __arg1;
+Obj _35val1485 = __arg1;
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35cc1059= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1472) {
+if (True == _35val1485) {
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc.union"));
+__arg0 = globalRef(intern("cora/lib/toc.diff"));
 __arg1 = y;
 __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12071,7 +11346,611 @@ __arg0 = _35cc1059;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2849) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label6:
+{
+Obj _35cc1059 = makeNative(4, _35clofun2924, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1482 = primIsCons(closureRef(co, 0));
+if (True == _35reg1482) {
+Obj _35reg1483 = primCar(closureRef(co, 0));
+Obj x = _35reg1483;
+Obj _35reg1484 = primCdr(closureRef(co, 0));
+Obj y = _35reg1484;
+Obj s2 = closureRef(co, 1);
+pushCont(co, 5, _35clofun2924, 3, y, s2, _35cc1059);
+__nargs = 3;
+__arg0 = globalRef(intern("elem?"));
+__arg1 = x;
+__arg2 = s2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1059;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label7:
+{
+Obj _35p1056 = __arg1;
+Obj _35p1057 = __arg2;
+Obj _35cc1058 = makeNative(6, _35clofun2924, 0, 2, _35p1056, _35p1057);
+Obj _35reg1486 = primEQ(Nil, _35p1056);
+if (True == _35reg1486) {
+Obj __ = _35p1057;
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2924) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1058;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label8:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label9:
+{
+Obj _35cc1067 = makeNative(8, _35clofun2924, 0, 0);
+Obj x = closureRef(co, 0);
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2924) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label10:
+{
+Obj _35cc1066 = makeNative(9, _35clofun2924, 0, 1, closureRef(co, 0));
+Obj _35reg1488 = primIsCons(closureRef(co, 0));
+if (True == _35reg1488) {
+Obj _35reg1489 = primCar(closureRef(co, 0));
+Obj _35reg1490 = primEQ(intern("%closure-ref"), _35reg1489);
+if (True == _35reg1490) {
+Obj _35reg1491 = primCdr(closureRef(co, 0));
+Obj _35reg1492 = primIsCons(_35reg1491);
+if (True == _35reg1492) {
+Obj _35reg1493 = primCdr(closureRef(co, 0));
+Obj _35reg1494 = primCar(_35reg1493);
+Obj __ = _35reg1494;
+Obj _35reg1495 = primCdr(closureRef(co, 0));
+Obj _35reg1496 = primCdr(_35reg1495);
+Obj _35reg1497 = primEQ(Nil, _35reg1496);
+if (True == _35reg1497) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2924) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1066;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1066;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1066;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1066;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label11:
+{
+Obj _35cc1065 = makeNative(10, _35clofun2924, 0, 1, closureRef(co, 0));
+Obj _35reg1498 = primIsCons(closureRef(co, 0));
+if (True == _35reg1498) {
+Obj _35reg1499 = primCar(closureRef(co, 0));
+Obj _35reg1500 = primEQ(intern("quote"), _35reg1499);
+if (True == _35reg1500) {
+Obj _35reg1501 = primCdr(closureRef(co, 0));
+Obj _35reg1502 = primIsCons(_35reg1501);
+if (True == _35reg1502) {
+Obj _35reg1503 = primCdr(closureRef(co, 0));
+Obj _35reg1504 = primCar(_35reg1503);
+Obj x = _35reg1504;
+Obj _35reg1505 = primCdr(closureRef(co, 0));
+Obj _35reg1506 = primCdr(_35reg1505);
+Obj _35reg1507 = primEQ(Nil, _35reg1506);
+if (True == _35reg1507) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2924) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1065;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1065;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1065;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1065;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label12:
+{
+Obj _35cc1064 = makeNative(11, _35clofun2924, 0, 1, closureRef(co, 0));
+Obj _35reg1508 = primIsCons(closureRef(co, 0));
+if (True == _35reg1508) {
+Obj _35reg1509 = primCar(closureRef(co, 0));
+Obj _35reg1510 = primEQ(intern("%builtin"), _35reg1509);
+if (True == _35reg1510) {
+Obj _35reg1511 = primCdr(closureRef(co, 0));
+Obj _35reg1512 = primIsCons(_35reg1511);
+if (True == _35reg1512) {
+Obj _35reg1513 = primCdr(closureRef(co, 0));
+Obj _35reg1514 = primCar(_35reg1513);
+Obj op = _35reg1514;
+Obj _35reg1515 = primCdr(closureRef(co, 0));
+Obj _35reg1516 = primCdr(_35reg1515);
+Obj _35reg1517 = primEQ(Nil, _35reg1516);
+if (True == _35reg1517) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2924) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1064;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1064;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1064;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1064;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label13:
+{
+Obj _35cc1063 = makeNative(12, _35clofun2924, 0, 1, closureRef(co, 0));
+Obj _35reg1518 = primIsCons(closureRef(co, 0));
+if (True == _35reg1518) {
+Obj _35reg1519 = primCar(closureRef(co, 0));
+Obj _35reg1520 = primEQ(intern("%global"), _35reg1519);
+if (True == _35reg1520) {
+Obj _35reg1521 = primCdr(closureRef(co, 0));
+Obj _35reg1522 = primIsCons(_35reg1521);
+if (True == _35reg1522) {
+Obj _35reg1523 = primCdr(closureRef(co, 0));
+Obj _35reg1524 = primCar(_35reg1523);
+Obj x = _35reg1524;
+Obj _35reg1525 = primCdr(closureRef(co, 0));
+Obj _35reg1526 = primCdr(_35reg1525);
+Obj _35reg1527 = primEQ(Nil, _35reg1526);
+if (True == _35reg1527) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2924) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1063;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label14:
+{
+Obj _35p1061 = __arg1;
+Obj _35cc1062 = makeNative(13, _35clofun2924, 0, 1, _35p1061);
+Obj _35reg1528 = primIsCons(_35p1061);
+if (True == _35reg1528) {
+Obj _35reg1529 = primCar(_35p1061);
+Obj _35reg1530 = primEQ(intern("%const"), _35reg1529);
+if (True == _35reg1530) {
+Obj _35reg1531 = primCdr(_35p1061);
+Obj _35reg1532 = primIsCons(_35reg1531);
+if (True == _35reg1532) {
+Obj _35reg1533 = primCdr(_35p1061);
+Obj _35reg1534 = primCar(_35reg1533);
+Obj x = _35reg1534;
+Obj _35reg1535 = primCdr(_35p1061);
+Obj _35reg1536 = primCdr(_35reg1535);
+Obj _35reg1537 = primEQ(Nil, _35reg1536);
+if (True == _35reg1537) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2924) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1062;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1062;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1062;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1062;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label15:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label16:
+{
+Obj _35val1543 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc.foldl"));
+__arg1 = globalRef(intern("cora/lib/toc.union"));
+__arg2 = Nil;
+__arg3 = _35val1543;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label17:
+{
+Obj _35cc1080 = makeNative(15, _35clofun2924, 0, 0);
+Obj _35reg1539 = primIsCons(closureRef(co, 0));
+if (True == _35reg1539) {
+Obj _35reg1540 = primCar(closureRef(co, 0));
+Obj f = _35reg1540;
+Obj _35reg1541 = primCdr(closureRef(co, 0));
+Obj args = _35reg1541;
+Obj _35reg1542 = primCons(f, args);
+pushCont(co, 16, _35clofun2924, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = globalRef(intern("cora/lib/toc.free-vars"));
+__arg2 = _35reg1542;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1080;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label18:
+{
+Obj _35val1561 = __arg1;
+Obj arg= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.diff"));
+__arg1 = _35val1561;
+__arg2 = arg;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label19:
+{
+Obj _35cc1079 = makeNative(17, _35clofun2924, 0, 1, closureRef(co, 0));
+Obj _35reg1544 = primIsCons(closureRef(co, 0));
+if (True == _35reg1544) {
+Obj _35reg1545 = primCar(closureRef(co, 0));
+Obj _35reg1546 = primEQ(intern("continuation"), _35reg1545);
+if (True == _35reg1546) {
+Obj _35reg1547 = primCdr(closureRef(co, 0));
+Obj _35reg1548 = primIsCons(_35reg1547);
+if (True == _35reg1548) {
+Obj _35reg1549 = primCdr(closureRef(co, 0));
+Obj _35reg1550 = primCar(_35reg1549);
+Obj arg = _35reg1550;
+Obj _35reg1551 = primCdr(closureRef(co, 0));
+Obj _35reg1552 = primCdr(_35reg1551);
+Obj _35reg1553 = primIsCons(_35reg1552);
+if (True == _35reg1553) {
+Obj _35reg1554 = primCdr(closureRef(co, 0));
+Obj _35reg1555 = primCdr(_35reg1554);
+Obj _35reg1556 = primCar(_35reg1555);
+Obj body = _35reg1556;
+Obj _35reg1557 = primCdr(closureRef(co, 0));
+Obj _35reg1558 = primCdr(_35reg1557);
+Obj _35reg1559 = primCdr(_35reg1558);
+Obj _35reg1560 = primEQ(Nil, _35reg1559);
+if (True == _35reg1560) {
+pushCont(co, 18, _35clofun2924, 1, arg);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
+__arg1 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1079;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1079;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1079;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1079;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1079;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label20:
+{
+Obj _35cc1078 = makeNative(19, _35clofun2924, 0, 1, closureRef(co, 0));
+Obj _35reg1562 = primIsCons(closureRef(co, 0));
+if (True == _35reg1562) {
+Obj _35reg1563 = primCar(closureRef(co, 0));
+Obj _35reg1564 = primEQ(intern("tailcall"), _35reg1563);
+if (True == _35reg1564) {
+Obj _35reg1565 = primCdr(closureRef(co, 0));
+Obj _35reg1566 = primIsCons(_35reg1565);
+if (True == _35reg1566) {
+Obj _35reg1567 = primCdr(closureRef(co, 0));
+Obj _35reg1568 = primCar(_35reg1567);
+Obj exp = _35reg1568;
+Obj _35reg1569 = primCdr(closureRef(co, 0));
+Obj _35reg1570 = primCdr(_35reg1569);
+Obj _35reg1571 = primEQ(Nil, _35reg1570);
+if (True == _35reg1571) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.free-vars"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1078;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1078;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1078;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1078;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2924) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12085,7 +11964,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2848(struct Cora* co){
+void _35clofun2923(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -12098,23 +11977,797 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1317 = __arg1;
-Obj find = _35val1317;
-pushCont(co, 20, _35clofun2847, 1, find);
+Obj _35cc1048 = makeNative(18, _35clofun2922, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj env = closureRef(co, 0);
+Obj _35reg1351 = primIsCons(closureRef(co, 1));
+if (True == _35reg1351) {
+Obj _35reg1352 = primCar(closureRef(co, 1));
+Obj _35reg1353 = primEQ(intern("let"), _35reg1352);
+if (True == _35reg1353) {
+Obj _35reg1354 = primCdr(closureRef(co, 1));
+Obj _35reg1355 = primIsCons(_35reg1354);
+if (True == _35reg1355) {
+Obj _35reg1356 = primCdr(closureRef(co, 1));
+Obj _35reg1357 = primCar(_35reg1356);
+Obj a = _35reg1357;
+Obj _35reg1358 = primCdr(closureRef(co, 1));
+Obj _35reg1359 = primCdr(_35reg1358);
+Obj _35reg1360 = primIsCons(_35reg1359);
+if (True == _35reg1360) {
+Obj _35reg1361 = primCdr(closureRef(co, 1));
+Obj _35reg1362 = primCdr(_35reg1361);
+Obj _35reg1363 = primCar(_35reg1362);
+Obj b = _35reg1363;
+Obj _35reg1364 = primCdr(closureRef(co, 1));
+Obj _35reg1365 = primCdr(_35reg1364);
+Obj _35reg1366 = primCdr(_35reg1365);
+Obj _35reg1367 = primIsCons(_35reg1366);
+if (True == _35reg1367) {
+Obj _35reg1368 = primCdr(closureRef(co, 1));
+Obj _35reg1369 = primCdr(_35reg1368);
+Obj _35reg1370 = primCdr(_35reg1369);
+Obj _35reg1371 = primCar(_35reg1370);
+Obj c = _35reg1371;
+Obj _35reg1372 = primCdr(closureRef(co, 1));
+Obj _35reg1373 = primCdr(_35reg1372);
+Obj _35reg1374 = primCdr(_35reg1373);
+Obj _35reg1375 = primCdr(_35reg1374);
+Obj _35reg1376 = primEQ(Nil, _35reg1375);
+if (True == _35reg1376) {
+pushCont(co, 20, _35clofun2922, 3, env, c, a);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.parse"));
+__arg1 = env;
+__arg2 = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1048;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1048;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1048;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1048;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1048;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1048;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35val1402 = __arg1;
+Obj _35val1401= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1403 = primCons(_35val1402, Nil);
+Obj _35reg1404 = primCons(_35val1401, _35reg1403);
+Obj _35reg1405 = primCons(intern("do"), _35reg1404);
+__nargs = 2;
+__arg1 = _35reg1405;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2923) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label2:
+{
+Obj _35val1401 = __arg1;
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 1, _35clofun2923, 1, _35val1401);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.parse"));
+__arg1 = env;
+__arg2 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35cc1047 = makeNative(0, _35clofun2923, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj env = closureRef(co, 0);
+Obj _35reg1384 = primIsCons(closureRef(co, 1));
+if (True == _35reg1384) {
+Obj _35reg1385 = primCar(closureRef(co, 1));
+Obj _35reg1386 = primEQ(intern("do"), _35reg1385);
+if (True == _35reg1386) {
+Obj _35reg1387 = primCdr(closureRef(co, 1));
+Obj _35reg1388 = primIsCons(_35reg1387);
+if (True == _35reg1388) {
+Obj _35reg1389 = primCdr(closureRef(co, 1));
+Obj _35reg1390 = primCar(_35reg1389);
+Obj x = _35reg1390;
+Obj _35reg1391 = primCdr(closureRef(co, 1));
+Obj _35reg1392 = primCdr(_35reg1391);
+Obj _35reg1393 = primIsCons(_35reg1392);
+if (True == _35reg1393) {
+Obj _35reg1394 = primCdr(closureRef(co, 1));
+Obj _35reg1395 = primCdr(_35reg1394);
+Obj _35reg1396 = primCar(_35reg1395);
+Obj y = _35reg1396;
+Obj _35reg1397 = primCdr(closureRef(co, 1));
+Obj _35reg1398 = primCdr(_35reg1397);
+Obj _35reg1399 = primCdr(_35reg1398);
+Obj _35reg1400 = primEQ(Nil, _35reg1399);
+if (True == _35reg1400) {
+pushCont(co, 2, _35clofun2923, 2, env, y);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.parse"));
+__arg1 = env;
+__arg2 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1047;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1047;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1047;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1047;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1047;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val1411 = __arg1;
+Obj _35reg1412 = primCons(intern("if"), _35val1411);
+__nargs = 2;
+__arg1 = _35reg1412;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2923) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label5:
+{
+Obj _35val1410 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 4, _35clofun2923, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = _35val1410;
+__arg2 = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label6:
+{
+Obj _35cc1046 = makeNative(3, _35clofun2923, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj env = closureRef(co, 0);
+Obj _35reg1406 = primIsCons(closureRef(co, 1));
+if (True == _35reg1406) {
+Obj _35reg1407 = primCar(closureRef(co, 1));
+Obj _35reg1408 = primEQ(intern("if"), _35reg1407);
+if (True == _35reg1408) {
+Obj _35reg1409 = primCdr(closureRef(co, 1));
+Obj args = _35reg1409;
+pushCont(co, 5, _35clofun2923, 1, args);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc.parse"));
+__arg1 = env;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1046;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1046;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label7:
+{
+Obj _35val1431 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1432 = primCons(_35val1431, Nil);
+Obj _35reg1433 = primCons(args, _35reg1432);
+Obj _35reg1434 = primCons(intern("lambda"), _35reg1433);
+__nargs = 2;
+__arg1 = _35reg1434;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2923) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label8:
+{
+Obj _35val1430 = __arg1;
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 7, _35clofun2923, 1, args);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.parse"));
+__arg1 = _35val1430;
+__arg2 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label9:
+{
+Obj _35cc1045 = makeNative(6, _35clofun2923, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj env = closureRef(co, 0);
+Obj _35reg1413 = primIsCons(closureRef(co, 1));
+if (True == _35reg1413) {
+Obj _35reg1414 = primCar(closureRef(co, 1));
+Obj _35reg1415 = primEQ(intern("lambda"), _35reg1414);
+if (True == _35reg1415) {
+Obj _35reg1416 = primCdr(closureRef(co, 1));
+Obj _35reg1417 = primIsCons(_35reg1416);
+if (True == _35reg1417) {
+Obj _35reg1418 = primCdr(closureRef(co, 1));
+Obj _35reg1419 = primCar(_35reg1418);
+Obj args = _35reg1419;
+Obj _35reg1420 = primCdr(closureRef(co, 1));
+Obj _35reg1421 = primCdr(_35reg1420);
+Obj _35reg1422 = primIsCons(_35reg1421);
+if (True == _35reg1422) {
+Obj _35reg1423 = primCdr(closureRef(co, 1));
+Obj _35reg1424 = primCdr(_35reg1423);
+Obj _35reg1425 = primCar(_35reg1424);
+Obj body = _35reg1425;
+Obj _35reg1426 = primCdr(closureRef(co, 1));
+Obj _35reg1427 = primCdr(_35reg1426);
+Obj _35reg1428 = primCdr(_35reg1427);
+Obj _35reg1429 = primEQ(Nil, _35reg1428);
+if (True == _35reg1429) {
+pushCont(co, 8, _35clofun2923, 2, body, args);
+__nargs = 3;
+__arg0 = globalRef(intern("append"));
+__arg1 = args;
+__arg2 = env;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1045;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1045;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1045;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1045;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1045;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label10:
+{
+Obj _35val1436 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1436) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2923) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg1437 = primCons(x, Nil);
+Obj _35reg1438 = primCons(intern("%global"), _35reg1437);
+__nargs = 2;
+__arg1 = _35reg1438;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2923) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label11:
+{
+Obj _35cc1044 = makeNative(9, _35clofun2923, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj env = closureRef(co, 0);
+Obj x = closureRef(co, 1);
+Obj _35reg1435 = primIsSymbol(x);
+if (True == _35reg1435) {
+pushCont(co, 10, _35clofun2923, 1, x);
+__nargs = 3;
+__arg0 = globalRef(intern("elem?"));
+__arg1 = x;
+__arg2 = env;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1044;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label12:
+{
+Obj _35cc1043 = makeNative(11, _35clofun2923, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj __ = closureRef(co, 0);
+Obj _35reg1439 = primIsCons(closureRef(co, 1));
+if (True == _35reg1439) {
+Obj _35reg1440 = primCar(closureRef(co, 1));
+Obj _35reg1441 = primEQ(intern("quote"), _35reg1440);
+if (True == _35reg1441) {
+Obj _35reg1442 = primCdr(closureRef(co, 1));
+Obj _35reg1443 = primIsCons(_35reg1442);
+if (True == _35reg1443) {
+Obj _35reg1444 = primCdr(closureRef(co, 1));
+Obj _35reg1445 = primCar(_35reg1444);
+Obj x = _35reg1445;
+Obj _35reg1446 = primCdr(closureRef(co, 1));
+Obj _35reg1447 = primCdr(_35reg1446);
+Obj _35reg1448 = primEQ(Nil, _35reg1447);
+if (True == _35reg1448) {
+Obj _35reg1449 = primCons(x, Nil);
+Obj _35reg1450 = primCons(intern("%const"), _35reg1449);
+__nargs = 2;
+__arg1 = _35reg1450;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2923) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1043;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1043;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1043;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1043;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label13:
+{
+Obj _35val1460 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1042= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1460) {
+if (True == True) {
+Obj _35reg1461 = primCons(x, Nil);
+Obj _35reg1462 = primCons(intern("%const"), _35reg1461);
+__nargs = 2;
+__arg1 = _35reg1462;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2923) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1042;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+Obj _35reg1463 = primCons(x, Nil);
+Obj _35reg1464 = primCons(intern("%const"), _35reg1463);
+__nargs = 2;
+__arg1 = _35reg1464;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2923) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1042;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label14:
+{
+Obj _35val1457 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1042= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1457) {
+if (True == True) {
+Obj _35reg1458 = primCons(x, Nil);
+Obj _35reg1459 = primCons(intern("%const"), _35reg1458);
+__nargs = 2;
+__arg1 = _35reg1459;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2923) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1042;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+pushCont(co, 13, _35clofun2923, 2, x, _35cc1042);
+__nargs = 2;
+__arg0 = globalRef(intern("null?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label15:
+{
+Obj _35val1451 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1042= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1451) {
+if (True == True) {
+Obj _35reg1452 = primCons(x, Nil);
+Obj _35reg1453 = primCons(intern("%const"), _35reg1452);
+__nargs = 2;
+__arg1 = _35reg1453;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2923) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1042;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+Obj _35reg1454 = primIsString(x);
+if (True == _35reg1454) {
+if (True == True) {
+Obj _35reg1455 = primCons(x, Nil);
+Obj _35reg1456 = primCons(intern("%const"), _35reg1455);
+__nargs = 2;
+__arg1 = _35reg1456;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2923) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1042;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+pushCont(co, 14, _35clofun2923, 2, x, _35cc1042);
+__nargs = 2;
+__arg0 = globalRef(intern("boolean?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label16:
+{
+Obj _35p1040 = __arg1;
+Obj _35p1041 = __arg2;
+Obj _35cc1042 = makeNative(12, _35clofun2923, 0, 2, _35p1040, _35p1041);
+Obj __ = _35p1040;
+Obj x = _35p1041;
+pushCont(co, 15, _35clofun2923, 2, x, _35cc1042);
+__nargs = 2;
+__arg0 = globalRef(intern("number?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label17:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeString1("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label18:
+{
+Obj _35val1469 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1470 = primCons(x, _35val1469);
+__nargs = 2;
+__arg1 = _35reg1470;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2923) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label19:
+{
+Obj _35cc1055 = makeNative(17, _35clofun2923, 0, 0);
+Obj _35reg1466 = primIsCons(closureRef(co, 0));
+if (True == _35reg1466) {
+Obj _35reg1467 = primCar(closureRef(co, 0));
+Obj x = _35reg1467;
+Obj _35reg1468 = primCdr(closureRef(co, 0));
+Obj y = _35reg1468;
+Obj s2 = closureRef(co, 1);
+pushCont(co, 18, _35clofun2923, 1, x);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.union"));
+__arg1 = y;
+__arg2 = s2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1055;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label20:
+{
+Obj _35val1474 = __arg1;
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc1054= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val1474) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc.union"));
+__arg1 = y;
+__arg2 = s2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1054;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2923) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void _35clofun2922(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val1319 = __arg1;
+Obj find = _35val1319;
+pushCont(co, 20, _35clofun2921, 1, find);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
 __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
 Obj x = __arg1;
-pushCont(co, 0, _35clofun2848, 0);
+pushCont(co, 0, _35clofun2922, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.assq"));
 __arg1 = x;
@@ -12122,19 +12775,19 @@ __arg2 = globalRef(intern("cora/lib/toc.*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1321 = __arg1;
+Obj _35val1323 = __arg1;
 Obj find= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1321) {
+if (True == _35val1323) {
 __nargs = 2;
 __arg1 = makeString1("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2848) { goto fail; }
+if (co->ctx.pc.func != _35clofun2922) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
@@ -12143,30 +12796,30 @@ __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35val1320 = __arg1;
-Obj find = _35val1320;
-pushCont(co, 2, _35clofun2848, 1, find);
+Obj _35val1322 = __arg1;
+Obj find = _35val1322;
+pushCont(co, 2, _35clofun2922, 1, find);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
 __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
 Obj x = __arg1;
-pushCont(co, 3, _35clofun2848, 0);
+pushCont(co, 3, _35clofun2922, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.assq"));
 __arg1 = x;
@@ -12174,7 +12827,7 @@ __arg2 = globalRef(intern("cora/lib/toc.*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12186,49 +12839,49 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc1044 = makeNative(5, _35clofun2848, 0, 0);
+Obj _35cc1039 = makeNative(5, _35clofun2922, 0, 0);
 Obj n = closureRef(co, 0);
 Obj res = closureRef(co, 1);
-Obj _35reg1323 = primSub(n, makeNumber(1));
-Obj _35reg1324 = primGenSym(intern("tmp"));
-Obj _35reg1325 = primCons(_35reg1324, res);
+Obj _35reg1325 = primSub(n, makeNumber(1));
+Obj _35reg1326 = primGenSym(intern("tmp"));
+Obj _35reg1327 = primCons(_35reg1326, res);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.temp-list"));
-__arg1 = _35reg1323;
-__arg2 = _35reg1325;
+__arg1 = _35reg1325;
+__arg2 = _35reg1327;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35p1041 = __arg1;
-Obj _35p1042 = __arg2;
-Obj _35cc1043 = makeNative(6, _35clofun2848, 0, 2, _35p1041, _35p1042);
-Obj _35reg1326 = primEQ(makeNumber(0), _35p1041);
-if (True == _35reg1326) {
-Obj res = _35p1042;
+Obj _35p1036 = __arg1;
+Obj _35p1037 = __arg2;
+Obj _35cc1038 = makeNative(6, _35clofun2922, 0, 2, _35p1036, _35p1037);
+Obj _35reg1328 = primEQ(makeNumber(0), _35p1036);
+if (True == _35reg1328) {
+Obj res = _35p1037;
 __nargs = 2;
 __arg1 = res;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2848) { goto fail; }
+if (co->ctx.pc.func != _35clofun2922) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1043;
+__arg0 = _35cc1038;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12241,143 +12894,143 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val1328 = __arg1;
+Obj _35val1330 = __arg1;
 Obj ls= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("map"));
-__arg1 = _35val1328;
+__arg1 = _35val1330;
 __arg2 = ls;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35cc1055 = makeNative(8, _35clofun2848, 0, 0);
+Obj _35cc1050 = makeNative(8, _35clofun2922, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ls = closureRef(co, 1);
-pushCont(co, 9, _35clofun2848, 1, ls);
+pushCont(co, 9, _35clofun2922, 1, ls);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.parse"));
 __arg1 = env;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val1339 = __arg1;
-Obj _35reg1337= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1340 = primCons(_35reg1337, _35val1339);
+Obj _35val1341 = __arg1;
+Obj _35reg1339= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1342 = primCons(_35reg1339, _35val1341);
 __nargs = 2;
-__arg1 = _35reg1340;
+__arg1 = _35reg1342;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2848) { goto fail; }
+if (co->ctx.pc.func != _35clofun2922) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label12:
 {
-Obj _35val1338 = __arg1;
+Obj _35val1340 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1337= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun2848, 1, _35reg1337);
+Obj _35reg1339= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 11, _35clofun2922, 1, _35reg1339);
 __nargs = 3;
 __arg0 = globalRef(intern("map"));
-__arg1 = _35val1338;
+__arg1 = _35val1340;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val1345 = __arg1;
+Obj _35val1347 = __arg1;
 Obj tmp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1346 = primCons(_35val1345, Nil);
-Obj _35reg1347 = primCons(tmp, _35reg1346);
-Obj _35reg1348 = primCons(intern("lambda"), _35reg1347);
+Obj _35reg1348 = primCons(_35val1347, Nil);
+Obj _35reg1349 = primCons(tmp, _35reg1348);
+Obj _35reg1350 = primCons(intern("lambda"), _35reg1349);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.parse"));
 __arg1 = env;
-__arg2 = _35reg1348;
+__arg2 = _35reg1350;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val1343 = __arg1;
+Obj _35val1345 = __arg1;
 Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj tmp = _35val1343;
-Obj _35reg1344 = primCons(op, args);
-pushCont(co, 13, _35clofun2848, 2, tmp, env);
+Obj tmp = _35val1345;
+Obj _35reg1346 = primCons(op, args);
+pushCont(co, 13, _35clofun2922, 2, tmp, env);
 __nargs = 3;
 __arg0 = globalRef(intern("append"));
-__arg1 = _35reg1344;
+__arg1 = _35reg1346;
 __arg2 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val1334 = __arg1;
+Obj _35val1336 = __arg1;
 Obj required= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj op= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj provided = _35val1334;
-Obj _35reg1335 = primEQ(required, provided);
-if (True == _35reg1335) {
-Obj _35reg1336 = primCons(op, Nil);
-Obj _35reg1337 = primCons(intern("%builtin"), _35reg1336);
-pushCont(co, 12, _35clofun2848, 2, args, _35reg1337);
+Obj provided = _35val1336;
+Obj _35reg1337 = primEQ(required, provided);
+if (True == _35reg1337) {
+Obj _35reg1338 = primCons(op, Nil);
+Obj _35reg1339 = primCons(intern("%builtin"), _35reg1338);
+pushCont(co, 12, _35clofun2922, 2, args, _35reg1339);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.parse"));
 __arg1 = env;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1341 = primGT(required, provided);
-if (True == _35reg1341) {
-Obj _35reg1342 = primSub(required, provided);
-pushCont(co, 14, _35clofun2848, 3, op, args, env);
+Obj _35reg1343 = primGT(required, provided);
+if (True == _35reg1343) {
+Obj _35reg1344 = primSub(required, provided);
+pushCont(co, 14, _35clofun2922, 3, op, args, env);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.temp-list"));
-__arg1 = _35reg1342;
+__arg1 = _35reg1344;
 __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -12386,7 +13039,7 @@ __arg1 = makeString1("primitive call mismatch");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12394,112 +13047,112 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35val1333 = __arg1;
+Obj _35val1335 = __arg1;
 Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj required = _35val1333;
-pushCont(co, 15, _35clofun2848, 4, required, op, args, env);
+Obj required = _35val1335;
+pushCont(co, 15, _35clofun2922, 4, required, op, args, env);
 __nargs = 2;
 __arg0 = globalRef(intern("length"));
 __arg1 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val1332 = __arg1;
+Obj _35val1334 = __arg1;
 Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35cc1054= co->ctx.stk.stack[co->ctx.stk.base + 3];
-if (True == _35val1332) {
-pushCont(co, 16, _35clofun2848, 3, op, args, env);
+Obj _35cc1049= co->ctx.stk.stack[co->ctx.stk.base + 3];
+if (True == _35val1334) {
+pushCont(co, 16, _35clofun2922, 3, op, args, env);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc.builtin->args"));
 __arg1 = op;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1054;
+__arg0 = _35cc1049;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label18:
 {
-Obj _35cc1054 = makeNative(10, _35clofun2848, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1049 = makeNative(10, _35clofun2922, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj env = closureRef(co, 0);
-Obj _35reg1329 = primIsCons(closureRef(co, 1));
-if (True == _35reg1329) {
-Obj _35reg1330 = primCar(closureRef(co, 1));
-Obj op = _35reg1330;
-Obj _35reg1331 = primCdr(closureRef(co, 1));
-Obj args = _35reg1331;
-pushCont(co, 17, _35clofun2848, 4, op, args, env, _35cc1054);
+Obj _35reg1331 = primIsCons(closureRef(co, 1));
+if (True == _35reg1331) {
+Obj _35reg1332 = primCar(closureRef(co, 1));
+Obj op = _35reg1332;
+Obj _35reg1333 = primCdr(closureRef(co, 1));
+Obj args = _35reg1333;
+pushCont(co, 17, _35clofun2922, 4, op, args, env, _35cc1049);
 __nargs = 2;
 __arg0 = globalRef(intern("builtin?"));
 __arg1 = op;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1054;
+__arg0 = _35cc1049;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label19:
 {
-Obj _35val1377 = __arg1;
-Obj _35val1375= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val1379 = __arg1;
+Obj _35val1377= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1378 = primCons(_35val1377, Nil);
-Obj _35reg1379 = primCons(_35val1375, _35reg1378);
-Obj _35reg1380 = primCons(a, _35reg1379);
-Obj _35reg1381 = primCons(intern("let"), _35reg1380);
+Obj _35reg1380 = primCons(_35val1379, Nil);
+Obj _35reg1381 = primCons(_35val1377, _35reg1380);
+Obj _35reg1382 = primCons(a, _35reg1381);
+Obj _35reg1383 = primCons(intern("let"), _35reg1382);
 __nargs = 2;
-__arg1 = _35reg1381;
+__arg1 = _35reg1383;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2848) { goto fail; }
+if (co->ctx.pc.func != _35clofun2922) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label20:
 {
-Obj _35val1375 = __arg1;
+Obj _35val1377 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1376 = primCons(a, env);
-pushCont(co, 19, _35clofun2848, 2, _35val1375, a);
+Obj _35reg1378 = primCons(a, env);
+pushCont(co, 19, _35clofun2922, 2, _35val1377, a);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.parse"));
-__arg1 = _35reg1376;
+__arg1 = _35reg1378;
 __arg2 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2848) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2922) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12512,7 +13165,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2847(struct Cora* co){
+void _35clofun2921(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -12531,20 +13184,20 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35cc1025 = makeNative(0, _35clofun2847, 0, 0);
+Obj _35cc1020 = makeNative(0, _35clofun2921, 0, 0);
 Obj var = closureRef(co, 0);
-Obj _35reg1205 = primIsCons(closureRef(co, 1));
-if (True == _35reg1205) {
-Obj _35reg1206 = primCar(closureRef(co, 1));
-Obj __ = _35reg1206;
-Obj _35reg1207 = primCdr(closureRef(co, 1));
-Obj y = _35reg1207;
+Obj _35reg1207 = primIsCons(closureRef(co, 1));
+if (True == _35reg1207) {
+Obj _35reg1208 = primCar(closureRef(co, 1));
+Obj __ = _35reg1208;
+Obj _35reg1209 = primCdr(closureRef(co, 1));
+Obj y = _35reg1209;
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.assq"));
 __arg1 = var;
@@ -12552,93 +13205,93 @@ __arg2 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1025;
+__arg0 = _35cc1020;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label2:
 {
-Obj _35cc1024 = makeNative(1, _35clofun2847, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1019 = makeNative(1, _35clofun2921, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
-Obj _35reg1208 = primIsCons(closureRef(co, 1));
-if (True == _35reg1208) {
-Obj _35reg1209 = primCar(closureRef(co, 1));
-Obj _35reg1210 = primIsCons(_35reg1209);
+Obj _35reg1210 = primIsCons(closureRef(co, 1));
 if (True == _35reg1210) {
 Obj _35reg1211 = primCar(closureRef(co, 1));
-Obj _35reg1212 = primCar(_35reg1211);
-Obj x = _35reg1212;
+Obj _35reg1212 = primIsCons(_35reg1211);
+if (True == _35reg1212) {
 Obj _35reg1213 = primCar(closureRef(co, 1));
-Obj _35reg1214 = primCdr(_35reg1213);
-Obj y = _35reg1214;
-Obj _35reg1215 = primCdr(closureRef(co, 1));
-Obj __ = _35reg1215;
-Obj _35reg1216 = primEQ(var, x);
-if (True == _35reg1216) {
-Obj _35reg1217 = primCons(x, y);
+Obj _35reg1214 = primCar(_35reg1213);
+Obj x = _35reg1214;
+Obj _35reg1215 = primCar(closureRef(co, 1));
+Obj _35reg1216 = primCdr(_35reg1215);
+Obj y = _35reg1216;
+Obj _35reg1217 = primCdr(closureRef(co, 1));
+Obj __ = _35reg1217;
+Obj _35reg1218 = primEQ(var, x);
+if (True == _35reg1218) {
+Obj _35reg1219 = primCons(x, y);
 __nargs = 2;
-__arg1 = _35reg1217;
+__arg1 = _35reg1219;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2847) { goto fail; }
+if (co->ctx.pc.func != _35clofun2921) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1024;
+__arg0 = _35cc1019;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1024;
+__arg0 = _35cc1019;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1024;
+__arg0 = _35cc1019;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35p1021 = __arg1;
-Obj _35p1022 = __arg2;
-Obj _35cc1023 = makeNative(2, _35clofun2847, 0, 2, _35p1021, _35p1022);
-Obj var = _35p1021;
-Obj _35reg1218 = primEQ(Nil, _35p1022);
-if (True == _35reg1218) {
+Obj _35p1016 = __arg1;
+Obj _35p1017 = __arg2;
+Obj _35cc1018 = makeNative(2, _35clofun2921, 0, 2, _35p1016, _35p1017);
+Obj var = _35p1016;
+Obj _35reg1220 = primEQ(Nil, _35p1017);
+if (True == _35reg1220) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2847) { goto fail; }
+if (co->ctx.pc.func != _35clofun2921) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1023;
+__arg0 = _35cc1018;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12651,39 +13304,39 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1223 = __arg1;
+Obj _35val1225 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc.foldl"));
 __arg1 = f;
-__arg2 = _35val1223;
+__arg2 = _35val1225;
 __arg3 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc1030 = makeNative(4, _35clofun2847, 0, 0);
+Obj _35cc1025 = makeNative(4, _35clofun2921, 0, 0);
 Obj f = closureRef(co, 0);
 Obj acc = closureRef(co, 1);
-Obj _35reg1220 = primIsCons(closureRef(co, 2));
-if (True == _35reg1220) {
-Obj _35reg1221 = primCar(closureRef(co, 2));
-Obj x = _35reg1221;
-Obj _35reg1222 = primCdr(closureRef(co, 2));
-Obj y = _35reg1222;
-pushCont(co, 5, _35clofun2847, 2, f, y);
+Obj _35reg1222 = primIsCons(closureRef(co, 2));
+if (True == _35reg1222) {
+Obj _35reg1223 = primCar(closureRef(co, 2));
+Obj x = _35reg1223;
+Obj _35reg1224 = primCdr(closureRef(co, 2));
+Obj y = _35reg1224;
+pushCont(co, 5, _35clofun2921, 2, f, y);
 __nargs = 3;
 __arg0 = f;
 __arg1 = acc;
@@ -12691,41 +13344,41 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1030;
+__arg0 = _35cc1025;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35p1026 = __arg1;
-Obj _35p1027 = __arg2;
-Obj _35p1028 = __arg3;
-Obj _35cc1029 = makeNative(6, _35clofun2847, 0, 3, _35p1026, _35p1027, _35p1028);
-Obj f = _35p1026;
-Obj acc = _35p1027;
-Obj _35reg1224 = primEQ(Nil, _35p1028);
-if (True == _35reg1224) {
+Obj _35p1021 = __arg1;
+Obj _35p1022 = __arg2;
+Obj _35p1023 = __arg3;
+Obj _35cc1024 = makeNative(6, _35clofun2921, 0, 3, _35p1021, _35p1022, _35p1023);
+Obj f = _35p1021;
+Obj acc = _35p1022;
+Obj _35reg1226 = primEQ(Nil, _35p1023);
+if (True == _35reg1226) {
 __nargs = 2;
 __arg1 = acc;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2847) { goto fail; }
+if (co->ctx.pc.func != _35clofun2921) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1029;
+__arg0 = _35cc1024;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12738,103 +13391,103 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35cc1036 = makeNative(8, _35clofun2847, 0, 0);
+Obj _35cc1031 = makeNative(8, _35clofun2921, 0, 0);
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1226 = primIsCons(closureRef(co, 2));
-if (True == _35reg1226) {
-Obj _35reg1227 = primCar(closureRef(co, 2));
-Obj a = _35reg1227;
-Obj _35reg1228 = primCdr(closureRef(co, 2));
-Obj b = _35reg1228;
-Obj _35reg1229 = primAdd(pos, makeNumber(1));
+Obj _35reg1228 = primIsCons(closureRef(co, 2));
+if (True == _35reg1228) {
+Obj _35reg1229 = primCar(closureRef(co, 2));
+Obj a = _35reg1229;
+Obj _35reg1230 = primCdr(closureRef(co, 2));
+Obj b = _35reg1230;
+Obj _35reg1231 = primAdd(pos, makeNumber(1));
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc.pos-in-list0"));
-__arg1 = _35reg1229;
+__arg1 = _35reg1231;
 __arg2 = x;
 __arg3 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1036;
+__arg0 = _35cc1031;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35cc1035 = makeNative(9, _35clofun2847, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1030 = makeNative(9, _35clofun2921, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1230 = primIsCons(closureRef(co, 2));
-if (True == _35reg1230) {
-Obj _35reg1231 = primCar(closureRef(co, 2));
-Obj a = _35reg1231;
-Obj _35reg1232 = primCdr(closureRef(co, 2));
-Obj b = _35reg1232;
-Obj _35reg1233 = primEQ(x, a);
-if (True == _35reg1233) {
+Obj _35reg1232 = primIsCons(closureRef(co, 2));
+if (True == _35reg1232) {
+Obj _35reg1233 = primCar(closureRef(co, 2));
+Obj a = _35reg1233;
+Obj _35reg1234 = primCdr(closureRef(co, 2));
+Obj b = _35reg1234;
+Obj _35reg1235 = primEQ(x, a);
+if (True == _35reg1235) {
 __nargs = 2;
 __arg1 = pos;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2847) { goto fail; }
+if (co->ctx.pc.func != _35clofun2921) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1035;
+__arg0 = _35cc1030;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1035;
+__arg0 = _35cc1030;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35p1031 = __arg1;
-Obj _35p1032 = __arg2;
-Obj _35p1033 = __arg3;
-Obj _35cc1034 = makeNative(10, _35clofun2847, 0, 3, _35p1031, _35p1032, _35p1033);
-Obj __ = _35p1031;
-Obj x = _35p1032;
-Obj _35reg1234 = primEQ(Nil, _35p1033);
-if (True == _35reg1234) {
+Obj _35p1026 = __arg1;
+Obj _35p1027 = __arg2;
+Obj _35p1028 = __arg3;
+Obj _35cc1029 = makeNative(10, _35clofun2921, 0, 3, _35p1026, _35p1027, _35p1028);
+Obj __ = _35p1026;
+Obj x = _35p1027;
+Obj _35reg1236 = primEQ(Nil, _35p1028);
+if (True == _35reg1236) {
 __nargs = 2;
 __arg1 = makeNumber(-1);
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2847) { goto fail; }
+if (co->ctx.pc.func != _35clofun2921) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1034;
+__arg0 = _35cc1029;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12851,7 +13504,7 @@ __arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12863,17 +13516,17 @@ __arg1 = makeString1("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val1240 = __arg1;
+Obj _35val1242 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj tl= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1241 = primLT(_35val1240, makeNumber(0));
-if (True == _35reg1241) {
+Obj _35reg1243 = primLT(_35val1242, makeNumber(0));
+if (True == _35reg1243) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.exist-in-env"));
 __arg1 = x;
@@ -12881,28 +13534,28 @@ __arg2 = tl;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2847) { goto fail; }
+if (co->ctx.pc.func != _35clofun2921) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
 
 label15:
 {
-Obj _35cc1040 = makeNative(13, _35clofun2847, 0, 0);
+Obj _35cc1035 = makeNative(13, _35clofun2921, 0, 0);
 Obj x = closureRef(co, 0);
-Obj _35reg1237 = primIsCons(closureRef(co, 1));
-if (True == _35reg1237) {
-Obj _35reg1238 = primCar(closureRef(co, 1));
-Obj hd = _35reg1238;
-Obj _35reg1239 = primCdr(closureRef(co, 1));
-Obj tl = _35reg1239;
-pushCont(co, 14, _35clofun2847, 2, x, tl);
+Obj _35reg1239 = primIsCons(closureRef(co, 1));
+if (True == _35reg1239) {
+Obj _35reg1240 = primCar(closureRef(co, 1));
+Obj hd = _35reg1240;
+Obj _35reg1241 = primCdr(closureRef(co, 1));
+Obj tl = _35reg1241;
+pushCont(co, 14, _35clofun2921, 2, x, tl);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.index"));
 __arg1 = x;
@@ -12910,72 +13563,72 @@ __arg2 = hd;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1040;
+__arg0 = _35cc1035;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label16:
 {
-Obj _35p1037 = __arg1;
-Obj _35p1038 = __arg2;
-Obj _35cc1039 = makeNative(15, _35clofun2847, 0, 2, _35p1037, _35p1038);
-Obj x = _35p1037;
-Obj _35reg1242 = primEQ(Nil, _35p1038);
-if (True == _35reg1242) {
+Obj _35p1032 = __arg1;
+Obj _35p1033 = __arg2;
+Obj _35cc1034 = makeNative(15, _35clofun2921, 0, 2, _35p1032, _35p1033);
+Obj x = _35p1032;
+Obj _35reg1244 = primEQ(Nil, _35p1033);
+if (True == _35reg1244) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2847) { goto fail; }
+if (co->ctx.pc.func != _35clofun2921) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1039;
+__arg0 = _35cc1034;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label17:
 {
-Obj _35val1314 = __arg1;
-Obj _35reg1315 = primNot(_35val1314);
+Obj _35val1316 = __arg1;
+Obj _35reg1317 = primNot(_35val1316);
 __nargs = 2;
-__arg1 = _35reg1315;
+__arg1 = _35reg1317;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2847) { goto fail; }
+if (co->ctx.pc.func != _35clofun2921) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label18:
 {
-Obj _35val1313 = __arg1;
-pushCont(co, 17, _35clofun2847, 0);
+Obj _35val1315 = __arg1;
+pushCont(co, 17, _35clofun2921, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
-__arg1 = _35val1313;
+__arg1 = _35val1315;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
 Obj x = __arg1;
-pushCont(co, 18, _35clofun2847, 0);
+pushCont(co, 18, _35clofun2921, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc.assq"));
 __arg1 = x;
@@ -12983,19 +13636,19 @@ __arg2 = globalRef(intern("cora/lib/toc.*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1318 = __arg1;
+Obj _35val1320 = __arg1;
 Obj find= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1318) {
+if (True == _35val1320) {
 __nargs = 2;
 __arg1 = makeString1("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2847) { goto fail; }
+if (co->ctx.pc.func != _35clofun2921) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
@@ -13004,7 +13657,7 @@ __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2847) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2921) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }


### PR DESCRIPTION
For example, such code:

```
(@import "cora/lib/infer" infer)

(:type

 (func .type-check-for-maybe
  [] ['maybe t] env s => ['succ s]
  exp ['maybe t] env s => (.check-type exp t env s))

 (deftype 'maybe .type-check-for-maybe))

(:declare 'fact `(int -> int))

(defun fact (n)
        (if (= n 0)
                1
                (* n (fact (- n 1)))))

(fact 5)
```

Some of them are mean to explained by the type checker, while some of them are used as code.
Use a preprocess stage to split them so the generated code is 


```
(begin 
(cora/lib/infer.check-type (macroexpand (backquote (import "cora/lib/infer"))) (tvar) () ()) 
(begin 
(func .type-check-for-maybe 
(list) (list (quote maybe) t) env s => (list (quote succ) s)
 exp (list (quote maybe) t) env s => (.check-type exp t env s))

 (deftype (quote maybe) .type-check-for-maybe))
 (declare (quote fact) (backquote (int -> int)))
 (cora/lib/infer.check-type (macroexpand (backquote (defun fact (n) (if (= n 0) 1 (* n (fact (- n 1))))))) (tvar) () ()) (cora/lib/infer.check-type (macroexpand (backquote (fact 5))) (tvar) () ()) (import "cora/lib/infer")


 (defun fact (n) (if (= n 0) 1 (* n (fact (- n 1))))) (fact 5))

```