### PR TITLE
*: support import in eval0

### DIFF
--- a/init.cora
+++ b/init.cora
@@ -1,3 +1,7 @@
+;; this file does not use define-library deliberately
+;; if we use it, we need to either append cora/init#cora in C or write car as (value 'car) here
+;; if we do not use it, there are some duplicated definitions, both cadr and cora/init#cadr exist
+
 (set 'null? (lambda (x) (= x ())))
 (set 'cadr (lambda (x) (car (cdr x))))
 (set 'caar (lambda (x) (car (car x))))
@@ -387,7 +391,6 @@
 				   symbol-cooked?
 				   reverse map macroexpand elem?  length filter append))
 
-;; todo, cleanup later
 (set 'cora/init#cadr cadr)
 (set 'cora/init#caar caar)
 (set 'cora/init#cdar cdar)

--- a/lib/toc.c
+++ b/lib/toc.c
@@ -2,30 +2,31 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun3142(struct Cora* co);
-void _35clofun3141(struct Cora* co);
-void _35clofun3140(struct Cora* co);
-void _35clofun3139(struct Cora* co);
-void _35clofun3138(struct Cora* co);
-void _35clofun3137(struct Cora* co);
-void _35clofun3136(struct Cora* co);
-void _35clofun3135(struct Cora* co);
-void _35clofun3134(struct Cora* co);
-void _35clofun3133(struct Cora* co);
-void _35clofun3132(struct Cora* co);
-void _35clofun3131(struct Cora* co);
-void _35clofun3130(struct Cora* co);
-void _35clofun3129(struct Cora* co);
-void _35clofun3128(struct Cora* co);
-void _35clofun3127(struct Cora* co);
-void _35clofun3126(struct Cora* co);
-void _35clofun3125(struct Cora* co);
-void _35clofun3124(struct Cora* co);
-void _35clofun3123(struct Cora* co);
-void _35clofun3122(struct Cora* co);
-void _35clofun3121(struct Cora* co);
-void _35clofun3120(struct Cora* co);
-void _35clofun3119(struct Cora* co);
+void _35clofun2020(struct Cora* co);
+void _35clofun2019(struct Cora* co);
+void _35clofun2018(struct Cora* co);
+void _35clofun2017(struct Cora* co);
+void _35clofun2016(struct Cora* co);
+void _35clofun2015(struct Cora* co);
+void _35clofun2014(struct Cora* co);
+void _35clofun2013(struct Cora* co);
+void _35clofun2012(struct Cora* co);
+void _35clofun2011(struct Cora* co);
+void _35clofun2010(struct Cora* co);
+void _35clofun2009(struct Cora* co);
+void _35clofun2008(struct Cora* co);
+void _35clofun2007(struct Cora* co);
+void _35clofun2006(struct Cora* co);
+void _35clofun2005(struct Cora* co);
+void _35clofun2004(struct Cora* co);
+void _35clofun2003(struct Cora* co);
+void _35clofun2002(struct Cora* co);
+void _35clofun2001(struct Cora* co);
+void _35clofun2000(struct Cora* co);
+void _35clofun1999(struct Cora* co);
+void _35clofun1998(struct Cora* co);
+void _35clofun1997(struct Cora* co);
+void _35clofun1996(struct Cora* co);
 
 
 void entry(struct Cora* co){
@@ -41,7 +42,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-pushCont(co, 14, _35clofun3142, 0);
+pushCont(co, 3, _35clofun2020, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#import"));
 __arg1 = makeCString("cora/lib/toc/internal");
@@ -61,191 +62,570 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3142(struct Cora* co){
+void _35clofun2020(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val3094 = __arg1;
-Obj _35val3092= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val3092;
-__arg2 = _35val3094;
+Obj exp = __arg1;
+Obj _35reg1929 = primIsSymbol(exp);
+if (True == _35reg1929) {
+pushCont(co, 18, _35clofun2018, 0);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#lookup-var"));
+__arg1 = exp;
+__arg2 = makeCString("");
+__arg3 = globalRef(intern("cora/lib/toc#*repl-ns*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2020) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+pushCont(co, 20, _35clofun2019, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#number?"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2020) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label1:
 {
-Obj _35val3092 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg3093 = primCdr(exp);
-pushCont(co, 0, _35clofun3142, 1, _35val3092);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg3093;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj _35val1768 = __arg1;
+Obj _35reg1773 = primSet(co, intern("cora/lib/toc#compile"), makeNative(4, _35clofun2015, 1, 0));
+Obj _35reg1779 = primSet(co, intern("cora/lib/toc#for-each"), makeNative(8, _35clofun2015, 2, 0));
+Obj _35reg1786 = primSet(co, intern("cora/lib/toc#generate-jumptable"), makeNative(12, _35clofun2015, 3, 0));
+Obj _35reg1807 = primSet(co, intern("cora/lib/toc#generate-toplevel-group"), makeNative(13, _35clofun2016, 2, 0));
+Obj _35reg1814 = primSet(co, intern("cora/lib/toc#generate-c"), makeNative(1, _35clofun2017, 2, 0));
+Obj _35reg1846 = primSet(co, intern("cora/lib/toc#handle-import-eagerly"), makeNative(7, _35clofun2017, 1, 0));
+Obj _35reg1887 = primSet(co, intern("cora/lib/toc#split-type-and-code"), makeNative(14, _35clofun2017, 4, 0));
+Obj _35reg1888 = primSet(co, intern("cora/lib/infer#*typecheck*"), False);
+Obj _35reg1891 = primSet(co, intern("cora/lib/toc#preprocess"), makeNative(17, _35clofun2017, 1, 0));
+Obj _35reg1897 = primSet(co, intern("cora/lib/toc#compile-to-c"), makeNative(2, _35clofun2018, 2, 0));
+Obj _35reg1899 = primSet(co, intern("set"), makeNative(3, _35clofun2018, 2, 0));
+Obj _35reg1901 = primSet(co, intern("car"), makeNative(4, _35clofun2018, 1, 0));
+Obj _35reg1903 = primSet(co, intern("cdr"), makeNative(5, _35clofun2018, 1, 0));
+Obj _35reg1905 = primSet(co, intern("cons"), makeNative(6, _35clofun2018, 2, 0));
+Obj _35reg1907 = primSet(co, intern("+"), makeNative(7, _35clofun2018, 2, 0));
+Obj _35reg1909 = primSet(co, intern("-"), makeNative(8, _35clofun2018, 2, 0));
+Obj _35reg1911 = primSet(co, intern("*"), makeNative(9, _35clofun2018, 2, 0));
+Obj _35reg1913 = primSet(co, intern("/"), makeNative(10, _35clofun2018, 2, 0));
+Obj _35reg1915 = primSet(co, intern("="), makeNative(11, _35clofun2018, 2, 0));
+Obj _35reg1917 = primSet(co, intern(">"), makeNative(12, _35clofun2018, 2, 0));
+Obj _35reg1919 = primSet(co, intern("<"), makeNative(13, _35clofun2018, 2, 0));
+Obj _35reg1921 = primSet(co, intern("gensym"), makeNative(14, _35clofun2018, 1, 0));
+Obj _35reg1923 = primSet(co, intern("symbol?"), makeNative(15, _35clofun2018, 1, 0));
+Obj _35reg1925 = primSet(co, intern("not"), makeNative(16, _35clofun2018, 1, 0));
+Obj _35reg1927 = primSet(co, intern("string?"), makeNative(17, _35clofun2018, 1, 0));
+Obj _35reg1928 = primSet(co, intern("cora/lib/toc#*repl-ns*"), Nil);
+Obj _35reg1995 = primSet(co, intern("cora/lib/toc#eval0"), makeNative(0, _35clofun2020, 1, 0));
+__nargs = 2;
+__arg1 = _35reg1995;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2020) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val3102 = __arg1;
-Obj _35val3100= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val200 = __arg1;
+Obj _35reg201 = primSet(co, intern("cora/lib/toc#*ns-export*"), Nil);
+Obj _35reg216 = primSet(co, intern("cora/lib/toc#assq"), makeNative(3, _35clofun1996, 2, 0));
+Obj _35reg222 = primSet(co, intern("cora/lib/toc#foldl"), makeNative(7, _35clofun1996, 3, 0));
+Obj _35reg232 = primSet(co, intern("cora/lib/toc#pos-in-list0"), makeNative(11, _35clofun1996, 3, 0));
+Obj _35reg233 = primSet(co, intern("cora/lib/toc#index"), makeNative(12, _35clofun1996, 2, 0));
+Obj _35reg240 = primSet(co, intern("cora/lib/toc#exist-in-env"), makeNative(16, _35clofun1996, 2, 0));
+Obj _35reg241 = primCons(intern("primSet"), Nil);
+Obj _35reg242 = primCons(makeNumber(2), _35reg241);
+Obj _35reg243 = primCons(intern("set"), _35reg242);
+Obj _35reg244 = primCons(intern("primCar"), Nil);
+Obj _35reg245 = primCons(makeNumber(1), _35reg244);
+Obj _35reg246 = primCons(intern("car"), _35reg245);
+Obj _35reg247 = primCons(intern("primCdr"), Nil);
+Obj _35reg248 = primCons(makeNumber(1), _35reg247);
+Obj _35reg249 = primCons(intern("cdr"), _35reg248);
+Obj _35reg250 = primCons(intern("primCons"), Nil);
+Obj _35reg251 = primCons(makeNumber(2), _35reg250);
+Obj _35reg252 = primCons(intern("cons"), _35reg251);
+Obj _35reg253 = primCons(intern("primIsCons"), Nil);
+Obj _35reg254 = primCons(makeNumber(1), _35reg253);
+Obj _35reg255 = primCons(intern("cons?"), _35reg254);
+Obj _35reg256 = primCons(intern("primAdd"), Nil);
+Obj _35reg257 = primCons(makeNumber(2), _35reg256);
+Obj _35reg258 = primCons(intern("+"), _35reg257);
+Obj _35reg259 = primCons(intern("primSub"), Nil);
+Obj _35reg260 = primCons(makeNumber(2), _35reg259);
+Obj _35reg261 = primCons(intern("-"), _35reg260);
+Obj _35reg262 = primCons(intern("primMul"), Nil);
+Obj _35reg263 = primCons(makeNumber(2), _35reg262);
+Obj _35reg264 = primCons(intern("*"), _35reg263);
+Obj _35reg265 = primCons(intern("primDiv"), Nil);
+Obj _35reg266 = primCons(makeNumber(2), _35reg265);
+Obj _35reg267 = primCons(intern("/"), _35reg266);
+Obj _35reg268 = primCons(intern("primEQ"), Nil);
+Obj _35reg269 = primCons(makeNumber(2), _35reg268);
+Obj _35reg270 = primCons(intern("="), _35reg269);
+Obj _35reg271 = primCons(intern("primGT"), Nil);
+Obj _35reg272 = primCons(makeNumber(2), _35reg271);
+Obj _35reg273 = primCons(intern(">"), _35reg272);
+Obj _35reg274 = primCons(intern("primLT"), Nil);
+Obj _35reg275 = primCons(makeNumber(2), _35reg274);
+Obj _35reg276 = primCons(intern("<"), _35reg275);
+Obj _35reg277 = primCons(intern("primGenSym"), Nil);
+Obj _35reg278 = primCons(makeNumber(1), _35reg277);
+Obj _35reg279 = primCons(intern("gensym"), _35reg278);
+Obj _35reg280 = primCons(intern("primIsSymbol"), Nil);
+Obj _35reg281 = primCons(makeNumber(1), _35reg280);
+Obj _35reg282 = primCons(intern("symbol?"), _35reg281);
+Obj _35reg283 = primCons(intern("primNot"), Nil);
+Obj _35reg284 = primCons(makeNumber(1), _35reg283);
+Obj _35reg285 = primCons(intern("not"), _35reg284);
+Obj _35reg286 = primCons(intern("primIsNumber"), Nil);
+Obj _35reg287 = primCons(makeNumber(1), _35reg286);
+Obj _35reg288 = primCons(intern("integer?"), _35reg287);
+Obj _35reg289 = primCons(intern("primIsString"), Nil);
+Obj _35reg290 = primCons(makeNumber(1), _35reg289);
+Obj _35reg291 = primCons(intern("string?"), _35reg290);
+Obj _35reg292 = primCons(_35reg291, Nil);
+Obj _35reg293 = primCons(_35reg288, _35reg292);
+Obj _35reg294 = primCons(_35reg285, _35reg293);
+Obj _35reg295 = primCons(_35reg282, _35reg294);
+Obj _35reg296 = primCons(_35reg279, _35reg295);
+Obj _35reg297 = primCons(_35reg276, _35reg296);
+Obj _35reg298 = primCons(_35reg273, _35reg297);
+Obj _35reg299 = primCons(_35reg270, _35reg298);
+Obj _35reg300 = primCons(_35reg267, _35reg299);
+Obj _35reg301 = primCons(_35reg264, _35reg300);
+Obj _35reg302 = primCons(_35reg261, _35reg301);
+Obj _35reg303 = primCons(_35reg258, _35reg302);
+Obj _35reg304 = primCons(_35reg255, _35reg303);
+Obj _35reg305 = primCons(_35reg252, _35reg304);
+Obj _35reg306 = primCons(_35reg249, _35reg305);
+Obj _35reg307 = primCons(_35reg246, _35reg306);
+Obj _35reg308 = primCons(_35reg243, _35reg307);
+Obj _35reg309 = primSet(co, intern("cora/lib/toc#*builtin-prims*"), _35reg308);
+Obj _35reg313 = primSet(co, intern("cora/lib/toc#builtin?"), makeNative(19, _35clofun1996, 1, 0));
+Obj _35reg316 = primSet(co, intern("cora/lib/toc#builtin->name"), makeNative(1, _35clofun1997, 1, 0));
+Obj _35reg319 = primSet(co, intern("cora/lib/toc#builtin->args"), makeNative(4, _35clofun1997, 1, 0));
+Obj _35reg324 = primSet(co, intern("cora/lib/toc#temp-list"), makeNative(7, _35clofun1997, 2, 0));
+Obj _35reg330 = primSet(co, intern("cora/lib/toc#var-with-ns"), makeNative(12, _35clofun1997, 2, 0));
+Obj _35reg342 = primSet(co, intern("cora/lib/toc#lookup-var"), makeNative(1, _35clofun1998, 3, 0));
+Obj _35reg531 = primSet(co, intern("cora/lib/toc#parse"), makeNative(15, _35clofun1999, 4, 0));
+Obj _35reg542 = primSet(co, intern("cora/lib/toc#union"), makeNative(0, _35clofun2000, 2, 0));
+Obj _35reg553 = primSet(co, intern("cora/lib/toc#diff"), makeNative(6, _35clofun2000, 2, 0));
+Obj _35reg604 = primSet(co, intern("cora/lib/toc#convert-protect?"), makeNative(13, _35clofun2000, 1, 0));
+Obj _35reg779 = primSet(co, intern("cora/lib/toc#free-vars"), makeNative(15, _35clofun2001, 1, 0));
+Obj _35reg852 = primSet(co, intern("cora/lib/toc#closure-convert"), makeNative(9, _35clofun2002, 2, 0));
+Obj _35reg855 = primSet(co, intern("cora/lib/toc#id"), makeNative(10, _35clofun2002, 1, 0));
+Obj _35reg992 = primSet(co, intern("cora/lib/toc#tailify"), makeNative(7, _35clofun2003, 2, 0));
+Obj _35reg1039 = primSet(co, intern("cora/lib/toc#tailify-list"), makeNative(17, _35clofun2003, 3, 0));
+Obj _35reg1118 = primSet(co, intern("cora/lib/toc#explicit-stack"), makeNative(14, _35clofun2004, 2, 0));
+Obj _35reg1294 = primSet(co, intern("cora/lib/toc#collect-lambda"), makeNative(7, _35clofun2006, 2, 0));
+Obj _35reg1307 = primSet(co, intern("cora/lib/toc#append-result"), makeNative(13, _35clofun2006, 5, 0));
+Obj _35reg1314 = primSet(co, intern("cora/lib/toc#wrap-var"), makeNative(15, _35clofun2006, 2, 0));
+Obj _35reg1334 = primSet(co, intern("cora/lib/toc#generate-call-list"), makeNative(8, _35clofun2007, 4, 0));
+Obj _35reg1604 = primSet(co, intern("cora/lib/toc#generate-inst"), makeNative(11, _35clofun2011, 4, 0));
+Obj _35reg1627 = primSet(co, intern("cora/lib/toc#generate-cont"), makeNative(3, _35clofun2012, 3, 0));
+Obj _35reg1636 = primSet(co, intern("cora/lib/toc#generate-inst-list-h"), makeNative(9, _35clofun2012, 5, 0));
+Obj _35reg1637 = primSet(co, intern("cora/lib/toc#generate-inst-list"), makeNative(10, _35clofun2012, 4, 0));
+Obj _35reg1642 = primSet(co, intern("cora/lib/toc#code-gen-func-declare"), makeNative(14, _35clofun2012, 2, 0));
+Obj _35reg1650 = primSet(co, intern("cora/lib/toc#local-from-params"), makeNative(0, _35clofun2013, 3, 0));
+Obj _35reg1655 = primSet(co, intern("cora/lib/toc#local-from-cont"), makeNative(5, _35clofun2013, 3, 0));
+Obj _35reg1662 = primSet(co, intern("cora/lib/toc#generate-call-args-reverse"), makeNative(9, _35clofun2013, 4, 0));
+Obj _35reg1724 = primSet(co, intern("cora/lib/toc#code-gen-toplevel"), makeNative(20, _35clofun2013, 2, 0));
+Obj _35reg1725 = primSet(co, intern("cora/lib/toc#parse-pass"), makeNative(0, _35clofun2014, 1, 0));
+Obj _35reg1726 = primSet(co, intern("cora/lib/toc#closure-convert-pass"), makeNative(1, _35clofun2014, 1, 0));
+Obj _35reg1727 = primSet(co, intern("cora/lib/toc#tailify-pass"), makeNative(2, _35clofun2014, 1, 0));
+Obj _35reg1728 = primSet(co, intern("cora/lib/toc#explicit-stack-pass"), makeNative(3, _35clofun2014, 1, 0));
+Obj _35reg1758 = primSet(co, intern("cora/lib/toc#collect-lambda-pass"), makeNative(14, _35clofun2014, 1, 0));
+Obj _35reg1765 = primSet(co, intern("cora/lib/toc#rewrite-->macro"), makeNative(17, _35clofun2014, 2, 0));
+pushCont(co, 1, _35clofun2020, 0);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val3100;
-__arg2 = _35val3102;
+__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
+__arg1 = intern("->");
+__arg2 = makeNative(20, _35clofun2014, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2020) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val3100 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg3101 = primCdr(exp);
-pushCont(co, 2, _35clofun3142, 1, _35val3100);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg3101;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj _35val3110 = __arg1;
-Obj _35val3108= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val3108;
-__arg2 = _35val3110;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35val3108 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg3109 = primCdr(exp);
-pushCont(co, 4, _35clofun3142, 1, _35val3108);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg3109;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val3117 = __arg1;
-Obj _35val3115= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val3115;
-__arg2 = _35val3117;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val3115 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg3116 = primCdr(exp);
-pushCont(co, 6, _35clofun3142, 1, _35val3115);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg3116;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35val3103 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val3103) {
-if (True == True) {
+Obj _35val199 = __arg1;
+pushCont(co, 2, _35clofun2020, 0);
 __nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3142) { goto fail; }
+__arg0 = globalRef(intern("cora/init#import"));
+__arg1 = makeCString("cora/lib/io");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2020) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void _35clofun2019(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+
 goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg3104 = primIsCons(exp);
-if (True == _35reg3104) {
-Obj _35reg3105 = primCar(exp);
-Obj _35reg3106 = primEQ(_35reg3105, intern("quote"));
-if (True == _35reg3106) {
+
+label0:
+{
+Obj _35val1943 = __arg1;
+Obj _35val1941= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val1941;
+__arg2 = _35val1943;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val1941 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1942 = primCdr(exp);
+pushCont(co, 0, _35clofun2019, 1, _35val1941);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg1942;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val1952 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#import"));
+__arg1 = _35val1952;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val1949 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1950 = primCons(_35val1949, globalRef(intern("cora/lib/toc#*repl-ns*")));
+Obj _35reg1951 = primSet(co, intern("cora/lib/toc#*repl-ns*"), _35reg1950);
+pushCont(co, 2, _35clofun2019, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg3107 = primCar(exp);
-pushCont(co, 5, _35clofun3142, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg3107;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no cond match");
+
+label4:
+{
+Obj _35val1956 = __arg1;
+Obj _35val1954= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val1954;
+__arg2 = _35val1956;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val1954 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1955 = primCdr(exp);
+pushCont(co, 4, _35clofun2019, 1, _35val1954);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg1955;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label6:
+{
+Obj _35val1965 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#import"));
+__arg1 = _35val1965;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label7:
+{
+Obj _35val1962 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1963 = primCons(_35val1962, globalRef(intern("cora/lib/toc#*repl-ns*")));
+Obj _35reg1964 = primSet(co, intern("cora/lib/toc#*repl-ns*"), _35reg1963);
+pushCont(co, 6, _35clofun2019, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label8:
+{
+Obj _35val1969 = __arg1;
+Obj _35val1967= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val1967;
+__arg2 = _35val1969;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label9:
+{
+Obj _35val1967 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1968 = primCdr(exp);
+pushCont(co, 8, _35clofun2019, 1, _35val1967);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg1968;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label10:
+{
+Obj _35val1978 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#import"));
+__arg1 = _35val1978;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label11:
+{
+Obj _35val1975 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1976 = primCons(_35val1975, globalRef(intern("cora/lib/toc#*repl-ns*")));
+Obj _35reg1977 = primSet(co, intern("cora/lib/toc#*repl-ns*"), _35reg1976);
+pushCont(co, 10, _35clofun2019, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label12:
+{
+Obj _35val1982 = __arg1;
+Obj _35val1980= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val1980;
+__arg2 = _35val1982;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label13:
+{
+Obj _35val1980 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1981 = primCdr(exp);
+pushCont(co, 12, _35clofun2019, 1, _35val1980);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg1981;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label14:
+{
+Obj _35val1990 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#import"));
+__arg1 = _35val1990;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label15:
+{
+Obj _35val1987 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1988 = primCons(_35val1987, globalRef(intern("cora/lib/toc#*repl-ns*")));
+Obj _35reg1989 = primSet(co, intern("cora/lib/toc#*repl-ns*"), _35reg1988);
+pushCont(co, 14, _35clofun2019, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label16:
+{
+Obj _35val1994 = __arg1;
+Obj _35val1992= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val1992;
+__arg2 = _35val1994;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label17:
+{
+Obj _35val1992 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1993 = primCdr(exp);
+pushCont(co, 16, _35clofun2019, 1, _35val1992);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg1993;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label18:
+{
+Obj _35val1970 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1970) {
+if (True == True) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2019) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg1971 = primCar(exp);
+Obj _35reg1972 = primEQ(_35reg1971, intern("quote"));
+if (True == _35reg1972) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1973 = primCar(exp);
+Obj _35reg1974 = primEQ(_35reg1973, intern("import"));
+if (True == _35reg1974) {
+pushCont(co, 11, _35clofun2019, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1979 = primCar(exp);
+pushCont(co, 13, _35clofun2019, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#eval0"));
+__arg1 = _35reg1979;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 }
 } else {
@@ -253,416 +633,223 @@ if (True == False) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3142) { goto fail; }
+if (co->ctx.pc.func != _35clofun2019) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg3111 = primIsCons(exp);
-if (True == _35reg3111) {
-Obj _35reg3112 = primCar(exp);
-Obj _35reg3113 = primEQ(_35reg3112, intern("quote"));
-if (True == _35reg3113) {
+Obj _35reg1983 = primCar(exp);
+Obj _35reg1984 = primEQ(_35reg1983, intern("quote"));
+if (True == _35reg1984) {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg3114 = primCar(exp);
-pushCont(co, 7, _35clofun3142, 1, exp);
+Obj _35reg1985 = primCar(exp);
+Obj _35reg1986 = primEQ(_35reg1985, intern("import"));
+if (True == _35reg1986) {
+pushCont(co, 15, _35clofun2019, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1991 = primCar(exp);
+pushCont(co, 17, _35clofun2019, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg3114;
+__arg1 = _35reg1991;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 }
 }
 }
 }
 
-label9:
+label19:
 {
-Obj _35val3095 = __arg1;
+Obj _35val1957 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val3095) {
+if (True == _35val1957) {
 if (True == True) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3142) { goto fail; }
+if (co->ctx.pc.func != _35clofun2019) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg3096 = primIsCons(exp);
-if (True == _35reg3096) {
-Obj _35reg3097 = primCar(exp);
-Obj _35reg3098 = primEQ(_35reg3097, intern("quote"));
-if (True == _35reg3098) {
+Obj _35reg1958 = primCar(exp);
+Obj _35reg1959 = primEQ(_35reg1958, intern("quote"));
+if (True == _35reg1959) {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg3099 = primCar(exp);
-pushCont(co, 3, _35clofun3142, 1, exp);
+Obj _35reg1960 = primCar(exp);
+Obj _35reg1961 = primEQ(_35reg1960, intern("import"));
+if (True == _35reg1961) {
+pushCont(co, 7, _35clofun2019, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1966 = primCar(exp);
+pushCont(co, 9, _35clofun2019, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg3099;
+__arg1 = _35reg1966;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
+}
 } else {
-pushCont(co, 8, _35clofun3142, 1, exp);
+pushCont(co, 18, _35clofun2019, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label10:
+label20:
 {
-Obj _35val3079 = __arg1;
+Obj _35val1931 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val3079) {
+if (True == _35val1931) {
 if (True == True) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3142) { goto fail; }
+if (co->ctx.pc.func != _35clofun2019) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg3080 = primIsCons(exp);
-if (True == _35reg3080) {
-Obj _35reg3081 = primCar(exp);
-Obj _35reg3082 = primEQ(_35reg3081, intern("quote"));
-if (True == _35reg3082) {
+Obj _35reg1932 = primCar(exp);
+Obj _35reg1933 = primEQ(_35reg1932, intern("quote"));
+if (True == _35reg1933) {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg3083 = primCar(exp);
-pushCont(co, 20, _35clofun3141, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg3083;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-Obj _35reg3087 = primIsString(exp);
-if (True == _35reg3087) {
-if (True == True) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3142) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg3088 = primIsCons(exp);
-if (True == _35reg3088) {
-Obj _35reg3089 = primCar(exp);
-Obj _35reg3090 = primEQ(_35reg3089, intern("quote"));
-if (True == _35reg3090) {
+Obj _35reg1934 = primCar(exp);
+Obj _35reg1935 = primEQ(_35reg1934, intern("import"));
+if (True == _35reg1935) {
+pushCont(co, 20, _35clofun2018, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg3091 = primCar(exp);
-pushCont(co, 1, _35clofun3142, 1, exp);
+Obj _35reg1940 = primCar(exp);
+pushCont(co, 1, _35clofun2019, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg3091;
+__arg1 = _35reg1940;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+}
 } else {
+Obj _35reg1944 = primIsString(exp);
+if (True == _35reg1944) {
+if (True == True) {
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no cond match");
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2019) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg1945 = primCar(exp);
+Obj _35reg1946 = primEQ(_35reg1945, intern("quote"));
+if (True == _35reg1946) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1947 = primCar(exp);
+Obj _35reg1948 = primEQ(_35reg1947, intern("import"));
+if (True == _35reg1948) {
+pushCont(co, 3, _35clofun2019, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1953 = primCar(exp);
+pushCont(co, 5, _35clofun2019, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#eval0"));
+__arg1 = _35reg1953;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
+}
 } else {
-pushCont(co, 9, _35clofun3142, 1, exp);
+pushCont(co, 19, _35clofun2019, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#boolean?"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
-}
-
-label11:
-{
-Obj exp = __arg1;
-Obj _35reg3078 = primIsSymbol(exp);
-if (True == _35reg3078) {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#value"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 10, _35clofun3142, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#number?"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35val2918 = __arg1;
-Obj _35reg2923 = primSet(co, intern("cora/lib/toc#compile"), makeNative(5, _35clofun3138, 1, 0));
-Obj _35reg2929 = primSet(co, intern("cora/lib/toc#for-each"), makeNative(9, _35clofun3138, 2, 0));
-Obj _35reg2936 = primSet(co, intern("cora/lib/toc#generate-jumptable"), makeNative(13, _35clofun3138, 3, 0));
-Obj _35reg2957 = primSet(co, intern("cora/lib/toc#generate-toplevel-group"), makeNative(14, _35clofun3139, 2, 0));
-Obj _35reg2964 = primSet(co, intern("cora/lib/toc#generate-c"), makeNative(2, _35clofun3140, 2, 0));
-Obj _35reg2996 = primSet(co, intern("cora/lib/toc#handle-import-eagerly"), makeNative(8, _35clofun3140, 1, 0));
-Obj _35reg3037 = primSet(co, intern("cora/lib/toc#split-type-and-code"), makeNative(15, _35clofun3140, 4, 0));
-Obj _35reg3038 = primSet(co, intern("cora/lib/infer#*typecheck*"), False);
-Obj _35reg3041 = primSet(co, intern("cora/lib/toc#preprocess"), makeNative(18, _35clofun3140, 1, 0));
-Obj _35reg3047 = primSet(co, intern("cora/lib/toc#compile-to-c"), makeNative(3, _35clofun3141, 2, 0));
-Obj _35reg3049 = primSet(co, intern("set"), makeNative(4, _35clofun3141, 2, 0));
-Obj _35reg3051 = primSet(co, intern("car"), makeNative(5, _35clofun3141, 1, 0));
-Obj _35reg3053 = primSet(co, intern("cdr"), makeNative(6, _35clofun3141, 1, 0));
-Obj _35reg3055 = primSet(co, intern("cons"), makeNative(7, _35clofun3141, 2, 0));
-Obj _35reg3057 = primSet(co, intern("+"), makeNative(8, _35clofun3141, 2, 0));
-Obj _35reg3059 = primSet(co, intern("-"), makeNative(9, _35clofun3141, 2, 0));
-Obj _35reg3061 = primSet(co, intern("*"), makeNative(10, _35clofun3141, 2, 0));
-Obj _35reg3063 = primSet(co, intern("/"), makeNative(11, _35clofun3141, 2, 0));
-Obj _35reg3065 = primSet(co, intern("="), makeNative(12, _35clofun3141, 2, 0));
-Obj _35reg3067 = primSet(co, intern(">"), makeNative(13, _35clofun3141, 2, 0));
-Obj _35reg3069 = primSet(co, intern("<"), makeNative(14, _35clofun3141, 2, 0));
-Obj _35reg3071 = primSet(co, intern("gensym"), makeNative(15, _35clofun3141, 1, 0));
-Obj _35reg3073 = primSet(co, intern("symbol?"), makeNative(16, _35clofun3141, 1, 0));
-Obj _35reg3075 = primSet(co, intern("not"), makeNative(17, _35clofun3141, 1, 0));
-Obj _35reg3077 = primSet(co, intern("string?"), makeNative(18, _35clofun3141, 1, 0));
-Obj _35reg3118 = primSet(co, intern("cora/lib/toc#eval0"), makeNative(11, _35clofun3142, 1, 0));
-__nargs = 2;
-__arg1 = _35reg3118;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3142) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label13:
-{
-Obj _35val1347 = __arg1;
-Obj _35reg1348 = primSet(co, intern("cora/lib/toc#*ns-export*"), Nil);
-Obj _35reg1363 = primSet(co, intern("cora/lib/toc#assq"), makeNative(3, _35clofun3119, 2, 0));
-Obj _35reg1369 = primSet(co, intern("cora/lib/toc#foldl"), makeNative(7, _35clofun3119, 3, 0));
-Obj _35reg1379 = primSet(co, intern("cora/lib/toc#pos-in-list0"), makeNative(11, _35clofun3119, 3, 0));
-Obj _35reg1380 = primSet(co, intern("cora/lib/toc#index"), makeNative(12, _35clofun3119, 2, 0));
-Obj _35reg1387 = primSet(co, intern("cora/lib/toc#exist-in-env"), makeNative(16, _35clofun3119, 2, 0));
-Obj _35reg1388 = primCons(intern("primSet"), Nil);
-Obj _35reg1389 = primCons(makeNumber(2), _35reg1388);
-Obj _35reg1390 = primCons(intern("set"), _35reg1389);
-Obj _35reg1391 = primCons(intern("primCar"), Nil);
-Obj _35reg1392 = primCons(makeNumber(1), _35reg1391);
-Obj _35reg1393 = primCons(intern("car"), _35reg1392);
-Obj _35reg1394 = primCons(intern("primCdr"), Nil);
-Obj _35reg1395 = primCons(makeNumber(1), _35reg1394);
-Obj _35reg1396 = primCons(intern("cdr"), _35reg1395);
-Obj _35reg1397 = primCons(intern("primCons"), Nil);
-Obj _35reg1398 = primCons(makeNumber(2), _35reg1397);
-Obj _35reg1399 = primCons(intern("cons"), _35reg1398);
-Obj _35reg1400 = primCons(intern("primIsCons"), Nil);
-Obj _35reg1401 = primCons(makeNumber(1), _35reg1400);
-Obj _35reg1402 = primCons(intern("cons?"), _35reg1401);
-Obj _35reg1403 = primCons(intern("primAdd"), Nil);
-Obj _35reg1404 = primCons(makeNumber(2), _35reg1403);
-Obj _35reg1405 = primCons(intern("+"), _35reg1404);
-Obj _35reg1406 = primCons(intern("primSub"), Nil);
-Obj _35reg1407 = primCons(makeNumber(2), _35reg1406);
-Obj _35reg1408 = primCons(intern("-"), _35reg1407);
-Obj _35reg1409 = primCons(intern("primMul"), Nil);
-Obj _35reg1410 = primCons(makeNumber(2), _35reg1409);
-Obj _35reg1411 = primCons(intern("*"), _35reg1410);
-Obj _35reg1412 = primCons(intern("primDiv"), Nil);
-Obj _35reg1413 = primCons(makeNumber(2), _35reg1412);
-Obj _35reg1414 = primCons(intern("/"), _35reg1413);
-Obj _35reg1415 = primCons(intern("primEQ"), Nil);
-Obj _35reg1416 = primCons(makeNumber(2), _35reg1415);
-Obj _35reg1417 = primCons(intern("="), _35reg1416);
-Obj _35reg1418 = primCons(intern("primGT"), Nil);
-Obj _35reg1419 = primCons(makeNumber(2), _35reg1418);
-Obj _35reg1420 = primCons(intern(">"), _35reg1419);
-Obj _35reg1421 = primCons(intern("primLT"), Nil);
-Obj _35reg1422 = primCons(makeNumber(2), _35reg1421);
-Obj _35reg1423 = primCons(intern("<"), _35reg1422);
-Obj _35reg1424 = primCons(intern("primGenSym"), Nil);
-Obj _35reg1425 = primCons(makeNumber(1), _35reg1424);
-Obj _35reg1426 = primCons(intern("gensym"), _35reg1425);
-Obj _35reg1427 = primCons(intern("primIsSymbol"), Nil);
-Obj _35reg1428 = primCons(makeNumber(1), _35reg1427);
-Obj _35reg1429 = primCons(intern("symbol?"), _35reg1428);
-Obj _35reg1430 = primCons(intern("primNot"), Nil);
-Obj _35reg1431 = primCons(makeNumber(1), _35reg1430);
-Obj _35reg1432 = primCons(intern("not"), _35reg1431);
-Obj _35reg1433 = primCons(intern("primIsNumber"), Nil);
-Obj _35reg1434 = primCons(makeNumber(1), _35reg1433);
-Obj _35reg1435 = primCons(intern("integer?"), _35reg1434);
-Obj _35reg1436 = primCons(intern("primIsString"), Nil);
-Obj _35reg1437 = primCons(makeNumber(1), _35reg1436);
-Obj _35reg1438 = primCons(intern("string?"), _35reg1437);
-Obj _35reg1439 = primCons(_35reg1438, Nil);
-Obj _35reg1440 = primCons(_35reg1435, _35reg1439);
-Obj _35reg1441 = primCons(_35reg1432, _35reg1440);
-Obj _35reg1442 = primCons(_35reg1429, _35reg1441);
-Obj _35reg1443 = primCons(_35reg1426, _35reg1442);
-Obj _35reg1444 = primCons(_35reg1423, _35reg1443);
-Obj _35reg1445 = primCons(_35reg1420, _35reg1444);
-Obj _35reg1446 = primCons(_35reg1417, _35reg1445);
-Obj _35reg1447 = primCons(_35reg1414, _35reg1446);
-Obj _35reg1448 = primCons(_35reg1411, _35reg1447);
-Obj _35reg1449 = primCons(_35reg1408, _35reg1448);
-Obj _35reg1450 = primCons(_35reg1405, _35reg1449);
-Obj _35reg1451 = primCons(_35reg1402, _35reg1450);
-Obj _35reg1452 = primCons(_35reg1399, _35reg1451);
-Obj _35reg1453 = primCons(_35reg1396, _35reg1452);
-Obj _35reg1454 = primCons(_35reg1393, _35reg1453);
-Obj _35reg1455 = primCons(_35reg1390, _35reg1454);
-Obj _35reg1456 = primSet(co, intern("cora/lib/toc#*builtin-prims*"), _35reg1455);
-Obj _35reg1460 = primSet(co, intern("cora/lib/toc#builtin?"), makeNative(19, _35clofun3119, 1, 0));
-Obj _35reg1463 = primSet(co, intern("cora/lib/toc#builtin->name"), makeNative(1, _35clofun3120, 1, 0));
-Obj _35reg1466 = primSet(co, intern("cora/lib/toc#builtin->args"), makeNative(4, _35clofun3120, 1, 0));
-Obj _35reg1471 = primSet(co, intern("cora/lib/toc#temp-list"), makeNative(7, _35clofun3120, 2, 0));
-Obj _35reg1477 = primSet(co, intern("cora/lib/toc#var-with-ns"), makeNative(12, _35clofun3120, 2, 0));
-Obj _35reg1495 = primSet(co, intern("cora/lib/toc#lookup-var-h"), makeNative(3, _35clofun3121, 3, 0));
-Obj _35reg1681 = primSet(co, intern("cora/lib/toc#parse"), makeNative(16, _35clofun3122, 4, 0));
-Obj _35reg1692 = primSet(co, intern("cora/lib/toc#union"), makeNative(1, _35clofun3123, 2, 0));
-Obj _35reg1703 = primSet(co, intern("cora/lib/toc#diff"), makeNative(7, _35clofun3123, 2, 0));
-Obj _35reg1754 = primSet(co, intern("cora/lib/toc#convert-protect?"), makeNative(14, _35clofun3123, 1, 0));
-Obj _35reg1929 = primSet(co, intern("cora/lib/toc#free-vars"), makeNative(16, _35clofun3124, 1, 0));
-Obj _35reg2002 = primSet(co, intern("cora/lib/toc#closure-convert"), makeNative(10, _35clofun3125, 2, 0));
-Obj _35reg2005 = primSet(co, intern("cora/lib/toc#id"), makeNative(11, _35clofun3125, 1, 0));
-Obj _35reg2142 = primSet(co, intern("cora/lib/toc#tailify"), makeNative(8, _35clofun3126, 2, 0));
-Obj _35reg2189 = primSet(co, intern("cora/lib/toc#tailify-list"), makeNative(18, _35clofun3126, 3, 0));
-Obj _35reg2268 = primSet(co, intern("cora/lib/toc#explicit-stack"), makeNative(15, _35clofun3127, 2, 0));
-Obj _35reg2444 = primSet(co, intern("cora/lib/toc#collect-lambda"), makeNative(8, _35clofun3129, 2, 0));
-Obj _35reg2457 = primSet(co, intern("cora/lib/toc#append-result"), makeNative(14, _35clofun3129, 5, 0));
-Obj _35reg2464 = primSet(co, intern("cora/lib/toc#wrap-var"), makeNative(16, _35clofun3129, 2, 0));
-Obj _35reg2484 = primSet(co, intern("cora/lib/toc#generate-call-list"), makeNative(9, _35clofun3130, 4, 0));
-Obj _35reg2754 = primSet(co, intern("cora/lib/toc#generate-inst"), makeNative(12, _35clofun3134, 4, 0));
-Obj _35reg2777 = primSet(co, intern("cora/lib/toc#generate-cont"), makeNative(4, _35clofun3135, 3, 0));
-Obj _35reg2786 = primSet(co, intern("cora/lib/toc#generate-inst-list-h"), makeNative(10, _35clofun3135, 5, 0));
-Obj _35reg2787 = primSet(co, intern("cora/lib/toc#generate-inst-list"), makeNative(11, _35clofun3135, 4, 0));
-Obj _35reg2792 = primSet(co, intern("cora/lib/toc#code-gen-func-declare"), makeNative(15, _35clofun3135, 2, 0));
-Obj _35reg2800 = primSet(co, intern("cora/lib/toc#local-from-params"), makeNative(1, _35clofun3136, 3, 0));
-Obj _35reg2805 = primSet(co, intern("cora/lib/toc#local-from-cont"), makeNative(6, _35clofun3136, 3, 0));
-Obj _35reg2812 = primSet(co, intern("cora/lib/toc#generate-call-args-reverse"), makeNative(10, _35clofun3136, 4, 0));
-Obj _35reg2874 = primSet(co, intern("cora/lib/toc#code-gen-toplevel"), makeNative(0, _35clofun3137, 2, 0));
-Obj _35reg2875 = primSet(co, intern("cora/lib/toc#parse-pass"), makeNative(1, _35clofun3137, 1, 0));
-Obj _35reg2876 = primSet(co, intern("cora/lib/toc#closure-convert-pass"), makeNative(2, _35clofun3137, 1, 0));
-Obj _35reg2877 = primSet(co, intern("cora/lib/toc#tailify-pass"), makeNative(3, _35clofun3137, 1, 0));
-Obj _35reg2878 = primSet(co, intern("cora/lib/toc#explicit-stack-pass"), makeNative(4, _35clofun3137, 1, 0));
-Obj _35reg2908 = primSet(co, intern("cora/lib/toc#collect-lambda-pass"), makeNative(15, _35clofun3137, 1, 0));
-Obj _35reg2915 = primSet(co, intern("cora/lib/toc#rewrite-->macro"), makeNative(18, _35clofun3137, 2, 0));
-pushCont(co, 12, _35clofun3142, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("->");
-__arg2 = makeNative(0, _35clofun3138, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35val1346 = __arg1;
-pushCont(co, 13, _35clofun3142, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#import"));
-__arg1 = makeCString("cora/lib/io");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3142) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 }
 
 fail:
@@ -674,7 +861,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3141(struct Cora* co){
+void _35clofun2018(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -687,268 +874,263 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val3044 = __arg1;
+Obj _35val1893 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc = _35val3044;
-pushCont(co, 20, _35clofun3140, 1, bc);
+pushCont(co, 20, _35clofun2017, 1, to);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/io#open-output-file"));
-__arg1 = to;
+__arg0 = globalRef(intern("cora/lib/toc#compile"));
+__arg1 = _35val1893;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3141) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2018) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val3043 = __arg1;
+Obj _35val1892 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun3141, 1, to);
+pushCont(co, 0, _35clofun2018, 1, to);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#compile"));
-__arg1 = _35val3043;
+__arg0 = globalRef(intern("cora/init#macroexpand"));
+__arg1 = _35val1892;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3141) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2018) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val3042 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 1, _35clofun3141, 1, to);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#macroexpand"));
-__arg1 = _35val3042;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3141) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
 Obj from = __arg1;
 Obj to = __arg2;
-pushCont(co, 2, _35clofun3141, 1, to);
+pushCont(co, 1, _35clofun2018, 1, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#preprocess"));
 __arg1 = from;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3141) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2018) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35tmp176 = __arg1;
+Obj _35tmp175 = __arg2;
+Obj _35reg1898 = primSet(co, _35tmp176, _35tmp175);
+__nargs = 2;
+__arg1 = _35reg1898;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label4:
 {
-Obj _35tmp1323 = __arg1;
-Obj _35tmp1322 = __arg2;
-Obj _35reg3048 = primSet(co, _35tmp1323, _35tmp1322);
+Obj _35tmp177 = __arg1;
+Obj _35reg1900 = primCar(_35tmp177);
 __nargs = 2;
-__arg1 = _35reg3048;
+__arg1 = _35reg1900;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label5:
 {
-Obj _35tmp1324 = __arg1;
-Obj _35reg3050 = primCar(_35tmp1324);
+Obj _35tmp178 = __arg1;
+Obj _35reg1902 = primCdr(_35tmp178);
 __nargs = 2;
-__arg1 = _35reg3050;
+__arg1 = _35reg1902;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label6:
 {
-Obj _35tmp1325 = __arg1;
-Obj _35reg3052 = primCdr(_35tmp1325);
+Obj _35tmp180 = __arg1;
+Obj _35tmp179 = __arg2;
+Obj _35reg1904 = primCons(_35tmp180, _35tmp179);
 __nargs = 2;
-__arg1 = _35reg3052;
+__arg1 = _35reg1904;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label7:
 {
-Obj _35tmp1327 = __arg1;
-Obj _35tmp1326 = __arg2;
-Obj _35reg3054 = primCons(_35tmp1327, _35tmp1326);
+Obj _35tmp182 = __arg1;
+Obj _35tmp181 = __arg2;
+Obj _35reg1906 = primAdd(_35tmp182, _35tmp181);
 __nargs = 2;
-__arg1 = _35reg3054;
+__arg1 = _35reg1906;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label8:
 {
-Obj _35tmp1329 = __arg1;
-Obj _35tmp1328 = __arg2;
-Obj _35reg3056 = primAdd(_35tmp1329, _35tmp1328);
+Obj _35tmp184 = __arg1;
+Obj _35tmp183 = __arg2;
+Obj _35reg1908 = primSub(_35tmp184, _35tmp183);
 __nargs = 2;
-__arg1 = _35reg3056;
+__arg1 = _35reg1908;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label9:
 {
-Obj _35tmp1331 = __arg1;
-Obj _35tmp1330 = __arg2;
-Obj _35reg3058 = primSub(_35tmp1331, _35tmp1330);
+Obj _35tmp186 = __arg1;
+Obj _35tmp185 = __arg2;
+Obj _35reg1910 = primMul(_35tmp186, _35tmp185);
 __nargs = 2;
-__arg1 = _35reg3058;
+__arg1 = _35reg1910;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label10:
 {
-Obj _35tmp1333 = __arg1;
-Obj _35tmp1332 = __arg2;
-Obj _35reg3060 = primMul(_35tmp1333, _35tmp1332);
+Obj _35tmp188 = __arg1;
+Obj _35tmp187 = __arg2;
+Obj _35reg1912 = primDiv(_35tmp188, _35tmp187);
 __nargs = 2;
-__arg1 = _35reg3060;
+__arg1 = _35reg1912;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label11:
 {
-Obj _35tmp1335 = __arg1;
-Obj _35tmp1334 = __arg2;
-Obj _35reg3062 = primDiv(_35tmp1335, _35tmp1334);
+Obj _35tmp190 = __arg1;
+Obj _35tmp189 = __arg2;
+Obj _35reg1914 = primEQ(_35tmp190, _35tmp189);
 __nargs = 2;
-__arg1 = _35reg3062;
+__arg1 = _35reg1914;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label12:
 {
-Obj _35tmp1337 = __arg1;
-Obj _35tmp1336 = __arg2;
-Obj _35reg3064 = primEQ(_35tmp1337, _35tmp1336);
+Obj _35tmp192 = __arg1;
+Obj _35tmp191 = __arg2;
+Obj _35reg1916 = primGT(_35tmp192, _35tmp191);
 __nargs = 2;
-__arg1 = _35reg3064;
+__arg1 = _35reg1916;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label13:
 {
-Obj _35tmp1339 = __arg1;
-Obj _35tmp1338 = __arg2;
-Obj _35reg3066 = primGT(_35tmp1339, _35tmp1338);
+Obj _35tmp194 = __arg1;
+Obj _35tmp193 = __arg2;
+Obj _35reg1918 = primLT(_35tmp194, _35tmp193);
 __nargs = 2;
-__arg1 = _35reg3066;
+__arg1 = _35reg1918;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label14:
 {
-Obj _35tmp1341 = __arg1;
-Obj _35tmp1340 = __arg2;
-Obj _35reg3068 = primLT(_35tmp1341, _35tmp1340);
+Obj _35tmp195 = __arg1;
+Obj _35reg1920 = primGenSym(_35tmp195);
 __nargs = 2;
-__arg1 = _35reg3068;
+__arg1 = _35reg1920;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label15:
 {
-Obj _35tmp1342 = __arg1;
-Obj _35reg3070 = primGenSym(_35tmp1342);
+Obj _35tmp196 = __arg1;
+Obj _35reg1922 = primIsSymbol(_35tmp196);
 __nargs = 2;
-__arg1 = _35reg3070;
+__arg1 = _35reg1922;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label16:
 {
-Obj _35tmp1343 = __arg1;
-Obj _35reg3072 = primIsSymbol(_35tmp1343);
+Obj _35tmp197 = __arg1;
+Obj _35reg1924 = primNot(_35tmp197);
 __nargs = 2;
-__arg1 = _35reg3072;
+__arg1 = _35reg1924;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label17:
 {
-Obj _35tmp1344 = __arg1;
-Obj _35reg3074 = primNot(_35tmp1344);
+Obj _35tmp198 = __arg1;
+Obj _35reg1926 = primIsString(_35tmp198);
 __nargs = 2;
-__arg1 = _35reg3074;
+__arg1 = _35reg1926;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
+if (co->ctx.pc.func != _35clofun2018) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label18:
 {
-Obj _35tmp1345 = __arg1;
-Obj _35reg3076 = primIsString(_35tmp1345);
+Obj _35val1930 = __arg1;
 __nargs = 2;
-__arg1 = _35reg3076;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3141) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("cora/init#value"));
+__arg1 = _35val1930;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2018) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val3086 = __arg1;
-Obj _35val3084= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val3084;
-__arg2 = _35val3086;
+Obj _35val1939 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#import"));
+__arg1 = _35val1939;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3141) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2018) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val3084 = __arg1;
+Obj _35val1936 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg3085 = primCdr(exp);
-pushCont(co, 19, _35clofun3141, 1, _35val3084);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg3085;
+Obj _35reg1937 = primCons(_35val1936, globalRef(intern("cora/lib/toc#*repl-ns*")));
+Obj _35reg1938 = primSet(co, intern("cora/lib/toc#*repl-ns*"), _35reg1937);
+pushCont(co, 19, _35clofun2018, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3141) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2018) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -961,7 +1143,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3140(struct Cora* co){
+void _35clofun2017(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -974,27 +1156,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2959 = __arg1;
+Obj _35val1808 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 20, _35clofun3139, 2, to, bc);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(17, _35clofun3139, 1, 1, to);
-__arg2 = bc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35val2958 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3140, 2, to, bc);
+pushCont(co, 20, _35clofun2016, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1002,15 +1167,15 @@ __arg2 = makeCString("#include \"runtime.h\"\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label2:
+label1:
 {
 Obj to = __arg1;
 Obj bc = __arg2;
-pushCont(co, 1, _35clofun3140, 2, to, bc);
+pushCont(co, 0, _35clofun2017, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1018,11 +1183,11 @@ __arg2 = makeCString("#include \"types.h\"\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label2:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -1030,24 +1195,24 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label4:
+label3:
 {
-Obj _35cc1313 = makeNative(3, _35clofun3140, 0, 0);
+Obj _35cc166 = makeNative(2, _35clofun2017, 0, 0);
 Obj __ = closureRef(co, 0);
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3140) { goto fail; }
+if (co->ctx.pc.func != _35clofun2017) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label5:
+label4:
 {
-Obj _35val2982 = __arg1;
+Obj _35val1832 = __arg1;
 Obj remain= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
@@ -1055,187 +1220,187 @@ __arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label5:
 {
-Obj _35cc1312 = makeNative(4, _35clofun3140, 0, 1, closureRef(co, 0));
-Obj _35reg2965 = primIsCons(closureRef(co, 0));
-if (True == _35reg2965) {
-Obj _35reg2966 = primCar(closureRef(co, 0));
-Obj _35reg2967 = primIsCons(_35reg2966);
-if (True == _35reg2967) {
-Obj _35reg2968 = primCar(closureRef(co, 0));
-Obj _35reg2969 = primCar(_35reg2968);
-Obj _35reg2970 = primEQ(intern("import"), _35reg2969);
-if (True == _35reg2970) {
-Obj _35reg2971 = primCar(closureRef(co, 0));
-Obj _35reg2972 = primCdr(_35reg2971);
-Obj _35reg2973 = primIsCons(_35reg2972);
-if (True == _35reg2973) {
-Obj _35reg2974 = primCar(closureRef(co, 0));
-Obj _35reg2975 = primCdr(_35reg2974);
-Obj _35reg2976 = primCar(_35reg2975);
-Obj pkg = _35reg2976;
-Obj _35reg2977 = primCar(closureRef(co, 0));
-Obj _35reg2978 = primCdr(_35reg2977);
-Obj _35reg2979 = primCdr(_35reg2978);
-Obj _35reg2980 = primEQ(Nil, _35reg2979);
-if (True == _35reg2980) {
-Obj _35reg2981 = primCdr(closureRef(co, 0));
-Obj remain = _35reg2981;
-pushCont(co, 5, _35clofun3140, 1, remain);
+Obj _35cc165 = makeNative(3, _35clofun2017, 0, 1, closureRef(co, 0));
+Obj _35reg1815 = primIsCons(closureRef(co, 0));
+if (True == _35reg1815) {
+Obj _35reg1816 = primCar(closureRef(co, 0));
+Obj _35reg1817 = primIsCons(_35reg1816);
+if (True == _35reg1817) {
+Obj _35reg1818 = primCar(closureRef(co, 0));
+Obj _35reg1819 = primCar(_35reg1818);
+Obj _35reg1820 = primEQ(intern("import"), _35reg1819);
+if (True == _35reg1820) {
+Obj _35reg1821 = primCar(closureRef(co, 0));
+Obj _35reg1822 = primCdr(_35reg1821);
+Obj _35reg1823 = primIsCons(_35reg1822);
+if (True == _35reg1823) {
+Obj _35reg1824 = primCar(closureRef(co, 0));
+Obj _35reg1825 = primCdr(_35reg1824);
+Obj _35reg1826 = primCar(_35reg1825);
+Obj pkg = _35reg1826;
+Obj _35reg1827 = primCar(closureRef(co, 0));
+Obj _35reg1828 = primCdr(_35reg1827);
+Obj _35reg1829 = primCdr(_35reg1828);
+Obj _35reg1830 = primEQ(Nil, _35reg1829);
+if (True == _35reg1830) {
+Obj _35reg1831 = primCdr(closureRef(co, 0));
+Obj remain = _35reg1831;
+pushCont(co, 4, _35clofun2017, 1, remain);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#import"));
 __arg1 = pkg;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1312;
+__arg0 = _35cc165;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1312;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1312;
+__arg0 = _35cc165;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1312;
+__arg0 = _35cc165;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1312;
+__arg0 = _35cc165;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc165;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label6:
+{
+Obj _35cc164 = makeNative(5, _35clofun2017, 0, 1, closureRef(co, 0));
+Obj _35reg1833 = primIsCons(closureRef(co, 0));
+if (True == _35reg1833) {
+Obj _35reg1834 = primCar(closureRef(co, 0));
+Obj _35reg1835 = primEQ(intern("begin"), _35reg1834);
+if (True == _35reg1835) {
+Obj _35reg1836 = primCdr(closureRef(co, 0));
+Obj remain = _35reg1836;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
+__arg1 = remain;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc164;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc164;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35cc1311 = makeNative(6, _35clofun3140, 0, 1, closureRef(co, 0));
-Obj _35reg2983 = primIsCons(closureRef(co, 0));
-if (True == _35reg2983) {
-Obj _35reg2984 = primCar(closureRef(co, 0));
-Obj _35reg2985 = primEQ(intern("begin"), _35reg2984);
-if (True == _35reg2985) {
-Obj _35reg2986 = primCdr(closureRef(co, 0));
-Obj remain = _35reg2986;
+Obj _35p162 = __arg1;
+Obj _35cc163 = makeNative(6, _35clofun2017, 0, 1, _35p162);
+Obj _35reg1837 = primIsCons(_35p162);
+if (True == _35reg1837) {
+Obj _35reg1838 = primCar(_35p162);
+Obj _35reg1839 = primEQ(intern("define-library"), _35reg1838);
+if (True == _35reg1839) {
+Obj _35reg1840 = primCdr(_35p162);
+Obj _35reg1841 = primIsCons(_35reg1840);
+if (True == _35reg1841) {
+Obj _35reg1842 = primCdr(_35p162);
+Obj _35reg1843 = primCar(_35reg1842);
+Obj __ = _35reg1843;
+Obj _35reg1844 = primCdr(_35p162);
+Obj _35reg1845 = primCdr(_35reg1844);
+Obj remain = _35reg1845;
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
 __arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1311;
+__arg0 = _35cc163;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1311;
+__arg0 = _35cc163;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc163;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
-{
-Obj _35p1309 = __arg1;
-Obj _35cc1310 = makeNative(7, _35clofun3140, 0, 1, _35p1309);
-Obj _35reg2987 = primIsCons(_35p1309);
-if (True == _35reg2987) {
-Obj _35reg2988 = primCar(_35p1309);
-Obj _35reg2989 = primEQ(intern("define-library"), _35reg2988);
-if (True == _35reg2989) {
-Obj _35reg2990 = primCdr(_35p1309);
-Obj _35reg2991 = primIsCons(_35reg2990);
-if (True == _35reg2991) {
-Obj _35reg2992 = primCdr(_35p1309);
-Obj _35reg2993 = primCar(_35reg2992);
-Obj __ = _35reg2993;
-Obj _35reg2994 = primCdr(_35p1309);
-Obj _35reg2995 = primCdr(_35reg2994);
-Obj remain = _35reg2995;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
-__arg1 = remain;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1310;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1310;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1310;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label9:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -1243,287 +1408,287 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label10:
+label9:
 {
-Obj _35cc1321 = makeNative(9, _35clofun3140, 0, 0);
-Obj _35reg2997 = primIsCons(closureRef(co, 0));
-if (True == _35reg2997) {
-Obj _35reg2998 = primCar(closureRef(co, 0));
-Obj exp = _35reg2998;
-Obj _35reg2999 = primCdr(closureRef(co, 0));
-Obj more = _35reg2999;
+Obj _35cc174 = makeNative(8, _35clofun2017, 0, 0);
+Obj _35reg1847 = primIsCons(closureRef(co, 0));
+if (True == _35reg1847) {
+Obj _35reg1848 = primCar(closureRef(co, 0));
+Obj exp = _35reg1848;
+Obj _35reg1849 = primCdr(closureRef(co, 0));
+Obj more = _35reg1849;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj _35reg3000 = primCons(exp, Nil);
-Obj _35reg3001 = primCons(intern("backquote"), _35reg3000);
-Obj _35reg3002 = primCons(_35reg3001, Nil);
-Obj _35reg3003 = primCons(intern("macroexpand"), _35reg3002);
-Obj _35reg3004 = primCons(intern("tvar"), Nil);
-Obj _35reg3005 = primCons(Nil, Nil);
-Obj _35reg3006 = primCons(Nil, _35reg3005);
-Obj _35reg3007 = primCons(_35reg3004, _35reg3006);
-Obj _35reg3008 = primCons(_35reg3003, _35reg3007);
-Obj _35reg3009 = primCons(intern("cora/lib/infer#check-type"), _35reg3008);
-Obj _35reg3010 = primCons(_35reg3009, type);
-Obj _35reg3011 = primCons(exp, code);
+Obj _35reg1850 = primCons(exp, Nil);
+Obj _35reg1851 = primCons(intern("backquote"), _35reg1850);
+Obj _35reg1852 = primCons(_35reg1851, Nil);
+Obj _35reg1853 = primCons(intern("macroexpand"), _35reg1852);
+Obj _35reg1854 = primCons(intern("tvar"), Nil);
+Obj _35reg1855 = primCons(Nil, Nil);
+Obj _35reg1856 = primCons(Nil, _35reg1855);
+Obj _35reg1857 = primCons(_35reg1854, _35reg1856);
+Obj _35reg1858 = primCons(_35reg1853, _35reg1857);
+Obj _35reg1859 = primCons(intern("cora/lib/infer#check-type"), _35reg1858);
+Obj _35reg1860 = primCons(_35reg1859, type);
+Obj _35reg1861 = primCons(exp, code);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
 __arg1 = more;
-__arg2 = _35reg3010;
-__arg3 = _35reg3011;
+__arg2 = _35reg1860;
+__arg3 = _35reg1861;
 co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1321;
+__arg0 = _35cc174;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label10:
+{
+Obj _35cc173 = makeNative(9, _35clofun2017, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35reg1862 = primIsCons(closureRef(co, 0));
+if (True == _35reg1862) {
+Obj _35reg1863 = primCar(closureRef(co, 0));
+Obj _35reg1864 = primIsCons(_35reg1863);
+if (True == _35reg1864) {
+Obj _35reg1865 = primCar(closureRef(co, 0));
+Obj _35reg1866 = primCar(_35reg1865);
+Obj _35reg1867 = primEQ(intern(":declare"), _35reg1866);
+if (True == _35reg1867) {
+Obj _35reg1868 = primCar(closureRef(co, 0));
+Obj _35reg1869 = primCdr(_35reg1868);
+Obj exp = _35reg1869;
+Obj _35reg1870 = primCdr(closureRef(co, 0));
+Obj more = _35reg1870;
+Obj type = closureRef(co, 1);
+Obj code = closureRef(co, 2);
+Obj k = closureRef(co, 3);
+Obj _35reg1871 = primCons(intern("declare"), exp);
+Obj _35reg1872 = primCons(_35reg1871, type);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
+__arg1 = more;
+__arg2 = _35reg1872;
+__arg3 = code;
+co->args[4] = k;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc173;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc173;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc173;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35cc1320 = makeNative(10, _35clofun3140, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg3012 = primIsCons(closureRef(co, 0));
-if (True == _35reg3012) {
-Obj _35reg3013 = primCar(closureRef(co, 0));
-Obj _35reg3014 = primIsCons(_35reg3013);
-if (True == _35reg3014) {
-Obj _35reg3015 = primCar(closureRef(co, 0));
-Obj _35reg3016 = primCar(_35reg3015);
-Obj _35reg3017 = primEQ(intern(":declare"), _35reg3016);
-if (True == _35reg3017) {
-Obj _35reg3018 = primCar(closureRef(co, 0));
-Obj _35reg3019 = primCdr(_35reg3018);
-Obj exp = _35reg3019;
-Obj _35reg3020 = primCdr(closureRef(co, 0));
-Obj more = _35reg3020;
+Obj _35cc172 = makeNative(10, _35clofun2017, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35reg1873 = primIsCons(closureRef(co, 0));
+if (True == _35reg1873) {
+Obj _35reg1874 = primCar(closureRef(co, 0));
+Obj _35reg1875 = primIsCons(_35reg1874);
+if (True == _35reg1875) {
+Obj _35reg1876 = primCar(closureRef(co, 0));
+Obj _35reg1877 = primCar(_35reg1876);
+Obj _35reg1878 = primEQ(intern(":type"), _35reg1877);
+if (True == _35reg1878) {
+Obj _35reg1879 = primCar(closureRef(co, 0));
+Obj _35reg1880 = primCdr(_35reg1879);
+Obj exp = _35reg1880;
+Obj _35reg1881 = primCdr(closureRef(co, 0));
+Obj more = _35reg1881;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj _35reg3021 = primCons(intern("declare"), exp);
-Obj _35reg3022 = primCons(_35reg3021, type);
+Obj _35reg1882 = primCons(intern("begin"), exp);
+Obj _35reg1883 = primCons(_35reg1882, type);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
 __arg1 = more;
-__arg2 = _35reg3022;
+__arg2 = _35reg1883;
 __arg3 = code;
 co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1320;
+__arg0 = _35cc172;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1320;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1320;
+__arg0 = _35cc172;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc172;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj _35cc1319 = makeNative(11, _35clofun3140, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg3023 = primIsCons(closureRef(co, 0));
-if (True == _35reg3023) {
-Obj _35reg3024 = primCar(closureRef(co, 0));
-Obj _35reg3025 = primIsCons(_35reg3024);
-if (True == _35reg3025) {
-Obj _35reg3026 = primCar(closureRef(co, 0));
-Obj _35reg3027 = primCar(_35reg3026);
-Obj _35reg3028 = primEQ(intern(":type"), _35reg3027);
-if (True == _35reg3028) {
-Obj _35reg3029 = primCar(closureRef(co, 0));
-Obj _35reg3030 = primCdr(_35reg3029);
-Obj exp = _35reg3030;
-Obj _35reg3031 = primCdr(closureRef(co, 0));
-Obj more = _35reg3031;
-Obj type = closureRef(co, 1);
-Obj code = closureRef(co, 2);
-Obj k = closureRef(co, 3);
-Obj _35reg3032 = primCons(intern("begin"), exp);
-Obj _35reg3033 = primCons(_35reg3032, type);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
-__arg1 = more;
-__arg2 = _35reg3033;
-__arg3 = code;
-co->args[4] = k;
+Obj _35val1886 = __arg1;
+Obj k= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val1885= co->ctx.stk.stack[co->ctx.stk.base + 1];
+__nargs = 3;
+__arg0 = k;
+__arg1 = _35val1885;
+__arg2 = _35val1886;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1319;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1319;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1319;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label13:
 {
-Obj _35val3036 = __arg1;
-Obj k= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val3035= co->ctx.stk.stack[co->ctx.stk.base + 1];
-__nargs = 3;
-__arg0 = k;
-__arg1 = _35val3035;
-__arg2 = _35val3036;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35val3035 = __arg1;
+Obj _35val1885 = __arg1;
 Obj code= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj k= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 13, _35clofun3140, 2, k, _35val3035);
+pushCont(co, 12, _35clofun2017, 2, k, _35val1885);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = code;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label14:
 {
-Obj _35p1314 = __arg1;
-Obj _35p1315 = __arg2;
-Obj _35p1316 = __arg3;
-Obj _35p1317 = co->args[4];
-Obj _35cc1318 = makeNative(12, _35clofun3140, 0, 4, _35p1314, _35p1315, _35p1316, _35p1317);
-Obj _35reg3034 = primEQ(Nil, _35p1314);
-if (True == _35reg3034) {
-Obj type = _35p1315;
-Obj code = _35p1316;
-Obj k = _35p1317;
-pushCont(co, 14, _35clofun3140, 2, code, k);
+Obj _35p167 = __arg1;
+Obj _35p168 = __arg2;
+Obj _35p169 = __arg3;
+Obj _35p170 = co->args[4];
+Obj _35cc171 = makeNative(11, _35clofun2017, 0, 4, _35p167, _35p168, _35p169, _35p170);
+Obj _35reg1884 = primEQ(Nil, _35p167);
+if (True == _35reg1884) {
+Obj type = _35p168;
+Obj code = _35p169;
+Obj k = _35p170;
+pushCont(co, 13, _35clofun2017, 2, code, k);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = type;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1318;
+__arg0 = _35cc171;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label16:
+label15:
 {
-Obj _35val3040 = __arg1;
+Obj _35val1890 = __arg1;
 Obj sexp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg1 = sexp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3140) { goto fail; }
+if (co->ctx.pc.func != _35clofun2017) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label17:
+label16:
 {
-Obj _35val3039 = __arg1;
-Obj sexp = _35val3039;
-pushCont(co, 16, _35clofun3140, 1, sexp);
+Obj _35val1889 = __arg1;
+Obj sexp = _35val1889;
+pushCont(co, 15, _35clofun2017, 1, sexp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label17:
 {
 Obj file_45path = __arg1;
-pushCont(co, 17, _35clofun3140, 0);
+pushCont(co, 16, _35clofun2017, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#read-file-as-sexp"));
 __arg1 = file_45path;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label18:
 {
-Obj _35val3046 = __arg1;
+Obj _35val1896 = __arg1;
 Obj stream= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io#close-output-file"));
@@ -1531,16 +1696,16 @@ __arg1 = stream;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label19:
 {
-Obj _35val3045 = __arg1;
+Obj _35val1895 = __arg1;
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stream = _35val3045;
-pushCont(co, 19, _35clofun3140, 1, stream);
+Obj stream = _35val1895;
+pushCont(co, 18, _35clofun2017, 1, stream);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#generate-c"));
 __arg1 = stream;
@@ -1548,7 +1713,23 @@ __arg2 = bc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3140) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj _35val1894 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj bc = _35val1894;
+pushCont(co, 19, _35clofun2017, 1, bc);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/io#open-output-file"));
+__arg1 = to;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1561,7 +1742,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3139(struct Cora* co){
+void _35clofun2016(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -1574,43 +1755,27 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2950 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 20, _35clofun3138, 1, to);
+Obj _35val1799 = __arg1;
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 20, _35clofun2015, 1, to);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("fail:\n");
+__arg0 = globalRef(intern("cora/lib/toc#for-each"));
+__arg1 = makeNative(13, _35clofun2015, 1, 1, to);
+__arg2 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2949 = __arg1;
+Obj _35val1798 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3139, 1, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(14, _35clofun3138, 1, 1, to);
-__arg2 = group;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj _35val2948 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun3139, 2, group, to);
+pushCont(co, 0, _35clofun2016, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1618,16 +1783,16 @@ __arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label2:
 {
-Obj _35val2947 = __arg1;
+Obj _35val1797 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun3139, 2, group, to);
+pushCont(co, 1, _35clofun2016, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1635,50 +1800,50 @@ __arg2 = makeCString("};\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val1796 = __arg1;
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 2, _35clofun2016, 2, group, to);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#generate-jumptable"));
+__arg1 = to;
+__arg2 = makeNumber(0);
+__arg3 = _35val1796;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val2946 = __arg1;
+Obj _35val1795 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 3, _35clofun3139, 2, group, to);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#generate-jumptable"));
-__arg1 = to;
-__arg2 = makeNumber(0);
-__arg3 = _35val2946;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35val2945 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun3139, 2, group, to);
+pushCont(co, 3, _35clofun2016, 2, group, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label5:
 {
-Obj _35val2944 = __arg1;
+Obj _35val1794 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun3139, 2, group, to);
+pushCont(co, 4, _35clofun2016, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1686,16 +1851,16 @@ __arg2 = makeCString("static void* jumpTable[] = {");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label6:
 {
-Obj _35val2943 = __arg1;
+Obj _35val1793 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 6, _35clofun3139, 2, group, to);
+pushCont(co, 5, _35clofun2016, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1703,16 +1868,16 @@ __arg2 = makeCString("Obj __arg3 = co->args[3];\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label7:
 {
-Obj _35val2942 = __arg1;
+Obj _35val1792 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun3139, 2, group, to);
+pushCont(co, 6, _35clofun2016, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1720,16 +1885,16 @@ __arg2 = makeCString("Obj __arg2 = co->args[2];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label9:
+label8:
 {
-Obj _35val2941 = __arg1;
+Obj _35val1791 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun3139, 2, group, to);
+pushCont(co, 7, _35clofun2016, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1737,16 +1902,16 @@ __arg2 = makeCString("Obj __arg1 = co->args[1];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label10:
+label9:
 {
-Obj _35val2940 = __arg1;
+Obj _35val1790 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun3139, 2, group, to);
+pushCont(co, 8, _35clofun2016, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1754,16 +1919,16 @@ __arg2 = makeCString("Obj __arg0 = co->args[0];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label10:
 {
-Obj _35val2939 = __arg1;
+Obj _35val1789 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun3139, 2, group, to);
+pushCont(co, 9, _35clofun2016, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1771,16 +1936,16 @@ __arg2 = makeCString("int __nargs = co->nargs;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label11:
 {
-Obj _35val2938 = __arg1;
+Obj _35val1788 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun3139, 2, group, to);
+pushCont(co, 10, _35clofun2016, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1788,45 +1953,45 @@ __arg2 = makeCString("{\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label12:
+{
+Obj _35val1787 = __arg1;
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 11, _35clofun2016, 2, group, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#code-gen-func-declare"));
+__arg1 = to;
+__arg2 = _35val1787;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val2937 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun3139, 2, group, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#code-gen-func-declare"));
-__arg1 = to;
-__arg2 = _35val2937;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
 Obj to = __arg1;
 Obj group = __arg2;
-pushCont(co, 13, _35clofun3139, 2, group, to);
+pushCont(co, 12, _35clofun2016, 2, group, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label14:
 {
-Obj _35val2961 = __arg1;
+Obj _35val1811 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = closureRef(co, 0);
@@ -1834,40 +1999,40 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label15:
+{
+Obj _35val1810 = __arg1;
+pushCont(co, 14, _35clofun2016, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#code-gen-func-declare"));
+__arg1 = closureRef(co, 0);
+__arg2 = _35val1810;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val2960 = __arg1;
-pushCont(co, 15, _35clofun3139, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#code-gen-func-declare"));
-__arg1 = closureRef(co, 0);
-__arg2 = _35val2960;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
 Obj group = __arg1;
-pushCont(co, 16, _35clofun3139, 0);
+pushCont(co, 15, _35clofun2016, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label17:
 {
 Obj group = __arg1;
 __nargs = 3;
@@ -1877,32 +2042,32 @@ __arg2 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label18:
+{
+Obj _35val1813 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#for-each"));
+__arg1 = makeNative(17, _35clofun2016, 1, 1, to);
+__arg2 = bc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val2963 = __arg1;
+Obj _35val1812 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(18, _35clofun3139, 1, 1, to);
-__arg2 = bc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val2962 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 19, _35clofun3139, 2, to, bc);
+pushCont(co, 18, _35clofun2016, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1910,7 +2075,24 @@ __arg2 = makeCString("\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3139) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj _35val1809 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 19, _35clofun2016, 2, to, bc);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#for-each"));
+__arg1 = makeNative(16, _35clofun2016, 1, 1, to);
+__arg2 = bc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1923,7 +2105,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3138(struct Cora* co){
+void _35clofun2015(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -1936,88 +2118,74 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj exp = __arg1;
-pushCont(co, 20, _35clofun3137, 1, exp);
+Obj _35val1772 = __arg1;
 __nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
+__arg0 = globalRef(intern("cora/lib/toc#collect-lambda-pass"));
+__arg1 = _35val1772;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2922 = __arg1;
+Obj _35val1771 = __arg1;
+pushCont(co, 0, _35clofun2015, 0);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#collect-lambda-pass"));
-__arg1 = _35val2922;
+__arg0 = globalRef(intern("cora/lib/toc#explicit-stack-pass"));
+__arg1 = _35val1771;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val2921 = __arg1;
-pushCont(co, 1, _35clofun3138, 0);
+Obj _35val1770 = __arg1;
+pushCont(co, 1, _35clofun2015, 0);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#explicit-stack-pass"));
-__arg1 = _35val2921;
+__arg0 = globalRef(intern("cora/lib/toc#tailify-pass"));
+__arg1 = _35val1770;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2920 = __arg1;
-pushCont(co, 2, _35clofun3138, 0);
+Obj _35val1769 = __arg1;
+pushCont(co, 2, _35clofun2015, 0);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#tailify-pass"));
-__arg1 = _35val2920;
+__arg0 = globalRef(intern("cora/lib/toc#closure-convert-pass"));
+__arg1 = _35val1769;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val2919 = __arg1;
-pushCont(co, 3, _35clofun3138, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#closure-convert-pass"));
-__arg1 = _35val2919;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
 Obj exp = __arg1;
-pushCont(co, 4, _35clofun3138, 0);
+pushCont(co, 3, _35clofun2015, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#parse-pass"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label5:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -2025,13 +2193,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label6:
 {
-Obj _35val2927 = __arg1;
+Obj _35val1777 = __arg1;
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 3;
@@ -2041,67 +2209,67 @@ __arg2 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label7:
 {
-Obj _35cc1308 = makeNative(6, _35clofun3138, 0, 0);
+Obj _35cc161 = makeNative(5, _35clofun2015, 0, 0);
 Obj fn = closureRef(co, 0);
-Obj _35reg2924 = primIsCons(closureRef(co, 1));
-if (True == _35reg2924) {
-Obj _35reg2925 = primCar(closureRef(co, 1));
-Obj x = _35reg2925;
-Obj _35reg2926 = primCdr(closureRef(co, 1));
-Obj y = _35reg2926;
-pushCont(co, 7, _35clofun3138, 2, fn, y);
+Obj _35reg1774 = primIsCons(closureRef(co, 1));
+if (True == _35reg1774) {
+Obj _35reg1775 = primCar(closureRef(co, 1));
+Obj x = _35reg1775;
+Obj _35reg1776 = primCdr(closureRef(co, 1));
+Obj y = _35reg1776;
+pushCont(co, 6, _35clofun2015, 2, fn, y);
 __nargs = 2;
 __arg0 = fn;
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1308;
+__arg0 = _35cc161;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label8:
+{
+Obj _35p158 = __arg1;
+Obj _35p159 = __arg2;
+Obj _35cc160 = makeNative(7, _35clofun2015, 0, 2, _35p158, _35p159);
+Obj fn = _35p158;
+Obj _35reg1778 = primEQ(Nil, _35p159);
+if (True == _35reg1778) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2015) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc160;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label9:
 {
-Obj _35p1305 = __arg1;
-Obj _35p1306 = __arg2;
-Obj _35cc1307 = makeNative(8, _35clofun3138, 0, 2, _35p1305, _35p1306);
-Obj fn = _35p1305;
-Obj _35reg2928 = primEQ(Nil, _35p1306);
-if (True == _35reg2928) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3138) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1307;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj _35val2931 = __arg1;
+Obj _35val1781 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj n= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -2112,36 +2280,36 @@ __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label10:
+{
+Obj _35val1784 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj n= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg1785 = primAdd(i, makeNumber(1));
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#generate-jumptable"));
+__arg1 = to;
+__arg2 = _35reg1785;
+__arg3 = n;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val2934 = __arg1;
+Obj _35val1783 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj n= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2935 = primAdd(i, makeNumber(1));
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#generate-jumptable"));
-__arg1 = to;
-__arg2 = _35reg2935;
-__arg3 = n;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35val2933 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj n= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 11, _35clofun3138, 3, i, to, n);
+pushCont(co, 10, _35clofun2015, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = to;
@@ -2149,18 +2317,18 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label12:
 {
 Obj to = __arg1;
 Obj i = __arg2;
 Obj n = __arg3;
-Obj _35reg2930 = primEQ(i, makeNumber(0));
-if (True == _35reg2930) {
-pushCont(co, 10, _35clofun3138, 2, to, n);
+Obj _35reg1780 = primEQ(i, makeNumber(0));
+if (True == _35reg1780) {
+pushCont(co, 9, _35clofun2015, 2, to, n);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2168,12 +2336,12 @@ __arg2 = makeCString("&&label0");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2932 = primLT(i, n);
-if (True == _35reg2932) {
-pushCont(co, 12, _35clofun3138, 3, i, to, n);
+Obj _35reg1782 = primLT(i, n);
+if (True == _35reg1782) {
+pushCont(co, 11, _35clofun2015, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2181,19 +2349,19 @@ __arg2 = makeCString(", &&label");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3138) { goto fail; }
+if (co->ctx.pc.func != _35clofun2015) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
 }
 
-label14:
+label13:
 {
 Obj x = __arg1;
 __nargs = 3;
@@ -2203,13 +2371,13 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label14:
 {
-Obj _35val2956 = __arg1;
+Obj _35val1806 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -2218,15 +2386,15 @@ __arg2 = makeCString("\n}\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label15:
 {
-Obj _35val2955 = __arg1;
+Obj _35val1805 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 15, _35clofun3138, 1, to);
+pushCont(co, 14, _35clofun2015, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2234,15 +2402,15 @@ __arg2 = makeCString("co->args[3] = __arg3;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label16:
 {
-Obj _35val2954 = __arg1;
+Obj _35val1804 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 16, _35clofun3138, 1, to);
+pushCont(co, 15, _35clofun2015, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2250,15 +2418,15 @@ __arg2 = makeCString("co->args[2] = __arg2;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label17:
 {
-Obj _35val2953 = __arg1;
+Obj _35val1803 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 17, _35clofun3138, 1, to);
+pushCont(co, 16, _35clofun2015, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2266,15 +2434,15 @@ __arg2 = makeCString("co->args[1] = __arg1;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label18:
 {
-Obj _35val2952 = __arg1;
+Obj _35val1802 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 18, _35clofun3138, 1, to);
+pushCont(co, 17, _35clofun2015, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2282,15 +2450,15 @@ __arg2 = makeCString("co->args[0] = __arg0;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label19:
 {
-Obj _35val2951 = __arg1;
+Obj _35val1801 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 19, _35clofun3138, 1, to);
+pushCont(co, 18, _35clofun2015, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2298,7 +2466,23 @@ __arg2 = makeCString("co->nargs = __nargs;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3138) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj _35val1800 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 19, _35clofun2015, 1, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("fail:\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2311,7 +2495,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3137(struct Cora* co){
+void _35clofun2014(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -2323,169 +2507,6 @@ static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
-{
-Obj _35p1297 = __arg1;
-Obj _35p1298 = __arg2;
-Obj _35cc1299 = makeNative(14, _35clofun3136, 0, 2, _35p1297, _35p1298);
-Obj w = _35p1297;
-Obj _35reg2815 = primIsCons(_35p1298);
-if (True == _35reg2815) {
-Obj _35reg2816 = primCar(_35p1298);
-Obj label = _35reg2816;
-Obj _35reg2817 = primCdr(_35p1298);
-Obj _35reg2818 = primIsCons(_35reg2817);
-if (True == _35reg2818) {
-Obj _35reg2819 = primCdr(_35p1298);
-Obj _35reg2820 = primCar(_35reg2819);
-Obj _35reg2821 = primIsCons(_35reg2820);
-if (True == _35reg2821) {
-Obj _35reg2822 = primCdr(_35p1298);
-Obj _35reg2823 = primCar(_35reg2822);
-Obj _35reg2824 = primCar(_35reg2823);
-Obj _35reg2825 = primEQ(intern("lambda"), _35reg2824);
-if (True == _35reg2825) {
-Obj _35reg2826 = primCdr(_35p1298);
-Obj _35reg2827 = primCar(_35reg2826);
-Obj _35reg2828 = primCdr(_35reg2827);
-Obj _35reg2829 = primIsCons(_35reg2828);
-if (True == _35reg2829) {
-Obj _35reg2830 = primCdr(_35p1298);
-Obj _35reg2831 = primCar(_35reg2830);
-Obj _35reg2832 = primCdr(_35reg2831);
-Obj _35reg2833 = primCar(_35reg2832);
-Obj params = _35reg2833;
-Obj _35reg2834 = primCdr(_35p1298);
-Obj _35reg2835 = primCar(_35reg2834);
-Obj _35reg2836 = primCdr(_35reg2835);
-Obj _35reg2837 = primCdr(_35reg2836);
-Obj _35reg2838 = primIsCons(_35reg2837);
-if (True == _35reg2838) {
-Obj _35reg2839 = primCdr(_35p1298);
-Obj _35reg2840 = primCar(_35reg2839);
-Obj _35reg2841 = primCdr(_35reg2840);
-Obj _35reg2842 = primCdr(_35reg2841);
-Obj _35reg2843 = primCar(_35reg2842);
-Obj actives = _35reg2843;
-Obj _35reg2844 = primCdr(_35p1298);
-Obj _35reg2845 = primCar(_35reg2844);
-Obj _35reg2846 = primCdr(_35reg2845);
-Obj _35reg2847 = primCdr(_35reg2846);
-Obj _35reg2848 = primCdr(_35reg2847);
-Obj _35reg2849 = primIsCons(_35reg2848);
-if (True == _35reg2849) {
-Obj _35reg2850 = primCdr(_35p1298);
-Obj _35reg2851 = primCar(_35reg2850);
-Obj _35reg2852 = primCdr(_35reg2851);
-Obj _35reg2853 = primCdr(_35reg2852);
-Obj _35reg2854 = primCdr(_35reg2853);
-Obj _35reg2855 = primCar(_35reg2854);
-Obj body = _35reg2855;
-Obj _35reg2856 = primCdr(_35p1298);
-Obj _35reg2857 = primCar(_35reg2856);
-Obj _35reg2858 = primCdr(_35reg2857);
-Obj _35reg2859 = primCdr(_35reg2858);
-Obj _35reg2860 = primCdr(_35reg2859);
-Obj _35reg2861 = primCdr(_35reg2860);
-Obj _35reg2862 = primEQ(Nil, _35reg2861);
-if (True == _35reg2862) {
-Obj _35reg2863 = primCdr(_35p1298);
-Obj _35reg2864 = primCdr(_35reg2863);
-Obj _35reg2865 = primEQ(Nil, _35reg2864);
-if (True == _35reg2865) {
-pushCont(co, 20, _35clofun3136, 5, actives, label, params, body, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("label");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1299;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1299;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1299;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1299;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1299;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1299;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1299;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1299;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1299;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label1:
 {
 Obj exp = __arg1;
 __nargs = 5;
@@ -2497,11 +2518,11 @@ co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label2:
+label1:
 {
 Obj exp = __arg1;
 __nargs = 3;
@@ -2511,11 +2532,11 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label2:
 {
 Obj exp = __arg1;
 __nargs = 3;
@@ -2525,11 +2546,11 @@ __arg2 = globalRef(intern("cora/lib/toc#id"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label4:
+label3:
 {
 Obj exp = __arg1;
 __nargs = 3;
@@ -2539,79 +2560,79 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val1736 = __arg1;
+Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj res = _35val1736;
+Obj _35reg1737 = primCons(intern("entry"), makeNumber(0));
+Obj _35reg1738 = primCons(e1, Nil);
+Obj _35reg1739 = primCons(Nil, _35reg1738);
+Obj _35reg1740 = primCons(Nil, _35reg1739);
+Obj _35reg1741 = primCons(intern("lambda"), _35reg1740);
+Obj _35reg1742 = primCons(_35reg1741, Nil);
+Obj _35reg1743 = primCons(_35reg1737, _35reg1742);
+Obj _35reg1744 = primCons(_35reg1743, Nil);
+Obj _35reg1745 = primCons(_35reg1744, res);
+__nargs = 2;
+__arg1 = _35reg1745;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2014) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label5:
 {
-Obj _35val2886 = __arg1;
-Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj res = _35val2886;
-Obj _35reg2887 = primCons(intern("entry"), makeNumber(0));
-Obj _35reg2888 = primCons(e1, Nil);
-Obj _35reg2889 = primCons(Nil, _35reg2888);
-Obj _35reg2890 = primCons(Nil, _35reg2889);
-Obj _35reg2891 = primCons(intern("lambda"), _35reg2890);
-Obj _35reg2892 = primCons(_35reg2891, Nil);
-Obj _35reg2893 = primCons(_35reg2887, _35reg2892);
-Obj _35reg2894 = primCons(_35reg2893, Nil);
-Obj _35reg2895 = primCons(_35reg2894, res);
+Obj _35val1747 = __arg1;
+Obj _35val1746= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1748 = primCons(_35val1746, _35val1747);
+Obj res = _35reg1748;
+Obj _35reg1749 = primCons(intern("entry"), makeNumber(0));
+Obj _35reg1750 = primCons(e1, Nil);
+Obj _35reg1751 = primCons(Nil, _35reg1750);
+Obj _35reg1752 = primCons(Nil, _35reg1751);
+Obj _35reg1753 = primCons(intern("lambda"), _35reg1752);
+Obj _35reg1754 = primCons(_35reg1753, Nil);
+Obj _35reg1755 = primCons(_35reg1749, _35reg1754);
+Obj _35reg1756 = primCons(_35reg1755, Nil);
+Obj _35reg1757 = primCons(_35reg1756, res);
 __nargs = 2;
-__arg1 = _35reg2895;
+__arg1 = _35reg1757;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3137) { goto fail; }
+if (co->ctx.pc.func != _35clofun2014) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label6:
 {
-Obj _35val2897 = __arg1;
-Obj _35val2896= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val1746 = __arg1;
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2898 = primCons(_35val2896, _35val2897);
-Obj res = _35reg2898;
-Obj _35reg2899 = primCons(intern("entry"), makeNumber(0));
-Obj _35reg2900 = primCons(e1, Nil);
-Obj _35reg2901 = primCons(Nil, _35reg2900);
-Obj _35reg2902 = primCons(Nil, _35reg2901);
-Obj _35reg2903 = primCons(intern("lambda"), _35reg2902);
-Obj _35reg2904 = primCons(_35reg2903, Nil);
-Obj _35reg2905 = primCons(_35reg2899, _35reg2904);
-Obj _35reg2906 = primCons(_35reg2905, Nil);
-Obj _35reg2907 = primCons(_35reg2906, res);
-__nargs = 2;
-__arg1 = _35reg2907;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3137) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+pushCont(co, 5, _35clofun2014, 2, _35val1746, e1);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#vector-ref"));
+__arg1 = v;
+__arg2 = makeNumber(2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val2896 = __arg1;
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 6, _35clofun3137, 2, _35val2896, e1);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#vector-ref"));
-__arg1 = v;
-__arg2 = makeNumber(2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35val2885 = __arg1;
+Obj _35val1735 = __arg1;
 Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val2885) {
-pushCont(co, 5, _35clofun3137, 1, e1);
+if (True == _35val1735) {
+pushCont(co, 4, _35clofun2014, 1, e1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -2619,44 +2640,44 @@ __arg2 = makeNumber(2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 7, _35clofun3137, 2, v, e1);
+pushCont(co, 6, _35clofun2014, 2, v, e1);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label9:
+label8:
 {
-Obj _35val2884 = __arg1;
+Obj _35val1734 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cur = _35val2884;
-pushCont(co, 8, _35clofun3137, 3, cur, v, e1);
+Obj cur = _35val1734;
+pushCont(co, 7, _35clofun2014, 3, cur, v, e1);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label10:
+label9:
 {
-Obj _35val2883 = __arg1;
+Obj _35val1733 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj e1 = _35val2883;
-pushCont(co, 9, _35clofun3137, 2, v, e1);
+Obj e1 = _35val1733;
+pushCont(co, 8, _35clofun2014, 2, v, e1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -2664,16 +2685,16 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label10:
 {
-Obj _35val2882 = __arg1;
+Obj _35val1732 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun3137, 1, v);
+pushCont(co, 9, _35clofun2014, 1, v);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
 __arg1 = v;
@@ -2681,16 +2702,16 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label11:
 {
-Obj _35val2881 = __arg1;
+Obj _35val1731 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun3137, 2, exp, v);
+pushCont(co, 10, _35clofun2014, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -2699,16 +2720,16 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label12:
 {
-Obj _35val2880 = __arg1;
+Obj _35val1730 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun3137, 2, exp, v);
+pushCont(co, 11, _35clofun2014, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -2717,16 +2738,16 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label13:
 {
-Obj _35val2879 = __arg1;
+Obj _35val1729 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v = _35val2879;
-pushCont(co, 13, _35clofun3137, 2, exp, v);
+Obj v = _35val1729;
+pushCont(co, 12, _35clofun2014, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -2735,25 +2756,25 @@ __arg3 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label14:
 {
 Obj exp = __arg1;
-pushCont(co, 14, _35clofun3137, 1, exp);
+pushCont(co, 13, _35clofun2014, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#vector"));
 __arg1 = makeNumber(3);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label15:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -2761,71 +2782,71 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label16:
 {
-Obj _35cc1304 = makeNative(16, _35clofun3137, 0, 0);
+Obj _35cc157 = makeNative(15, _35clofun2014, 0, 0);
 Obj obj = closureRef(co, 0);
-Obj _35reg2909 = primIsCons(closureRef(co, 1));
-if (True == _35reg2909) {
-Obj _35reg2910 = primCar(closureRef(co, 1));
-Obj hd = _35reg2910;
-Obj _35reg2911 = primCdr(closureRef(co, 1));
-Obj more = _35reg2911;
-Obj _35reg2912 = primCons(obj, Nil);
-Obj _35reg2913 = primCons(hd, _35reg2912);
+Obj _35reg1759 = primIsCons(closureRef(co, 1));
+if (True == _35reg1759) {
+Obj _35reg1760 = primCar(closureRef(co, 1));
+Obj hd = _35reg1760;
+Obj _35reg1761 = primCdr(closureRef(co, 1));
+Obj more = _35reg1761;
+Obj _35reg1762 = primCons(obj, Nil);
+Obj _35reg1763 = primCons(hd, _35reg1762);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#rewrite-->macro"));
-__arg1 = _35reg2913;
+__arg1 = _35reg1763;
 __arg2 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1304;
+__arg0 = _35cc157;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label17:
+{
+Obj _35p154 = __arg1;
+Obj _35p155 = __arg2;
+Obj _35cc156 = makeNative(16, _35clofun2014, 0, 2, _35p154, _35p155);
+Obj obj = _35p154;
+Obj _35reg1764 = primEQ(Nil, _35p155);
+if (True == _35reg1764) {
+__nargs = 2;
+__arg1 = obj;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2014) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc156;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label18:
 {
-Obj _35p1301 = __arg1;
-Obj _35p1302 = __arg2;
-Obj _35cc1303 = makeNative(17, _35clofun3137, 0, 2, _35p1301, _35p1302);
-Obj obj = _35p1301;
-Obj _35reg2914 = primEQ(Nil, _35p1302);
-if (True == _35reg2914) {
-__nargs = 2;
-__arg1 = obj;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3137) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1303;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label19:
-{
-Obj _35val2917 = __arg1;
+Obj _35val1767 = __arg1;
 Obj obj= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fns = _35val2917;
+Obj fns = _35val1767;
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#rewrite-->macro"));
 __arg1 = obj;
@@ -2833,23 +2854,37 @@ __arg2 = fns;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label19:
 {
-Obj _35val2916 = __arg1;
+Obj _35val1766 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj obj = _35val2916;
-pushCont(co, 19, _35clofun3137, 1, obj);
+Obj obj = _35val1766;
+pushCont(co, 18, _35clofun2014, 1, obj);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3137) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj exp = __arg1;
+pushCont(co, 19, _35clofun2014, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2862,7 +2897,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3136(struct Cora* co){
+void _35clofun2013(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -2875,30 +2910,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2793 = __arg1;
-Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 20, _35clofun3135, 2, i, w);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = intern("ignore");
-__arg2 = Nil;
-__arg3 = w;
-co->args[4] = var;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
 Obj w = __arg1;
 Obj i = __arg2;
 Obj var = __arg3;
-pushCont(co, 0, _35clofun3136, 3, var, i, w);
+pushCont(co, 20, _35clofun2012, 3, var, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -2906,13 +2921,13 @@ __arg2 = makeCString("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label2:
+label1:
 {
-Obj _35val2804 = __arg1;
+Obj _35val1654 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -2921,16 +2936,16 @@ __arg2 = makeCString("];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label2:
 {
-Obj _35val2803 = __arg1;
+Obj _35val1653 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun3136, 1, w);
+pushCont(co, 1, _35clofun2013, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -2938,16 +2953,16 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label4:
+label3:
 {
-Obj _35val2802 = __arg1;
+Obj _35val1652 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 3, _35clofun3136, 2, i, w);
+pushCont(co, 2, _35clofun2013, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -2955,17 +2970,17 @@ __arg2 = makeCString("= co->ctx.stk.stack[co->ctx.stk.base + ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label5:
+label4:
 {
-Obj _35val2801 = __arg1;
+Obj _35val1651 = __arg1;
 Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 4, _35clofun3136, 2, i, w);
+pushCont(co, 3, _35clofun2013, 2, i, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = intern("ignore");
@@ -2975,16 +2990,16 @@ co->args[4] = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label5:
 {
 Obj w = __arg1;
 Obj i = __arg2;
 Obj var = __arg3;
-pushCont(co, 5, _35clofun3136, 3, var, i, w);
+pushCont(co, 4, _35clofun2013, 3, var, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -2992,11 +3007,11 @@ __arg2 = makeCString("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label6:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -3004,44 +3019,44 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label7:
+{
+Obj _35val1659 = __arg1;
+Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg1660 = primAdd(idx, makeNumber(1));
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
+__arg1 = fn;
+__arg2 = w;
+__arg3 = _35reg1660;
+co->args[4] = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val2809 = __arg1;
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2810 = primAdd(idx, makeNumber(1));
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
-__arg1 = fn;
-__arg2 = w;
-__arg3 = _35reg2810;
-co->args[4] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35cc1296 = makeNative(7, _35clofun3136, 0, 0);
+Obj _35cc149 = makeNative(6, _35clofun2013, 0, 0);
 Obj fn = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj idx = closureRef(co, 2);
-Obj _35reg2806 = primIsCons(closureRef(co, 3));
-if (True == _35reg2806) {
-Obj _35reg2807 = primCar(closureRef(co, 3));
-Obj a = _35reg2807;
-Obj _35reg2808 = primCdr(closureRef(co, 3));
-Obj b = _35reg2808;
-pushCont(co, 8, _35clofun3136, 4, idx, fn, w, b);
+Obj _35reg1656 = primIsCons(closureRef(co, 3));
+if (True == _35reg1656) {
+Obj _35reg1657 = primCar(closureRef(co, 3));
+Obj a = _35reg1657;
+Obj _35reg1658 = primCdr(closureRef(co, 3));
+Obj b = _35reg1658;
+pushCont(co, 7, _35clofun2013, 4, idx, fn, w, b);
 __nargs = 4;
 __arg0 = fn;
 __arg1 = w;
@@ -3050,48 +3065,48 @@ __arg3 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1296;
+__arg0 = _35cc149;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label9:
+{
+Obj _35p144 = __arg1;
+Obj _35p145 = __arg2;
+Obj _35p146 = __arg3;
+Obj _35p147 = co->args[4];
+Obj _35cc148 = makeNative(8, _35clofun2013, 0, 4, _35p144, _35p145, _35p146, _35p147);
+Obj fn = _35p144;
+Obj w = _35p145;
+Obj idx = _35p146;
+Obj _35reg1661 = primEQ(Nil, _35p147);
+if (True == _35reg1661) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2013) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc148;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
-{
-Obj _35p1291 = __arg1;
-Obj _35p1292 = __arg2;
-Obj _35p1293 = __arg3;
-Obj _35p1294 = co->args[4];
-Obj _35cc1295 = makeNative(9, _35clofun3136, 0, 4, _35p1291, _35p1292, _35p1293, _35p1294);
-Obj fn = _35p1291;
-Obj w = _35p1292;
-Obj idx = _35p1293;
-Obj _35reg2811 = primEQ(Nil, _35p1294);
-if (True == _35reg2811) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3136) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1295;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label11:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -3099,57 +3114,57 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label11:
 {
-Obj _35val2814 = __arg1;
+Obj _35val1664 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io#display"));
 __arg1 = makeCString("\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label12:
 {
-Obj _35val2813 = __arg1;
+Obj _35val1663 = __arg1;
 Obj other= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 12, _35clofun3136, 0);
+pushCont(co, 11, _35clofun2013, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io#display"));
 __arg1 = other;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label13:
 {
-Obj _35cc1300 = makeNative(11, _35clofun3136, 0, 0);
+Obj _35cc153 = makeNative(10, _35clofun2013, 0, 0);
 Obj w = closureRef(co, 0);
 Obj other = closureRef(co, 1);
-pushCont(co, 13, _35clofun3136, 1, other);
+pushCont(co, 12, _35clofun2013, 1, other);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io#display"));
 __arg1 = makeCString("wrong format of toplevel\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label14:
 {
-Obj _35val2873 = __arg1;
+Obj _35val1723 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -3158,41 +3173,41 @@ __arg2 = makeCString("}\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label15:
 {
-Obj _35val2871 = __arg1;
+Obj _35val1721 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2872 = primCar(label);
-pushCont(co, 15, _35clofun3136, 1, w);
+Obj _35reg1722 = primCar(label);
+pushCont(co, 14, _35clofun2013, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = _35reg2872;
+__arg1 = _35reg1722;
 __arg2 = params;
 __arg3 = w;
 co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label16:
 {
-Obj _35val2870 = __arg1;
+Obj _35val1720 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 16, _35clofun3136, 4, label, params, body, w);
+pushCont(co, 15, _35clofun2013, 4, label, params, body, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
 __arg1 = globalRef(intern("cora/lib/toc#local-from-cont"));
@@ -3202,19 +3217,19 @@ co->args[4] = actives;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label17:
 {
-Obj _35val2869 = __arg1;
+Obj _35val1719 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 17, _35clofun3136, 5, actives, label, params, body, w);
+pushCont(co, 16, _35clofun2013, 5, actives, label, params, body, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
 __arg1 = globalRef(intern("cora/lib/toc#local-from-params"));
@@ -3224,19 +3239,19 @@ co->args[4] = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label18:
 {
-Obj _35val2868 = __arg1;
+Obj _35val1718 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 18, _35clofun3136, 5, actives, label, params, body, w);
+pushCont(co, 17, _35clofun2013, 5, actives, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3244,29 +3259,192 @@ __arg2 = makeCString(":\n{\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label19:
 {
-Obj _35val2866 = __arg1;
+Obj _35val1716 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2867 = primCdr(label);
-pushCont(co, 19, _35clofun3136, 5, actives, label, params, body, w);
+Obj _35reg1717 = primCdr(label);
+pushCont(co, 18, _35clofun2013, 5, actives, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = _35reg2867;
+__arg2 = _35reg1717;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3136) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj _35p150 = __arg1;
+Obj _35p151 = __arg2;
+Obj _35cc152 = makeNative(13, _35clofun2013, 0, 2, _35p150, _35p151);
+Obj w = _35p150;
+Obj _35reg1665 = primIsCons(_35p151);
+if (True == _35reg1665) {
+Obj _35reg1666 = primCar(_35p151);
+Obj label = _35reg1666;
+Obj _35reg1667 = primCdr(_35p151);
+Obj _35reg1668 = primIsCons(_35reg1667);
+if (True == _35reg1668) {
+Obj _35reg1669 = primCdr(_35p151);
+Obj _35reg1670 = primCar(_35reg1669);
+Obj _35reg1671 = primIsCons(_35reg1670);
+if (True == _35reg1671) {
+Obj _35reg1672 = primCdr(_35p151);
+Obj _35reg1673 = primCar(_35reg1672);
+Obj _35reg1674 = primCar(_35reg1673);
+Obj _35reg1675 = primEQ(intern("lambda"), _35reg1674);
+if (True == _35reg1675) {
+Obj _35reg1676 = primCdr(_35p151);
+Obj _35reg1677 = primCar(_35reg1676);
+Obj _35reg1678 = primCdr(_35reg1677);
+Obj _35reg1679 = primIsCons(_35reg1678);
+if (True == _35reg1679) {
+Obj _35reg1680 = primCdr(_35p151);
+Obj _35reg1681 = primCar(_35reg1680);
+Obj _35reg1682 = primCdr(_35reg1681);
+Obj _35reg1683 = primCar(_35reg1682);
+Obj params = _35reg1683;
+Obj _35reg1684 = primCdr(_35p151);
+Obj _35reg1685 = primCar(_35reg1684);
+Obj _35reg1686 = primCdr(_35reg1685);
+Obj _35reg1687 = primCdr(_35reg1686);
+Obj _35reg1688 = primIsCons(_35reg1687);
+if (True == _35reg1688) {
+Obj _35reg1689 = primCdr(_35p151);
+Obj _35reg1690 = primCar(_35reg1689);
+Obj _35reg1691 = primCdr(_35reg1690);
+Obj _35reg1692 = primCdr(_35reg1691);
+Obj _35reg1693 = primCar(_35reg1692);
+Obj actives = _35reg1693;
+Obj _35reg1694 = primCdr(_35p151);
+Obj _35reg1695 = primCar(_35reg1694);
+Obj _35reg1696 = primCdr(_35reg1695);
+Obj _35reg1697 = primCdr(_35reg1696);
+Obj _35reg1698 = primCdr(_35reg1697);
+Obj _35reg1699 = primIsCons(_35reg1698);
+if (True == _35reg1699) {
+Obj _35reg1700 = primCdr(_35p151);
+Obj _35reg1701 = primCar(_35reg1700);
+Obj _35reg1702 = primCdr(_35reg1701);
+Obj _35reg1703 = primCdr(_35reg1702);
+Obj _35reg1704 = primCdr(_35reg1703);
+Obj _35reg1705 = primCar(_35reg1704);
+Obj body = _35reg1705;
+Obj _35reg1706 = primCdr(_35p151);
+Obj _35reg1707 = primCar(_35reg1706);
+Obj _35reg1708 = primCdr(_35reg1707);
+Obj _35reg1709 = primCdr(_35reg1708);
+Obj _35reg1710 = primCdr(_35reg1709);
+Obj _35reg1711 = primCdr(_35reg1710);
+Obj _35reg1712 = primEQ(Nil, _35reg1711);
+if (True == _35reg1712) {
+Obj _35reg1713 = primCdr(_35p151);
+Obj _35reg1714 = primCdr(_35reg1713);
+Obj _35reg1715 = primEQ(Nil, _35reg1714);
+if (True == _35reg1715) {
+pushCont(co, 19, _35clofun2013, 5, actives, label, params, body, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("label");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc152;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc152;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc152;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc152;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc152;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc152;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc152;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc152;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc152;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 fail:
@@ -3278,7 +3456,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3135(struct Cora* co){
+void _35clofun2012(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -3291,50 +3469,32 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2769 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 20, _35clofun3134, 3, self, stacks, w);
+Obj _35val1617 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg1618 = primCar(label);
+pushCont(co, 20, _35clofun2011, 3, self, stacks, w);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
-__arg2 = makeCString(", ");
+__arg2 = _35reg1618;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2767 = __arg1;
+Obj _35val1616 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2768 = primCar(label);
-pushCont(co, 0, _35clofun3135, 3, self, stacks, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
-__arg1 = w;
-__arg2 = _35reg2768;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj _35val2766 = __arg1;
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 1, _35clofun3135, 4, label, self, stacks, w);
+pushCont(co, 0, _35clofun2012, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3342,53 +3502,53 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val1614 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg1615 = primCdr(label);
+pushCont(co, 1, _35clofun2012, 4, label, self, stacks, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = _35reg1615;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2764 = __arg1;
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2765 = primCdr(label);
-pushCont(co, 2, _35clofun3135, 4, label, self, stacks, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = _35reg2765;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj _35p1280 = __arg1;
-Obj _35p1281 = __arg2;
-Obj _35p1282 = __arg3;
-Obj _35cc1283 = makeNative(13, _35clofun3134, 0, 0);
-Obj self = _35p1280;
-Obj w = _35p1281;
-Obj _35reg2755 = primIsCons(_35p1282);
-if (True == _35reg2755) {
-Obj _35reg2756 = primCar(_35p1282);
-Obj _35reg2757 = primEQ(intern("%continuation"), _35reg2756);
-if (True == _35reg2757) {
-Obj _35reg2758 = primCdr(_35p1282);
-Obj _35reg2759 = primIsCons(_35reg2758);
-if (True == _35reg2759) {
-Obj _35reg2760 = primCdr(_35p1282);
-Obj _35reg2761 = primCar(_35reg2760);
-Obj label = _35reg2761;
-Obj _35reg2762 = primCdr(_35p1282);
-Obj _35reg2763 = primCdr(_35reg2762);
-Obj stacks = _35reg2763;
-pushCont(co, 3, _35clofun3135, 4, label, self, stacks, w);
+Obj _35p133 = __arg1;
+Obj _35p134 = __arg2;
+Obj _35p135 = __arg3;
+Obj _35cc136 = makeNative(12, _35clofun2011, 0, 0);
+Obj self = _35p133;
+Obj w = _35p134;
+Obj _35reg1605 = primIsCons(_35p135);
+if (True == _35reg1605) {
+Obj _35reg1606 = primCar(_35p135);
+Obj _35reg1607 = primEQ(intern("%continuation"), _35reg1606);
+if (True == _35reg1607) {
+Obj _35reg1608 = primCdr(_35p135);
+Obj _35reg1609 = primIsCons(_35reg1608);
+if (True == _35reg1609) {
+Obj _35reg1610 = primCdr(_35p135);
+Obj _35reg1611 = primCar(_35reg1610);
+Obj label = _35reg1611;
+Obj _35reg1612 = primCdr(_35p135);
+Obj _35reg1613 = primCdr(_35reg1612);
+Obj stacks = _35reg1613;
+pushCont(co, 2, _35clofun2012, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3396,38 +3556,38 @@ __arg2 = makeCString("pushCont(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1283;
+__arg0 = _35cc136;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1283;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1283;
+__arg0 = _35cc136;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc136;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label5:
+label4:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -3435,13 +3595,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label5:
 {
-Obj _35val2784 = __arg1;
+Obj _35val1634 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -3457,21 +3617,21 @@ co->args[5] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label6:
 {
-Obj _35val2782 = __arg1;
+Obj _35val1632 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2783 = primNot(_35val2782);
-if (True == _35reg2783) {
-pushCont(co, 6, _35clofun3135, 5, self, env, fn, w, b);
+Obj _35reg1633 = primNot(_35val1632);
+if (True == _35reg1633) {
+pushCont(co, 5, _35clofun2012, 5, self, env, fn, w, b);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3479,7 +3639,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
@@ -3493,44 +3653,44 @@ co->args[5] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label8:
+label7:
 {
-Obj _35val2781 = __arg1;
+Obj _35val1631 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 7, _35clofun3135, 5, self, env, fn, w, b);
+pushCont(co, 6, _35clofun2012, 5, self, env, fn, w, b);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label9:
+label8:
 {
-Obj _35cc1290 = makeNative(5, _35clofun3135, 0, 0);
+Obj _35cc143 = makeNative(4, _35clofun2012, 0, 0);
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj fn = closureRef(co, 2);
 Obj w = closureRef(co, 3);
-Obj _35reg2778 = primIsCons(closureRef(co, 4));
-if (True == _35reg2778) {
-Obj _35reg2779 = primCar(closureRef(co, 4));
-Obj a = _35reg2779;
-Obj _35reg2780 = primCdr(closureRef(co, 4));
-Obj b = _35reg2780;
-pushCont(co, 8, _35clofun3135, 5, self, env, fn, w, b);
+Obj _35reg1628 = primIsCons(closureRef(co, 4));
+if (True == _35reg1628) {
+Obj _35reg1629 = primCar(closureRef(co, 4));
+Obj a = _35reg1629;
+Obj _35reg1630 = primCdr(closureRef(co, 4));
+Obj b = _35reg1630;
+pushCont(co, 7, _35clofun2012, 5, self, env, fn, w, b);
 __nargs = 5;
 __arg0 = fn;
 __arg1 = self;
@@ -3540,50 +3700,50 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1290;
+__arg0 = _35cc143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label9:
+{
+Obj _35p137 = __arg1;
+Obj _35p138 = __arg2;
+Obj _35p139 = __arg3;
+Obj _35p140 = co->args[4];
+Obj _35p141 = co->args[5];
+Obj _35cc142 = makeNative(8, _35clofun2012, 0, 5, _35p137, _35p138, _35p139, _35p140, _35p141);
+Obj self = _35p137;
+Obj env = _35p138;
+Obj fn = _35p139;
+Obj w = _35p140;
+Obj _35reg1635 = primEQ(Nil, _35p141);
+if (True == _35reg1635) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2012) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc142;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
-{
-Obj _35p1284 = __arg1;
-Obj _35p1285 = __arg2;
-Obj _35p1286 = __arg3;
-Obj _35p1287 = co->args[4];
-Obj _35p1288 = co->args[5];
-Obj _35cc1289 = makeNative(9, _35clofun3135, 0, 5, _35p1284, _35p1285, _35p1286, _35p1287, _35p1288);
-Obj self = _35p1284;
-Obj env = _35p1285;
-Obj fn = _35p1286;
-Obj w = _35p1287;
-Obj _35reg2785 = primEQ(Nil, _35p1288);
-if (True == _35reg2785) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3135) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1289;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label11:
 {
 Obj self = __arg1;
 Obj env = __arg2;
@@ -3599,13 +3759,13 @@ co->args[5] = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label11:
 {
-Obj _35val2791 = __arg1;
+Obj _35val1641 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -3614,15 +3774,15 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label12:
 {
-Obj _35val2790 = __arg1;
+Obj _35val1640 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 12, _35clofun3135, 1, w);
+pushCont(co, 11, _35clofun2012, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3630,33 +3790,33 @@ __arg2 = makeCString("(struct Cora* co");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label13:
+{
+Obj _35val1638 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1639 = primCar(label);
+pushCont(co, 12, _35clofun2012, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
+__arg1 = w;
+__arg2 = _35reg1639;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2788 = __arg1;
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2789 = primCar(label);
-pushCont(co, 13, _35clofun3135, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
-__arg1 = w;
-__arg2 = _35reg2789;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
 Obj w = __arg1;
 Obj label = __arg2;
-pushCont(co, 14, _35clofun3135, 2, label, w);
+pushCont(co, 13, _35clofun2012, 2, label, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3664,13 +3824,13 @@ __arg2 = makeCString("void ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label15:
 {
-Obj _35val2797 = __arg1;
+Obj _35val1647 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -3679,16 +3839,16 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label16:
 {
-Obj _35val2796 = __arg1;
+Obj _35val1646 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 16, _35clofun3135, 1, w);
+pushCont(co, 15, _35clofun2012, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -3696,13 +3856,13 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label17:
 {
-Obj _35val2799 = __arg1;
+Obj _35val1649 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -3711,16 +3871,16 @@ __arg2 = makeCString("];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label18:
 {
-Obj _35val2798 = __arg1;
+Obj _35val1648 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 18, _35clofun3135, 1, w);
+pushCont(co, 17, _35clofun2012, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -3728,18 +3888,18 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label19:
 {
-Obj _35val2794 = __arg1;
+Obj _35val1644 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2795 = primLT(i, makeNumber(4));
-if (True == _35reg2795) {
-pushCont(co, 17, _35clofun3135, 2, i, w);
+Obj _35reg1645 = primLT(i, makeNumber(4));
+if (True == _35reg1645) {
+pushCont(co, 16, _35clofun2012, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3747,10 +3907,10 @@ __arg2 = makeCString(" = __arg");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 19, _35clofun3135, 2, i, w);
+pushCont(co, 18, _35clofun2012, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3758,9 +3918,29 @@ __arg2 = makeCString(" = co->args[");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+
+label20:
+{
+Obj _35val1643 = __arg1;
+Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 19, _35clofun2012, 2, i, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = intern("ignore");
+__arg2 = Nil;
+__arg3 = w;
+co->args[4] = var;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 fail:
@@ -3772,7 +3952,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3134(struct Cora* co){
+void _35clofun2011(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -3785,109 +3965,28 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2706 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2706) {
-pushCont(co, 17, _35clofun3133, 2, x, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("makeNumber(");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2709 = primIsString(x);
-if (True == _35reg2709) {
-pushCont(co, 20, _35clofun3133, 2, x, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("makeCString(\"");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2713 = primEQ(x, Nil);
-if (True == _35reg2713) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("Nil");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2714 = primEQ(x, True);
-if (True == _35reg2714) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("True");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2715 = primEQ(x, False);
-if (True == _35reg2715) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("False");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-}
-}
-}
-
-label1:
-{
-Obj _35cc1270 = makeNative(12, _35clofun3133, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc123 = makeNative(11, _35clofun2010, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2692 = primIsCons(closureRef(co, 3));
-if (True == _35reg2692) {
-Obj _35reg2693 = primCar(closureRef(co, 3));
-Obj _35reg2694 = primEQ(intern("%const"), _35reg2693);
-if (True == _35reg2694) {
-Obj _35reg2695 = primCdr(closureRef(co, 3));
-Obj _35reg2696 = primIsCons(_35reg2695);
-if (True == _35reg2696) {
-Obj _35reg2697 = primCdr(closureRef(co, 3));
-Obj _35reg2698 = primCar(_35reg2697);
-Obj x = _35reg2698;
-Obj _35reg2699 = primCdr(closureRef(co, 3));
-Obj _35reg2700 = primCdr(_35reg2699);
-Obj _35reg2701 = primEQ(Nil, _35reg2700);
-if (True == _35reg2701) {
-Obj _35reg2702 = primIsSymbol(x);
-if (True == _35reg2702) {
-pushCont(co, 15, _35clofun3133, 2, x, w);
+Obj _35reg1542 = primIsCons(closureRef(co, 3));
+if (True == _35reg1542) {
+Obj _35reg1543 = primCar(closureRef(co, 3));
+Obj _35reg1544 = primEQ(intern("%const"), _35reg1543);
+if (True == _35reg1544) {
+Obj _35reg1545 = primCdr(closureRef(co, 3));
+Obj _35reg1546 = primIsCons(_35reg1545);
+if (True == _35reg1546) {
+Obj _35reg1547 = primCdr(closureRef(co, 3));
+Obj _35reg1548 = primCar(_35reg1547);
+Obj x = _35reg1548;
+Obj _35reg1549 = primCdr(closureRef(co, 3));
+Obj _35reg1550 = primCdr(_35reg1549);
+Obj _35reg1551 = primEQ(Nil, _35reg1550);
+if (True == _35reg1551) {
+Obj _35reg1552 = primIsSymbol(x);
+if (True == _35reg1552) {
+pushCont(co, 14, _35clofun2010, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3895,60 +3994,60 @@ __arg2 = makeCString("intern(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 0, _35clofun3134, 2, x, w);
+pushCont(co, 20, _35clofun2010, 2, x, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#number?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1270;
+__arg0 = _35cc123;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1270;
+__arg0 = _35cc123;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1270;
+__arg0 = _35cc123;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1270;
+__arg0 = _35cc123;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label2:
+label1:
 {
-Obj _35val2727 = __arg1;
+Obj _35val1577 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -3957,16 +4056,16 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label2:
 {
-Obj _35val2726 = __arg1;
+Obj _35val1576 = __arg1;
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun3134, 1, w);
+pushCont(co, 1, _35clofun2011, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -3974,32 +4073,32 @@ __arg2 = idx;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label4:
+label3:
 {
-Obj _35cc1269 = makeNative(1, _35clofun3134, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc122 = makeNative(0, _35clofun2011, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2716 = primIsCons(closureRef(co, 3));
-if (True == _35reg2716) {
-Obj _35reg2717 = primCar(closureRef(co, 3));
-Obj _35reg2718 = primEQ(intern("%stack-ref"), _35reg2717);
-if (True == _35reg2718) {
-Obj _35reg2719 = primCdr(closureRef(co, 3));
-Obj _35reg2720 = primIsCons(_35reg2719);
-if (True == _35reg2720) {
-Obj _35reg2721 = primCdr(closureRef(co, 3));
-Obj _35reg2722 = primCar(_35reg2721);
-Obj idx = _35reg2722;
-Obj _35reg2723 = primCdr(closureRef(co, 3));
-Obj _35reg2724 = primCdr(_35reg2723);
-Obj _35reg2725 = primEQ(Nil, _35reg2724);
-if (True == _35reg2725) {
-pushCont(co, 3, _35clofun3134, 2, idx, w);
+Obj _35reg1566 = primIsCons(closureRef(co, 3));
+if (True == _35reg1566) {
+Obj _35reg1567 = primCar(closureRef(co, 3));
+Obj _35reg1568 = primEQ(intern("%stack-ref"), _35reg1567);
+if (True == _35reg1568) {
+Obj _35reg1569 = primCdr(closureRef(co, 3));
+Obj _35reg1570 = primIsCons(_35reg1569);
+if (True == _35reg1570) {
+Obj _35reg1571 = primCdr(closureRef(co, 3));
+Obj _35reg1572 = primCar(_35reg1571);
+Obj idx = _35reg1572;
+Obj _35reg1573 = primCdr(closureRef(co, 3));
+Obj _35reg1574 = primCdr(_35reg1573);
+Obj _35reg1575 = primEQ(Nil, _35reg1574);
+if (True == _35reg1575) {
+pushCont(co, 2, _35clofun2011, 2, idx, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4007,49 +4106,49 @@ __arg2 = makeCString("stackRef(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1269;
+__arg0 = _35cc122;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1269;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1269;
+__arg0 = _35cc122;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1269;
+__arg0 = _35cc122;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc122;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label5:
+label4:
 {
-Obj _35val2739 = __arg1;
+Obj _35val1589 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -4058,16 +4157,16 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label5:
 {
-Obj _35val2738 = __arg1;
+Obj _35val1588 = __arg1;
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun3134, 1, w);
+pushCont(co, 4, _35clofun2011, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -4075,32 +4174,32 @@ __arg2 = idx;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label6:
 {
-Obj _35cc1268 = makeNative(4, _35clofun3134, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc121 = makeNative(3, _35clofun2011, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2728 = primIsCons(closureRef(co, 3));
-if (True == _35reg2728) {
-Obj _35reg2729 = primCar(closureRef(co, 3));
-Obj _35reg2730 = primEQ(intern("%closure-ref"), _35reg2729);
-if (True == _35reg2730) {
-Obj _35reg2731 = primCdr(closureRef(co, 3));
-Obj _35reg2732 = primIsCons(_35reg2731);
-if (True == _35reg2732) {
-Obj _35reg2733 = primCdr(closureRef(co, 3));
-Obj _35reg2734 = primCar(_35reg2733);
-Obj idx = _35reg2734;
-Obj _35reg2735 = primCdr(closureRef(co, 3));
-Obj _35reg2736 = primCdr(_35reg2735);
-Obj _35reg2737 = primEQ(Nil, _35reg2736);
-if (True == _35reg2737) {
-pushCont(co, 6, _35clofun3134, 2, idx, w);
+Obj _35reg1578 = primIsCons(closureRef(co, 3));
+if (True == _35reg1578) {
+Obj _35reg1579 = primCar(closureRef(co, 3));
+Obj _35reg1580 = primEQ(intern("%closure-ref"), _35reg1579);
+if (True == _35reg1580) {
+Obj _35reg1581 = primCdr(closureRef(co, 3));
+Obj _35reg1582 = primIsCons(_35reg1581);
+if (True == _35reg1582) {
+Obj _35reg1583 = primCdr(closureRef(co, 3));
+Obj _35reg1584 = primCar(_35reg1583);
+Obj idx = _35reg1584;
+Obj _35reg1585 = primCdr(closureRef(co, 3));
+Obj _35reg1586 = primCdr(_35reg1585);
+Obj _35reg1587 = primEQ(Nil, _35reg1586);
+if (True == _35reg1587) {
+pushCont(co, 5, _35clofun2011, 2, idx, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4108,49 +4207,49 @@ __arg2 = makeCString("closureRef(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1268;
+__arg0 = _35cc121;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1268;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1268;
+__arg0 = _35cc121;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1268;
+__arg0 = _35cc121;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc121;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label8:
+label7:
 {
-Obj _35val2752 = __arg1;
+Obj _35val1602 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -4159,64 +4258,64 @@ __arg2 = makeCString("\"))");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label8:
+{
+Obj _35val1601 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 7, _35clofun2011, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = _35val1601;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val2751 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 8, _35clofun3134, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = _35val2751;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35val2750 = __arg1;
+Obj _35val1600 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun3134, 1, w);
+pushCont(co, 8, _35clofun2011, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label10:
 {
-Obj _35cc1267 = makeNative(7, _35clofun3134, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc120 = makeNative(6, _35clofun2011, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2740 = primIsCons(closureRef(co, 3));
-if (True == _35reg2740) {
-Obj _35reg2741 = primCar(closureRef(co, 3));
-Obj _35reg2742 = primEQ(intern("%global"), _35reg2741);
-if (True == _35reg2742) {
-Obj _35reg2743 = primCdr(closureRef(co, 3));
-Obj _35reg2744 = primIsCons(_35reg2743);
-if (True == _35reg2744) {
-Obj _35reg2745 = primCdr(closureRef(co, 3));
-Obj _35reg2746 = primCar(_35reg2745);
-Obj x = _35reg2746;
-Obj _35reg2747 = primCdr(closureRef(co, 3));
-Obj _35reg2748 = primCdr(_35reg2747);
-Obj _35reg2749 = primEQ(Nil, _35reg2748);
-if (True == _35reg2749) {
-pushCont(co, 10, _35clofun3134, 2, x, w);
+Obj _35reg1590 = primIsCons(closureRef(co, 3));
+if (True == _35reg1590) {
+Obj _35reg1591 = primCar(closureRef(co, 3));
+Obj _35reg1592 = primEQ(intern("%global"), _35reg1591);
+if (True == _35reg1592) {
+Obj _35reg1593 = primCdr(closureRef(co, 3));
+Obj _35reg1594 = primIsCons(_35reg1593);
+if (True == _35reg1594) {
+Obj _35reg1595 = primCdr(closureRef(co, 3));
+Obj _35reg1596 = primCar(_35reg1595);
+Obj x = _35reg1596;
+Obj _35reg1597 = primCdr(closureRef(co, 3));
+Obj _35reg1598 = primCdr(_35reg1597);
+Obj _35reg1599 = primEQ(Nil, _35reg1598);
+if (True == _35reg1599) {
+pushCont(co, 9, _35clofun2011, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4224,59 +4323,59 @@ __arg2 = makeCString("globalRef(intern(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1267;
+__arg0 = _35cc120;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1267;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1267;
+__arg0 = _35cc120;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1267;
+__arg0 = _35cc120;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc120;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label12:
+label11:
 {
-Obj _35p1262 = __arg1;
-Obj _35p1263 = __arg2;
-Obj _35p1264 = __arg3;
-Obj _35p1265 = co->args[4];
-Obj _35cc1266 = makeNative(11, _35clofun3134, 0, 4, _35p1262, _35p1263, _35p1264, _35p1265);
-Obj self = _35p1262;
-Obj env = _35p1263;
-Obj w = _35p1264;
-Obj x = _35p1265;
-Obj _35reg2753 = primIsSymbol(x);
-if (True == _35reg2753) {
+Obj _35p115 = __arg1;
+Obj _35p116 = __arg2;
+Obj _35p117 = __arg3;
+Obj _35p118 = co->args[4];
+Obj _35cc119 = makeNative(10, _35clofun2011, 0, 4, _35p115, _35p116, _35p117, _35p118);
+Obj self = _35p115;
+Obj env = _35p116;
+Obj w = _35p117;
+Obj x = _35p118;
+Obj _35reg1603 = primIsSymbol(x);
+if (True == _35reg1603) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -4284,20 +4383,20 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1266;
+__arg0 = _35cc119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label13:
+label12:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -4305,13 +4404,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label13:
 {
-Obj _35val2775 = __arg1;
+Obj _35val1625 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
@@ -4322,14 +4421,14 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label14:
 {
 Obj x = __arg1;
-pushCont(co, 14, _35clofun3134, 1, x);
+pushCont(co, 13, _35clofun2011, 1, x);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = closureRef(co, 1);
@@ -4337,13 +4436,13 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label15:
 {
-Obj _35val2776 = __arg1;
+Obj _35val1626 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -4352,27 +4451,27 @@ __arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label16:
 {
-Obj _35val2773 = __arg1;
+Obj _35val1623 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2774 = primNot(_35val2773);
-if (True == _35reg2774) {
-pushCont(co, 16, _35clofun3134, 1, w);
+Obj _35reg1624 = primNot(_35val1623);
+if (True == _35reg1624) {
+pushCont(co, 15, _35clofun2011, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(15, _35clofun3134, 1, 2, self, w);
+__arg1 = makeNative(14, _35clofun2011, 1, 2, self, w);
 __arg2 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
@@ -4383,60 +4482,78 @@ __arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label18:
+label17:
 {
-Obj _35val2772 = __arg1;
+Obj _35val1622 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 17, _35clofun3134, 3, self, stacks, w);
+pushCont(co, 16, _35clofun2011, 3, self, stacks, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label18:
+{
+Obj _35val1621 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 17, _35clofun2011, 3, self, stacks, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = _35val1621;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val2771 = __arg1;
+Obj _35val1620 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 18, _35clofun3134, 3, self, stacks, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = _35val2771;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val2770 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 19, _35clofun3134, 3, self, stacks, w);
+pushCont(co, 18, _35clofun2011, 3, self, stacks, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj _35val1619 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 19, _35clofun2011, 3, self, stacks, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4449,7 +4566,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3133(struct Cora* co){
+void _35clofun2010(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -4462,141 +4579,121 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2646 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 20, _35clofun3132, 5, f, self, env, args, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
-__arg1 = w;
-__arg2 = _35val2646;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35cc1272 = makeNative(15, _35clofun3132, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc125 = makeNative(14, _35clofun2009, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2629 = primIsCons(closureRef(co, 3));
-if (True == _35reg2629) {
-Obj _35reg2630 = primCar(closureRef(co, 3));
-Obj _35reg2631 = primIsCons(_35reg2630);
-if (True == _35reg2631) {
-Obj _35reg2632 = primCar(closureRef(co, 3));
-Obj _35reg2633 = primCar(_35reg2632);
-Obj _35reg2634 = primEQ(intern("%builtin"), _35reg2633);
-if (True == _35reg2634) {
-Obj _35reg2635 = primCar(closureRef(co, 3));
-Obj _35reg2636 = primCdr(_35reg2635);
-Obj _35reg2637 = primIsCons(_35reg2636);
-if (True == _35reg2637) {
-Obj _35reg2638 = primCar(closureRef(co, 3));
-Obj _35reg2639 = primCdr(_35reg2638);
-Obj _35reg2640 = primCar(_35reg2639);
-Obj f = _35reg2640;
-Obj _35reg2641 = primCar(closureRef(co, 3));
-Obj _35reg2642 = primCdr(_35reg2641);
-Obj _35reg2643 = primCdr(_35reg2642);
-Obj _35reg2644 = primEQ(Nil, _35reg2643);
-if (True == _35reg2644) {
-Obj _35reg2645 = primCdr(closureRef(co, 3));
-Obj args = _35reg2645;
-pushCont(co, 0, _35clofun3133, 5, f, self, env, args, w);
+Obj _35reg1479 = primIsCons(closureRef(co, 3));
+if (True == _35reg1479) {
+Obj _35reg1480 = primCar(closureRef(co, 3));
+Obj _35reg1481 = primIsCons(_35reg1480);
+if (True == _35reg1481) {
+Obj _35reg1482 = primCar(closureRef(co, 3));
+Obj _35reg1483 = primCar(_35reg1482);
+Obj _35reg1484 = primEQ(intern("%builtin"), _35reg1483);
+if (True == _35reg1484) {
+Obj _35reg1485 = primCar(closureRef(co, 3));
+Obj _35reg1486 = primCdr(_35reg1485);
+Obj _35reg1487 = primIsCons(_35reg1486);
+if (True == _35reg1487) {
+Obj _35reg1488 = primCar(closureRef(co, 3));
+Obj _35reg1489 = primCdr(_35reg1488);
+Obj _35reg1490 = primCar(_35reg1489);
+Obj f = _35reg1490;
+Obj _35reg1491 = primCar(closureRef(co, 3));
+Obj _35reg1492 = primCdr(_35reg1491);
+Obj _35reg1493 = primCdr(_35reg1492);
+Obj _35reg1494 = primEQ(Nil, _35reg1493);
+if (True == _35reg1494) {
+Obj _35reg1495 = primCdr(closureRef(co, 3));
+Obj args = _35reg1495;
+pushCont(co, 20, _35clofun2009, 5, f, self, env, args, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#builtin->name"));
 __arg1 = f;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1272;
+__arg0 = _35cc125;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1272;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1272;
+__arg0 = _35cc125;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1272;
+__arg0 = _35cc125;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1272;
+__arg0 = _35cc125;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc125;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label2:
+label1:
 {
-Obj _35val2685 = __arg1;
+Obj _35val1535 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2686 = primCons(a, env);
+Obj _35reg1536 = primCons(a, env);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
-__arg2 = _35reg2686;
+__arg2 = _35reg1536;
 __arg3 = w;
 co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label2:
 {
-Obj _35val2684 = __arg1;
+Obj _35val1534 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 2, _35clofun3133, 5, a, env, self, w, c);
+pushCont(co, 1, _35clofun2010, 5, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4604,20 +4701,20 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label4:
+label3:
 {
-Obj _35val2683 = __arg1;
+Obj _35val1533 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 3, _35clofun3133, 5, a, env, self, w, c);
+pushCont(co, 2, _35clofun2010, 5, a, env, self, w, c);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -4627,20 +4724,20 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label5:
+label4:
 {
-Obj _35val2682 = __arg1;
+Obj _35val1532 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 4, _35clofun3133, 6, b, a, env, self, w, c);
+pushCont(co, 3, _35clofun2010, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4648,20 +4745,20 @@ __arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label5:
 {
-Obj _35val2681 = __arg1;
+Obj _35val1531 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 5, _35clofun3133, 6, b, a, env, self, w, c);
+pushCont(co, 4, _35clofun2010, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -4669,41 +4766,41 @@ __arg2 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label6:
 {
-Obj _35val2690 = __arg1;
+Obj _35val1540 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2691 = primCons(a, env);
+Obj _35reg1541 = primCons(a, env);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
-__arg2 = _35reg2691;
+__arg2 = _35reg1541;
 __arg3 = w;
 co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label7:
 {
-Obj _35val2689 = __arg1;
+Obj _35val1539 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 7, _35clofun3133, 5, a, env, self, w, c);
+pushCont(co, 6, _35clofun2010, 5, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4711,20 +4808,20 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label9:
+label8:
 {
-Obj _35val2688 = __arg1;
+Obj _35val1538 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 8, _35clofun3133, 5, a, env, self, w, c);
+pushCont(co, 7, _35clofun2010, 5, a, env, self, w, c);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -4734,20 +4831,20 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label10:
+label9:
 {
-Obj _35val2687 = __arg1;
+Obj _35val1537 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 9, _35clofun3133, 6, b, a, env, self, w, c);
+pushCont(co, 8, _35clofun2010, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4755,23 +4852,23 @@ __arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label10:
 {
-Obj _35val2679 = __arg1;
+Obj _35val1529 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj idx = _35val2679;
-Obj _35reg2680 = primLT(idx, makeNumber(0));
-if (True == _35reg2680) {
-pushCont(co, 6, _35clofun3133, 6, b, a, env, self, w, c);
+Obj idx = _35val1529;
+Obj _35reg1530 = primLT(idx, makeNumber(0));
+if (True == _35reg1530) {
+pushCont(co, 5, _35clofun2010, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4779,11 +4876,11 @@ __arg2 = makeCString("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
-pushCont(co, 10, _35clofun3133, 6, b, a, env, self, w, c);
+pushCont(co, 9, _35clofun2010, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -4791,53 +4888,53 @@ __arg2 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label12:
+label11:
 {
-Obj _35cc1271 = makeNative(1, _35clofun3133, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc124 = makeNative(0, _35clofun2010, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2653 = primIsCons(closureRef(co, 3));
-if (True == _35reg2653) {
-Obj _35reg2654 = primCar(closureRef(co, 3));
-Obj _35reg2655 = primEQ(intern("let"), _35reg2654);
-if (True == _35reg2655) {
-Obj _35reg2656 = primCdr(closureRef(co, 3));
-Obj _35reg2657 = primIsCons(_35reg2656);
-if (True == _35reg2657) {
-Obj _35reg2658 = primCdr(closureRef(co, 3));
-Obj _35reg2659 = primCar(_35reg2658);
-Obj a = _35reg2659;
-Obj _35reg2660 = primCdr(closureRef(co, 3));
-Obj _35reg2661 = primCdr(_35reg2660);
-Obj _35reg2662 = primIsCons(_35reg2661);
-if (True == _35reg2662) {
-Obj _35reg2663 = primCdr(closureRef(co, 3));
-Obj _35reg2664 = primCdr(_35reg2663);
-Obj _35reg2665 = primCar(_35reg2664);
-Obj b = _35reg2665;
-Obj _35reg2666 = primCdr(closureRef(co, 3));
-Obj _35reg2667 = primCdr(_35reg2666);
-Obj _35reg2668 = primCdr(_35reg2667);
-Obj _35reg2669 = primIsCons(_35reg2668);
-if (True == _35reg2669) {
-Obj _35reg2670 = primCdr(closureRef(co, 3));
-Obj _35reg2671 = primCdr(_35reg2670);
-Obj _35reg2672 = primCdr(_35reg2671);
-Obj _35reg2673 = primCar(_35reg2672);
-Obj c = _35reg2673;
-Obj _35reg2674 = primCdr(closureRef(co, 3));
-Obj _35reg2675 = primCdr(_35reg2674);
-Obj _35reg2676 = primCdr(_35reg2675);
-Obj _35reg2677 = primCdr(_35reg2676);
-Obj _35reg2678 = primEQ(Nil, _35reg2677);
-if (True == _35reg2678) {
-pushCont(co, 11, _35clofun3133, 6, b, a, env, self, w, c);
+Obj _35reg1503 = primIsCons(closureRef(co, 3));
+if (True == _35reg1503) {
+Obj _35reg1504 = primCar(closureRef(co, 3));
+Obj _35reg1505 = primEQ(intern("let"), _35reg1504);
+if (True == _35reg1505) {
+Obj _35reg1506 = primCdr(closureRef(co, 3));
+Obj _35reg1507 = primIsCons(_35reg1506);
+if (True == _35reg1507) {
+Obj _35reg1508 = primCdr(closureRef(co, 3));
+Obj _35reg1509 = primCar(_35reg1508);
+Obj a = _35reg1509;
+Obj _35reg1510 = primCdr(closureRef(co, 3));
+Obj _35reg1511 = primCdr(_35reg1510);
+Obj _35reg1512 = primIsCons(_35reg1511);
+if (True == _35reg1512) {
+Obj _35reg1513 = primCdr(closureRef(co, 3));
+Obj _35reg1514 = primCdr(_35reg1513);
+Obj _35reg1515 = primCar(_35reg1514);
+Obj b = _35reg1515;
+Obj _35reg1516 = primCdr(closureRef(co, 3));
+Obj _35reg1517 = primCdr(_35reg1516);
+Obj _35reg1518 = primCdr(_35reg1517);
+Obj _35reg1519 = primIsCons(_35reg1518);
+if (True == _35reg1519) {
+Obj _35reg1520 = primCdr(closureRef(co, 3));
+Obj _35reg1521 = primCdr(_35reg1520);
+Obj _35reg1522 = primCdr(_35reg1521);
+Obj _35reg1523 = primCar(_35reg1522);
+Obj c = _35reg1523;
+Obj _35reg1524 = primCdr(closureRef(co, 3));
+Obj _35reg1525 = primCdr(_35reg1524);
+Obj _35reg1526 = primCdr(_35reg1525);
+Obj _35reg1527 = primCdr(_35reg1526);
+Obj _35reg1528 = primEQ(Nil, _35reg1527);
+if (True == _35reg1528) {
+pushCont(co, 10, _35clofun2010, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#index"));
 __arg1 = a;
@@ -4845,67 +4942,67 @@ __arg2 = env;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1271;
+__arg0 = _35cc124;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1271;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1271;
+__arg0 = _35cc124;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1271;
+__arg0 = _35cc124;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1271;
+__arg0 = _35cc124;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1271;
+__arg0 = _35cc124;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc124;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label13:
+label12:
 {
-Obj _35val2705 = __arg1;
+Obj _35val1555 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -4914,45 +5011,45 @@ __arg2 = makeCString("\")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label13:
+{
+Obj _35val1554 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 12, _35clofun2010, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = _35val1554;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2704 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 13, _35clofun3133, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = _35val2704;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35val2703 = __arg1;
+Obj _35val1553 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 14, _35clofun3133, 1, w);
+pushCont(co, 13, _35clofun2010, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label15:
 {
-Obj _35val2708 = __arg1;
+Obj _35val1558 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -4961,16 +5058,16 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label16:
 {
-Obj _35val2707 = __arg1;
+Obj _35val1557 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 16, _35clofun3133, 1, w);
+pushCont(co, 15, _35clofun2010, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -4978,13 +5075,13 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label17:
 {
-Obj _35val2712 = __arg1;
+Obj _35val1562 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -4993,40 +5090,121 @@ __arg2 = makeCString("\")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label18:
+{
+Obj _35val1561 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 17, _35clofun2010, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = _35val1561;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val2711 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 18, _35clofun3133, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = _35val2711;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val2710 = __arg1;
+Obj _35val1560 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 19, _35clofun3133, 1, w);
+pushCont(co, 18, _35clofun2010, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc/internal#escape-str"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj _35val1556 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1556) {
+pushCont(co, 16, _35clofun2010, 2, x, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("makeNumber(");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1559 = primIsString(x);
+if (True == _35reg1559) {
+pushCont(co, 19, _35clofun2010, 2, x, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("makeCString(\"");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1563 = primEQ(x, Nil);
+if (True == _35reg1563) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("Nil");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1564 = primEQ(x, True);
+if (True == _35reg1564) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("True");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1565 = primEQ(x, False);
+if (True == _35reg1565) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("False");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+}
+}
 }
 
 fail:
@@ -5038,7 +5216,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3132(struct Cora* co){
+void _35clofun2009(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -5051,49 +5229,30 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2591 = __arg1;
+Obj _35val1440 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 20, _35clofun3131, 4, self, env, frees, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = _35val2591;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35val2590 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3132, 4, self, env, frees, w);
+pushCont(co, 20, _35clofun2008, 4, self, env, frees, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label2:
+label1:
 {
-Obj _35val2589 = __arg1;
+Obj _35val1439 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 1, _35clofun3132, 4, self, env, frees, w);
+pushCont(co, 0, _35clofun2009, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5101,19 +5260,19 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label2:
 {
-Obj _35val2588 = __arg1;
+Obj _35val1438 = __arg1;
 Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 2, _35clofun3132, 4, self, env, frees, w);
+pushCont(co, 1, _35clofun2009, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -5121,19 +5280,19 @@ __arg2 = nargs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label4:
+label3:
 {
-Obj _35val2587 = __arg1;
+Obj _35val1437 = __arg1;
 Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 3, _35clofun3132, 5, nargs, self, env, frees, w);
+pushCont(co, 2, _35clofun2009, 5, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5141,42 +5300,42 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val1435 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
+Obj _35reg1436 = primCar(label);
+pushCont(co, 3, _35clofun2009, 5, nargs, self, env, frees, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
+__arg1 = w;
+__arg2 = _35reg1436;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val2585 = __arg1;
+Obj _35val1434 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj _35reg2586 = primCar(label);
-pushCont(co, 4, _35clofun3132, 5, nargs, self, env, frees, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
-__arg1 = w;
-__arg2 = _35reg2586;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val2584 = __arg1;
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 5, _35clofun3132, 6, label, nargs, self, env, frees, w);
+pushCont(co, 4, _35clofun2009, 6, label, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5184,62 +5343,62 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label6:
 {
-Obj _35val2582 = __arg1;
+Obj _35val1432 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj _35reg2583 = primCdr(label);
-pushCont(co, 6, _35clofun3132, 6, label, nargs, self, env, frees, w);
+Obj _35reg1433 = primCdr(label);
+pushCont(co, 5, _35clofun2009, 6, label, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = _35reg2583;
+__arg2 = _35reg1433;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label7:
 {
-Obj _35cc1274 = makeNative(16, _35clofun3131, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc127 = makeNative(15, _35clofun2008, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2566 = primIsCons(closureRef(co, 3));
-if (True == _35reg2566) {
-Obj _35reg2567 = primCar(closureRef(co, 3));
-Obj _35reg2568 = primEQ(intern("%closure"), _35reg2567);
-if (True == _35reg2568) {
-Obj _35reg2569 = primCdr(closureRef(co, 3));
-Obj _35reg2570 = primIsCons(_35reg2569);
-if (True == _35reg2570) {
-Obj _35reg2571 = primCdr(closureRef(co, 3));
-Obj _35reg2572 = primCar(_35reg2571);
-Obj label = _35reg2572;
-Obj _35reg2573 = primCdr(closureRef(co, 3));
-Obj _35reg2574 = primCdr(_35reg2573);
-Obj _35reg2575 = primIsCons(_35reg2574);
-if (True == _35reg2575) {
-Obj _35reg2576 = primCdr(closureRef(co, 3));
-Obj _35reg2577 = primCdr(_35reg2576);
-Obj _35reg2578 = primCar(_35reg2577);
-Obj nargs = _35reg2578;
-Obj _35reg2579 = primCdr(closureRef(co, 3));
-Obj _35reg2580 = primCdr(_35reg2579);
-Obj _35reg2581 = primCdr(_35reg2580);
-Obj frees = _35reg2581;
-pushCont(co, 7, _35clofun3132, 6, label, nargs, self, env, frees, w);
+Obj _35reg1416 = primIsCons(closureRef(co, 3));
+if (True == _35reg1416) {
+Obj _35reg1417 = primCar(closureRef(co, 3));
+Obj _35reg1418 = primEQ(intern("%closure"), _35reg1417);
+if (True == _35reg1418) {
+Obj _35reg1419 = primCdr(closureRef(co, 3));
+Obj _35reg1420 = primIsCons(_35reg1419);
+if (True == _35reg1420) {
+Obj _35reg1421 = primCdr(closureRef(co, 3));
+Obj _35reg1422 = primCar(_35reg1421);
+Obj label = _35reg1422;
+Obj _35reg1423 = primCdr(closureRef(co, 3));
+Obj _35reg1424 = primCdr(_35reg1423);
+Obj _35reg1425 = primIsCons(_35reg1424);
+if (True == _35reg1425) {
+Obj _35reg1426 = primCdr(closureRef(co, 3));
+Obj _35reg1427 = primCdr(_35reg1426);
+Obj _35reg1428 = primCar(_35reg1427);
+Obj nargs = _35reg1428;
+Obj _35reg1429 = primCdr(closureRef(co, 3));
+Obj _35reg1430 = primCdr(_35reg1429);
+Obj _35reg1431 = primCdr(_35reg1430);
+Obj frees = _35reg1431;
+pushCont(co, 6, _35clofun2009, 6, label, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5247,49 +5406,49 @@ __arg2 = makeCString("makeNative(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1274;
+__arg0 = _35cc127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1274;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1274;
+__arg0 = _35cc127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1274;
+__arg0 = _35cc127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label9:
+label8:
 {
-Obj _35val2628 = __arg1;
+Obj _35val1478 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -5298,18 +5457,18 @@ __arg2 = makeCString("}\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label10:
+label9:
 {
-Obj _35val2627 = __arg1;
+Obj _35val1477 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 9, _35clofun3132, 1, w);
+pushCont(co, 8, _35clofun2009, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5319,18 +5478,18 @@ co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label10:
 {
-Obj _35val2626 = __arg1;
+Obj _35val1476 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 10, _35clofun3132, 4, self, env, c, w);
+pushCont(co, 9, _35clofun2009, 4, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5338,19 +5497,19 @@ __arg2 = makeCString("} else {\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label11:
 {
-Obj _35val2625 = __arg1;
+Obj _35val1475 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 11, _35clofun3132, 4, self, env, c, w);
+pushCont(co, 10, _35clofun2009, 4, self, env, c, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5360,19 +5519,19 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label12:
 {
-Obj _35val2624 = __arg1;
+Obj _35val1474 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 12, _35clofun3132, 5, b, self, env, c, w);
+pushCont(co, 11, _35clofun2009, 5, b, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5380,20 +5539,20 @@ __arg2 = makeCString(") {\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label13:
 {
-Obj _35val2623 = __arg1;
+Obj _35val1473 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 13, _35clofun3132, 5, b, self, env, c, w);
+pushCont(co, 12, _35clofun2009, 5, b, self, env, c, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5403,52 +5562,52 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label14:
 {
-Obj _35cc1273 = makeNative(8, _35clofun3132, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc126 = makeNative(7, _35clofun2009, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2597 = primIsCons(closureRef(co, 3));
-if (True == _35reg2597) {
-Obj _35reg2598 = primCar(closureRef(co, 3));
-Obj _35reg2599 = primEQ(intern("if"), _35reg2598);
-if (True == _35reg2599) {
-Obj _35reg2600 = primCdr(closureRef(co, 3));
-Obj _35reg2601 = primIsCons(_35reg2600);
-if (True == _35reg2601) {
-Obj _35reg2602 = primCdr(closureRef(co, 3));
-Obj _35reg2603 = primCar(_35reg2602);
-Obj a = _35reg2603;
-Obj _35reg2604 = primCdr(closureRef(co, 3));
-Obj _35reg2605 = primCdr(_35reg2604);
-Obj _35reg2606 = primIsCons(_35reg2605);
-if (True == _35reg2606) {
-Obj _35reg2607 = primCdr(closureRef(co, 3));
-Obj _35reg2608 = primCdr(_35reg2607);
-Obj _35reg2609 = primCar(_35reg2608);
-Obj b = _35reg2609;
-Obj _35reg2610 = primCdr(closureRef(co, 3));
-Obj _35reg2611 = primCdr(_35reg2610);
-Obj _35reg2612 = primCdr(_35reg2611);
-Obj _35reg2613 = primIsCons(_35reg2612);
-if (True == _35reg2613) {
-Obj _35reg2614 = primCdr(closureRef(co, 3));
-Obj _35reg2615 = primCdr(_35reg2614);
-Obj _35reg2616 = primCdr(_35reg2615);
-Obj _35reg2617 = primCar(_35reg2616);
-Obj c = _35reg2617;
-Obj _35reg2618 = primCdr(closureRef(co, 3));
-Obj _35reg2619 = primCdr(_35reg2618);
-Obj _35reg2620 = primCdr(_35reg2619);
-Obj _35reg2621 = primCdr(_35reg2620);
-Obj _35reg2622 = primEQ(Nil, _35reg2621);
-if (True == _35reg2622) {
-pushCont(co, 14, _35clofun3132, 6, a, b, self, env, c, w);
+Obj _35reg1447 = primIsCons(closureRef(co, 3));
+if (True == _35reg1447) {
+Obj _35reg1448 = primCar(closureRef(co, 3));
+Obj _35reg1449 = primEQ(intern("if"), _35reg1448);
+if (True == _35reg1449) {
+Obj _35reg1450 = primCdr(closureRef(co, 3));
+Obj _35reg1451 = primIsCons(_35reg1450);
+if (True == _35reg1451) {
+Obj _35reg1452 = primCdr(closureRef(co, 3));
+Obj _35reg1453 = primCar(_35reg1452);
+Obj a = _35reg1453;
+Obj _35reg1454 = primCdr(closureRef(co, 3));
+Obj _35reg1455 = primCdr(_35reg1454);
+Obj _35reg1456 = primIsCons(_35reg1455);
+if (True == _35reg1456) {
+Obj _35reg1457 = primCdr(closureRef(co, 3));
+Obj _35reg1458 = primCdr(_35reg1457);
+Obj _35reg1459 = primCar(_35reg1458);
+Obj b = _35reg1459;
+Obj _35reg1460 = primCdr(closureRef(co, 3));
+Obj _35reg1461 = primCdr(_35reg1460);
+Obj _35reg1462 = primCdr(_35reg1461);
+Obj _35reg1463 = primIsCons(_35reg1462);
+if (True == _35reg1463) {
+Obj _35reg1464 = primCdr(closureRef(co, 3));
+Obj _35reg1465 = primCdr(_35reg1464);
+Obj _35reg1466 = primCdr(_35reg1465);
+Obj _35reg1467 = primCar(_35reg1466);
+Obj c = _35reg1467;
+Obj _35reg1468 = primCdr(closureRef(co, 3));
+Obj _35reg1469 = primCdr(_35reg1468);
+Obj _35reg1470 = primCdr(_35reg1469);
+Obj _35reg1471 = primCdr(_35reg1470);
+Obj _35reg1472 = primEQ(Nil, _35reg1471);
+if (True == _35reg1472) {
+pushCont(co, 13, _35clofun2009, 6, a, b, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5456,67 +5615,67 @@ __arg2 = makeCString("if (True == ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1273;
+__arg0 = _35cc126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1273;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1273;
+__arg0 = _35cc126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1273;
+__arg0 = _35cc126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1273;
+__arg0 = _35cc126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1273;
+__arg0 = _35cc126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc126;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label16:
+label15:
 {
-Obj _35val2650 = __arg1;
+Obj _35val1500 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -5525,34 +5684,34 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label16:
+{
+Obj _35val1499 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 15, _35clofun2009, 1, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val2649 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 16, _35clofun3132, 1, w);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val2652 = __arg1;
+Obj _35val1502 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -5561,18 +5720,18 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label18:
 {
-Obj _35val2651 = __arg1;
+Obj _35val1501 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun3132, 1, w);
+pushCont(co, 17, _35clofun2009, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
 __arg1 = self;
@@ -5582,21 +5741,21 @@ co->args[4] = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label19:
 {
-Obj _35val2647 = __arg1;
+Obj _35val1497 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2648 = primEQ(f, intern("set"));
-if (True == _35reg2648) {
-pushCont(co, 17, _35clofun3132, 4, self, env, args, w);
+Obj _35reg1498 = primEQ(f, intern("set"));
+if (True == _35reg1498) {
+pushCont(co, 16, _35clofun2009, 4, self, env, args, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5604,10 +5763,10 @@ __arg2 = makeCString("(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 19, _35clofun3132, 4, self, env, args, w);
+pushCont(co, 18, _35clofun2009, 4, self, env, args, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5615,9 +5774,29 @@ __arg2 = makeCString("(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+
+label20:
+{
+Obj _35val1496 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 19, _35clofun2009, 5, f, self, env, args, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
+__arg1 = w;
+__arg2 = _35val1496;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 fail:
@@ -5629,7 +5808,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3131(struct Cora* co){
+void _35clofun2008(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -5642,35 +5821,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2488 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 20, _35clofun3130, 4, f, args, self, w);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35cc1279 = makeNative(10, _35clofun3130, 0, 0);
+Obj _35cc132 = makeNative(9, _35clofun2007, 0, 0);
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2485 = primIsCons(closureRef(co, 3));
-if (True == _35reg2485) {
-Obj _35reg2486 = primCar(closureRef(co, 3));
-Obj f = _35reg2486;
-Obj _35reg2487 = primCdr(closureRef(co, 3));
-Obj args = _35reg2487;
-pushCont(co, 0, _35clofun3131, 4, f, args, self, w);
+Obj _35reg1335 = primIsCons(closureRef(co, 3));
+if (True == _35reg1335) {
+Obj _35reg1336 = primCar(closureRef(co, 3));
+Obj f = _35reg1336;
+Obj _35reg1337 = primCdr(closureRef(co, 3));
+Obj args = _35reg1337;
+pushCont(co, 20, _35clofun2007, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5678,22 +5839,22 @@ __arg2 = makeCString("__nargs = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1279;
+__arg0 = _35cc132;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label2:
+label1:
 {
-Obj _35val2518 = __arg1;
+Obj _35val1368 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -5707,41 +5868,41 @@ co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label2:
 {
-Obj _35cc1278 = makeNative(1, _35clofun3131, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc131 = makeNative(0, _35clofun2008, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2501 = primIsCons(closureRef(co, 3));
-if (True == _35reg2501) {
-Obj _35reg2502 = primCar(closureRef(co, 3));
-Obj _35reg2503 = primEQ(intern("call"), _35reg2502);
-if (True == _35reg2503) {
-Obj _35reg2504 = primCdr(closureRef(co, 3));
-Obj _35reg2505 = primIsCons(_35reg2504);
-if (True == _35reg2505) {
-Obj _35reg2506 = primCdr(closureRef(co, 3));
-Obj _35reg2507 = primCar(_35reg2506);
-Obj exp = _35reg2507;
-Obj _35reg2508 = primCdr(closureRef(co, 3));
-Obj _35reg2509 = primCdr(_35reg2508);
-Obj _35reg2510 = primIsCons(_35reg2509);
-if (True == _35reg2510) {
-Obj _35reg2511 = primCdr(closureRef(co, 3));
-Obj _35reg2512 = primCdr(_35reg2511);
-Obj _35reg2513 = primCar(_35reg2512);
-Obj cont = _35reg2513;
-Obj _35reg2514 = primCdr(closureRef(co, 3));
-Obj _35reg2515 = primCdr(_35reg2514);
-Obj _35reg2516 = primCdr(_35reg2515);
-Obj _35reg2517 = primEQ(Nil, _35reg2516);
-if (True == _35reg2517) {
-pushCont(co, 2, _35clofun3131, 4, self, env, w, exp);
+Obj _35reg1351 = primIsCons(closureRef(co, 3));
+if (True == _35reg1351) {
+Obj _35reg1352 = primCar(closureRef(co, 3));
+Obj _35reg1353 = primEQ(intern("call"), _35reg1352);
+if (True == _35reg1353) {
+Obj _35reg1354 = primCdr(closureRef(co, 3));
+Obj _35reg1355 = primIsCons(_35reg1354);
+if (True == _35reg1355) {
+Obj _35reg1356 = primCdr(closureRef(co, 3));
+Obj _35reg1357 = primCar(_35reg1356);
+Obj exp = _35reg1357;
+Obj _35reg1358 = primCdr(closureRef(co, 3));
+Obj _35reg1359 = primCdr(_35reg1358);
+Obj _35reg1360 = primIsCons(_35reg1359);
+if (True == _35reg1360) {
+Obj _35reg1361 = primCdr(closureRef(co, 3));
+Obj _35reg1362 = primCdr(_35reg1361);
+Obj _35reg1363 = primCar(_35reg1362);
+Obj cont = _35reg1363;
+Obj _35reg1364 = primCdr(closureRef(co, 3));
+Obj _35reg1365 = primCdr(_35reg1364);
+Obj _35reg1366 = primCdr(_35reg1365);
+Obj _35reg1367 = primEQ(Nil, _35reg1366);
+if (True == _35reg1367) {
+pushCont(co, 1, _35clofun2008, 4, self, env, w, exp);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#generate-cont"));
 __arg1 = self;
@@ -5750,76 +5911,76 @@ __arg3 = cont;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1278;
+__arg0 = _35cc131;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1278;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1278;
+__arg0 = _35cc131;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1278;
+__arg0 = _35cc131;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1278;
+__arg0 = _35cc131;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc131;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label4:
+label3:
 {
-Obj _35cc1277 = makeNative(3, _35clofun3131, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc130 = makeNative(2, _35clofun2008, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2519 = primIsCons(closureRef(co, 3));
-if (True == _35reg2519) {
-Obj _35reg2520 = primCar(closureRef(co, 3));
-Obj _35reg2521 = primEQ(intern("tailcall"), _35reg2520);
-if (True == _35reg2521) {
-Obj _35reg2522 = primCdr(closureRef(co, 3));
-Obj _35reg2523 = primIsCons(_35reg2522);
-if (True == _35reg2523) {
-Obj _35reg2524 = primCdr(closureRef(co, 3));
-Obj _35reg2525 = primCar(_35reg2524);
-Obj exp = _35reg2525;
-Obj _35reg2526 = primCdr(closureRef(co, 3));
-Obj _35reg2527 = primCdr(_35reg2526);
-Obj _35reg2528 = primEQ(Nil, _35reg2527);
-if (True == _35reg2528) {
+Obj _35reg1369 = primIsCons(closureRef(co, 3));
+if (True == _35reg1369) {
+Obj _35reg1370 = primCar(closureRef(co, 3));
+Obj _35reg1371 = primEQ(intern("tailcall"), _35reg1370);
+if (True == _35reg1371) {
+Obj _35reg1372 = primCdr(closureRef(co, 3));
+Obj _35reg1373 = primIsCons(_35reg1372);
+if (True == _35reg1373) {
+Obj _35reg1374 = primCdr(closureRef(co, 3));
+Obj _35reg1375 = primCar(_35reg1374);
+Obj exp = _35reg1375;
+Obj _35reg1376 = primCdr(closureRef(co, 3));
+Obj _35reg1377 = primCdr(_35reg1376);
+Obj _35reg1378 = primEQ(Nil, _35reg1377);
+if (True == _35reg1378) {
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5829,49 +5990,49 @@ co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1277;
+__arg0 = _35cc130;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1277;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1277;
+__arg0 = _35cc130;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1277;
+__arg0 = _35cc130;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc130;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label5:
+label4:
 {
-Obj _35val2546 = __arg1;
+Obj _35val1396 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -5880,15 +6041,15 @@ __arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label5:
 {
-Obj _35val2545 = __arg1;
+Obj _35val1395 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 5, _35clofun3131, 1, w);
+pushCont(co, 4, _35clofun2008, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5896,16 +6057,16 @@ __arg2 = makeCString(") { goto fail; }\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label6:
 {
-Obj _35val2544 = __arg1;
+Obj _35val1394 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 6, _35clofun3131, 1, w);
+pushCont(co, 5, _35clofun2008, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -5913,16 +6074,16 @@ __arg2 = self;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label7:
 {
-Obj _35val2543 = __arg1;
+Obj _35val1393 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun3131, 2, self, w);
+pushCont(co, 6, _35clofun2008, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5930,16 +6091,16 @@ __arg2 = makeCString("if (co->ctx.pc.func != ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label9:
+label8:
 {
-Obj _35val2542 = __arg1;
+Obj _35val1392 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun3131, 2, self, w);
+pushCont(co, 7, _35clofun2008, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5947,16 +6108,16 @@ __arg2 = makeCString("co->ctx = co->callstack.data[--co->callstack.len];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label10:
+label9:
 {
-Obj _35val2541 = __arg1;
+Obj _35val1391 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun3131, 2, self, w);
+pushCont(co, 8, _35clofun2008, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5964,18 +6125,18 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label10:
 {
-Obj _35val2540 = __arg1;
+Obj _35val1390 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 10, _35clofun3131, 2, self, w);
+pushCont(co, 9, _35clofun2008, 2, self, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5985,18 +6146,18 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label11:
 {
-Obj _35val2539 = __arg1;
+Obj _35val1389 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 11, _35clofun3131, 4, env, x, self, w);
+pushCont(co, 10, _35clofun2008, 4, env, x, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6004,32 +6165,32 @@ __arg2 = makeCString("__arg1 = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label12:
 {
-Obj _35cc1276 = makeNative(4, _35clofun3131, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc129 = makeNative(3, _35clofun2008, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2529 = primIsCons(closureRef(co, 3));
-if (True == _35reg2529) {
-Obj _35reg2530 = primCar(closureRef(co, 3));
-Obj _35reg2531 = primEQ(intern("return"), _35reg2530);
-if (True == _35reg2531) {
-Obj _35reg2532 = primCdr(closureRef(co, 3));
-Obj _35reg2533 = primIsCons(_35reg2532);
-if (True == _35reg2533) {
-Obj _35reg2534 = primCdr(closureRef(co, 3));
-Obj _35reg2535 = primCar(_35reg2534);
-Obj x = _35reg2535;
-Obj _35reg2536 = primCdr(closureRef(co, 3));
-Obj _35reg2537 = primCdr(_35reg2536);
-Obj _35reg2538 = primEQ(Nil, _35reg2537);
-if (True == _35reg2538) {
-pushCont(co, 12, _35clofun3131, 4, env, x, self, w);
+Obj _35reg1379 = primIsCons(closureRef(co, 3));
+if (True == _35reg1379) {
+Obj _35reg1380 = primCar(closureRef(co, 3));
+Obj _35reg1381 = primEQ(intern("return"), _35reg1380);
+if (True == _35reg1381) {
+Obj _35reg1382 = primCdr(closureRef(co, 3));
+Obj _35reg1383 = primIsCons(_35reg1382);
+if (True == _35reg1383) {
+Obj _35reg1384 = primCdr(closureRef(co, 3));
+Obj _35reg1385 = primCar(_35reg1384);
+Obj x = _35reg1385;
+Obj _35reg1386 = primCdr(closureRef(co, 3));
+Obj _35reg1387 = primCdr(_35reg1386);
+Obj _35reg1388 = primEQ(Nil, _35reg1387);
+if (True == _35reg1388) {
+pushCont(co, 11, _35clofun2008, 4, env, x, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6037,49 +6198,49 @@ __arg2 = makeCString("__nargs = 2;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1276;
+__arg0 = _35cc129;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1276;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1276;
+__arg0 = _35cc129;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1276;
+__arg0 = _35cc129;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc129;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label14:
+label13:
 {
-Obj _35val2565 = __arg1;
+Obj _35val1415 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -6093,18 +6254,18 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label14:
 {
-Obj _35val2564 = __arg1;
+Obj _35val1414 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 14, _35clofun3131, 4, self, env, w, b);
+pushCont(co, 13, _35clofun2008, 4, self, env, w, b);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6112,41 +6273,41 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label15:
 {
-Obj _35cc1275 = makeNative(13, _35clofun3131, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc128 = makeNative(12, _35clofun2008, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2547 = primIsCons(closureRef(co, 3));
-if (True == _35reg2547) {
-Obj _35reg2548 = primCar(closureRef(co, 3));
-Obj _35reg2549 = primEQ(intern("do"), _35reg2548);
-if (True == _35reg2549) {
-Obj _35reg2550 = primCdr(closureRef(co, 3));
-Obj _35reg2551 = primIsCons(_35reg2550);
-if (True == _35reg2551) {
-Obj _35reg2552 = primCdr(closureRef(co, 3));
-Obj _35reg2553 = primCar(_35reg2552);
-Obj a = _35reg2553;
-Obj _35reg2554 = primCdr(closureRef(co, 3));
-Obj _35reg2555 = primCdr(_35reg2554);
-Obj _35reg2556 = primIsCons(_35reg2555);
-if (True == _35reg2556) {
-Obj _35reg2557 = primCdr(closureRef(co, 3));
-Obj _35reg2558 = primCdr(_35reg2557);
-Obj _35reg2559 = primCar(_35reg2558);
-Obj b = _35reg2559;
-Obj _35reg2560 = primCdr(closureRef(co, 3));
-Obj _35reg2561 = primCdr(_35reg2560);
-Obj _35reg2562 = primCdr(_35reg2561);
-Obj _35reg2563 = primEQ(Nil, _35reg2562);
-if (True == _35reg2563) {
-pushCont(co, 15, _35clofun3131, 4, self, env, w, b);
+Obj _35reg1397 = primIsCons(closureRef(co, 3));
+if (True == _35reg1397) {
+Obj _35reg1398 = primCar(closureRef(co, 3));
+Obj _35reg1399 = primEQ(intern("do"), _35reg1398);
+if (True == _35reg1399) {
+Obj _35reg1400 = primCdr(closureRef(co, 3));
+Obj _35reg1401 = primIsCons(_35reg1400);
+if (True == _35reg1401) {
+Obj _35reg1402 = primCdr(closureRef(co, 3));
+Obj _35reg1403 = primCar(_35reg1402);
+Obj a = _35reg1403;
+Obj _35reg1404 = primCdr(closureRef(co, 3));
+Obj _35reg1405 = primCdr(_35reg1404);
+Obj _35reg1406 = primIsCons(_35reg1405);
+if (True == _35reg1406) {
+Obj _35reg1407 = primCdr(closureRef(co, 3));
+Obj _35reg1408 = primCdr(_35reg1407);
+Obj _35reg1409 = primCar(_35reg1408);
+Obj b = _35reg1409;
+Obj _35reg1410 = primCdr(closureRef(co, 3));
+Obj _35reg1411 = primCdr(_35reg1410);
+Obj _35reg1412 = primCdr(_35reg1411);
+Obj _35reg1413 = primEQ(Nil, _35reg1412);
+if (True == _35reg1413) {
+pushCont(co, 14, _35clofun2008, 4, self, env, w, b);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -6156,58 +6317,58 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1275;
+__arg0 = _35cc128;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1275;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1275;
+__arg0 = _35cc128;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1275;
+__arg0 = _35cc128;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1275;
+__arg0 = _35cc128;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc128;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label17:
+label16:
 {
-Obj _35val2596 = __arg1;
+Obj _35val1446 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -6216,18 +6377,18 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label17:
 {
-Obj _35val2595 = __arg1;
+Obj _35val1445 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 17, _35clofun3131, 1, w);
+pushCont(co, 16, _35clofun2008, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
 __arg1 = self;
@@ -6237,20 +6398,20 @@ co->args[4] = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label18:
 {
-Obj _35val2593 = __arg1;
+Obj _35val1443 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2594 = primNot(_35val2593);
-if (True == _35reg2594) {
-pushCont(co, 18, _35clofun3131, 4, self, env, frees, w);
+Obj _35reg1444 = primNot(_35val1443);
+if (True == _35reg1444) {
+pushCont(co, 17, _35clofun2008, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6258,7 +6419,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
@@ -6269,26 +6430,45 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label20:
+label19:
 {
-Obj _35val2592 = __arg1;
+Obj _35val1442 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun3131, 4, self, env, frees, w);
+pushCont(co, 18, _35clofun2008, 4, self, env, frees, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj _35val1441 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 19, _35clofun2008, 4, self, env, frees, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = _35val1441;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6301,7 +6481,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3130(struct Cora* co){
+void _35clofun2007(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -6314,33 +6494,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2471 = __arg1;
+Obj _35val1320 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 20, _35clofun3129, 5, x, i, self, w, more);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(" = ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35val2470 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 0, _35clofun3130, 5, x, i, self, w, more);
+pushCont(co, 20, _35clofun2006, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -6348,39 +6508,39 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val1331 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg1332 = primAdd(i, makeNumber(1));
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
+__arg1 = self;
+__arg2 = w;
+__arg3 = _35reg1332;
+co->args[4] = more;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val2481 = __arg1;
+Obj _35val1330 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2482 = primAdd(i, makeNumber(1));
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
-__arg1 = self;
-__arg2 = w;
-__arg3 = _35reg2482;
-co->args[4] = more;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj _35val2480 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 2, _35clofun3130, 4, i, self, w, more);
+pushCont(co, 1, _35clofun2007, 4, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6388,19 +6548,19 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label4:
+label3:
 {
-Obj _35val2479 = __arg1;
+Obj _35val1329 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 3, _35clofun3130, 4, i, self, w, more);
+pushCont(co, 2, _35clofun2007, 4, i, self, w, more);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -6410,19 +6570,19 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label5:
+label4:
 {
-Obj _35val2478 = __arg1;
+Obj _35val1328 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 4, _35clofun3130, 5, x, i, self, w, more);
+pushCont(co, 3, _35clofun2007, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6430,19 +6590,19 @@ __arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label5:
 {
-Obj _35val2477 = __arg1;
+Obj _35val1327 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 5, _35clofun3130, 5, x, i, self, w, more);
+pushCont(co, 4, _35clofun2007, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6450,19 +6610,19 @@ __arg2 = makeCString("]");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label6:
 {
-Obj _35val2476 = __arg1;
+Obj _35val1326 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 6, _35clofun3130, 5, x, i, self, w, more);
+pushCont(co, 5, _35clofun2007, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -6470,26 +6630,26 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label7:
 {
-Obj _35cc1261 = makeNative(17, _35clofun3129, 0, 0);
+Obj _35cc114 = makeNative(16, _35clofun2006, 0, 0);
 Obj self = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj i = closureRef(co, 2);
-Obj _35reg2465 = primIsCons(closureRef(co, 3));
-if (True == _35reg2465) {
-Obj _35reg2466 = primCar(closureRef(co, 3));
-Obj x = _35reg2466;
-Obj _35reg2467 = primCdr(closureRef(co, 3));
-Obj more = _35reg2467;
-Obj _35reg2468 = primGT(i, makeNumber(3));
-Obj _35reg2469 = primNot(_35reg2468);
-if (True == _35reg2469) {
-pushCont(co, 1, _35clofun3130, 5, x, i, self, w, more);
+Obj _35reg1315 = primIsCons(closureRef(co, 3));
+if (True == _35reg1315) {
+Obj _35reg1316 = primCar(closureRef(co, 3));
+Obj x = _35reg1316;
+Obj _35reg1317 = primCdr(closureRef(co, 3));
+Obj more = _35reg1317;
+Obj _35reg1318 = primGT(i, makeNumber(3));
+Obj _35reg1319 = primNot(_35reg1318);
+if (True == _35reg1319) {
+pushCont(co, 0, _35clofun2007, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6497,10 +6657,10 @@ __arg2 = makeCString("__arg");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 7, _35clofun3130, 5, x, i, self, w, more);
+pushCont(co, 6, _35clofun2007, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6508,49 +6668,49 @@ __arg2 = makeCString("co->args[");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1261;
+__arg0 = _35cc114;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label8:
+{
+Obj _35p109 = __arg1;
+Obj _35p110 = __arg2;
+Obj _35p111 = __arg3;
+Obj _35p112 = co->args[4];
+Obj _35cc113 = makeNative(7, _35clofun2007, 0, 4, _35p109, _35p110, _35p111, _35p112);
+Obj self = _35p109;
+Obj w = _35p110;
+Obj i = _35p111;
+Obj _35reg1333 = primEQ(Nil, _35p112);
+if (True == _35reg1333) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2007) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc113;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label9:
-{
-Obj _35p1256 = __arg1;
-Obj _35p1257 = __arg2;
-Obj _35p1258 = __arg3;
-Obj _35p1259 = co->args[4];
-Obj _35cc1260 = makeNative(8, _35clofun3130, 0, 4, _35p1256, _35p1257, _35p1258, _35p1259);
-Obj self = _35p1256;
-Obj w = _35p1257;
-Obj i = _35p1258;
-Obj _35reg2483 = primEQ(Nil, _35p1259);
-if (True == _35reg2483) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3130) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1260;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -6558,13 +6718,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label10:
 {
-Obj _35val2500 = __arg1;
+Obj _35val1350 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -6573,15 +6733,15 @@ __arg2 = makeCString("goto *jumpTable[ps.label];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label11:
 {
-Obj _35val2499 = __arg1;
+Obj _35val1349 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 11, _35clofun3130, 1, w);
+pushCont(co, 10, _35clofun2007, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6589,16 +6749,16 @@ __arg2 = makeCString(") { co->ctx.pc = ps; goto fail; };\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label12:
 {
-Obj _35val2498 = __arg1;
+Obj _35val1348 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun3130, 1, w);
+pushCont(co, 11, _35clofun2007, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -6606,16 +6766,16 @@ __arg2 = self;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label13:
 {
-Obj _35val2497 = __arg1;
+Obj _35val1347 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 13, _35clofun3130, 2, self, w);
+pushCont(co, 12, _35clofun2007, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6623,16 +6783,16 @@ __arg2 = makeCString("if (ps.func != ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label14:
 {
-Obj _35val2496 = __arg1;
+Obj _35val1346 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 14, _35clofun3130, 2, self, w);
+pushCont(co, 13, _35clofun2007, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6640,16 +6800,16 @@ __arg2 = makeCString("if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) {
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label15:
 {
-Obj _35val2495 = __arg1;
+Obj _35val1345 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 15, _35clofun3130, 2, self, w);
+pushCont(co, 14, _35clofun2007, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6657,16 +6817,16 @@ __arg2 = makeCString("struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n"
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label16:
 {
-Obj _35val2494 = __arg1;
+Obj _35val1344 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 16, _35clofun3130, 2, self, w);
+pushCont(co, 15, _35clofun2007, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6674,40 +6834,40 @@ __arg2 = makeCString("co->ctx.frees = __arg0;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label17:
 {
-Obj _35val2492 = __arg1;
+Obj _35val1342 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2493 = primCons(f, args);
-pushCont(co, 17, _35clofun3130, 2, self, w);
+Obj _35reg1343 = primCons(f, args);
+pushCont(co, 16, _35clofun2007, 2, self, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
 __arg1 = self;
 __arg2 = w;
 __arg3 = makeNumber(0);
-co->args[4] = _35reg2493;
+co->args[4] = _35reg1343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label18:
 {
-Obj _35val2491 = __arg1;
+Obj _35val1341 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun3130, 4, f, args, self, w);
+pushCont(co, 17, _35clofun2007, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6715,27 +6875,45 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label19:
+{
+Obj _35val1339 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg1340 = primAdd(makeNumber(1), _35val1339);
+pushCont(co, 18, _35clofun2007, 4, f, args, self, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = _35reg1340;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val2489 = __arg1;
+Obj _35val1338 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2490 = primAdd(makeNumber(1), _35val2489);
-pushCont(co, 19, _35clofun3130, 4, f, args, self, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = _35reg2490;
+pushCont(co, 19, _35clofun2007, 4, f, args, self, w);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#length"));
+__arg1 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6748,7 +6926,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3129(struct Cora* co){
+void _35clofun2006(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -6761,77 +6939,60 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2419 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2420 = primCons(name, idx);
-Obj _35reg2421 = primCons(_35reg2420, fvs);
-Obj _35reg2422 = primCons(clo_45or_45cont, _35reg2421);
+Obj _35val1282 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1281= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg1283 = primCons(_35val1282, fvs);
+Obj _35reg1284 = primCons(_35reg1281, _35reg1283);
+Obj _35reg1285 = primCons(clo_45or_45cont, _35reg1284);
 __nargs = 2;
-__arg1 = _35reg2422;
+__arg1 = _35reg1285;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3129) { goto fail; }
+if (co->ctx.pc.func != _35clofun2006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj _35val2432 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2431= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2433 = primCons(_35val2432, fvs);
-Obj _35reg2434 = primCons(_35reg2431, _35reg2433);
-Obj _35reg2435 = primCons(clo_45or_45cont, _35reg2434);
-__nargs = 2;
-__arg1 = _35reg2435;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3129) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label2:
-{
-Obj _35val2430 = __arg1;
+Obj _35val1280 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2431 = primCons(name, idx);
-pushCont(co, 1, _35clofun3129, 3, fvs, _35reg2431, clo_45or_45cont);
+Obj _35reg1281 = primCons(name, idx);
+pushCont(co, 0, _35clofun2006, 3, fvs, _35reg1281, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label2:
 {
-Obj _35val2440 = __arg1;
+Obj _35val1290 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2441 = primCons(name, idx);
-Obj _35reg2442 = primCons(_35reg2441, fvs);
-Obj _35reg2443 = primCons(clo_45or_45cont, _35reg2442);
+Obj _35reg1291 = primCons(name, idx);
+Obj _35reg1292 = primCons(_35reg1291, fvs);
+Obj _35reg1293 = primCons(clo_45or_45cont, _35reg1292);
 __nargs = 2;
-__arg1 = _35reg2443;
+__arg1 = _35reg1293;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3129) { goto fail; }
+if (co->ctx.pc.func != _35clofun2006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label4:
+label3:
 {
-Obj _35val2423 = __arg1;
+Obj _35val1273 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -6839,123 +7000,123 @@ Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 5];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 6];
-Obj _35reg2424 = primCar(_35val2423);
-Obj name = _35reg2424;
-Obj _35reg2425 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2425) {
-Obj _35reg2426 = primCons(body1, Nil);
-Obj _35reg2427 = primCons(Nil, _35reg2426);
-Obj _35reg2428 = primCons(params, _35reg2427);
-Obj _35reg2429 = primCons(intern("lambda"), _35reg2428);
-pushCont(co, 2, _35clofun3129, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj _35reg1274 = primCar(_35val1273);
+Obj name = _35reg1274;
+Obj _35reg1275 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg1275) {
+Obj _35reg1276 = primCons(body1, Nil);
+Obj _35reg1277 = primCons(Nil, _35reg1276);
+Obj _35reg1278 = primCons(params, _35reg1277);
+Obj _35reg1279 = primCons(intern("lambda"), _35reg1278);
+pushCont(co, 1, _35clofun2006, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2429;
+co->args[5] = _35reg1279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2436 = primCons(body1, Nil);
-Obj _35reg2437 = primCons(fvs, _35reg2436);
-Obj _35reg2438 = primCons(params, _35reg2437);
-Obj _35reg2439 = primCons(intern("lambda"), _35reg2438);
-pushCont(co, 3, _35clofun3129, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg1286 = primCons(body1, Nil);
+Obj _35reg1287 = primCons(fvs, _35reg1286);
+Obj _35reg1288 = primCons(params, _35reg1287);
+Obj _35reg1289 = primCons(intern("lambda"), _35reg1288);
+pushCont(co, 2, _35clofun2006, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2439;
+co->args[5] = _35reg1289;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label5:
+label4:
 {
-Obj _35val2401 = __arg1;
+Obj _35val1251 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj cur = _35val2401;
-Obj _35reg2402 = primEQ(idx, makeNumber(0));
-if (True == _35reg2402) {
-Obj _35reg2403 = primGenSym(intern("clofun"));
-Obj name = _35reg2403;
-Obj _35reg2404 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2404) {
-Obj _35reg2405 = primCons(body1, Nil);
-Obj _35reg2406 = primCons(Nil, _35reg2405);
-Obj _35reg2407 = primCons(params, _35reg2406);
-Obj _35reg2408 = primCons(intern("lambda"), _35reg2407);
-pushCont(co, 20, _35clofun3128, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj cur = _35val1251;
+Obj _35reg1252 = primEQ(idx, makeNumber(0));
+if (True == _35reg1252) {
+Obj _35reg1253 = primGenSym(intern("clofun"));
+Obj name = _35reg1253;
+Obj _35reg1254 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg1254) {
+Obj _35reg1255 = primCons(body1, Nil);
+Obj _35reg1256 = primCons(Nil, _35reg1255);
+Obj _35reg1257 = primCons(params, _35reg1256);
+Obj _35reg1258 = primCons(intern("lambda"), _35reg1257);
+pushCont(co, 19, _35clofun2005, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2408;
+co->args[5] = _35reg1258;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2415 = primCons(body1, Nil);
-Obj _35reg2416 = primCons(fvs, _35reg2415);
-Obj _35reg2417 = primCons(params, _35reg2416);
-Obj _35reg2418 = primCons(intern("lambda"), _35reg2417);
-pushCont(co, 0, _35clofun3129, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg1265 = primCons(body1, Nil);
+Obj _35reg1266 = primCons(fvs, _35reg1265);
+Obj _35reg1267 = primCons(params, _35reg1266);
+Obj _35reg1268 = primCons(intern("lambda"), _35reg1267);
+pushCont(co, 20, _35clofun2005, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2418;
+co->args[5] = _35reg1268;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 4, _35clofun3129, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
+pushCont(co, 3, _35clofun2006, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label6:
+label5:
 {
-Obj _35val2400 = __arg1;
+Obj _35val1250 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val2400;
-pushCont(co, 5, _35clofun3129, 6, body1, params, v, idx, fvs, clo_45or_45cont);
+Obj idx = _35val1250;
+pushCont(co, 4, _35clofun2006, 6, body1, params, v, idx, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -6963,19 +7124,19 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label6:
 {
-Obj _35val2399 = __arg1;
+Obj _35val1249 = __arg1;
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj body1 = _35val2399;
-pushCont(co, 6, _35clofun3129, 5, body1, params, v, fvs, clo_45or_45cont);
+Obj body1 = _35val1249;
+pushCont(co, 5, _35clofun2006, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -6983,68 +7144,68 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label7:
 {
-Obj _35p1251 = __arg1;
-Obj _35p1252 = __arg2;
-Obj _35cc1253 = makeNative(19, _35clofun3127, 0, 2, _35p1251, _35p1252);
-Obj v = _35p1251;
-Obj _35reg2270 = primIsCons(_35p1252);
-if (True == _35reg2270) {
-Obj _35reg2271 = primCar(_35p1252);
-Obj clo_45or_45cont = _35reg2271;
-Obj _35reg2272 = primCdr(_35p1252);
-Obj _35reg2273 = primIsCons(_35reg2272);
-if (True == _35reg2273) {
-Obj _35reg2274 = primCdr(_35p1252);
-Obj _35reg2275 = primCar(_35reg2274);
-Obj _35reg2276 = primIsCons(_35reg2275);
-if (True == _35reg2276) {
-Obj _35reg2277 = primCdr(_35p1252);
-Obj _35reg2278 = primCar(_35reg2277);
-Obj _35reg2279 = primCar(_35reg2278);
-Obj _35reg2280 = primEQ(intern("lambda"), _35reg2279);
-if (True == _35reg2280) {
-Obj _35reg2281 = primCdr(_35p1252);
-Obj _35reg2282 = primCar(_35reg2281);
-Obj _35reg2283 = primCdr(_35reg2282);
-Obj _35reg2284 = primIsCons(_35reg2283);
-if (True == _35reg2284) {
-Obj _35reg2285 = primCdr(_35p1252);
-Obj _35reg2286 = primCar(_35reg2285);
-Obj _35reg2287 = primCdr(_35reg2286);
-Obj _35reg2288 = primCar(_35reg2287);
-Obj params = _35reg2288;
-Obj _35reg2289 = primCdr(_35p1252);
-Obj _35reg2290 = primCar(_35reg2289);
-Obj _35reg2291 = primCdr(_35reg2290);
-Obj _35reg2292 = primCdr(_35reg2291);
-Obj _35reg2293 = primIsCons(_35reg2292);
-if (True == _35reg2293) {
-Obj _35reg2294 = primCdr(_35p1252);
-Obj _35reg2295 = primCar(_35reg2294);
-Obj _35reg2296 = primCdr(_35reg2295);
-Obj _35reg2297 = primCdr(_35reg2296);
-Obj _35reg2298 = primCar(_35reg2297);
-Obj body = _35reg2298;
-Obj _35reg2299 = primCdr(_35p1252);
-Obj _35reg2300 = primCar(_35reg2299);
-Obj _35reg2301 = primCdr(_35reg2300);
-Obj _35reg2302 = primCdr(_35reg2301);
-Obj _35reg2303 = primCdr(_35reg2302);
-Obj _35reg2304 = primEQ(Nil, _35reg2303);
-if (True == _35reg2304) {
-Obj _35reg2305 = primCdr(_35p1252);
-Obj _35reg2306 = primCdr(_35reg2305);
-Obj fvs = _35reg2306;
-Obj _35reg2307 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2307) {
+Obj _35p104 = __arg1;
+Obj _35p105 = __arg2;
+Obj _35cc106 = makeNative(18, _35clofun2004, 0, 2, _35p104, _35p105);
+Obj v = _35p104;
+Obj _35reg1120 = primIsCons(_35p105);
+if (True == _35reg1120) {
+Obj _35reg1121 = primCar(_35p105);
+Obj clo_45or_45cont = _35reg1121;
+Obj _35reg1122 = primCdr(_35p105);
+Obj _35reg1123 = primIsCons(_35reg1122);
+if (True == _35reg1123) {
+Obj _35reg1124 = primCdr(_35p105);
+Obj _35reg1125 = primCar(_35reg1124);
+Obj _35reg1126 = primIsCons(_35reg1125);
+if (True == _35reg1126) {
+Obj _35reg1127 = primCdr(_35p105);
+Obj _35reg1128 = primCar(_35reg1127);
+Obj _35reg1129 = primCar(_35reg1128);
+Obj _35reg1130 = primEQ(intern("lambda"), _35reg1129);
+if (True == _35reg1130) {
+Obj _35reg1131 = primCdr(_35p105);
+Obj _35reg1132 = primCar(_35reg1131);
+Obj _35reg1133 = primCdr(_35reg1132);
+Obj _35reg1134 = primIsCons(_35reg1133);
+if (True == _35reg1134) {
+Obj _35reg1135 = primCdr(_35p105);
+Obj _35reg1136 = primCar(_35reg1135);
+Obj _35reg1137 = primCdr(_35reg1136);
+Obj _35reg1138 = primCar(_35reg1137);
+Obj params = _35reg1138;
+Obj _35reg1139 = primCdr(_35p105);
+Obj _35reg1140 = primCar(_35reg1139);
+Obj _35reg1141 = primCdr(_35reg1140);
+Obj _35reg1142 = primCdr(_35reg1141);
+Obj _35reg1143 = primIsCons(_35reg1142);
+if (True == _35reg1143) {
+Obj _35reg1144 = primCdr(_35p105);
+Obj _35reg1145 = primCar(_35reg1144);
+Obj _35reg1146 = primCdr(_35reg1145);
+Obj _35reg1147 = primCdr(_35reg1146);
+Obj _35reg1148 = primCar(_35reg1147);
+Obj body = _35reg1148;
+Obj _35reg1149 = primCdr(_35p105);
+Obj _35reg1150 = primCar(_35reg1149);
+Obj _35reg1151 = primCdr(_35reg1150);
+Obj _35reg1152 = primCdr(_35reg1151);
+Obj _35reg1153 = primCdr(_35reg1152);
+Obj _35reg1154 = primEQ(Nil, _35reg1153);
+if (True == _35reg1154) {
+Obj _35reg1155 = primCdr(_35p105);
+Obj _35reg1156 = primCdr(_35reg1155);
+Obj fvs = _35reg1156;
+Obj _35reg1157 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg1157) {
 if (True == True) {
-pushCont(co, 8, _35clofun3128, 4, params, v, fvs, clo_45or_45cont);
+pushCont(co, 7, _35clofun2005, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
 __arg1 = v;
@@ -7052,22 +7213,22 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1253;
+__arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj _35reg2353 = primEQ(clo_45or_45cont, intern("%continuation"));
-if (True == _35reg2353) {
+Obj _35reg1203 = primEQ(clo_45or_45cont, intern("%continuation"));
+if (True == _35reg1203) {
 if (True == True) {
-pushCont(co, 18, _35clofun3128, 4, params, v, fvs, clo_45or_45cont);
+pushCont(co, 17, _35clofun2005, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
 __arg1 = v;
@@ -7075,20 +7236,20 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1253;
+__arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-pushCont(co, 7, _35clofun3129, 4, params, v, fvs, clo_45or_45cont);
+pushCont(co, 6, _35clofun2006, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
 __arg1 = v;
@@ -7096,87 +7257,87 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1253;
+__arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1253;
+__arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1253;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1253;
+__arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1253;
+__arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1253;
+__arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1253;
+__arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1253;
+__arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc106;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label9:
+label8:
 {
-Obj _35val2451 = __arg1;
+Obj _35val1301 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -7187,51 +7348,51 @@ __arg3 = cur1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label9:
+{
+Obj _35val1305 = __arg1;
+Obj res= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1306 = primCons(_35val1305, res);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/init#vector-set!"));
+__arg1 = v;
+__arg2 = makeNumber(2);
+__arg3 = _35reg1306;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val2455 = __arg1;
-Obj res= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2456 = primCons(_35val2455, res);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#vector-set!"));
-__arg1 = v;
-__arg2 = makeNumber(2);
-__arg3 = _35reg2456;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val2454 = __arg1;
+Obj _35val1304 = __arg1;
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj res = _35val2454;
-pushCont(co, 10, _35clofun3129, 2, res, v);
+Obj res = _35val1304;
+pushCont(co, 9, _35clofun2006, 2, res, v);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = cur1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label11:
 {
-Obj _35val2453 = __arg1;
+Obj _35val1303 = __arg1;
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun3129, 2, cur1, v);
+pushCont(co, 10, _35clofun2006, 2, cur1, v);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7239,16 +7400,16 @@ __arg2 = makeNumber(2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label12:
 {
-Obj _35val2452 = __arg1;
+Obj _35val1302 = __arg1;
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun3129, 2, cur1, v);
+pushCont(co, 11, _35clofun2006, 2, cur1, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -7257,38 +7418,38 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label13:
 {
 Obj v = __arg1;
 Obj idx = __arg2;
 Obj cur = __arg3;
 Obj name = co->args[4];
 Obj val = co->args[5];
-Obj _35reg2445 = primCons(name, idx);
-Obj _35reg2446 = primCons(val, Nil);
-Obj _35reg2447 = primCons(_35reg2445, _35reg2446);
-Obj _35reg2448 = primCons(_35reg2447, cur);
-Obj cur1 = _35reg2448;
-Obj _35reg2449 = primLT(idx, makeNumber(20));
-if (True == _35reg2449) {
-Obj _35reg2450 = primAdd(idx, makeNumber(1));
-pushCont(co, 9, _35clofun3129, 2, v, cur1);
+Obj _35reg1295 = primCons(name, idx);
+Obj _35reg1296 = primCons(val, Nil);
+Obj _35reg1297 = primCons(_35reg1295, _35reg1296);
+Obj _35reg1298 = primCons(_35reg1297, cur);
+Obj cur1 = _35reg1298;
+Obj _35reg1299 = primLT(idx, makeNumber(20));
+if (True == _35reg1299) {
+Obj _35reg1300 = primAdd(idx, makeNumber(1));
+pushCont(co, 8, _35clofun2006, 2, v, cur1);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
 __arg2 = makeNumber(0);
-__arg3 = _35reg2450;
+__arg3 = _35reg1300;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 13, _35clofun3129, 2, cur1, v);
+pushCont(co, 12, _35clofun2006, 2, cur1, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -7297,45 +7458,45 @@ __arg3 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label15:
+label14:
 {
-Obj _35val2459 = __arg1;
+Obj _35val1309 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj tmp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2460 = primCons(_35val2459, Nil);
-Obj _35reg2461 = primCons(x, _35reg2460);
-Obj _35reg2462 = primCons(tmp, _35reg2461);
-Obj _35reg2463 = primCons(intern("let"), _35reg2462);
+Obj _35reg1310 = primCons(_35val1309, Nil);
+Obj _35reg1311 = primCons(x, _35reg1310);
+Obj _35reg1312 = primCons(tmp, _35reg1311);
+Obj _35reg1313 = primCons(intern("let"), _35reg1312);
 __nargs = 2;
-__arg1 = _35reg2463;
+__arg1 = _35reg1313;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3129) { goto fail; }
+if (co->ctx.pc.func != _35clofun2006) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label16:
+label15:
 {
 Obj x = __arg1;
 Obj k = __arg2;
-Obj _35reg2458 = primGenSym(intern("reg"));
-Obj tmp = _35reg2458;
-pushCont(co, 15, _35clofun3129, 2, x, tmp);
+Obj _35reg1308 = primGenSym(intern("reg"));
+Obj tmp = _35reg1308;
+pushCont(co, 14, _35clofun2006, 2, x, tmp);
 __nargs = 2;
 __arg0 = k;
 __arg1 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label16:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -7343,39 +7504,39 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label17:
+{
+Obj _35val1324 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg1325 = primAdd(i, makeNumber(1));
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
+__arg1 = self;
+__arg2 = w;
+__arg3 = _35reg1325;
+co->args[4] = more;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val2474 = __arg1;
+Obj _35val1323 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2475 = primAdd(i, makeNumber(1));
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
-__arg1 = self;
-__arg2 = w;
-__arg3 = _35reg2475;
-co->args[4] = more;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35val2473 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun3129, 4, i, self, w, more);
+pushCont(co, 17, _35clofun2006, 4, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -7383,19 +7544,19 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label19:
 {
-Obj _35val2472 = __arg1;
+Obj _35val1322 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 19, _35clofun3129, 4, i, self, w, more);
+pushCont(co, 18, _35clofun2006, 4, i, self, w, more);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -7405,7 +7566,27 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj _35val1321 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 19, _35clofun2006, 5, x, i, self, w, more);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(" = ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7418,7 +7599,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3128(struct Cora* co){
+void _35clofun2005(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -7431,97 +7612,77 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2318 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2319 = primCons(name, idx);
-pushCont(co, 20, _35clofun3127, 3, fvs, _35reg2319, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = params;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35val2328 = __arg1;
+Obj _35val1178 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2329 = primCons(name, idx);
-Obj _35reg2330 = primCons(_35reg2329, fvs);
-Obj _35reg2331 = primCons(clo_45or_45cont, _35reg2330);
+Obj _35reg1179 = primCons(name, idx);
+Obj _35reg1180 = primCons(_35reg1179, fvs);
+Obj _35reg1181 = primCons(clo_45or_45cont, _35reg1180);
 __nargs = 2;
-__arg1 = _35reg2331;
+__arg1 = _35reg1181;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3128) { goto fail; }
+if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label1:
+{
+Obj _35val1191 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1190= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg1192 = primCons(_35val1191, fvs);
+Obj _35reg1193 = primCons(_35reg1190, _35reg1192);
+Obj _35reg1194 = primCons(clo_45or_45cont, _35reg1193);
+__nargs = 2;
+__arg1 = _35reg1194;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2005) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val2341 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2340= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2342 = primCons(_35val2341, fvs);
-Obj _35reg2343 = primCons(_35reg2340, _35reg2342);
-Obj _35reg2344 = primCons(clo_45or_45cont, _35reg2343);
-__nargs = 2;
-__arg1 = _35reg2344;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3128) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label3:
-{
-Obj _35val2339 = __arg1;
+Obj _35val1189 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2340 = primCons(name, idx);
-pushCont(co, 2, _35clofun3128, 3, fvs, _35reg2340, clo_45or_45cont);
+Obj _35reg1190 = primCons(name, idx);
+pushCont(co, 1, _35clofun2005, 3, fvs, _35reg1190, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label4:
+label3:
 {
-Obj _35val2349 = __arg1;
+Obj _35val1199 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2350 = primCons(name, idx);
-Obj _35reg2351 = primCons(_35reg2350, fvs);
-Obj _35reg2352 = primCons(clo_45or_45cont, _35reg2351);
+Obj _35reg1200 = primCons(name, idx);
+Obj _35reg1201 = primCons(_35reg1200, fvs);
+Obj _35reg1202 = primCons(clo_45or_45cont, _35reg1201);
 __nargs = 2;
-__arg1 = _35reg2352;
+__arg1 = _35reg1202;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3128) { goto fail; }
+if (co->ctx.pc.func != _35clofun2005) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label5:
+label4:
 {
-Obj _35val2332 = __arg1;
+Obj _35val1182 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -7529,123 +7690,123 @@ Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 5];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 6];
-Obj _35reg2333 = primCar(_35val2332);
-Obj name = _35reg2333;
-Obj _35reg2334 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2334) {
-Obj _35reg2335 = primCons(body1, Nil);
-Obj _35reg2336 = primCons(Nil, _35reg2335);
-Obj _35reg2337 = primCons(params, _35reg2336);
-Obj _35reg2338 = primCons(intern("lambda"), _35reg2337);
-pushCont(co, 3, _35clofun3128, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj _35reg1183 = primCar(_35val1182);
+Obj name = _35reg1183;
+Obj _35reg1184 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg1184) {
+Obj _35reg1185 = primCons(body1, Nil);
+Obj _35reg1186 = primCons(Nil, _35reg1185);
+Obj _35reg1187 = primCons(params, _35reg1186);
+Obj _35reg1188 = primCons(intern("lambda"), _35reg1187);
+pushCont(co, 2, _35clofun2005, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2338;
+co->args[5] = _35reg1188;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2345 = primCons(body1, Nil);
-Obj _35reg2346 = primCons(fvs, _35reg2345);
-Obj _35reg2347 = primCons(params, _35reg2346);
-Obj _35reg2348 = primCons(intern("lambda"), _35reg2347);
-pushCont(co, 4, _35clofun3128, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg1195 = primCons(body1, Nil);
+Obj _35reg1196 = primCons(fvs, _35reg1195);
+Obj _35reg1197 = primCons(params, _35reg1196);
+Obj _35reg1198 = primCons(intern("lambda"), _35reg1197);
+pushCont(co, 3, _35clofun2005, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2348;
+co->args[5] = _35reg1198;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35val1160 = __arg1;
+Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
+Obj cur = _35val1160;
+Obj _35reg1161 = primEQ(idx, makeNumber(0));
+if (True == _35reg1161) {
+Obj _35reg1162 = primGenSym(intern("clofun"));
+Obj name = _35reg1162;
+Obj _35reg1163 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg1163) {
+Obj _35reg1164 = primCons(body1, Nil);
+Obj _35reg1165 = primCons(Nil, _35reg1164);
+Obj _35reg1166 = primCons(params, _35reg1165);
+Obj _35reg1167 = primCons(intern("lambda"), _35reg1166);
+pushCont(co, 20, _35clofun2004, 5, name, idx, params, fvs, clo_45or_45cont);
+__nargs = 6;
+__arg0 = globalRef(intern("cora/lib/toc#append-result"));
+__arg1 = v;
+__arg2 = idx;
+__arg3 = cur;
+co->args[4] = name;
+co->args[5] = _35reg1167;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1174 = primCons(body1, Nil);
+Obj _35reg1175 = primCons(fvs, _35reg1174);
+Obj _35reg1176 = primCons(params, _35reg1175);
+Obj _35reg1177 = primCons(intern("lambda"), _35reg1176);
+pushCont(co, 0, _35clofun2005, 4, name, idx, fvs, clo_45or_45cont);
+__nargs = 6;
+__arg0 = globalRef(intern("cora/lib/toc#append-result"));
+__arg1 = v;
+__arg2 = idx;
+__arg3 = cur;
+co->args[4] = name;
+co->args[5] = _35reg1177;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+pushCont(co, 4, _35clofun2005, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#caar"));
+__arg1 = cur;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label6:
 {
-Obj _35val2310 = __arg1;
-Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj cur = _35val2310;
-Obj _35reg2311 = primEQ(idx, makeNumber(0));
-if (True == _35reg2311) {
-Obj _35reg2312 = primGenSym(intern("clofun"));
-Obj name = _35reg2312;
-Obj _35reg2313 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2313) {
-Obj _35reg2314 = primCons(body1, Nil);
-Obj _35reg2315 = primCons(Nil, _35reg2314);
-Obj _35reg2316 = primCons(params, _35reg2315);
-Obj _35reg2317 = primCons(intern("lambda"), _35reg2316);
-pushCont(co, 0, _35clofun3128, 5, name, idx, params, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2317;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2324 = primCons(body1, Nil);
-Obj _35reg2325 = primCons(fvs, _35reg2324);
-Obj _35reg2326 = primCons(params, _35reg2325);
-Obj _35reg2327 = primCons(intern("lambda"), _35reg2326);
-pushCont(co, 1, _35clofun3128, 4, name, idx, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2327;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 5, _35clofun3128, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#caar"));
-__arg1 = cur;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label7:
-{
-Obj _35val2309 = __arg1;
+Obj _35val1159 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val2309;
-pushCont(co, 6, _35clofun3128, 6, body1, params, v, idx, fvs, clo_45or_45cont);
+Obj idx = _35val1159;
+pushCont(co, 5, _35clofun2005, 6, body1, params, v, idx, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7653,19 +7814,19 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label7:
 {
-Obj _35val2308 = __arg1;
+Obj _35val1158 = __arg1;
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj body1 = _35val2308;
-pushCont(co, 7, _35clofun3128, 5, body1, params, v, fvs, clo_45or_45cont);
+Obj body1 = _35val1158;
+pushCont(co, 6, _35clofun2005, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7673,119 +7834,119 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label8:
+{
+Obj _35val1216 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1215= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg1217 = primCons(_35val1216, fvs);
+Obj _35reg1218 = primCons(_35reg1215, _35reg1217);
+Obj _35reg1219 = primCons(clo_45or_45cont, _35reg1218);
+__nargs = 2;
+__arg1 = _35reg1219;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label9:
 {
-Obj _35val2366 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2365= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2367 = primCons(_35val2366, fvs);
-Obj _35reg2368 = primCons(_35reg2365, _35reg2367);
-Obj _35reg2369 = primCons(clo_45or_45cont, _35reg2368);
-__nargs = 2;
-__arg1 = _35reg2369;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3128) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label10:
-{
-Obj _35val2364 = __arg1;
+Obj _35val1214 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2365 = primCons(name, idx);
-pushCont(co, 9, _35clofun3128, 3, fvs, _35reg2365, clo_45or_45cont);
+Obj _35reg1215 = primCons(name, idx);
+pushCont(co, 8, _35clofun2005, 3, fvs, _35reg1215, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label10:
 {
-Obj _35val2374 = __arg1;
+Obj _35val1224 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2375 = primCons(name, idx);
-Obj _35reg2376 = primCons(_35reg2375, fvs);
-Obj _35reg2377 = primCons(clo_45or_45cont, _35reg2376);
+Obj _35reg1225 = primCons(name, idx);
+Obj _35reg1226 = primCons(_35reg1225, fvs);
+Obj _35reg1227 = primCons(clo_45or_45cont, _35reg1226);
 __nargs = 2;
-__arg1 = _35reg2377;
+__arg1 = _35reg1227;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3128) { goto fail; }
+if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label11:
+{
+Obj _35val1237 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1236= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg1238 = primCons(_35val1237, fvs);
+Obj _35reg1239 = primCons(_35reg1236, _35reg1238);
+Obj _35reg1240 = primCons(clo_45or_45cont, _35reg1239);
+__nargs = 2;
+__arg1 = _35reg1240;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2005) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label12:
 {
-Obj _35val2387 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2386= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2388 = primCons(_35val2387, fvs);
-Obj _35reg2389 = primCons(_35reg2386, _35reg2388);
-Obj _35reg2390 = primCons(clo_45or_45cont, _35reg2389);
-__nargs = 2;
-__arg1 = _35reg2390;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3128) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label13:
-{
-Obj _35val2385 = __arg1;
+Obj _35val1235 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2386 = primCons(name, idx);
-pushCont(co, 12, _35clofun3128, 3, fvs, _35reg2386, clo_45or_45cont);
+Obj _35reg1236 = primCons(name, idx);
+pushCont(co, 11, _35clofun2005, 3, fvs, _35reg1236, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label13:
 {
-Obj _35val2395 = __arg1;
+Obj _35val1245 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2396 = primCons(name, idx);
-Obj _35reg2397 = primCons(_35reg2396, fvs);
-Obj _35reg2398 = primCons(clo_45or_45cont, _35reg2397);
+Obj _35reg1246 = primCons(name, idx);
+Obj _35reg1247 = primCons(_35reg1246, fvs);
+Obj _35reg1248 = primCons(clo_45or_45cont, _35reg1247);
 __nargs = 2;
-__arg1 = _35reg2398;
+__arg1 = _35reg1248;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3128) { goto fail; }
+if (co->ctx.pc.func != _35clofun2005) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label15:
+label14:
 {
-Obj _35val2378 = __arg1;
+Obj _35val1228 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -7793,123 +7954,123 @@ Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 5];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 6];
-Obj _35reg2379 = primCar(_35val2378);
-Obj name = _35reg2379;
-Obj _35reg2380 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2380) {
-Obj _35reg2381 = primCons(body1, Nil);
-Obj _35reg2382 = primCons(Nil, _35reg2381);
-Obj _35reg2383 = primCons(params, _35reg2382);
-Obj _35reg2384 = primCons(intern("lambda"), _35reg2383);
-pushCont(co, 13, _35clofun3128, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj _35reg1229 = primCar(_35val1228);
+Obj name = _35reg1229;
+Obj _35reg1230 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg1230) {
+Obj _35reg1231 = primCons(body1, Nil);
+Obj _35reg1232 = primCons(Nil, _35reg1231);
+Obj _35reg1233 = primCons(params, _35reg1232);
+Obj _35reg1234 = primCons(intern("lambda"), _35reg1233);
+pushCont(co, 12, _35clofun2005, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2384;
+co->args[5] = _35reg1234;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2391 = primCons(body1, Nil);
-Obj _35reg2392 = primCons(fvs, _35reg2391);
-Obj _35reg2393 = primCons(params, _35reg2392);
-Obj _35reg2394 = primCons(intern("lambda"), _35reg2393);
-pushCont(co, 14, _35clofun3128, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg1241 = primCons(body1, Nil);
+Obj _35reg1242 = primCons(fvs, _35reg1241);
+Obj _35reg1243 = primCons(params, _35reg1242);
+Obj _35reg1244 = primCons(intern("lambda"), _35reg1243);
+pushCont(co, 13, _35clofun2005, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2394;
+co->args[5] = _35reg1244;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label16:
+label15:
 {
-Obj _35val2356 = __arg1;
+Obj _35val1206 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj cur = _35val2356;
-Obj _35reg2357 = primEQ(idx, makeNumber(0));
-if (True == _35reg2357) {
-Obj _35reg2358 = primGenSym(intern("clofun"));
-Obj name = _35reg2358;
-Obj _35reg2359 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2359) {
-Obj _35reg2360 = primCons(body1, Nil);
-Obj _35reg2361 = primCons(Nil, _35reg2360);
-Obj _35reg2362 = primCons(params, _35reg2361);
-Obj _35reg2363 = primCons(intern("lambda"), _35reg2362);
-pushCont(co, 10, _35clofun3128, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj cur = _35val1206;
+Obj _35reg1207 = primEQ(idx, makeNumber(0));
+if (True == _35reg1207) {
+Obj _35reg1208 = primGenSym(intern("clofun"));
+Obj name = _35reg1208;
+Obj _35reg1209 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg1209) {
+Obj _35reg1210 = primCons(body1, Nil);
+Obj _35reg1211 = primCons(Nil, _35reg1210);
+Obj _35reg1212 = primCons(params, _35reg1211);
+Obj _35reg1213 = primCons(intern("lambda"), _35reg1212);
+pushCont(co, 9, _35clofun2005, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2363;
+co->args[5] = _35reg1213;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2370 = primCons(body1, Nil);
-Obj _35reg2371 = primCons(fvs, _35reg2370);
-Obj _35reg2372 = primCons(params, _35reg2371);
-Obj _35reg2373 = primCons(intern("lambda"), _35reg2372);
-pushCont(co, 11, _35clofun3128, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg1220 = primCons(body1, Nil);
+Obj _35reg1221 = primCons(fvs, _35reg1220);
+Obj _35reg1222 = primCons(params, _35reg1221);
+Obj _35reg1223 = primCons(intern("lambda"), _35reg1222);
+pushCont(co, 10, _35clofun2005, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg2373;
+co->args[5] = _35reg1223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 15, _35clofun3128, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
+pushCont(co, 14, _35clofun2005, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label17:
+label16:
 {
-Obj _35val2355 = __arg1;
+Obj _35val1205 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val2355;
-pushCont(co, 16, _35clofun3128, 6, body1, params, v, idx, fvs, clo_45or_45cont);
+Obj idx = _35val1205;
+pushCont(co, 15, _35clofun2005, 6, body1, params, v, idx, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7917,19 +8078,19 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label17:
 {
-Obj _35val2354 = __arg1;
+Obj _35val1204 = __arg1;
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj body1 = _35val2354;
-pushCont(co, 17, _35clofun3128, 5, body1, params, v, fvs, clo_45or_45cont);
+Obj body1 = _35val1204;
+pushCont(co, 16, _35clofun2005, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7937,44 +8098,61 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label18:
+{
+Obj _35val1261 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1260= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg1262 = primCons(_35val1261, fvs);
+Obj _35reg1263 = primCons(_35reg1260, _35reg1262);
+Obj _35reg1264 = primCons(clo_45or_45cont, _35reg1263);
+__nargs = 2;
+__arg1 = _35reg1264;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label19:
 {
-Obj _35val2411 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2410= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2412 = primCons(_35val2411, fvs);
-Obj _35reg2413 = primCons(_35reg2410, _35reg2412);
-Obj _35reg2414 = primCons(clo_45or_45cont, _35reg2413);
-__nargs = 2;
-__arg1 = _35reg2414;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3128) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label20:
-{
-Obj _35val2409 = __arg1;
+Obj _35val1259 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2410 = primCons(name, idx);
-pushCont(co, 19, _35clofun3128, 3, fvs, _35reg2410, clo_45or_45cont);
+Obj _35reg1260 = primCons(name, idx);
+pushCont(co, 18, _35clofun2005, 3, fvs, _35reg1260, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label20:
+{
+Obj _35val1269 = __arg1;
+Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg1270 = primCons(name, idx);
+Obj _35reg1271 = primCons(_35reg1270, fvs);
+Obj _35reg1272 = primCons(clo_45or_45cont, _35reg1271);
+__nargs = 2;
+__arg1 = _35reg1272;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 fail:
@@ -7986,7 +8164,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3127(struct Cora* co){
+void _35clofun2004(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -7999,54 +8177,24 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1250 = makeNative(19, _35clofun3126, 0, 0);
-Obj fvs = closureRef(co, 0);
-Obj _35reg2190 = primIsCons(closureRef(co, 1));
-if (True == _35reg2190) {
-Obj _35reg2191 = primCar(closureRef(co, 1));
-Obj f = _35reg2191;
-Obj _35reg2192 = primCdr(closureRef(co, 1));
-Obj args = _35reg2192;
-pushCont(co, 20, _35clofun3126, 2, f, args);
+Obj _35val1064 = __arg1;
+Obj _35val1063= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1065 = primCons(_35val1064, Nil);
+Obj _35reg1066 = primCons(_35val1063, _35reg1065);
+Obj _35reg1067 = primCons(intern("call"), _35reg1066);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
-__arg1 = fvs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1250;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+__arg1 = _35reg1067;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2004) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj _35val2214 = __arg1;
-Obj _35val2213= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2215 = primCons(_35val2214, Nil);
-Obj _35reg2216 = primCons(_35val2213, _35reg2215);
-Obj _35reg2217 = primCons(intern("call"), _35reg2216);
-__nargs = 2;
-__arg1 = _35reg2217;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3127) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label2:
-{
-Obj _35val2213 = __arg1;
+Obj _35val1063 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun3127, 1, _35val2213);
+pushCont(co, 0, _35clofun2004, 1, _35val1063);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
@@ -8054,137 +8202,137 @@ __arg2 = cont;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val1062 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 1, _35clofun2004, 2, fvs, cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = _35val1062;
+__arg2 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2212 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 2, _35clofun3127, 2, fvs, cont);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val2212;
-__arg2 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj _35cc1249 = makeNative(0, _35clofun3127, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc102 = makeNative(20, _35clofun2003, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2195 = primIsCons(closureRef(co, 1));
-if (True == _35reg2195) {
-Obj _35reg2196 = primCar(closureRef(co, 1));
-Obj _35reg2197 = primEQ(intern("call"), _35reg2196);
-if (True == _35reg2197) {
-Obj _35reg2198 = primCdr(closureRef(co, 1));
-Obj _35reg2199 = primIsCons(_35reg2198);
-if (True == _35reg2199) {
-Obj _35reg2200 = primCdr(closureRef(co, 1));
-Obj _35reg2201 = primCar(_35reg2200);
-Obj exp = _35reg2201;
-Obj _35reg2202 = primCdr(closureRef(co, 1));
-Obj _35reg2203 = primCdr(_35reg2202);
-Obj _35reg2204 = primIsCons(_35reg2203);
-if (True == _35reg2204) {
-Obj _35reg2205 = primCdr(closureRef(co, 1));
-Obj _35reg2206 = primCdr(_35reg2205);
-Obj _35reg2207 = primCar(_35reg2206);
-Obj cont = _35reg2207;
-Obj _35reg2208 = primCdr(closureRef(co, 1));
-Obj _35reg2209 = primCdr(_35reg2208);
-Obj _35reg2210 = primCdr(_35reg2209);
-Obj _35reg2211 = primEQ(Nil, _35reg2210);
-if (True == _35reg2211) {
-pushCont(co, 3, _35clofun3127, 3, exp, fvs, cont);
+Obj _35reg1045 = primIsCons(closureRef(co, 1));
+if (True == _35reg1045) {
+Obj _35reg1046 = primCar(closureRef(co, 1));
+Obj _35reg1047 = primEQ(intern("call"), _35reg1046);
+if (True == _35reg1047) {
+Obj _35reg1048 = primCdr(closureRef(co, 1));
+Obj _35reg1049 = primIsCons(_35reg1048);
+if (True == _35reg1049) {
+Obj _35reg1050 = primCdr(closureRef(co, 1));
+Obj _35reg1051 = primCar(_35reg1050);
+Obj exp = _35reg1051;
+Obj _35reg1052 = primCdr(closureRef(co, 1));
+Obj _35reg1053 = primCdr(_35reg1052);
+Obj _35reg1054 = primIsCons(_35reg1053);
+if (True == _35reg1054) {
+Obj _35reg1055 = primCdr(closureRef(co, 1));
+Obj _35reg1056 = primCdr(_35reg1055);
+Obj _35reg1057 = primCar(_35reg1056);
+Obj cont = _35reg1057;
+Obj _35reg1058 = primCdr(closureRef(co, 1));
+Obj _35reg1059 = primCdr(_35reg1058);
+Obj _35reg1060 = primCdr(_35reg1059);
+Obj _35reg1061 = primEQ(Nil, _35reg1060);
+if (True == _35reg1061) {
+pushCont(co, 2, _35clofun2004, 3, exp, fvs, cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1249;
+__arg0 = _35cc102;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1249;
+__arg0 = _35cc102;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1249;
+__arg0 = _35cc102;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1249;
+__arg0 = _35cc102;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1249;
+__arg0 = _35cc102;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+
+label4:
+{
+Obj _35val1089 = __arg1;
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs2= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1090 = primCons(_35val1089, Nil);
+Obj _35reg1091 = primCons(val, _35reg1090);
+Obj _35reg1092 = primCons(intern("lambda"), _35reg1091);
+Obj _35reg1093 = primCons(_35reg1092, fvs2);
+Obj _35reg1094 = primCons(intern("%continuation"), _35reg1093);
+__nargs = 2;
+__arg1 = _35reg1094;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2004) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label5:
 {
-Obj _35val2239 = __arg1;
-Obj val= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fvs2= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2240 = primCons(_35val2239, Nil);
-Obj _35reg2241 = primCons(val, _35reg2240);
-Obj _35reg2242 = primCons(intern("lambda"), _35reg2241);
-Obj _35reg2243 = primCons(_35reg2242, fvs2);
-Obj _35reg2244 = primCons(intern("%continuation"), _35reg2243);
-__nargs = 2;
-__arg1 = _35reg2244;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3127) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label6:
-{
-Obj _35val2238 = __arg1;
+Obj _35val1088 = __arg1;
 Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs2 = _35val2238;
-pushCont(co, 5, _35clofun3127, 2, val, fvs2);
+Obj fvs2 = _35val1088;
+pushCont(co, 4, _35clofun2004, 2, val, fvs2);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs1;
@@ -8192,191 +8340,191 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label6:
+{
+Obj _35val1087 = __arg1;
+Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 5, _35clofun2004, 3, fvs1, body, val);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = _35val1087;
+__arg2 = fvs1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val2237 = __arg1;
-Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 6, _35clofun3127, 3, fvs1, body, val);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val2237;
-__arg2 = fvs1;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35val2236 = __arg1;
+Obj _35val1086 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs1 = _35val2236;
-pushCont(co, 7, _35clofun3127, 3, fvs1, body, val);
+Obj fvs1 = _35val1086;
+pushCont(co, 6, _35clofun2004, 3, fvs1, body, val);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label8:
+{
+Obj _35val1085 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 7, _35clofun2004, 3, fvs, body, val);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#diff"));
+__arg1 = _35val1085;
+__arg2 = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val2235 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 8, _35clofun3127, 3, fvs, body, val);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = _35val2235;
-__arg2 = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35cc1248 = makeNative(4, _35clofun3127, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc101 = makeNative(3, _35clofun2004, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2218 = primIsCons(closureRef(co, 1));
-if (True == _35reg2218) {
-Obj _35reg2219 = primCar(closureRef(co, 1));
-Obj _35reg2220 = primEQ(intern("continuation"), _35reg2219);
-if (True == _35reg2220) {
-Obj _35reg2221 = primCdr(closureRef(co, 1));
-Obj _35reg2222 = primIsCons(_35reg2221);
-if (True == _35reg2222) {
-Obj _35reg2223 = primCdr(closureRef(co, 1));
-Obj _35reg2224 = primCar(_35reg2223);
-Obj val = _35reg2224;
-Obj _35reg2225 = primCdr(closureRef(co, 1));
-Obj _35reg2226 = primCdr(_35reg2225);
-Obj _35reg2227 = primIsCons(_35reg2226);
-if (True == _35reg2227) {
-Obj _35reg2228 = primCdr(closureRef(co, 1));
-Obj _35reg2229 = primCdr(_35reg2228);
-Obj _35reg2230 = primCar(_35reg2229);
-Obj body = _35reg2230;
-Obj _35reg2231 = primCdr(closureRef(co, 1));
-Obj _35reg2232 = primCdr(_35reg2231);
-Obj _35reg2233 = primCdr(_35reg2232);
-Obj _35reg2234 = primEQ(Nil, _35reg2233);
-if (True == _35reg2234) {
-pushCont(co, 9, _35clofun3127, 3, fvs, body, val);
+Obj _35reg1068 = primIsCons(closureRef(co, 1));
+if (True == _35reg1068) {
+Obj _35reg1069 = primCar(closureRef(co, 1));
+Obj _35reg1070 = primEQ(intern("continuation"), _35reg1069);
+if (True == _35reg1070) {
+Obj _35reg1071 = primCdr(closureRef(co, 1));
+Obj _35reg1072 = primIsCons(_35reg1071);
+if (True == _35reg1072) {
+Obj _35reg1073 = primCdr(closureRef(co, 1));
+Obj _35reg1074 = primCar(_35reg1073);
+Obj val = _35reg1074;
+Obj _35reg1075 = primCdr(closureRef(co, 1));
+Obj _35reg1076 = primCdr(_35reg1075);
+Obj _35reg1077 = primIsCons(_35reg1076);
+if (True == _35reg1077) {
+Obj _35reg1078 = primCdr(closureRef(co, 1));
+Obj _35reg1079 = primCdr(_35reg1078);
+Obj _35reg1080 = primCar(_35reg1079);
+Obj body = _35reg1080;
+Obj _35reg1081 = primCdr(closureRef(co, 1));
+Obj _35reg1082 = primCdr(_35reg1081);
+Obj _35reg1083 = primCdr(_35reg1082);
+Obj _35reg1084 = primEQ(Nil, _35reg1083);
+if (True == _35reg1084) {
+pushCont(co, 8, _35clofun2004, 3, fvs, body, val);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1248;
+__arg0 = _35cc101;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1248;
+__arg0 = _35cc101;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1248;
+__arg0 = _35cc101;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1248;
+__arg0 = _35cc101;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1248;
+__arg0 = _35cc101;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+
+label10:
+{
+Obj _35val1112 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1113 = primCons(_35val1112, Nil);
+Obj _35reg1114 = primCons(args, _35reg1113);
+Obj _35reg1115 = primCons(intern("lambda"), _35reg1114);
+__nargs = 2;
+__arg1 = _35reg1115;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2004) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label11:
 {
-Obj _35val2262 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2263 = primCons(_35val2262, Nil);
-Obj _35reg2264 = primCons(args, _35reg2263);
-Obj _35reg2265 = primCons(intern("lambda"), _35reg2264);
-__nargs = 2;
-__arg1 = _35reg2265;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3127) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label12:
-{
-Obj _35cc1247 = makeNative(10, _35clofun3127, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc100 = makeNative(9, _35clofun2004, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2245 = primIsCons(closureRef(co, 1));
-if (True == _35reg2245) {
-Obj _35reg2246 = primCar(closureRef(co, 1));
-Obj _35reg2247 = primEQ(intern("lambda"), _35reg2246);
-if (True == _35reg2247) {
-Obj _35reg2248 = primCdr(closureRef(co, 1));
-Obj _35reg2249 = primIsCons(_35reg2248);
-if (True == _35reg2249) {
-Obj _35reg2250 = primCdr(closureRef(co, 1));
-Obj _35reg2251 = primCar(_35reg2250);
-Obj args = _35reg2251;
-Obj _35reg2252 = primCdr(closureRef(co, 1));
-Obj _35reg2253 = primCdr(_35reg2252);
-Obj _35reg2254 = primIsCons(_35reg2253);
-if (True == _35reg2254) {
-Obj _35reg2255 = primCdr(closureRef(co, 1));
-Obj _35reg2256 = primCdr(_35reg2255);
-Obj _35reg2257 = primCar(_35reg2256);
-Obj body = _35reg2257;
-Obj _35reg2258 = primCdr(closureRef(co, 1));
-Obj _35reg2259 = primCdr(_35reg2258);
-Obj _35reg2260 = primCdr(_35reg2259);
-Obj _35reg2261 = primEQ(Nil, _35reg2260);
-if (True == _35reg2261) {
-pushCont(co, 11, _35clofun3127, 1, args);
+Obj _35reg1095 = primIsCons(closureRef(co, 1));
+if (True == _35reg1095) {
+Obj _35reg1096 = primCar(closureRef(co, 1));
+Obj _35reg1097 = primEQ(intern("lambda"), _35reg1096);
+if (True == _35reg1097) {
+Obj _35reg1098 = primCdr(closureRef(co, 1));
+Obj _35reg1099 = primIsCons(_35reg1098);
+if (True == _35reg1099) {
+Obj _35reg1100 = primCdr(closureRef(co, 1));
+Obj _35reg1101 = primCar(_35reg1100);
+Obj args = _35reg1101;
+Obj _35reg1102 = primCdr(closureRef(co, 1));
+Obj _35reg1103 = primCdr(_35reg1102);
+Obj _35reg1104 = primIsCons(_35reg1103);
+if (True == _35reg1104) {
+Obj _35reg1105 = primCdr(closureRef(co, 1));
+Obj _35reg1106 = primCdr(_35reg1105);
+Obj _35reg1107 = primCar(_35reg1106);
+Obj body = _35reg1107;
+Obj _35reg1108 = primCdr(closureRef(co, 1));
+Obj _35reg1109 = primCdr(_35reg1108);
+Obj _35reg1110 = primCdr(_35reg1109);
+Obj _35reg1111 = primEQ(Nil, _35reg1110);
+if (True == _35reg1111) {
+pushCont(co, 10, _35clofun2004, 1, args);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
@@ -8384,119 +8532,119 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1247;
+__arg0 = _35cc100;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1247;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1247;
+__arg0 = _35cc100;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1247;
+__arg0 = _35cc100;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1247;
+__arg0 = _35cc100;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc100;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label12:
+{
+Obj _35cc99 = makeNative(11, _35clofun2004, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj var = closureRef(co, 1);
+Obj _35reg1116 = primIsSymbol(var);
+if (True == _35reg1116) {
+__nargs = 2;
+__arg1 = var;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2004) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc99;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label13:
 {
-Obj _35cc1246 = makeNative(12, _35clofun3127, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj var = closureRef(co, 1);
-Obj _35reg2266 = primIsSymbol(var);
-if (True == _35reg2266) {
+Obj _35val1117 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc98= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1117) {
 __nargs = 2;
-__arg1 = var;
+__arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3127) { goto fail; }
+if (co->ctx.pc.func != _35clofun2004) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1246;
+__arg0 = _35cc98;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label14:
 {
-Obj _35val2267 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1245= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2267) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3127) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1245;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj _35p1243 = __arg1;
-Obj _35p1244 = __arg2;
-Obj _35cc1245 = makeNative(13, _35clofun3127, 0, 2, _35p1243, _35p1244);
-Obj __ = _35p1243;
-Obj x = _35p1244;
-pushCont(co, 14, _35clofun3127, 2, x, _35cc1245);
+Obj _35p96 = __arg1;
+Obj _35p97 = __arg2;
+Obj _35cc98 = makeNative(12, _35clofun2004, 0, 2, _35p96, _35p97);
+Obj __ = _35p96;
+Obj x = _35p97;
+pushCont(co, 13, _35clofun2004, 2, x, _35cc98);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label15:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -8504,23 +8652,23 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label16:
 {
-Obj _35cc1255 = makeNative(16, _35clofun3127, 0, 0);
+Obj _35cc108 = makeNative(15, _35clofun2004, 0, 0);
 Obj v = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3127) { goto fail; }
+if (co->ctx.pc.func != _35clofun2004) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label18:
+label17:
 {
 Obj e = __arg1;
 __nargs = 3;
@@ -8530,51 +8678,71 @@ __arg2 = e;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label18:
 {
-Obj _35cc1254 = makeNative(17, _35clofun3127, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc107 = makeNative(16, _35clofun2004, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj v = closureRef(co, 0);
 Obj f_45args = closureRef(co, 1);
-Obj _35reg2269 = primIsCons(f_45args);
-if (True == _35reg2269) {
+Obj _35reg1119 = primIsCons(f_45args);
+if (True == _35reg1119) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = makeNative(18, _35clofun3127, 1, 1, v);
+__arg1 = makeNative(17, _35clofun2004, 1, 1, v);
 __arg2 = f_45args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1254;
+__arg0 = _35cc107;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
+label19:
+{
+Obj _35val1170 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1169= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg1171 = primCons(_35val1170, fvs);
+Obj _35reg1172 = primCons(_35reg1169, _35reg1171);
+Obj _35reg1173 = primCons(clo_45or_45cont, _35reg1172);
+__nargs = 2;
+__arg1 = _35reg1173;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2004) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
 label20:
 {
-Obj _35val2320 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2319= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2321 = primCons(_35val2320, fvs);
-Obj _35reg2322 = primCons(_35reg2319, _35reg2321);
-Obj _35reg2323 = primCons(clo_45or_45cont, _35reg2322);
+Obj _35val1168 = __arg1;
+Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj _35reg1169 = primCons(name, idx);
+pushCont(co, 19, _35clofun2004, 3, fvs, _35reg1169, clo_45or_45cont);
 __nargs = 2;
-__arg1 = _35reg2323;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3127) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("cora/init#length"));
+__arg1 = params;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 fail:
@@ -8586,7 +8754,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3126(struct Cora* co){
+void _35clofun2003(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -8599,109 +8767,25 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1234 = makeNative(18, _35clofun3125, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2085 = primIsCons(closureRef(co, 0));
-if (True == _35reg2085) {
-Obj _35reg2086 = primCar(closureRef(co, 0));
-Obj _35reg2087 = primEQ(intern("do"), _35reg2086);
-if (True == _35reg2087) {
-Obj _35reg2088 = primCdr(closureRef(co, 0));
-Obj _35reg2089 = primIsCons(_35reg2088);
-if (True == _35reg2089) {
-Obj _35reg2090 = primCdr(closureRef(co, 0));
-Obj _35reg2091 = primCar(_35reg2090);
-Obj a = _35reg2091;
-Obj _35reg2092 = primCdr(closureRef(co, 0));
-Obj _35reg2093 = primCdr(_35reg2092);
-Obj _35reg2094 = primIsCons(_35reg2093);
-if (True == _35reg2094) {
-Obj _35reg2095 = primCdr(closureRef(co, 0));
-Obj _35reg2096 = primCdr(_35reg2095);
-Obj _35reg2097 = primCar(_35reg2096);
-Obj b = _35reg2097;
-Obj _35reg2098 = primCdr(closureRef(co, 0));
-Obj _35reg2099 = primCdr(_35reg2098);
-Obj _35reg2100 = primCdr(_35reg2099);
-Obj _35reg2101 = primEQ(Nil, _35reg2100);
-if (True == _35reg2101) {
-Obj next = closureRef(co, 1);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#tailify"));
-__arg1 = a;
-__arg2 = makeNative(20, _35clofun3125, 1, 2, b, next);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1234;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1234;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1234;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1234;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1234;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+Obj _35val984 = __arg1;
+Obj _35val983= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg985 = primCons(_35val984, Nil);
+Obj _35reg986 = primCons(_35val983, _35reg985);
+Obj _35reg987 = primCons(ra, _35reg986);
+Obj _35reg988 = primCons(intern("if"), _35reg987);
+__nargs = 2;
+__arg1 = _35reg988;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2003) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj _35val2134 = __arg1;
-Obj _35val2133= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2135 = primCons(_35val2134, Nil);
-Obj _35reg2136 = primCons(_35val2133, _35reg2135);
-Obj _35reg2137 = primCons(ra, _35reg2136);
-Obj _35reg2138 = primCons(intern("if"), _35reg2137);
-__nargs = 2;
-__arg1 = _35reg2138;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3126) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label2:
-{
-Obj _35val2133 = __arg1;
+Obj _35val983 = __arg1;
 Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 1, _35clofun3126, 2, _35val2133, ra);
+pushCont(co, 0, _35clofun2003, 2, _35val983, ra);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 1);
@@ -8709,14 +8793,14 @@ __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label2:
 {
 Obj ra = __arg1;
-pushCont(co, 2, _35clofun3126, 1, ra);
+pushCont(co, 1, _35clofun2003, 1, ra);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 0);
@@ -8724,159 +8808,159 @@ __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label4:
+label3:
 {
-Obj _35cc1233 = makeNative(0, _35clofun3126, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2107 = primIsCons(closureRef(co, 0));
-if (True == _35reg2107) {
-Obj _35reg2108 = primCar(closureRef(co, 0));
-Obj _35reg2109 = primEQ(intern("if"), _35reg2108);
-if (True == _35reg2109) {
-Obj _35reg2110 = primCdr(closureRef(co, 0));
-Obj _35reg2111 = primIsCons(_35reg2110);
-if (True == _35reg2111) {
-Obj _35reg2112 = primCdr(closureRef(co, 0));
-Obj _35reg2113 = primCar(_35reg2112);
-Obj a = _35reg2113;
-Obj _35reg2114 = primCdr(closureRef(co, 0));
-Obj _35reg2115 = primCdr(_35reg2114);
-Obj _35reg2116 = primIsCons(_35reg2115);
-if (True == _35reg2116) {
-Obj _35reg2117 = primCdr(closureRef(co, 0));
-Obj _35reg2118 = primCdr(_35reg2117);
-Obj _35reg2119 = primCar(_35reg2118);
-Obj b = _35reg2119;
-Obj _35reg2120 = primCdr(closureRef(co, 0));
-Obj _35reg2121 = primCdr(_35reg2120);
-Obj _35reg2122 = primCdr(_35reg2121);
-Obj _35reg2123 = primIsCons(_35reg2122);
-if (True == _35reg2123) {
-Obj _35reg2124 = primCdr(closureRef(co, 0));
-Obj _35reg2125 = primCdr(_35reg2124);
-Obj _35reg2126 = primCdr(_35reg2125);
-Obj _35reg2127 = primCar(_35reg2126);
-Obj c = _35reg2127;
-Obj _35reg2128 = primCdr(closureRef(co, 0));
-Obj _35reg2129 = primCdr(_35reg2128);
-Obj _35reg2130 = primCdr(_35reg2129);
-Obj _35reg2131 = primCdr(_35reg2130);
-Obj _35reg2132 = primEQ(Nil, _35reg2131);
-if (True == _35reg2132) {
+Obj _35cc86 = makeNative(20, _35clofun2002, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg957 = primIsCons(closureRef(co, 0));
+if (True == _35reg957) {
+Obj _35reg958 = primCar(closureRef(co, 0));
+Obj _35reg959 = primEQ(intern("if"), _35reg958);
+if (True == _35reg959) {
+Obj _35reg960 = primCdr(closureRef(co, 0));
+Obj _35reg961 = primIsCons(_35reg960);
+if (True == _35reg961) {
+Obj _35reg962 = primCdr(closureRef(co, 0));
+Obj _35reg963 = primCar(_35reg962);
+Obj a = _35reg963;
+Obj _35reg964 = primCdr(closureRef(co, 0));
+Obj _35reg965 = primCdr(_35reg964);
+Obj _35reg966 = primIsCons(_35reg965);
+if (True == _35reg966) {
+Obj _35reg967 = primCdr(closureRef(co, 0));
+Obj _35reg968 = primCdr(_35reg967);
+Obj _35reg969 = primCar(_35reg968);
+Obj b = _35reg969;
+Obj _35reg970 = primCdr(closureRef(co, 0));
+Obj _35reg971 = primCdr(_35reg970);
+Obj _35reg972 = primCdr(_35reg971);
+Obj _35reg973 = primIsCons(_35reg972);
+if (True == _35reg973) {
+Obj _35reg974 = primCdr(closureRef(co, 0));
+Obj _35reg975 = primCdr(_35reg974);
+Obj _35reg976 = primCdr(_35reg975);
+Obj _35reg977 = primCar(_35reg976);
+Obj c = _35reg977;
+Obj _35reg978 = primCdr(closureRef(co, 0));
+Obj _35reg979 = primCdr(_35reg978);
+Obj _35reg980 = primCdr(_35reg979);
+Obj _35reg981 = primCdr(_35reg980);
+Obj _35reg982 = primEQ(Nil, _35reg981);
+if (True == _35reg982) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = a;
-__arg2 = makeNative(3, _35clofun3126, 1, 3, b, c, next);
+__arg2 = makeNative(2, _35clofun2003, 1, 3, b, c, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1233;
+__arg0 = _35cc86;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1233;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1233;
+__arg0 = _35cc86;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1233;
+__arg0 = _35cc86;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1233;
+__arg0 = _35cc86;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1233;
+__arg0 = _35cc86;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc86;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val989 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc85= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val989) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2003) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc85;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35val2139 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1232= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2139) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3126) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1232;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label6:
-{
-Obj _35cc1232 = makeNative(4, _35clofun3126, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc85 = makeNative(3, _35clofun2003, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj x = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
-pushCont(co, 5, _35clofun3126, 2, x, _35cc1232);
+pushCont(co, 4, _35clofun2003, 2, x, _35cc85);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label6:
 {
-Obj _35val2141 = __arg1;
+Obj _35val991 = __arg1;
 Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc1231= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val2141) {
+Obj _35cc84= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val991) {
 if (True == True) {
 __nargs = 2;
 __arg0 = next;
@@ -8884,15 +8968,15 @@ __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1231;
+__arg0 = _35cc84;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8903,29 +8987,29 @@ __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1231;
+__arg0 = _35cc84;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 }
 
-label8:
+label7:
 {
-Obj _35p1229 = __arg1;
-Obj _35p1230 = __arg2;
-Obj _35cc1231 = makeNative(6, _35clofun3126, 0, 2, _35p1229, _35p1230);
-Obj x = _35p1229;
-Obj next = _35p1230;
-Obj _35reg2140 = primIsSymbol(x);
-if (True == _35reg2140) {
+Obj _35p82 = __arg1;
+Obj _35p83 = __arg2;
+Obj _35cc84 = makeNative(5, _35clofun2003, 0, 2, _35p82, _35p83);
+Obj x = _35p82;
+Obj next = _35p83;
+Obj _35reg990 = primIsSymbol(x);
+if (True == _35reg990) {
 if (True == True) {
 __nargs = 2;
 __arg0 = next;
@@ -8933,31 +9017,31 @@ __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1231;
+__arg0 = _35cc84;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 7, _35clofun3126, 3, next, x, _35cc1231);
+pushCont(co, 6, _35clofun2003, 3, next, x, _35cc84);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label9:
+label8:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -8965,100 +9049,100 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label9:
+{
+Obj hd1 = __arg1;
+Obj _35reg996 = primCons(hd1, closureRef(co, 1));
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#tailify-list"));
+__arg1 = closureRef(co, 0);
+__arg2 = _35reg996;
+__arg3 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj hd1 = __arg1;
-Obj _35reg2146 = primCons(hd1, closureRef(co, 1));
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#tailify-list"));
-__arg1 = closureRef(co, 0);
-__arg2 = _35reg2146;
-__arg3 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35cc1242 = makeNative(9, _35clofun3126, 0, 0);
-Obj _35reg2143 = primIsCons(closureRef(co, 0));
-if (True == _35reg2143) {
-Obj _35reg2144 = primCar(closureRef(co, 0));
-Obj hd = _35reg2144;
-Obj _35reg2145 = primCdr(closureRef(co, 0));
-Obj tl = _35reg2145;
+Obj _35cc95 = makeNative(8, _35clofun2003, 0, 0);
+Obj _35reg993 = primIsCons(closureRef(co, 0));
+if (True == _35reg993) {
+Obj _35reg994 = primCar(closureRef(co, 0));
+Obj hd = _35reg994;
+Obj _35reg995 = primCdr(closureRef(co, 0));
+Obj tl = _35reg995;
 Obj ls = closureRef(co, 1);
 Obj next = closureRef(co, 2);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = hd;
-__arg2 = makeNative(10, _35clofun3126, 1, 3, tl, ls, next);
+__arg2 = makeNative(9, _35clofun2003, 1, 3, tl, ls, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1242;
+__arg0 = _35cc95;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
+label11:
+{
+Obj _35val1008 = __arg1;
+Obj _35reg1007= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1009 = primCons(_35val1008, Nil);
+Obj _35reg1010 = primCons(_35reg1007, _35reg1009);
+Obj _35reg1011 = primCons(intern("continuation"), _35reg1010);
+Obj _35reg1012 = primCons(_35reg1011, Nil);
+Obj _35reg1013 = primCons(exp, _35reg1012);
+Obj _35reg1014 = primCons(intern("call"), _35reg1013);
+__nargs = 2;
+__arg1 = _35reg1014;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2003) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
 label12:
 {
-Obj _35val2158 = __arg1;
-Obj _35reg2157= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val1020 = __arg1;
+Obj _35reg1019= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2159 = primCons(_35val2158, Nil);
-Obj _35reg2160 = primCons(_35reg2157, _35reg2159);
-Obj _35reg2161 = primCons(intern("continuation"), _35reg2160);
-Obj _35reg2162 = primCons(_35reg2161, Nil);
-Obj _35reg2163 = primCons(exp, _35reg2162);
-Obj _35reg2164 = primCons(intern("call"), _35reg2163);
+Obj _35reg1021 = primCons(_35val1020, Nil);
+Obj _35reg1022 = primCons(_35reg1019, _35reg1021);
+Obj _35reg1023 = primCons(intern("continuation"), _35reg1022);
+Obj _35reg1024 = primCons(_35reg1023, Nil);
+Obj _35reg1025 = primCons(exp, _35reg1024);
+Obj _35reg1026 = primCons(intern("call"), _35reg1025);
 __nargs = 2;
-__arg1 = _35reg2164;
+__arg1 = _35reg1026;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3126) { goto fail; }
+if (co->ctx.pc.func != _35clofun2003) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label13:
 {
-Obj _35val2170 = __arg1;
-Obj _35reg2169= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2171 = primCons(_35val2170, Nil);
-Obj _35reg2172 = primCons(_35reg2169, _35reg2171);
-Obj _35reg2173 = primCons(intern("continuation"), _35reg2172);
-Obj _35reg2174 = primCons(_35reg2173, Nil);
-Obj _35reg2175 = primCons(exp, _35reg2174);
-Obj _35reg2176 = primCons(intern("call"), _35reg2175);
-__nargs = 2;
-__arg1 = _35reg2176;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3126) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label14:
-{
-Obj _35val2151 = __arg1;
+Obj _35val1001 = __arg1;
 Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2152 = primEQ(_35val2151, intern("%builtin"));
-if (True == _35reg2152) {
+Obj _35reg1002 = primEQ(_35val1001, intern("%builtin"));
+if (True == _35reg1002) {
 if (True == True) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#wrap-var"));
@@ -9067,30 +9151,30 @@ __arg2 = next;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2153 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
-if (True == _35reg2153) {
-Obj _35reg2154 = primCons(exp, Nil);
-Obj _35reg2155 = primCons(intern("tailcall"), _35reg2154);
+Obj _35reg1003 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
+if (True == _35reg1003) {
+Obj _35reg1004 = primCons(exp, Nil);
+Obj _35reg1005 = primCons(intern("tailcall"), _35reg1004);
 __nargs = 2;
-__arg1 = _35reg2155;
+__arg1 = _35reg1005;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3126) { goto fail; }
+if (co->ctx.pc.func != _35clofun2003) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg2156 = primGenSym(intern("val"));
-Obj val = _35reg2156;
-Obj _35reg2157 = primCons(val, Nil);
-pushCont(co, 12, _35clofun3126, 2, _35reg2157, exp);
+Obj _35reg1006 = primGenSym(intern("val"));
+Obj val = _35reg1006;
+Obj _35reg1007 = primCons(val, Nil);
+pushCont(co, 11, _35clofun2003, 2, _35reg1007, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9103,68 +9187,68 @@ __arg2 = next;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2165 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
-if (True == _35reg2165) {
-Obj _35reg2166 = primCons(exp, Nil);
-Obj _35reg2167 = primCons(intern("tailcall"), _35reg2166);
+Obj _35reg1015 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
+if (True == _35reg1015) {
+Obj _35reg1016 = primCons(exp, Nil);
+Obj _35reg1017 = primCons(intern("tailcall"), _35reg1016);
 __nargs = 2;
-__arg1 = _35reg2167;
+__arg1 = _35reg1017;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3126) { goto fail; }
+if (co->ctx.pc.func != _35clofun2003) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg2168 = primGenSym(intern("val"));
-Obj val = _35reg2168;
-Obj _35reg2169 = primCons(val, Nil);
-pushCont(co, 13, _35clofun3126, 2, _35reg2169, exp);
+Obj _35reg1018 = primGenSym(intern("val"));
+Obj val = _35reg1018;
+Obj _35reg1019 = primCons(val, Nil);
+pushCont(co, 12, _35clofun2003, 2, _35reg1019, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 }
 }
 
-label15:
+label14:
 {
-Obj _35val2182 = __arg1;
-Obj _35reg2181= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val1032 = __arg1;
+Obj _35reg1031= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2183 = primCons(_35val2182, Nil);
-Obj _35reg2184 = primCons(_35reg2181, _35reg2183);
-Obj _35reg2185 = primCons(intern("continuation"), _35reg2184);
-Obj _35reg2186 = primCons(_35reg2185, Nil);
-Obj _35reg2187 = primCons(exp, _35reg2186);
-Obj _35reg2188 = primCons(intern("call"), _35reg2187);
+Obj _35reg1033 = primCons(_35val1032, Nil);
+Obj _35reg1034 = primCons(_35reg1031, _35reg1033);
+Obj _35reg1035 = primCons(intern("continuation"), _35reg1034);
+Obj _35reg1036 = primCons(_35reg1035, Nil);
+Obj _35reg1037 = primCons(exp, _35reg1036);
+Obj _35reg1038 = primCons(intern("call"), _35reg1037);
 __nargs = 2;
-__arg1 = _35reg2188;
+__arg1 = _35reg1038;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3126) { goto fail; }
+if (co->ctx.pc.func != _35clofun2003) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label16:
+label15:
 {
-Obj _35val2150 = __arg1;
+Obj _35val1000 = __arg1;
 Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2150) {
-pushCont(co, 14, _35clofun3126, 2, next, exp);
+if (True == _35val1000) {
+pushCont(co, 13, _35clofun2003, 2, next, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 if (True == False) {
@@ -9175,84 +9259,84 @@ __arg2 = next;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2177 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
-if (True == _35reg2177) {
-Obj _35reg2178 = primCons(exp, Nil);
-Obj _35reg2179 = primCons(intern("tailcall"), _35reg2178);
+Obj _35reg1027 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
+if (True == _35reg1027) {
+Obj _35reg1028 = primCons(exp, Nil);
+Obj _35reg1029 = primCons(intern("tailcall"), _35reg1028);
 __nargs = 2;
-__arg1 = _35reg2179;
+__arg1 = _35reg1029;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3126) { goto fail; }
+if (co->ctx.pc.func != _35clofun2003) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg2180 = primGenSym(intern("val"));
-Obj val = _35reg2180;
-Obj _35reg2181 = primCons(val, Nil);
-pushCont(co, 15, _35clofun3126, 2, _35reg2181, exp);
+Obj _35reg1030 = primGenSym(intern("val"));
+Obj val = _35reg1030;
+Obj _35reg1031 = primCons(val, Nil);
+pushCont(co, 14, _35clofun2003, 2, _35reg1031, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 }
+}
+
+label16:
+{
+Obj _35val998 = __arg1;
+Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp = _35val998;
+Obj _35reg999 = primCar(exp);
+pushCont(co, 15, _35clofun2003, 2, next, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#pair?"));
+__arg1 = _35reg999;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val2148 = __arg1;
-Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp = _35val2148;
-Obj _35reg2149 = primCar(exp);
-pushCont(co, 16, _35clofun3126, 2, next, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#pair?"));
-__arg1 = _35reg2149;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35p1238 = __arg1;
-Obj _35p1239 = __arg2;
-Obj _35p1240 = __arg3;
-Obj _35cc1241 = makeNative(11, _35clofun3126, 0, 3, _35p1238, _35p1239, _35p1240);
-Obj _35reg2147 = primEQ(Nil, _35p1238);
-if (True == _35reg2147) {
-Obj ls = _35p1239;
-Obj next = _35p1240;
-pushCont(co, 17, _35clofun3126, 1, next);
+Obj _35p91 = __arg1;
+Obj _35p92 = __arg2;
+Obj _35p93 = __arg3;
+Obj _35cc94 = makeNative(10, _35clofun2003, 0, 3, _35p91, _35p92, _35p93);
+Obj _35reg997 = primEQ(Nil, _35p91);
+if (True == _35reg997) {
+Obj ls = _35p92;
+Obj next = _35p93;
+pushCont(co, 16, _35clofun2003, 1, next);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = ls;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1241;
+__arg0 = _35cc94;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label19:
+label18:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -9260,25 +9344,55 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label19:
+{
+Obj _35val1043 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1044 = primCons(f, args);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = _35val1043;
+__arg2 = _35reg1044;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val2193 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2194 = primCons(f, args);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val2193;
-__arg2 = _35reg2194;
+Obj _35cc103 = makeNative(18, _35clofun2003, 0, 0);
+Obj fvs = closureRef(co, 0);
+Obj _35reg1040 = primIsCons(closureRef(co, 1));
+if (True == _35reg1040) {
+Obj _35reg1041 = primCar(closureRef(co, 1));
+Obj f = _35reg1041;
+Obj _35reg1042 = primCdr(closureRef(co, 1));
+Obj args = _35reg1042;
+pushCont(co, 19, _35clofun2003, 2, f, args);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
+__arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc103;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 fail:
@@ -9290,7 +9404,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3125(struct Cora* co){
+void _35clofun2002(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -9303,62 +9417,44 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1961 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 20, _35clofun3124, 2, _35val1961, a);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
-__arg1 = fvs;
-__arg2 = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35cc1227 = makeNative(19, _35clofun3124, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc80 = makeNative(18, _35clofun2001, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg1935 = primIsCons(closureRef(co, 1));
-if (True == _35reg1935) {
-Obj _35reg1936 = primCar(closureRef(co, 1));
-Obj _35reg1937 = primEQ(intern("let"), _35reg1936);
-if (True == _35reg1937) {
-Obj _35reg1938 = primCdr(closureRef(co, 1));
-Obj _35reg1939 = primIsCons(_35reg1938);
-if (True == _35reg1939) {
-Obj _35reg1940 = primCdr(closureRef(co, 1));
-Obj _35reg1941 = primCar(_35reg1940);
-Obj a = _35reg1941;
-Obj _35reg1942 = primCdr(closureRef(co, 1));
-Obj _35reg1943 = primCdr(_35reg1942);
-Obj _35reg1944 = primIsCons(_35reg1943);
-if (True == _35reg1944) {
-Obj _35reg1945 = primCdr(closureRef(co, 1));
-Obj _35reg1946 = primCdr(_35reg1945);
-Obj _35reg1947 = primCar(_35reg1946);
-Obj b = _35reg1947;
-Obj _35reg1948 = primCdr(closureRef(co, 1));
-Obj _35reg1949 = primCdr(_35reg1948);
-Obj _35reg1950 = primCdr(_35reg1949);
-Obj _35reg1951 = primIsCons(_35reg1950);
-if (True == _35reg1951) {
-Obj _35reg1952 = primCdr(closureRef(co, 1));
-Obj _35reg1953 = primCdr(_35reg1952);
-Obj _35reg1954 = primCdr(_35reg1953);
-Obj _35reg1955 = primCar(_35reg1954);
-Obj c = _35reg1955;
-Obj _35reg1956 = primCdr(closureRef(co, 1));
-Obj _35reg1957 = primCdr(_35reg1956);
-Obj _35reg1958 = primCdr(_35reg1957);
-Obj _35reg1959 = primCdr(_35reg1958);
-Obj _35reg1960 = primEQ(Nil, _35reg1959);
-if (True == _35reg1960) {
-pushCont(co, 0, _35clofun3125, 3, fvs, c, a);
+Obj _35reg785 = primIsCons(closureRef(co, 1));
+if (True == _35reg785) {
+Obj _35reg786 = primCar(closureRef(co, 1));
+Obj _35reg787 = primEQ(intern("let"), _35reg786);
+if (True == _35reg787) {
+Obj _35reg788 = primCdr(closureRef(co, 1));
+Obj _35reg789 = primIsCons(_35reg788);
+if (True == _35reg789) {
+Obj _35reg790 = primCdr(closureRef(co, 1));
+Obj _35reg791 = primCar(_35reg790);
+Obj a = _35reg791;
+Obj _35reg792 = primCdr(closureRef(co, 1));
+Obj _35reg793 = primCdr(_35reg792);
+Obj _35reg794 = primIsCons(_35reg793);
+if (True == _35reg794) {
+Obj _35reg795 = primCdr(closureRef(co, 1));
+Obj _35reg796 = primCdr(_35reg795);
+Obj _35reg797 = primCar(_35reg796);
+Obj b = _35reg797;
+Obj _35reg798 = primCdr(closureRef(co, 1));
+Obj _35reg799 = primCdr(_35reg798);
+Obj _35reg800 = primCdr(_35reg799);
+Obj _35reg801 = primIsCons(_35reg800);
+if (True == _35reg801) {
+Obj _35reg802 = primCdr(closureRef(co, 1));
+Obj _35reg803 = primCdr(_35reg802);
+Obj _35reg804 = primCdr(_35reg803);
+Obj _35reg805 = primCar(_35reg804);
+Obj c = _35reg805;
+Obj _35reg806 = primCdr(closureRef(co, 1));
+Obj _35reg807 = primCdr(_35reg806);
+Obj _35reg808 = primCdr(_35reg807);
+Obj _35reg809 = primCdr(_35reg808);
+Obj _35reg810 = primEQ(Nil, _35reg809);
+if (True == _35reg810) {
+pushCont(co, 20, _35clofun2001, 3, fvs, c, a);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs;
@@ -9366,122 +9462,122 @@ __arg2 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1227;
+__arg0 = _35cc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1227;
+__arg0 = _35cc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1227;
+__arg0 = _35cc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1227;
+__arg0 = _35cc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1227;
+__arg0 = _35cc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1227;
+__arg0 = _35cc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+
+label1:
+{
+Obj _35val843 = __arg1;
+Obj _35reg841= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg844 = primCons(_35reg841, _35val843);
+Obj _35reg845 = primCons(intern("%closure"), _35reg844);
+__nargs = 2;
+__arg1 = _35reg845;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val1993 = __arg1;
-Obj _35reg1991= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1994 = primCons(_35reg1991, _35val1993);
-Obj _35reg1995 = primCons(intern("%closure"), _35reg1994);
-__nargs = 2;
-__arg1 = _35reg1995;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3125) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label3:
-{
-Obj _35val1992 = __arg1;
+Obj _35val842 = __arg1;
 Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1991= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun3125, 1, _35reg1991);
+Obj _35reg841= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 1, _35clofun2002, 1, _35reg841);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val1992;
+__arg1 = _35val842;
 __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label4:
+label3:
 {
-Obj _35val1988 = __arg1;
+Obj _35val838 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1989 = primCons(_35val1988, Nil);
-Obj _35reg1990 = primCons(args, _35reg1989);
-Obj _35reg1991 = primCons(intern("lambda"), _35reg1990);
-pushCont(co, 3, _35clofun3125, 2, fvs1, _35reg1991);
+Obj _35reg839 = primCons(_35val838, Nil);
+Obj _35reg840 = primCons(args, _35reg839);
+Obj _35reg841 = primCons(intern("lambda"), _35reg840);
+pushCont(co, 2, _35clofun2002, 2, fvs1, _35reg841);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label5:
+label4:
 {
-Obj _35val1987 = __arg1;
+Obj _35val837 = __arg1;
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs1 = _35val1987;
-pushCont(co, 4, _35clofun3125, 3, args, fvs, fvs1);
+Obj fvs1 = _35val837;
+pushCont(co, 3, _35clofun2002, 3, args, fvs, fvs1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs1;
@@ -9489,128 +9585,128 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35cc79 = makeNative(0, _35clofun2002, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj _35reg817 = primIsCons(closureRef(co, 1));
+if (True == _35reg817) {
+Obj _35reg818 = primCar(closureRef(co, 1));
+Obj _35reg819 = primEQ(intern("lambda"), _35reg818);
+if (True == _35reg819) {
+Obj _35reg820 = primCdr(closureRef(co, 1));
+Obj _35reg821 = primIsCons(_35reg820);
+if (True == _35reg821) {
+Obj _35reg822 = primCdr(closureRef(co, 1));
+Obj _35reg823 = primCar(_35reg822);
+Obj args = _35reg823;
+Obj _35reg824 = primCdr(closureRef(co, 1));
+Obj _35reg825 = primCdr(_35reg824);
+Obj _35reg826 = primIsCons(_35reg825);
+if (True == _35reg826) {
+Obj _35reg827 = primCdr(closureRef(co, 1));
+Obj _35reg828 = primCdr(_35reg827);
+Obj _35reg829 = primCar(_35reg828);
+Obj body = _35reg829;
+Obj _35reg830 = primCdr(closureRef(co, 1));
+Obj _35reg831 = primCdr(_35reg830);
+Obj _35reg832 = primCdr(_35reg831);
+Obj _35reg833 = primEQ(Nil, _35reg832);
+if (True == _35reg833) {
+Obj _35reg834 = primCons(body, Nil);
+Obj _35reg835 = primCons(args, _35reg834);
+Obj _35reg836 = primCons(intern("lambda"), _35reg835);
+pushCont(co, 4, _35clofun2002, 3, body, args, fvs);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = _35reg836;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc79;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc79;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc79;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc79;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc79;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label6:
 {
-Obj _35cc1226 = makeNative(1, _35clofun3125, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg1967 = primIsCons(closureRef(co, 1));
-if (True == _35reg1967) {
-Obj _35reg1968 = primCar(closureRef(co, 1));
-Obj _35reg1969 = primEQ(intern("lambda"), _35reg1968);
-if (True == _35reg1969) {
-Obj _35reg1970 = primCdr(closureRef(co, 1));
-Obj _35reg1971 = primIsCons(_35reg1970);
-if (True == _35reg1971) {
-Obj _35reg1972 = primCdr(closureRef(co, 1));
-Obj _35reg1973 = primCar(_35reg1972);
-Obj args = _35reg1973;
-Obj _35reg1974 = primCdr(closureRef(co, 1));
-Obj _35reg1975 = primCdr(_35reg1974);
-Obj _35reg1976 = primIsCons(_35reg1975);
-if (True == _35reg1976) {
-Obj _35reg1977 = primCdr(closureRef(co, 1));
-Obj _35reg1978 = primCdr(_35reg1977);
-Obj _35reg1979 = primCar(_35reg1978);
-Obj body = _35reg1979;
-Obj _35reg1980 = primCdr(closureRef(co, 1));
-Obj _35reg1981 = primCdr(_35reg1980);
-Obj _35reg1982 = primCdr(_35reg1981);
-Obj _35reg1983 = primEQ(Nil, _35reg1982);
-if (True == _35reg1983) {
-Obj _35reg1984 = primCons(body, Nil);
-Obj _35reg1985 = primCons(args, _35reg1984);
-Obj _35reg1986 = primCons(intern("lambda"), _35reg1985);
-pushCont(co, 5, _35clofun3125, 3, body, args, fvs);
+Obj _35val847 = __arg1;
+Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj pos = _35val847;
+Obj _35reg848 = primEQ(makeNumber(-1), pos);
+if (True == _35reg848) {
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = _35reg1986;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = var;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = _35cc1226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj _35reg849 = primCons(pos, Nil);
+Obj _35reg850 = primCons(intern("%closure-ref"), _35reg849);
+__nargs = 2;
+__arg1 = _35reg850;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 }
 
 label7:
 {
-Obj _35val1997 = __arg1;
-Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj pos = _35val1997;
-Obj _35reg1998 = primEQ(makeNumber(-1), pos);
-if (True == _35reg1998) {
-__nargs = 2;
-__arg1 = var;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3125) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg1999 = primCons(pos, Nil);
-Obj _35reg2000 = primCons(intern("%closure-ref"), _35reg1999);
-__nargs = 2;
-__arg1 = _35reg2000;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3125) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label8:
-{
-Obj _35cc1225 = makeNative(6, _35clofun3125, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc78 = makeNative(5, _35clofun2002, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj _35reg1996 = primIsSymbol(var);
-if (True == _35reg1996) {
-pushCont(co, 7, _35clofun3125, 1, var);
+Obj _35reg846 = primIsSymbol(var);
+if (True == _35reg846) {
+pushCont(co, 6, _35clofun2002, 1, var);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#index"));
 __arg1 = var;
@@ -9618,72 +9714,72 @@ __arg2 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1225;
+__arg0 = _35cc78;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label8:
+{
+Obj _35val851 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc77= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val851) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc77;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label9:
 {
-Obj _35val2001 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1224= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2001) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3125) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1224;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj _35p1222 = __arg1;
-Obj _35p1223 = __arg2;
-Obj _35cc1224 = makeNative(8, _35clofun3125, 0, 2, _35p1222, _35p1223);
-Obj __ = _35p1222;
-Obj x = _35p1223;
-pushCont(co, 9, _35clofun3125, 2, x, _35cc1224);
+Obj _35p75 = __arg1;
+Obj _35p76 = __arg2;
+Obj _35cc77 = makeNative(7, _35clofun2002, 0, 2, _35p75, _35p76);
+Obj __ = _35p75;
+Obj x = _35p76;
+pushCont(co, 8, _35clofun2002, 2, x, _35cc77);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label10:
 {
 Obj x = __arg1;
-Obj _35reg2003 = primCons(x, Nil);
-Obj _35reg2004 = primCons(intern("return"), _35reg2003);
+Obj _35reg853 = primCons(x, Nil);
+Obj _35reg854 = primCons(intern("return"), _35reg853);
 __nargs = 2;
-__arg1 = _35reg2004;
+__arg1 = _35reg854;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3125) { goto fail; }
+if (co->ctx.pc.func != _35clofun2002) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label12:
+label11:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -9691,117 +9787,117 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label12:
 {
-Obj _35cc1237 = makeNative(12, _35clofun3125, 0, 0);
-Obj _35reg2006 = primIsCons(closureRef(co, 0));
-if (True == _35reg2006) {
-Obj _35reg2007 = primCar(closureRef(co, 0));
-Obj f = _35reg2007;
-Obj _35reg2008 = primCdr(closureRef(co, 0));
-Obj args = _35reg2008;
+Obj _35cc90 = makeNative(11, _35clofun2002, 0, 0);
+Obj _35reg856 = primIsCons(closureRef(co, 0));
+if (True == _35reg856) {
+Obj _35reg857 = primCar(closureRef(co, 0));
+Obj f = _35reg857;
+Obj _35reg858 = primCdr(closureRef(co, 0));
+Obj args = _35reg858;
 Obj next = closureRef(co, 1);
-Obj _35reg2009 = primCons(f, args);
+Obj _35reg859 = primCons(f, args);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#tailify-list"));
-__arg1 = _35reg2009;
+__arg1 = _35reg859;
 __arg2 = Nil;
 __arg3 = next;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1237;
+__arg0 = _35cc90;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+
+label13:
+{
+Obj _35val898 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj next= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg899 = primCons(_35val898, Nil);
+Obj _35reg900 = primCons(args, _35reg899);
+Obj _35reg901 = primCons(intern("lambda"), _35reg900);
+Obj _35reg902 = primCons(_35reg901, frees);
+Obj _35reg903 = primCons(intern("%closure"), _35reg902);
+__nargs = 2;
+__arg0 = next;
+__arg1 = _35reg903;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val2048 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj next= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2049 = primCons(_35val2048, Nil);
-Obj _35reg2050 = primCons(args, _35reg2049);
-Obj _35reg2051 = primCons(intern("lambda"), _35reg2050);
-Obj _35reg2052 = primCons(_35reg2051, frees);
-Obj _35reg2053 = primCons(intern("%closure"), _35reg2052);
-__nargs = 2;
-__arg0 = next;
-__arg1 = _35reg2053;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35cc1236 = makeNative(13, _35clofun3125, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2010 = primIsCons(closureRef(co, 0));
-if (True == _35reg2010) {
-Obj _35reg2011 = primCar(closureRef(co, 0));
-Obj _35reg2012 = primEQ(intern("%closure"), _35reg2011);
-if (True == _35reg2012) {
-Obj _35reg2013 = primCdr(closureRef(co, 0));
-Obj _35reg2014 = primIsCons(_35reg2013);
-if (True == _35reg2014) {
-Obj _35reg2015 = primCdr(closureRef(co, 0));
-Obj _35reg2016 = primCar(_35reg2015);
-Obj _35reg2017 = primIsCons(_35reg2016);
-if (True == _35reg2017) {
-Obj _35reg2018 = primCdr(closureRef(co, 0));
-Obj _35reg2019 = primCar(_35reg2018);
-Obj _35reg2020 = primCar(_35reg2019);
-Obj _35reg2021 = primEQ(intern("lambda"), _35reg2020);
-if (True == _35reg2021) {
-Obj _35reg2022 = primCdr(closureRef(co, 0));
-Obj _35reg2023 = primCar(_35reg2022);
-Obj _35reg2024 = primCdr(_35reg2023);
-Obj _35reg2025 = primIsCons(_35reg2024);
-if (True == _35reg2025) {
-Obj _35reg2026 = primCdr(closureRef(co, 0));
-Obj _35reg2027 = primCar(_35reg2026);
-Obj _35reg2028 = primCdr(_35reg2027);
-Obj _35reg2029 = primCar(_35reg2028);
-Obj args = _35reg2029;
-Obj _35reg2030 = primCdr(closureRef(co, 0));
-Obj _35reg2031 = primCar(_35reg2030);
-Obj _35reg2032 = primCdr(_35reg2031);
-Obj _35reg2033 = primCdr(_35reg2032);
-Obj _35reg2034 = primIsCons(_35reg2033);
-if (True == _35reg2034) {
-Obj _35reg2035 = primCdr(closureRef(co, 0));
-Obj _35reg2036 = primCar(_35reg2035);
-Obj _35reg2037 = primCdr(_35reg2036);
-Obj _35reg2038 = primCdr(_35reg2037);
-Obj _35reg2039 = primCar(_35reg2038);
-Obj body = _35reg2039;
-Obj _35reg2040 = primCdr(closureRef(co, 0));
-Obj _35reg2041 = primCar(_35reg2040);
-Obj _35reg2042 = primCdr(_35reg2041);
-Obj _35reg2043 = primCdr(_35reg2042);
-Obj _35reg2044 = primCdr(_35reg2043);
-Obj _35reg2045 = primEQ(Nil, _35reg2044);
-if (True == _35reg2045) {
-Obj _35reg2046 = primCdr(closureRef(co, 0));
-Obj _35reg2047 = primCdr(_35reg2046);
-Obj frees = _35reg2047;
+Obj _35cc89 = makeNative(12, _35clofun2002, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg860 = primIsCons(closureRef(co, 0));
+if (True == _35reg860) {
+Obj _35reg861 = primCar(closureRef(co, 0));
+Obj _35reg862 = primEQ(intern("%closure"), _35reg861);
+if (True == _35reg862) {
+Obj _35reg863 = primCdr(closureRef(co, 0));
+Obj _35reg864 = primIsCons(_35reg863);
+if (True == _35reg864) {
+Obj _35reg865 = primCdr(closureRef(co, 0));
+Obj _35reg866 = primCar(_35reg865);
+Obj _35reg867 = primIsCons(_35reg866);
+if (True == _35reg867) {
+Obj _35reg868 = primCdr(closureRef(co, 0));
+Obj _35reg869 = primCar(_35reg868);
+Obj _35reg870 = primCar(_35reg869);
+Obj _35reg871 = primEQ(intern("lambda"), _35reg870);
+if (True == _35reg871) {
+Obj _35reg872 = primCdr(closureRef(co, 0));
+Obj _35reg873 = primCar(_35reg872);
+Obj _35reg874 = primCdr(_35reg873);
+Obj _35reg875 = primIsCons(_35reg874);
+if (True == _35reg875) {
+Obj _35reg876 = primCdr(closureRef(co, 0));
+Obj _35reg877 = primCar(_35reg876);
+Obj _35reg878 = primCdr(_35reg877);
+Obj _35reg879 = primCar(_35reg878);
+Obj args = _35reg879;
+Obj _35reg880 = primCdr(closureRef(co, 0));
+Obj _35reg881 = primCar(_35reg880);
+Obj _35reg882 = primCdr(_35reg881);
+Obj _35reg883 = primCdr(_35reg882);
+Obj _35reg884 = primIsCons(_35reg883);
+if (True == _35reg884) {
+Obj _35reg885 = primCdr(closureRef(co, 0));
+Obj _35reg886 = primCar(_35reg885);
+Obj _35reg887 = primCdr(_35reg886);
+Obj _35reg888 = primCdr(_35reg887);
+Obj _35reg889 = primCar(_35reg888);
+Obj body = _35reg889;
+Obj _35reg890 = primCdr(closureRef(co, 0));
+Obj _35reg891 = primCar(_35reg890);
+Obj _35reg892 = primCdr(_35reg891);
+Obj _35reg893 = primCdr(_35reg892);
+Obj _35reg894 = primCdr(_35reg893);
+Obj _35reg895 = primEQ(Nil, _35reg894);
+if (True == _35reg895) {
+Obj _35reg896 = primCdr(closureRef(co, 0));
+Obj _35reg897 = primCdr(_35reg896);
+Obj frees = _35reg897;
 Obj next = closureRef(co, 1);
-pushCont(co, 14, _35clofun3125, 3, args, frees, next);
+pushCont(co, 13, _35clofun2002, 3, args, frees, next);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = body;
@@ -9809,101 +9905,101 @@ __arg2 = globalRef(intern("cora/lib/toc#id"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1236;
+__arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1236;
+__arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1236;
+__arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1236;
+__arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1236;
+__arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1236;
+__arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1236;
+__arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1236;
+__arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+
+label15:
+{
+Obj _35val930 = __arg1;
+Obj rb= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg931 = primCons(_35val930, Nil);
+Obj _35reg932 = primCons(rb, _35reg931);
+Obj _35reg933 = primCons(closureRef(co, 0), _35reg932);
+Obj _35reg934 = primCons(intern("let"), _35reg933);
+__nargs = 2;
+__arg1 = _35reg934;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label16:
 {
-Obj _35val2080 = __arg1;
-Obj rb= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2081 = primCons(_35val2080, Nil);
-Obj _35reg2082 = primCons(rb, _35reg2081);
-Obj _35reg2083 = primCons(closureRef(co, 0), _35reg2082);
-Obj _35reg2084 = primCons(intern("let"), _35reg2083);
-__nargs = 2;
-__arg1 = _35reg2084;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3125) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label17:
-{
 Obj rb = __arg1;
-pushCont(co, 16, _35clofun3125, 1, rb);
+pushCont(co, 15, _35clofun2002, 1, rb);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 1);
@@ -9911,152 +10007,236 @@ __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label17:
 {
-Obj _35cc1235 = makeNative(15, _35clofun3125, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2054 = primIsCons(closureRef(co, 0));
-if (True == _35reg2054) {
-Obj _35reg2055 = primCar(closureRef(co, 0));
-Obj _35reg2056 = primEQ(intern("let"), _35reg2055);
-if (True == _35reg2056) {
-Obj _35reg2057 = primCdr(closureRef(co, 0));
-Obj _35reg2058 = primIsCons(_35reg2057);
-if (True == _35reg2058) {
-Obj _35reg2059 = primCdr(closureRef(co, 0));
-Obj _35reg2060 = primCar(_35reg2059);
-Obj a = _35reg2060;
-Obj _35reg2061 = primCdr(closureRef(co, 0));
-Obj _35reg2062 = primCdr(_35reg2061);
-Obj _35reg2063 = primIsCons(_35reg2062);
-if (True == _35reg2063) {
-Obj _35reg2064 = primCdr(closureRef(co, 0));
-Obj _35reg2065 = primCdr(_35reg2064);
-Obj _35reg2066 = primCar(_35reg2065);
-Obj b = _35reg2066;
-Obj _35reg2067 = primCdr(closureRef(co, 0));
-Obj _35reg2068 = primCdr(_35reg2067);
-Obj _35reg2069 = primCdr(_35reg2068);
-Obj _35reg2070 = primIsCons(_35reg2069);
-if (True == _35reg2070) {
-Obj _35reg2071 = primCdr(closureRef(co, 0));
-Obj _35reg2072 = primCdr(_35reg2071);
-Obj _35reg2073 = primCdr(_35reg2072);
-Obj _35reg2074 = primCar(_35reg2073);
-Obj c = _35reg2074;
-Obj _35reg2075 = primCdr(closureRef(co, 0));
-Obj _35reg2076 = primCdr(_35reg2075);
-Obj _35reg2077 = primCdr(_35reg2076);
-Obj _35reg2078 = primCdr(_35reg2077);
-Obj _35reg2079 = primEQ(Nil, _35reg2078);
-if (True == _35reg2079) {
+Obj _35cc88 = makeNative(14, _35clofun2002, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg904 = primIsCons(closureRef(co, 0));
+if (True == _35reg904) {
+Obj _35reg905 = primCar(closureRef(co, 0));
+Obj _35reg906 = primEQ(intern("let"), _35reg905);
+if (True == _35reg906) {
+Obj _35reg907 = primCdr(closureRef(co, 0));
+Obj _35reg908 = primIsCons(_35reg907);
+if (True == _35reg908) {
+Obj _35reg909 = primCdr(closureRef(co, 0));
+Obj _35reg910 = primCar(_35reg909);
+Obj a = _35reg910;
+Obj _35reg911 = primCdr(closureRef(co, 0));
+Obj _35reg912 = primCdr(_35reg911);
+Obj _35reg913 = primIsCons(_35reg912);
+if (True == _35reg913) {
+Obj _35reg914 = primCdr(closureRef(co, 0));
+Obj _35reg915 = primCdr(_35reg914);
+Obj _35reg916 = primCar(_35reg915);
+Obj b = _35reg916;
+Obj _35reg917 = primCdr(closureRef(co, 0));
+Obj _35reg918 = primCdr(_35reg917);
+Obj _35reg919 = primCdr(_35reg918);
+Obj _35reg920 = primIsCons(_35reg919);
+if (True == _35reg920) {
+Obj _35reg921 = primCdr(closureRef(co, 0));
+Obj _35reg922 = primCdr(_35reg921);
+Obj _35reg923 = primCdr(_35reg922);
+Obj _35reg924 = primCar(_35reg923);
+Obj c = _35reg924;
+Obj _35reg925 = primCdr(closureRef(co, 0));
+Obj _35reg926 = primCdr(_35reg925);
+Obj _35reg927 = primCdr(_35reg926);
+Obj _35reg928 = primCdr(_35reg927);
+Obj _35reg929 = primEQ(Nil, _35reg928);
+if (True == _35reg929) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = b;
-__arg2 = makeNative(17, _35clofun3125, 1, 3, a, c, next);
+__arg2 = makeNative(16, _35clofun2002, 1, 3, a, c, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1235;
+__arg0 = _35cc88;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1235;
+__arg0 = _35cc88;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1235;
+__arg0 = _35cc88;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1235;
+__arg0 = _35cc88;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1235;
+__arg0 = _35cc88;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1235;
+__arg0 = _35cc88;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
+
+label18:
+{
+Obj _35val953 = __arg1;
+Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg954 = primCons(_35val953, Nil);
+Obj _35reg955 = primCons(ra, _35reg954);
+Obj _35reg956 = primCons(intern("do"), _35reg955);
+__nargs = 2;
+__arg1 = _35reg956;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label19:
 {
-Obj _35val2103 = __arg1;
-Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2104 = primCons(_35val2103, Nil);
-Obj _35reg2105 = primCons(ra, _35reg2104);
-Obj _35reg2106 = primCons(intern("do"), _35reg2105);
-__nargs = 2;
-__arg1 = _35reg2106;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3125) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj ra = __arg1;
+Obj _35reg952 = primIsSymbol(ra);
+if (True == _35reg952) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#tailify"));
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 18, _35clofun2002, 1, ra);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#tailify"));
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label20:
 {
-Obj ra = __arg1;
-Obj _35reg2102 = primIsSymbol(ra);
-if (True == _35reg2102) {
+Obj _35cc87 = makeNative(17, _35clofun2002, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg935 = primIsCons(closureRef(co, 0));
+if (True == _35reg935) {
+Obj _35reg936 = primCar(closureRef(co, 0));
+Obj _35reg937 = primEQ(intern("do"), _35reg936);
+if (True == _35reg937) {
+Obj _35reg938 = primCdr(closureRef(co, 0));
+Obj _35reg939 = primIsCons(_35reg938);
+if (True == _35reg939) {
+Obj _35reg940 = primCdr(closureRef(co, 0));
+Obj _35reg941 = primCar(_35reg940);
+Obj a = _35reg941;
+Obj _35reg942 = primCdr(closureRef(co, 0));
+Obj _35reg943 = primCdr(_35reg942);
+Obj _35reg944 = primIsCons(_35reg943);
+if (True == _35reg944) {
+Obj _35reg945 = primCdr(closureRef(co, 0));
+Obj _35reg946 = primCdr(_35reg945);
+Obj _35reg947 = primCar(_35reg946);
+Obj b = _35reg947;
+Obj _35reg948 = primCdr(closureRef(co, 0));
+Obj _35reg949 = primCdr(_35reg948);
+Obj _35reg950 = primCdr(_35reg949);
+Obj _35reg951 = primEQ(Nil, _35reg950);
+if (True == _35reg951) {
+Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 1);
+__arg1 = a;
+__arg2 = makeNative(19, _35clofun2002, 1, 2, b, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 19, _35clofun3125, 1, ra);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#tailify"));
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 1);
+__nargs = 1;
+__arg0 = _35cc87;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc87;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc87;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc87;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc87;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -10070,7 +10250,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3124(struct Cora* co){
+void _35clofun2001(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -10083,1374 +10263,743 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1807 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#foldl"));
-__arg1 = globalRef(intern("cora/lib/toc#union"));
-__arg2 = Nil;
-__arg3 = _35val1807;
+Obj _35cc71 = makeNative(19, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35reg638 = primIsCons(closureRef(co, 0));
+if (True == _35reg638) {
+Obj _35reg639 = primCar(closureRef(co, 0));
+Obj _35reg640 = primEQ(intern("call"), _35reg639);
+if (True == _35reg640) {
+Obj _35reg641 = primCdr(closureRef(co, 0));
+Obj _35reg642 = primIsCons(_35reg641);
+if (True == _35reg642) {
+Obj _35reg643 = primCdr(closureRef(co, 0));
+Obj _35reg644 = primCar(_35reg643);
+Obj exp = _35reg644;
+Obj _35reg645 = primCdr(closureRef(co, 0));
+Obj _35reg646 = primCdr(_35reg645);
+Obj _35reg647 = primIsCons(_35reg646);
+if (True == _35reg647) {
+Obj _35reg648 = primCdr(closureRef(co, 0));
+Obj _35reg649 = primCdr(_35reg648);
+Obj _35reg650 = primCar(_35reg649);
+Obj cont = _35reg650;
+Obj _35reg651 = primCdr(closureRef(co, 0));
+Obj _35reg652 = primCdr(_35reg651);
+Obj _35reg653 = primCdr(_35reg652);
+Obj _35reg654 = primEQ(Nil, _35reg653);
+if (True == _35reg654) {
+Obj _35reg655 = primCons(cont, Nil);
+Obj _35reg656 = primCons(exp, _35reg655);
+pushCont(co, 20, _35clofun2000, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg2 = _35reg656;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc71;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc71;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc71;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc71;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc71;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label1:
 {
-Obj _35cc1218 = makeNative(20, _35clofun3123, 0, 1, closureRef(co, 0));
-Obj _35reg1788 = primIsCons(closureRef(co, 0));
-if (True == _35reg1788) {
-Obj _35reg1789 = primCar(closureRef(co, 0));
-Obj _35reg1790 = primEQ(intern("call"), _35reg1789);
-if (True == _35reg1790) {
-Obj _35reg1791 = primCdr(closureRef(co, 0));
-Obj _35reg1792 = primIsCons(_35reg1791);
-if (True == _35reg1792) {
-Obj _35reg1793 = primCdr(closureRef(co, 0));
-Obj _35reg1794 = primCar(_35reg1793);
-Obj exp = _35reg1794;
-Obj _35reg1795 = primCdr(closureRef(co, 0));
-Obj _35reg1796 = primCdr(_35reg1795);
-Obj _35reg1797 = primIsCons(_35reg1796);
-if (True == _35reg1797) {
-Obj _35reg1798 = primCdr(closureRef(co, 0));
-Obj _35reg1799 = primCdr(_35reg1798);
-Obj _35reg1800 = primCar(_35reg1799);
-Obj cont = _35reg1800;
-Obj _35reg1801 = primCdr(closureRef(co, 0));
-Obj _35reg1802 = primCdr(_35reg1801);
-Obj _35reg1803 = primCdr(_35reg1802);
-Obj _35reg1804 = primEQ(Nil, _35reg1803);
-if (True == _35reg1804) {
-Obj _35reg1805 = primCons(cont, Nil);
-Obj _35reg1806 = primCons(exp, _35reg1805);
-pushCont(co, 0, _35clofun3124, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg2 = _35reg1806;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1218;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1218;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1218;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1218;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1218;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label2:
-{
-Obj _35cc1217 = makeNative(1, _35clofun3124, 0, 1, closureRef(co, 0));
-Obj _35reg1808 = primIsCons(closureRef(co, 0));
-if (True == _35reg1808) {
-Obj _35reg1809 = primCar(closureRef(co, 0));
-Obj _35reg1810 = primEQ(intern("return"), _35reg1809);
-if (True == _35reg1810) {
-Obj _35reg1811 = primCdr(closureRef(co, 0));
-Obj _35reg1812 = primIsCons(_35reg1811);
-if (True == _35reg1812) {
-Obj _35reg1813 = primCdr(closureRef(co, 0));
-Obj _35reg1814 = primCar(_35reg1813);
-Obj x = _35reg1814;
-Obj _35reg1815 = primCdr(closureRef(co, 0));
-Obj _35reg1816 = primCdr(_35reg1815);
-Obj _35reg1817 = primEQ(Nil, _35reg1816);
-if (True == _35reg1817) {
+Obj _35cc70 = makeNative(0, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35reg658 = primIsCons(closureRef(co, 0));
+if (True == _35reg658) {
+Obj _35reg659 = primCar(closureRef(co, 0));
+Obj _35reg660 = primEQ(intern("return"), _35reg659);
+if (True == _35reg660) {
+Obj _35reg661 = primCdr(closureRef(co, 0));
+Obj _35reg662 = primIsCons(_35reg661);
+if (True == _35reg662) {
+Obj _35reg663 = primCdr(closureRef(co, 0));
+Obj _35reg664 = primCar(_35reg663);
+Obj x = _35reg664;
+Obj _35reg665 = primCdr(closureRef(co, 0));
+Obj _35reg666 = primCdr(_35reg665);
+Obj _35reg667 = primEQ(Nil, _35reg666);
+if (True == _35reg667) {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1217;
+__arg0 = _35cc70;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1217;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1217;
+__arg0 = _35cc70;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1217;
+__arg0 = _35cc70;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc70;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35cc69 = makeNative(1, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35reg668 = primIsCons(closureRef(co, 0));
+if (True == _35reg668) {
+Obj _35reg669 = primCar(closureRef(co, 0));
+Obj _35reg670 = primEQ(intern("%closure"), _35reg669);
+if (True == _35reg670) {
+Obj _35reg671 = primCdr(closureRef(co, 0));
+Obj _35reg672 = primIsCons(_35reg671);
+if (True == _35reg672) {
+Obj _35reg673 = primCdr(closureRef(co, 0));
+Obj _35reg674 = primCar(_35reg673);
+Obj lam = _35reg674;
+Obj _35reg675 = primCdr(closureRef(co, 0));
+Obj _35reg676 = primCdr(_35reg675);
+Obj more = _35reg676;
+Obj _35reg677 = primCons(lam, more);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = _35reg677;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc69;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc69;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc69;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35cc1216 = makeNative(2, _35clofun3124, 0, 1, closureRef(co, 0));
-Obj _35reg1818 = primIsCons(closureRef(co, 0));
-if (True == _35reg1818) {
-Obj _35reg1819 = primCar(closureRef(co, 0));
-Obj _35reg1820 = primEQ(intern("%closure"), _35reg1819);
-if (True == _35reg1820) {
-Obj _35reg1821 = primCdr(closureRef(co, 0));
-Obj _35reg1822 = primIsCons(_35reg1821);
-if (True == _35reg1822) {
-Obj _35reg1823 = primCdr(closureRef(co, 0));
-Obj _35reg1824 = primCar(_35reg1823);
-Obj lam = _35reg1824;
-Obj _35reg1825 = primCdr(closureRef(co, 0));
-Obj _35reg1826 = primCdr(_35reg1825);
-Obj more = _35reg1826;
-Obj _35reg1827 = primCons(lam, more);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = _35reg1827;
+Obj _35val707 = __arg1;
+Obj _35val704= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#union"));
+__arg1 = _35val704;
+__arg2 = _35val707;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1216;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1216;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1216;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label4:
 {
-Obj _35val1857 = __arg1;
-Obj _35val1854= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val705 = __arg1;
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val704= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg706 = primCons(a, Nil);
+pushCont(co, 3, _35clofun2001, 1, _35val704);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#union"));
-__arg1 = _35val1854;
-__arg2 = _35val1857;
+__arg0 = globalRef(intern("cora/lib/toc#diff"));
+__arg1 = _35val705;
+__arg2 = _35reg706;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1855 = __arg1;
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val1854= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1856 = primCons(a, Nil);
-pushCont(co, 4, _35clofun3124, 1, _35val1854);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = _35val1855;
-__arg2 = _35reg1856;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val1854 = __arg1;
+Obj _35val704 = __arg1;
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun3124, 2, a, _35val1854);
+pushCont(co, 4, _35clofun2001, 2, a, _35val704);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label6:
 {
-Obj _35cc1215 = makeNative(3, _35clofun3124, 0, 1, closureRef(co, 0));
-Obj _35reg1828 = primIsCons(closureRef(co, 0));
-if (True == _35reg1828) {
-Obj _35reg1829 = primCar(closureRef(co, 0));
-Obj _35reg1830 = primEQ(intern("let"), _35reg1829);
-if (True == _35reg1830) {
-Obj _35reg1831 = primCdr(closureRef(co, 0));
-Obj _35reg1832 = primIsCons(_35reg1831);
-if (True == _35reg1832) {
-Obj _35reg1833 = primCdr(closureRef(co, 0));
-Obj _35reg1834 = primCar(_35reg1833);
-Obj a = _35reg1834;
-Obj _35reg1835 = primCdr(closureRef(co, 0));
-Obj _35reg1836 = primCdr(_35reg1835);
-Obj _35reg1837 = primIsCons(_35reg1836);
-if (True == _35reg1837) {
-Obj _35reg1838 = primCdr(closureRef(co, 0));
-Obj _35reg1839 = primCdr(_35reg1838);
-Obj _35reg1840 = primCar(_35reg1839);
-Obj b = _35reg1840;
-Obj _35reg1841 = primCdr(closureRef(co, 0));
-Obj _35reg1842 = primCdr(_35reg1841);
-Obj _35reg1843 = primCdr(_35reg1842);
-Obj _35reg1844 = primIsCons(_35reg1843);
-if (True == _35reg1844) {
-Obj _35reg1845 = primCdr(closureRef(co, 0));
-Obj _35reg1846 = primCdr(_35reg1845);
-Obj _35reg1847 = primCdr(_35reg1846);
-Obj _35reg1848 = primCar(_35reg1847);
-Obj c = _35reg1848;
-Obj _35reg1849 = primCdr(closureRef(co, 0));
-Obj _35reg1850 = primCdr(_35reg1849);
-Obj _35reg1851 = primCdr(_35reg1850);
-Obj _35reg1852 = primCdr(_35reg1851);
-Obj _35reg1853 = primEQ(Nil, _35reg1852);
-if (True == _35reg1853) {
-pushCont(co, 6, _35clofun3124, 2, c, a);
+Obj _35cc68 = makeNative(2, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35reg678 = primIsCons(closureRef(co, 0));
+if (True == _35reg678) {
+Obj _35reg679 = primCar(closureRef(co, 0));
+Obj _35reg680 = primEQ(intern("let"), _35reg679);
+if (True == _35reg680) {
+Obj _35reg681 = primCdr(closureRef(co, 0));
+Obj _35reg682 = primIsCons(_35reg681);
+if (True == _35reg682) {
+Obj _35reg683 = primCdr(closureRef(co, 0));
+Obj _35reg684 = primCar(_35reg683);
+Obj a = _35reg684;
+Obj _35reg685 = primCdr(closureRef(co, 0));
+Obj _35reg686 = primCdr(_35reg685);
+Obj _35reg687 = primIsCons(_35reg686);
+if (True == _35reg687) {
+Obj _35reg688 = primCdr(closureRef(co, 0));
+Obj _35reg689 = primCdr(_35reg688);
+Obj _35reg690 = primCar(_35reg689);
+Obj b = _35reg690;
+Obj _35reg691 = primCdr(closureRef(co, 0));
+Obj _35reg692 = primCdr(_35reg691);
+Obj _35reg693 = primCdr(_35reg692);
+Obj _35reg694 = primIsCons(_35reg693);
+if (True == _35reg694) {
+Obj _35reg695 = primCdr(closureRef(co, 0));
+Obj _35reg696 = primCdr(_35reg695);
+Obj _35reg697 = primCdr(_35reg696);
+Obj _35reg698 = primCar(_35reg697);
+Obj c = _35reg698;
+Obj _35reg699 = primCdr(closureRef(co, 0));
+Obj _35reg700 = primCdr(_35reg699);
+Obj _35reg701 = primCdr(_35reg700);
+Obj _35reg702 = primCdr(_35reg701);
+Obj _35reg703 = primEQ(Nil, _35reg702);
+if (True == _35reg703) {
+pushCont(co, 5, _35clofun2001, 2, c, a);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1215;
+__arg0 = _35cc68;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1215;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1215;
+__arg0 = _35cc68;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1215;
+__arg0 = _35cc68;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1215;
+__arg0 = _35cc68;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1215;
+__arg0 = _35cc68;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-Obj _35val1877 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#foldl"));
-__arg1 = globalRef(intern("cora/lib/toc#union"));
-__arg2 = Nil;
-__arg3 = _35val1877;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35cc1214 = makeNative(7, _35clofun3124, 0, 1, closureRef(co, 0));
-Obj _35reg1858 = primIsCons(closureRef(co, 0));
-if (True == _35reg1858) {
-Obj _35reg1859 = primCar(closureRef(co, 0));
-Obj _35reg1860 = primEQ(intern("do"), _35reg1859);
-if (True == _35reg1860) {
-Obj _35reg1861 = primCdr(closureRef(co, 0));
-Obj _35reg1862 = primIsCons(_35reg1861);
-if (True == _35reg1862) {
-Obj _35reg1863 = primCdr(closureRef(co, 0));
-Obj _35reg1864 = primCar(_35reg1863);
-Obj x = _35reg1864;
-Obj _35reg1865 = primCdr(closureRef(co, 0));
-Obj _35reg1866 = primCdr(_35reg1865);
-Obj _35reg1867 = primIsCons(_35reg1866);
-if (True == _35reg1867) {
-Obj _35reg1868 = primCdr(closureRef(co, 0));
-Obj _35reg1869 = primCdr(_35reg1868);
-Obj _35reg1870 = primCar(_35reg1869);
-Obj y = _35reg1870;
-Obj _35reg1871 = primCdr(closureRef(co, 0));
-Obj _35reg1872 = primCdr(_35reg1871);
-Obj _35reg1873 = primCdr(_35reg1872);
-Obj _35reg1874 = primEQ(Nil, _35reg1873);
-if (True == _35reg1874) {
-Obj _35reg1875 = primCons(y, Nil);
-Obj _35reg1876 = primCons(x, _35reg1875);
-pushCont(co, 8, _35clofun3124, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg2 = _35reg1876;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1214;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1214;
+__arg0 = _35cc68;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1214;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1214;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1214;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj _35val1907 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#foldl"));
-__arg1 = globalRef(intern("cora/lib/toc#union"));
-__arg2 = Nil;
-__arg3 = _35val1907;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35cc1213 = makeNative(9, _35clofun3124, 0, 1, closureRef(co, 0));
-Obj _35reg1878 = primIsCons(closureRef(co, 0));
-if (True == _35reg1878) {
-Obj _35reg1879 = primCar(closureRef(co, 0));
-Obj _35reg1880 = primEQ(intern("if"), _35reg1879);
-if (True == _35reg1880) {
-Obj _35reg1881 = primCdr(closureRef(co, 0));
-Obj _35reg1882 = primIsCons(_35reg1881);
-if (True == _35reg1882) {
-Obj _35reg1883 = primCdr(closureRef(co, 0));
-Obj _35reg1884 = primCar(_35reg1883);
-Obj x = _35reg1884;
-Obj _35reg1885 = primCdr(closureRef(co, 0));
-Obj _35reg1886 = primCdr(_35reg1885);
-Obj _35reg1887 = primIsCons(_35reg1886);
-if (True == _35reg1887) {
-Obj _35reg1888 = primCdr(closureRef(co, 0));
-Obj _35reg1889 = primCdr(_35reg1888);
-Obj _35reg1890 = primCar(_35reg1889);
-Obj y = _35reg1890;
-Obj _35reg1891 = primCdr(closureRef(co, 0));
-Obj _35reg1892 = primCdr(_35reg1891);
-Obj _35reg1893 = primCdr(_35reg1892);
-Obj _35reg1894 = primIsCons(_35reg1893);
-if (True == _35reg1894) {
-Obj _35reg1895 = primCdr(closureRef(co, 0));
-Obj _35reg1896 = primCdr(_35reg1895);
-Obj _35reg1897 = primCdr(_35reg1896);
-Obj _35reg1898 = primCar(_35reg1897);
-Obj z = _35reg1898;
-Obj _35reg1899 = primCdr(closureRef(co, 0));
-Obj _35reg1900 = primCdr(_35reg1899);
-Obj _35reg1901 = primCdr(_35reg1900);
-Obj _35reg1902 = primCdr(_35reg1901);
-Obj _35reg1903 = primEQ(Nil, _35reg1902);
-if (True == _35reg1903) {
-Obj _35reg1904 = primCons(z, Nil);
-Obj _35reg1905 = primCons(y, _35reg1904);
-Obj _35reg1906 = primCons(x, _35reg1905);
-pushCont(co, 10, _35clofun3124, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg2 = _35reg1906;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1213;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1213;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1213;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1213;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1213;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1213;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35val1925 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = _35val1925;
-__arg2 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35cc1212 = makeNative(11, _35clofun3124, 0, 1, closureRef(co, 0));
-Obj _35reg1908 = primIsCons(closureRef(co, 0));
-if (True == _35reg1908) {
-Obj _35reg1909 = primCar(closureRef(co, 0));
-Obj _35reg1910 = primEQ(intern("lambda"), _35reg1909);
-if (True == _35reg1910) {
-Obj _35reg1911 = primCdr(closureRef(co, 0));
-Obj _35reg1912 = primIsCons(_35reg1911);
-if (True == _35reg1912) {
-Obj _35reg1913 = primCdr(closureRef(co, 0));
-Obj _35reg1914 = primCar(_35reg1913);
-Obj args = _35reg1914;
-Obj _35reg1915 = primCdr(closureRef(co, 0));
-Obj _35reg1916 = primCdr(_35reg1915);
-Obj _35reg1917 = primIsCons(_35reg1916);
-if (True == _35reg1917) {
-Obj _35reg1918 = primCdr(closureRef(co, 0));
-Obj _35reg1919 = primCdr(_35reg1918);
-Obj _35reg1920 = primCar(_35reg1919);
-Obj body = _35reg1920;
-Obj _35reg1921 = primCdr(closureRef(co, 0));
-Obj _35reg1922 = primCdr(_35reg1921);
-Obj _35reg1923 = primCdr(_35reg1922);
-Obj _35reg1924 = primEQ(Nil, _35reg1923);
-if (True == _35reg1924) {
-pushCont(co, 12, _35clofun3124, 1, args);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1212;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1212;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1212;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1212;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1212;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label14:
-{
-Obj _35cc1211 = makeNative(13, _35clofun3124, 0, 1, closureRef(co, 0));
-Obj x = closureRef(co, 0);
-Obj _35reg1926 = primIsSymbol(x);
-if (True == _35reg1926) {
-Obj _35reg1927 = primCons(x, Nil);
-__nargs = 2;
-__arg1 = _35reg1927;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3124) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1211;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj _35val1928 = __arg1;
-Obj _35cc1210= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1928) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3124) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1210;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label16:
-{
-Obj _35p1209 = __arg1;
-Obj _35cc1210 = makeNative(14, _35clofun3124, 0, 1, _35p1209);
-Obj x = _35p1209;
-pushCont(co, 15, _35clofun3124, 1, _35cc1210);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val1933 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1934 = primCons(f, args);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val1933;
-__arg2 = _35reg1934;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35cc1228 = makeNative(17, _35clofun3124, 0, 0);
-Obj fvs = closureRef(co, 0);
-Obj _35reg1930 = primIsCons(closureRef(co, 1));
-if (True == _35reg1930) {
-Obj _35reg1931 = primCar(closureRef(co, 1));
-Obj f = _35reg1931;
-Obj _35reg1932 = primCdr(closureRef(co, 1));
-Obj args = _35reg1932;
-pushCont(co, 18, _35clofun3124, 2, f, args);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
-__arg1 = fvs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1228;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
-{
-Obj _35val1962 = __arg1;
-Obj _35val1961= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1963 = primCons(_35val1962, Nil);
-Obj _35reg1964 = primCons(_35val1961, _35reg1963);
-Obj _35reg1965 = primCons(a, _35reg1964);
-Obj _35reg1966 = primCons(intern("let"), _35reg1965);
-__nargs = 2;
-__arg1 = _35reg1966;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3124) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-fail:
-co->nargs = __nargs;
-co->args[0] = __arg0;
-co->args[1] = __arg1;
-co->args[2] = __arg2;
-co->args[3] = __arg3;
-
-}
-
-void _35clofun3123(struct Cora* co){
-int __nargs = co->nargs;
-Obj __arg0 = co->args[0];
-Obj __arg1 = co->args[1];
-Obj __arg2 = co->args[2];
-Obj __arg3 = co->args[3];
-
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
-
-goto *jumpTable[co->ctx.pc.label];
-
-label0:
-{
-Obj _35cc1195 = makeNative(19, _35clofun3122, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1687 = primIsCons(closureRef(co, 0));
-if (True == _35reg1687) {
-Obj _35reg1688 = primCar(closureRef(co, 0));
-Obj x = _35reg1688;
-Obj _35reg1689 = primCdr(closureRef(co, 0));
-Obj y = _35reg1689;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 20, _35clofun3122, 3, y, s2, _35cc1195);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#elem?"));
-__arg1 = x;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1195;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label1:
-{
-Obj _35p1192 = __arg1;
-Obj _35p1193 = __arg2;
-Obj _35cc1194 = makeNative(0, _35clofun3123, 0, 2, _35p1192, _35p1193);
-Obj _35reg1691 = primEQ(Nil, _35p1192);
-if (True == _35reg1691) {
-Obj s2 = _35p1193;
-__nargs = 2;
-__arg1 = s2;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3123) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1194;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label2:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj _35val1696 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1697 = primCons(x, _35val1696);
-__nargs = 2;
-__arg1 = _35reg1697;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3123) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label4:
-{
-Obj _35cc1201 = makeNative(2, _35clofun3123, 0, 0);
-Obj _35reg1693 = primIsCons(closureRef(co, 0));
-if (True == _35reg1693) {
-Obj _35reg1694 = primCar(closureRef(co, 0));
-Obj x = _35reg1694;
-Obj _35reg1695 = primCdr(closureRef(co, 0));
-Obj y = _35reg1695;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 3, _35clofun3123, 1, x);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = y;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1201;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label5:
-{
-Obj _35val1701 = __arg1;
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc1200= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1701) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = y;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1200;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label6:
-{
-Obj _35cc1200 = makeNative(4, _35clofun3123, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1698 = primIsCons(closureRef(co, 0));
-if (True == _35reg1698) {
-Obj _35reg1699 = primCar(closureRef(co, 0));
-Obj x = _35reg1699;
-Obj _35reg1700 = primCdr(closureRef(co, 0));
-Obj y = _35reg1700;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 5, _35clofun3123, 3, y, s2, _35cc1200);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#elem?"));
-__arg1 = x;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1200;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35p1197 = __arg1;
-Obj _35p1198 = __arg2;
-Obj _35cc1199 = makeNative(6, _35clofun3123, 0, 2, _35p1197, _35p1198);
-Obj _35reg1702 = primEQ(Nil, _35p1197);
-if (True == _35reg1702) {
-Obj __ = _35p1198;
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3123) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1199;
+Obj _35val727 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#foldl"));
+__arg1 = globalRef(intern("cora/lib/toc#union"));
+__arg2 = Nil;
+__arg3 = _35val727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 
 label8:
 {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
+Obj _35cc67 = makeNative(6, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35reg708 = primIsCons(closureRef(co, 0));
+if (True == _35reg708) {
+Obj _35reg709 = primCar(closureRef(co, 0));
+Obj _35reg710 = primEQ(intern("do"), _35reg709);
+if (True == _35reg710) {
+Obj _35reg711 = primCdr(closureRef(co, 0));
+Obj _35reg712 = primIsCons(_35reg711);
+if (True == _35reg712) {
+Obj _35reg713 = primCdr(closureRef(co, 0));
+Obj _35reg714 = primCar(_35reg713);
+Obj x = _35reg714;
+Obj _35reg715 = primCdr(closureRef(co, 0));
+Obj _35reg716 = primCdr(_35reg715);
+Obj _35reg717 = primIsCons(_35reg716);
+if (True == _35reg717) {
+Obj _35reg718 = primCdr(closureRef(co, 0));
+Obj _35reg719 = primCdr(_35reg718);
+Obj _35reg720 = primCar(_35reg719);
+Obj y = _35reg720;
+Obj _35reg721 = primCdr(closureRef(co, 0));
+Obj _35reg722 = primCdr(_35reg721);
+Obj _35reg723 = primCdr(_35reg722);
+Obj _35reg724 = primEQ(Nil, _35reg723);
+if (True == _35reg724) {
+Obj _35reg725 = primCons(y, Nil);
+Obj _35reg726 = primCons(x, _35reg725);
+pushCont(co, 7, _35clofun2001, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg2 = _35reg726;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc67;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc67;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc67;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc67;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc67;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label9:
 {
-Obj _35cc1208 = makeNative(8, _35clofun3123, 0, 0);
-Obj x = closureRef(co, 0);
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3123) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val757 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#foldl"));
+__arg1 = globalRef(intern("cora/lib/toc#union"));
+__arg2 = Nil;
+__arg3 = _35val757;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35cc1207 = makeNative(9, _35clofun3123, 0, 1, closureRef(co, 0));
-Obj _35reg1704 = primIsCons(closureRef(co, 0));
-if (True == _35reg1704) {
-Obj _35reg1705 = primCar(closureRef(co, 0));
-Obj _35reg1706 = primEQ(intern("%closure-ref"), _35reg1705);
-if (True == _35reg1706) {
-Obj _35reg1707 = primCdr(closureRef(co, 0));
-Obj _35reg1708 = primIsCons(_35reg1707);
-if (True == _35reg1708) {
-Obj _35reg1709 = primCdr(closureRef(co, 0));
-Obj _35reg1710 = primCar(_35reg1709);
-Obj __ = _35reg1710;
-Obj _35reg1711 = primCdr(closureRef(co, 0));
-Obj _35reg1712 = primCdr(_35reg1711);
-Obj _35reg1713 = primEQ(Nil, _35reg1712);
-if (True == _35reg1713) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3123) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1207;
+Obj _35cc66 = makeNative(8, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35reg728 = primIsCons(closureRef(co, 0));
+if (True == _35reg728) {
+Obj _35reg729 = primCar(closureRef(co, 0));
+Obj _35reg730 = primEQ(intern("if"), _35reg729);
+if (True == _35reg730) {
+Obj _35reg731 = primCdr(closureRef(co, 0));
+Obj _35reg732 = primIsCons(_35reg731);
+if (True == _35reg732) {
+Obj _35reg733 = primCdr(closureRef(co, 0));
+Obj _35reg734 = primCar(_35reg733);
+Obj x = _35reg734;
+Obj _35reg735 = primCdr(closureRef(co, 0));
+Obj _35reg736 = primCdr(_35reg735);
+Obj _35reg737 = primIsCons(_35reg736);
+if (True == _35reg737) {
+Obj _35reg738 = primCdr(closureRef(co, 0));
+Obj _35reg739 = primCdr(_35reg738);
+Obj _35reg740 = primCar(_35reg739);
+Obj y = _35reg740;
+Obj _35reg741 = primCdr(closureRef(co, 0));
+Obj _35reg742 = primCdr(_35reg741);
+Obj _35reg743 = primCdr(_35reg742);
+Obj _35reg744 = primIsCons(_35reg743);
+if (True == _35reg744) {
+Obj _35reg745 = primCdr(closureRef(co, 0));
+Obj _35reg746 = primCdr(_35reg745);
+Obj _35reg747 = primCdr(_35reg746);
+Obj _35reg748 = primCar(_35reg747);
+Obj z = _35reg748;
+Obj _35reg749 = primCdr(closureRef(co, 0));
+Obj _35reg750 = primCdr(_35reg749);
+Obj _35reg751 = primCdr(_35reg750);
+Obj _35reg752 = primCdr(_35reg751);
+Obj _35reg753 = primEQ(Nil, _35reg752);
+if (True == _35reg753) {
+Obj _35reg754 = primCons(z, Nil);
+Obj _35reg755 = primCons(y, _35reg754);
+Obj _35reg756 = primCons(x, _35reg755);
+pushCont(co, 9, _35clofun2001, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg2 = _35reg756;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc66;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1207;
+__arg0 = _35cc66;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1207;
+__arg0 = _35cc66;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1207;
+__arg0 = _35cc66;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc66;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc66;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35cc1206 = makeNative(10, _35clofun3123, 0, 1, closureRef(co, 0));
-Obj _35reg1714 = primIsCons(closureRef(co, 0));
-if (True == _35reg1714) {
-Obj _35reg1715 = primCar(closureRef(co, 0));
-Obj _35reg1716 = primEQ(intern("quote"), _35reg1715);
-if (True == _35reg1716) {
-Obj _35reg1717 = primCdr(closureRef(co, 0));
-Obj _35reg1718 = primIsCons(_35reg1717);
-if (True == _35reg1718) {
-Obj _35reg1719 = primCdr(closureRef(co, 0));
-Obj _35reg1720 = primCar(_35reg1719);
-Obj x = _35reg1720;
-Obj _35reg1721 = primCdr(closureRef(co, 0));
-Obj _35reg1722 = primCdr(_35reg1721);
-Obj _35reg1723 = primEQ(Nil, _35reg1722);
-if (True == _35reg1723) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3123) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1206;
+Obj _35val775 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#diff"));
+__arg1 = _35val775;
+__arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1206;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1206;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1206;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label12:
 {
-Obj _35cc1205 = makeNative(11, _35clofun3123, 0, 1, closureRef(co, 0));
-Obj _35reg1724 = primIsCons(closureRef(co, 0));
-if (True == _35reg1724) {
-Obj _35reg1725 = primCar(closureRef(co, 0));
-Obj _35reg1726 = primEQ(intern("%builtin"), _35reg1725);
-if (True == _35reg1726) {
-Obj _35reg1727 = primCdr(closureRef(co, 0));
-Obj _35reg1728 = primIsCons(_35reg1727);
-if (True == _35reg1728) {
-Obj _35reg1729 = primCdr(closureRef(co, 0));
-Obj _35reg1730 = primCar(_35reg1729);
-Obj op = _35reg1730;
-Obj _35reg1731 = primCdr(closureRef(co, 0));
-Obj _35reg1732 = primCdr(_35reg1731);
-Obj _35reg1733 = primEQ(Nil, _35reg1732);
-if (True == _35reg1733) {
+Obj _35cc65 = makeNative(10, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35reg758 = primIsCons(closureRef(co, 0));
+if (True == _35reg758) {
+Obj _35reg759 = primCar(closureRef(co, 0));
+Obj _35reg760 = primEQ(intern("lambda"), _35reg759);
+if (True == _35reg760) {
+Obj _35reg761 = primCdr(closureRef(co, 0));
+Obj _35reg762 = primIsCons(_35reg761);
+if (True == _35reg762) {
+Obj _35reg763 = primCdr(closureRef(co, 0));
+Obj _35reg764 = primCar(_35reg763);
+Obj args = _35reg764;
+Obj _35reg765 = primCdr(closureRef(co, 0));
+Obj _35reg766 = primCdr(_35reg765);
+Obj _35reg767 = primIsCons(_35reg766);
+if (True == _35reg767) {
+Obj _35reg768 = primCdr(closureRef(co, 0));
+Obj _35reg769 = primCdr(_35reg768);
+Obj _35reg770 = primCar(_35reg769);
+Obj body = _35reg770;
+Obj _35reg771 = primCdr(closureRef(co, 0));
+Obj _35reg772 = primCdr(_35reg771);
+Obj _35reg773 = primCdr(_35reg772);
+Obj _35reg774 = primEQ(Nil, _35reg773);
+if (True == _35reg774) {
+pushCont(co, 11, _35clofun2001, 1, args);
 __nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3123) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1205;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc65;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1205;
+__arg0 = _35cc65;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1205;
+__arg0 = _35cc65;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1205;
+__arg0 = _35cc65;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc65;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label13:
 {
-Obj _35cc1204 = makeNative(12, _35clofun3123, 0, 1, closureRef(co, 0));
-Obj _35reg1734 = primIsCons(closureRef(co, 0));
-if (True == _35reg1734) {
-Obj _35reg1735 = primCar(closureRef(co, 0));
-Obj _35reg1736 = primEQ(intern("%global"), _35reg1735);
-if (True == _35reg1736) {
-Obj _35reg1737 = primCdr(closureRef(co, 0));
-Obj _35reg1738 = primIsCons(_35reg1737);
-if (True == _35reg1738) {
-Obj _35reg1739 = primCdr(closureRef(co, 0));
-Obj _35reg1740 = primCar(_35reg1739);
-Obj x = _35reg1740;
-Obj _35reg1741 = primCdr(closureRef(co, 0));
-Obj _35reg1742 = primCdr(_35reg1741);
-Obj _35reg1743 = primEQ(Nil, _35reg1742);
-if (True == _35reg1743) {
+Obj _35cc64 = makeNative(12, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj x = closureRef(co, 0);
+Obj _35reg776 = primIsSymbol(x);
+if (True == _35reg776) {
+Obj _35reg777 = primCons(x, Nil);
 __nargs = 2;
-__arg1 = True;
+__arg1 = _35reg777;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3123) { goto fail; }
+if (co->ctx.pc.func != _35clofun2001) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1204;
+__arg0 = _35cc64;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1204;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1204;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1204;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label14:
 {
-Obj _35p1202 = __arg1;
-Obj _35cc1203 = makeNative(13, _35clofun3123, 0, 1, _35p1202);
-Obj _35reg1744 = primIsCons(_35p1202);
-if (True == _35reg1744) {
-Obj _35reg1745 = primCar(_35p1202);
-Obj _35reg1746 = primEQ(intern("%const"), _35reg1745);
-if (True == _35reg1746) {
-Obj _35reg1747 = primCdr(_35p1202);
-Obj _35reg1748 = primIsCons(_35reg1747);
-if (True == _35reg1748) {
-Obj _35reg1749 = primCdr(_35p1202);
-Obj _35reg1750 = primCar(_35reg1749);
-Obj x = _35reg1750;
-Obj _35reg1751 = primCdr(_35p1202);
-Obj _35reg1752 = primCdr(_35reg1751);
-Obj _35reg1753 = primEQ(Nil, _35reg1752);
-if (True == _35reg1753) {
+Obj _35val778 = __arg1;
+Obj _35cc63= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val778) {
 __nargs = 2;
-__arg1 = True;
+__arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3123) { goto fail; }
+if (co->ctx.pc.func != _35clofun2001) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1203;
+__arg0 = _35cc63;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1203;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1203;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1203;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label15:
+{
+Obj _35p62 = __arg1;
+Obj _35cc63 = makeNative(13, _35clofun2001, 0, 1, _35p62);
+Obj x = _35p62;
+pushCont(co, 14, _35clofun2001, 1, _35cc63);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label16:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -11458,216 +11007,89 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val1759 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#foldl"));
-__arg1 = globalRef(intern("cora/lib/toc#union"));
-__arg2 = Nil;
-__arg3 = _35val1759;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35cc1221 = makeNative(15, _35clofun3123, 0, 0);
-Obj _35reg1755 = primIsCons(closureRef(co, 0));
-if (True == _35reg1755) {
-Obj _35reg1756 = primCar(closureRef(co, 0));
-Obj f = _35reg1756;
-Obj _35reg1757 = primCdr(closureRef(co, 0));
-Obj args = _35reg1757;
-Obj _35reg1758 = primCons(f, args);
-pushCont(co, 16, _35clofun3123, 0);
+Obj _35val783 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg784 = primCons(f, args);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg2 = _35reg1758;
+__arg1 = _35val783;
+__arg2 = _35reg784;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1221;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label18:
 {
-Obj _35val1777 = __arg1;
-Obj arg= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = _35val1777;
-__arg2 = arg;
+Obj _35cc81 = makeNative(16, _35clofun2001, 0, 0);
+Obj fvs = closureRef(co, 0);
+Obj _35reg780 = primIsCons(closureRef(co, 1));
+if (True == _35reg780) {
+Obj _35reg781 = primCar(closureRef(co, 1));
+Obj f = _35reg781;
+Obj _35reg782 = primCdr(closureRef(co, 1));
+Obj args = _35reg782;
+pushCont(co, 17, _35clofun2001, 2, f, args);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
+__arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc81;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label19:
 {
-Obj _35cc1220 = makeNative(17, _35clofun3123, 0, 1, closureRef(co, 0));
-Obj _35reg1760 = primIsCons(closureRef(co, 0));
-if (True == _35reg1760) {
-Obj _35reg1761 = primCar(closureRef(co, 0));
-Obj _35reg1762 = primEQ(intern("continuation"), _35reg1761);
-if (True == _35reg1762) {
-Obj _35reg1763 = primCdr(closureRef(co, 0));
-Obj _35reg1764 = primIsCons(_35reg1763);
-if (True == _35reg1764) {
-Obj _35reg1765 = primCdr(closureRef(co, 0));
-Obj _35reg1766 = primCar(_35reg1765);
-Obj arg = _35reg1766;
-Obj _35reg1767 = primCdr(closureRef(co, 0));
-Obj _35reg1768 = primCdr(_35reg1767);
-Obj _35reg1769 = primIsCons(_35reg1768);
-if (True == _35reg1769) {
-Obj _35reg1770 = primCdr(closureRef(co, 0));
-Obj _35reg1771 = primCdr(_35reg1770);
-Obj _35reg1772 = primCar(_35reg1771);
-Obj body = _35reg1772;
-Obj _35reg1773 = primCdr(closureRef(co, 0));
-Obj _35reg1774 = primCdr(_35reg1773);
-Obj _35reg1775 = primCdr(_35reg1774);
-Obj _35reg1776 = primEQ(Nil, _35reg1775);
-if (True == _35reg1776) {
-pushCont(co, 18, _35clofun3123, 1, arg);
+Obj _35val812 = __arg1;
+Obj _35val811= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg813 = primCons(_35val812, Nil);
+Obj _35reg814 = primCons(_35val811, _35reg813);
+Obj _35reg815 = primCons(a, _35reg814);
+Obj _35reg816 = primCons(intern("let"), _35reg815);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1220;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1220;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1220;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1220;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1220;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+__arg1 = _35reg816;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2001) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label20:
 {
-Obj _35cc1219 = makeNative(19, _35clofun3123, 0, 1, closureRef(co, 0));
-Obj _35reg1778 = primIsCons(closureRef(co, 0));
-if (True == _35reg1778) {
-Obj _35reg1779 = primCar(closureRef(co, 0));
-Obj _35reg1780 = primEQ(intern("tailcall"), _35reg1779);
-if (True == _35reg1780) {
-Obj _35reg1781 = primCdr(closureRef(co, 0));
-Obj _35reg1782 = primIsCons(_35reg1781);
-if (True == _35reg1782) {
-Obj _35reg1783 = primCdr(closureRef(co, 0));
-Obj _35reg1784 = primCar(_35reg1783);
-Obj exp = _35reg1784;
-Obj _35reg1785 = primCdr(closureRef(co, 0));
-Obj _35reg1786 = primCdr(_35reg1785);
-Obj _35reg1787 = primEQ(Nil, _35reg1786);
-if (True == _35reg1787) {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = exp;
+Obj _35val811 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 19, _35clofun2001, 2, _35val811, a);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
+__arg1 = fvs;
+__arg2 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1219;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1219;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1219;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1219;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 fail:
@@ -11679,7 +11101,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3122(struct Cora* co){
+void _35clofun2000(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -11692,135 +11114,757 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1187 = makeNative(18, _35clofun3121, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj _35reg1569 = primIsCons(closureRef(co, 3));
-if (True == _35reg1569) {
-Obj _35reg1570 = primCar(closureRef(co, 3));
-Obj _35reg1571 = primEQ(intern("let"), _35reg1570);
-if (True == _35reg1571) {
-Obj _35reg1572 = primCdr(closureRef(co, 3));
-Obj _35reg1573 = primIsCons(_35reg1572);
-if (True == _35reg1573) {
-Obj _35reg1574 = primCdr(closureRef(co, 3));
-Obj _35reg1575 = primCar(_35reg1574);
-Obj a = _35reg1575;
-Obj _35reg1576 = primCdr(closureRef(co, 3));
-Obj _35reg1577 = primCdr(_35reg1576);
-Obj _35reg1578 = primIsCons(_35reg1577);
-if (True == _35reg1578) {
-Obj _35reg1579 = primCdr(closureRef(co, 3));
-Obj _35reg1580 = primCdr(_35reg1579);
-Obj _35reg1581 = primCar(_35reg1580);
-Obj b = _35reg1581;
-Obj _35reg1582 = primCdr(closureRef(co, 3));
-Obj _35reg1583 = primCdr(_35reg1582);
-Obj _35reg1584 = primCdr(_35reg1583);
-Obj _35reg1585 = primIsCons(_35reg1584);
-if (True == _35reg1585) {
-Obj _35reg1586 = primCdr(closureRef(co, 3));
-Obj _35reg1587 = primCdr(_35reg1586);
-Obj _35reg1588 = primCdr(_35reg1587);
-Obj _35reg1589 = primCar(_35reg1588);
-Obj c = _35reg1589;
-Obj _35reg1590 = primCdr(closureRef(co, 3));
-Obj _35reg1591 = primCdr(_35reg1590);
-Obj _35reg1592 = primCdr(_35reg1591);
-Obj _35reg1593 = primCdr(_35reg1592);
-Obj _35reg1594 = primEQ(Nil, _35reg1593);
-if (True == _35reg1594) {
-pushCont(co, 20, _35clofun3121, 5, env, ns, import, c, a);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj _35p45 = __arg1;
+Obj _35p46 = __arg2;
+Obj _35cc47 = makeNative(20, _35clofun1999, 0, 2, _35p45, _35p46);
+Obj _35reg541 = primEQ(Nil, _35p45);
+if (True == _35reg541) {
+Obj s2 = _35p46;
+__nargs = 2;
+__arg1 = s2;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1187;
+__arg0 = _35cc47;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1187;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1187;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1187;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1187;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1187;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35val1620 = __arg1;
-Obj _35val1619= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1621 = primCons(_35val1620, Nil);
-Obj _35reg1622 = primCons(_35val1619, _35reg1621);
-Obj _35reg1623 = primCons(intern("do"), _35reg1622);
 __nargs = 2;
-__arg1 = _35reg1623;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3122) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1619 = __arg1;
+Obj _35val546 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg547 = primCons(x, _35val546);
+__nargs = 2;
+__arg1 = _35reg547;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label3:
+{
+Obj _35cc54 = makeNative(1, _35clofun2000, 0, 0);
+Obj _35reg543 = primIsCons(closureRef(co, 0));
+if (True == _35reg543) {
+Obj _35reg544 = primCar(closureRef(co, 0));
+Obj x = _35reg544;
+Obj _35reg545 = primCdr(closureRef(co, 0));
+Obj y = _35reg545;
+Obj s2 = closureRef(co, 1);
+pushCont(co, 2, _35clofun2000, 1, x);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#diff"));
+__arg1 = y;
+__arg2 = s2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc54;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val551 = __arg1;
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc53= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val551) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#diff"));
+__arg1 = y;
+__arg2 = s2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc53;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35cc53 = makeNative(3, _35clofun2000, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg548 = primIsCons(closureRef(co, 0));
+if (True == _35reg548) {
+Obj _35reg549 = primCar(closureRef(co, 0));
+Obj x = _35reg549;
+Obj _35reg550 = primCdr(closureRef(co, 0));
+Obj y = _35reg550;
+Obj s2 = closureRef(co, 1);
+pushCont(co, 4, _35clofun2000, 3, y, s2, _35cc53);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#elem?"));
+__arg1 = x;
+__arg2 = s2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc53;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label6:
+{
+Obj _35p50 = __arg1;
+Obj _35p51 = __arg2;
+Obj _35cc52 = makeNative(5, _35clofun2000, 0, 2, _35p50, _35p51);
+Obj _35reg552 = primEQ(Nil, _35p50);
+if (True == _35reg552) {
+Obj __ = _35p51;
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc52;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label7:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label8:
+{
+Obj _35cc61 = makeNative(7, _35clofun2000, 0, 0);
+Obj x = closureRef(co, 0);
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label9:
+{
+Obj _35cc60 = makeNative(8, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35reg554 = primIsCons(closureRef(co, 0));
+if (True == _35reg554) {
+Obj _35reg555 = primCar(closureRef(co, 0));
+Obj _35reg556 = primEQ(intern("%closure-ref"), _35reg555);
+if (True == _35reg556) {
+Obj _35reg557 = primCdr(closureRef(co, 0));
+Obj _35reg558 = primIsCons(_35reg557);
+if (True == _35reg558) {
+Obj _35reg559 = primCdr(closureRef(co, 0));
+Obj _35reg560 = primCar(_35reg559);
+Obj __ = _35reg560;
+Obj _35reg561 = primCdr(closureRef(co, 0));
+Obj _35reg562 = primCdr(_35reg561);
+Obj _35reg563 = primEQ(Nil, _35reg562);
+if (True == _35reg563) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc60;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc60;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc60;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc60;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label10:
+{
+Obj _35cc59 = makeNative(9, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35reg564 = primIsCons(closureRef(co, 0));
+if (True == _35reg564) {
+Obj _35reg565 = primCar(closureRef(co, 0));
+Obj _35reg566 = primEQ(intern("quote"), _35reg565);
+if (True == _35reg566) {
+Obj _35reg567 = primCdr(closureRef(co, 0));
+Obj _35reg568 = primIsCons(_35reg567);
+if (True == _35reg568) {
+Obj _35reg569 = primCdr(closureRef(co, 0));
+Obj _35reg570 = primCar(_35reg569);
+Obj x = _35reg570;
+Obj _35reg571 = primCdr(closureRef(co, 0));
+Obj _35reg572 = primCdr(_35reg571);
+Obj _35reg573 = primEQ(Nil, _35reg572);
+if (True == _35reg573) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc59;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc59;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc59;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc59;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label11:
+{
+Obj _35cc58 = makeNative(10, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35reg574 = primIsCons(closureRef(co, 0));
+if (True == _35reg574) {
+Obj _35reg575 = primCar(closureRef(co, 0));
+Obj _35reg576 = primEQ(intern("%builtin"), _35reg575);
+if (True == _35reg576) {
+Obj _35reg577 = primCdr(closureRef(co, 0));
+Obj _35reg578 = primIsCons(_35reg577);
+if (True == _35reg578) {
+Obj _35reg579 = primCdr(closureRef(co, 0));
+Obj _35reg580 = primCar(_35reg579);
+Obj op = _35reg580;
+Obj _35reg581 = primCdr(closureRef(co, 0));
+Obj _35reg582 = primCdr(_35reg581);
+Obj _35reg583 = primEQ(Nil, _35reg582);
+if (True == _35reg583) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc58;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc58;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc58;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc58;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label12:
+{
+Obj _35cc57 = makeNative(11, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35reg584 = primIsCons(closureRef(co, 0));
+if (True == _35reg584) {
+Obj _35reg585 = primCar(closureRef(co, 0));
+Obj _35reg586 = primEQ(intern("%global"), _35reg585);
+if (True == _35reg586) {
+Obj _35reg587 = primCdr(closureRef(co, 0));
+Obj _35reg588 = primIsCons(_35reg587);
+if (True == _35reg588) {
+Obj _35reg589 = primCdr(closureRef(co, 0));
+Obj _35reg590 = primCar(_35reg589);
+Obj x = _35reg590;
+Obj _35reg591 = primCdr(closureRef(co, 0));
+Obj _35reg592 = primCdr(_35reg591);
+Obj _35reg593 = primEQ(Nil, _35reg592);
+if (True == _35reg593) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc57;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc57;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc57;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc57;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label13:
+{
+Obj _35p55 = __arg1;
+Obj _35cc56 = makeNative(12, _35clofun2000, 0, 1, _35p55);
+Obj _35reg594 = primIsCons(_35p55);
+if (True == _35reg594) {
+Obj _35reg595 = primCar(_35p55);
+Obj _35reg596 = primEQ(intern("%const"), _35reg595);
+if (True == _35reg596) {
+Obj _35reg597 = primCdr(_35p55);
+Obj _35reg598 = primIsCons(_35reg597);
+if (True == _35reg598) {
+Obj _35reg599 = primCdr(_35p55);
+Obj _35reg600 = primCar(_35reg599);
+Obj x = _35reg600;
+Obj _35reg601 = primCdr(_35p55);
+Obj _35reg602 = primCdr(_35reg601);
+Obj _35reg603 = primEQ(Nil, _35reg602);
+if (True == _35reg603) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc56;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc56;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc56;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc56;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label14:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label15:
+{
+Obj _35val609 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#foldl"));
+__arg1 = globalRef(intern("cora/lib/toc#union"));
+__arg2 = Nil;
+__arg3 = _35val609;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label16:
+{
+Obj _35cc74 = makeNative(14, _35clofun2000, 0, 0);
+Obj _35reg605 = primIsCons(closureRef(co, 0));
+if (True == _35reg605) {
+Obj _35reg606 = primCar(closureRef(co, 0));
+Obj f = _35reg606;
+Obj _35reg607 = primCdr(closureRef(co, 0));
+Obj args = _35reg607;
+Obj _35reg608 = primCons(f, args);
+pushCont(co, 15, _35clofun2000, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg2 = _35reg608;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc74;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label17:
+{
+Obj _35val627 = __arg1;
+Obj arg= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#diff"));
+__arg1 = _35val627;
+__arg2 = arg;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label18:
+{
+Obj _35cc73 = makeNative(16, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35reg610 = primIsCons(closureRef(co, 0));
+if (True == _35reg610) {
+Obj _35reg611 = primCar(closureRef(co, 0));
+Obj _35reg612 = primEQ(intern("continuation"), _35reg611);
+if (True == _35reg612) {
+Obj _35reg613 = primCdr(closureRef(co, 0));
+Obj _35reg614 = primIsCons(_35reg613);
+if (True == _35reg614) {
+Obj _35reg615 = primCdr(closureRef(co, 0));
+Obj _35reg616 = primCar(_35reg615);
+Obj arg = _35reg616;
+Obj _35reg617 = primCdr(closureRef(co, 0));
+Obj _35reg618 = primCdr(_35reg617);
+Obj _35reg619 = primIsCons(_35reg618);
+if (True == _35reg619) {
+Obj _35reg620 = primCdr(closureRef(co, 0));
+Obj _35reg621 = primCdr(_35reg620);
+Obj _35reg622 = primCar(_35reg621);
+Obj body = _35reg622;
+Obj _35reg623 = primCdr(closureRef(co, 0));
+Obj _35reg624 = primCdr(_35reg623);
+Obj _35reg625 = primCdr(_35reg624);
+Obj _35reg626 = primEQ(Nil, _35reg625);
+if (True == _35reg626) {
+pushCont(co, 17, _35clofun2000, 1, arg);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc73;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc73;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc73;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc73;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc73;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label19:
+{
+Obj _35cc72 = makeNative(18, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35reg628 = primIsCons(closureRef(co, 0));
+if (True == _35reg628) {
+Obj _35reg629 = primCar(closureRef(co, 0));
+Obj _35reg630 = primEQ(intern("tailcall"), _35reg629);
+if (True == _35reg630) {
+Obj _35reg631 = primCdr(closureRef(co, 0));
+Obj _35reg632 = primIsCons(_35reg631);
+if (True == _35reg632) {
+Obj _35reg633 = primCdr(closureRef(co, 0));
+Obj _35reg634 = primCar(_35reg633);
+Obj exp = _35reg634;
+Obj _35reg635 = primCdr(closureRef(co, 0));
+Obj _35reg636 = primCdr(_35reg635);
+Obj _35reg637 = primEQ(Nil, _35reg636);
+if (True == _35reg637) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc72;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc72;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc72;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc72;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label20:
+{
+Obj _35val657 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#foldl"));
+__arg1 = globalRef(intern("cora/lib/toc#union"));
+__arg2 = Nil;
+__arg3 = _35val657;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void _35clofun1999(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val466 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 1, _35clofun3122, 1, _35val1619);
+pushCont(co, 20, _35clofun1998, 1, _35val466);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -11830,41 +11874,41 @@ co->args[4] = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label1:
 {
-Obj _35cc1186 = makeNative(0, _35clofun3122, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc39 = makeNative(19, _35clofun1998, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj _35reg1602 = primIsCons(closureRef(co, 3));
-if (True == _35reg1602) {
-Obj _35reg1603 = primCar(closureRef(co, 3));
-Obj _35reg1604 = primEQ(intern("do"), _35reg1603);
-if (True == _35reg1604) {
-Obj _35reg1605 = primCdr(closureRef(co, 3));
-Obj _35reg1606 = primIsCons(_35reg1605);
-if (True == _35reg1606) {
-Obj _35reg1607 = primCdr(closureRef(co, 3));
-Obj _35reg1608 = primCar(_35reg1607);
-Obj x = _35reg1608;
-Obj _35reg1609 = primCdr(closureRef(co, 3));
-Obj _35reg1610 = primCdr(_35reg1609);
-Obj _35reg1611 = primIsCons(_35reg1610);
-if (True == _35reg1611) {
-Obj _35reg1612 = primCdr(closureRef(co, 3));
-Obj _35reg1613 = primCdr(_35reg1612);
-Obj _35reg1614 = primCar(_35reg1613);
-Obj y = _35reg1614;
-Obj _35reg1615 = primCdr(closureRef(co, 3));
-Obj _35reg1616 = primCdr(_35reg1615);
-Obj _35reg1617 = primCdr(_35reg1616);
-Obj _35reg1618 = primEQ(Nil, _35reg1617);
-if (True == _35reg1618) {
-pushCont(co, 2, _35clofun3122, 4, env, ns, import, y);
+Obj _35reg449 = primIsCons(closureRef(co, 3));
+if (True == _35reg449) {
+Obj _35reg450 = primCar(closureRef(co, 3));
+Obj _35reg451 = primEQ(intern("do"), _35reg450);
+if (True == _35reg451) {
+Obj _35reg452 = primCdr(closureRef(co, 3));
+Obj _35reg453 = primIsCons(_35reg452);
+if (True == _35reg453) {
+Obj _35reg454 = primCdr(closureRef(co, 3));
+Obj _35reg455 = primCar(_35reg454);
+Obj x = _35reg455;
+Obj _35reg456 = primCdr(closureRef(co, 3));
+Obj _35reg457 = primCdr(_35reg456);
+Obj _35reg458 = primIsCons(_35reg457);
+if (True == _35reg458) {
+Obj _35reg459 = primCdr(closureRef(co, 3));
+Obj _35reg460 = primCdr(_35reg459);
+Obj _35reg461 = primCar(_35reg460);
+Obj y = _35reg461;
+Obj _35reg462 = primCdr(closureRef(co, 3));
+Obj _35reg463 = primCdr(_35reg462);
+Obj _35reg464 = primCdr(_35reg463);
+Obj _35reg465 = primEQ(Nil, _35reg464);
+if (True == _35reg465) {
+pushCont(co, 0, _35clofun1999, 4, env, ns, import, y);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -11874,96 +11918,96 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1186;
+__arg0 = _35cc39;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1186;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1186;
+__arg0 = _35cc39;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1186;
+__arg0 = _35cc39;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1186;
+__arg0 = _35cc39;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc39;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label4:
+label2:
 {
-Obj _35val1629 = __arg1;
-Obj _35reg1630 = primCons(intern("if"), _35val1629);
+Obj _35val476 = __arg1;
+Obj _35reg477 = primCons(intern("if"), _35val476);
 __nargs = 2;
-__arg1 = _35reg1630;
+__arg1 = _35reg477;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3122) { goto fail; }
+if (co->ctx.pc.func != _35clofun1999) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label5:
+label3:
 {
-Obj _35val1628 = __arg1;
+Obj _35val475 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 4, _35clofun3122, 0);
+pushCont(co, 2, _35clofun1999, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val1628;
+__arg1 = _35val475;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label4:
 {
-Obj _35cc1185 = makeNative(3, _35clofun3122, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc38 = makeNative(1, _35clofun1999, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj _35reg1624 = primIsCons(closureRef(co, 3));
-if (True == _35reg1624) {
-Obj _35reg1625 = primCar(closureRef(co, 3));
-Obj _35reg1626 = primEQ(intern("if"), _35reg1625);
-if (True == _35reg1626) {
-Obj _35reg1627 = primCdr(closureRef(co, 3));
-Obj args = _35reg1627;
-pushCont(co, 5, _35clofun3122, 1, args);
+Obj _35reg471 = primIsCons(closureRef(co, 3));
+if (True == _35reg471) {
+Obj _35reg472 = primCar(closureRef(co, 3));
+Obj _35reg473 = primEQ(intern("if"), _35reg472);
+if (True == _35reg473) {
+Obj _35reg474 = primCdr(closureRef(co, 3));
+Obj args = _35reg474;
+pushCont(co, 3, _35clofun1999, 1, args);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -11972,94 +12016,94 @@ __arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1185;
+__arg0 = _35cc38;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1185;
+__arg0 = _35cc38;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label7:
+label5:
 {
-Obj _35val1649 = __arg1;
+Obj _35val496 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1650 = primCons(_35val1649, Nil);
-Obj _35reg1651 = primCons(args, _35reg1650);
-Obj _35reg1652 = primCons(intern("lambda"), _35reg1651);
+Obj _35reg497 = primCons(_35val496, Nil);
+Obj _35reg498 = primCons(args, _35reg497);
+Obj _35reg499 = primCons(intern("lambda"), _35reg498);
 __nargs = 2;
-__arg1 = _35reg1652;
+__arg1 = _35reg499;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3122) { goto fail; }
+if (co->ctx.pc.func != _35clofun1999) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label8:
+label6:
 {
-Obj _35val1648 = __arg1;
+Obj _35val495 = __arg1;
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 7, _35clofun3122, 1, args);
+pushCont(co, 5, _35clofun1999, 1, args);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = _35val1648;
+__arg1 = _35val495;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label9:
+label7:
 {
-Obj _35cc1184 = makeNative(6, _35clofun3122, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc37 = makeNative(4, _35clofun1999, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj _35reg1631 = primIsCons(closureRef(co, 3));
-if (True == _35reg1631) {
-Obj _35reg1632 = primCar(closureRef(co, 3));
-Obj _35reg1633 = primEQ(intern("lambda"), _35reg1632);
-if (True == _35reg1633) {
-Obj _35reg1634 = primCdr(closureRef(co, 3));
-Obj _35reg1635 = primIsCons(_35reg1634);
-if (True == _35reg1635) {
-Obj _35reg1636 = primCdr(closureRef(co, 3));
-Obj _35reg1637 = primCar(_35reg1636);
-Obj args = _35reg1637;
-Obj _35reg1638 = primCdr(closureRef(co, 3));
-Obj _35reg1639 = primCdr(_35reg1638);
-Obj _35reg1640 = primIsCons(_35reg1639);
-if (True == _35reg1640) {
-Obj _35reg1641 = primCdr(closureRef(co, 3));
-Obj _35reg1642 = primCdr(_35reg1641);
-Obj _35reg1643 = primCar(_35reg1642);
-Obj body = _35reg1643;
-Obj _35reg1644 = primCdr(closureRef(co, 3));
-Obj _35reg1645 = primCdr(_35reg1644);
-Obj _35reg1646 = primCdr(_35reg1645);
-Obj _35reg1647 = primEQ(Nil, _35reg1646);
-if (True == _35reg1647) {
-pushCont(co, 8, _35clofun3122, 4, ns, import, body, args);
+Obj _35reg478 = primIsCons(closureRef(co, 3));
+if (True == _35reg478) {
+Obj _35reg479 = primCar(closureRef(co, 3));
+Obj _35reg480 = primEQ(intern("lambda"), _35reg479);
+if (True == _35reg480) {
+Obj _35reg481 = primCdr(closureRef(co, 3));
+Obj _35reg482 = primIsCons(_35reg481);
+if (True == _35reg482) {
+Obj _35reg483 = primCdr(closureRef(co, 3));
+Obj _35reg484 = primCar(_35reg483);
+Obj args = _35reg484;
+Obj _35reg485 = primCdr(closureRef(co, 3));
+Obj _35reg486 = primCdr(_35reg485);
+Obj _35reg487 = primIsCons(_35reg486);
+if (True == _35reg487) {
+Obj _35reg488 = primCdr(closureRef(co, 3));
+Obj _35reg489 = primCdr(_35reg488);
+Obj _35reg490 = primCar(_35reg489);
+Obj body = _35reg490;
+Obj _35reg491 = primCdr(closureRef(co, 3));
+Obj _35reg492 = primCdr(_35reg491);
+Obj _35reg493 = primCdr(_35reg492);
+Obj _35reg494 = primEQ(Nil, _35reg493);
+if (True == _35reg494) {
+pushCont(co, 6, _35clofun1999, 4, ns, import, body, args);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#append"));
 __arg1 = args;
@@ -12067,91 +12111,104 @@ __arg2 = env;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1184;
+__arg0 = _35cc37;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1184;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1184;
+__arg0 = _35cc37;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1184;
+__arg0 = _35cc37;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1184;
+__arg0 = _35cc37;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc37;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label10:
+label8:
 {
-Obj _35val1654 = __arg1;
+Obj _35val502 = __arg1;
+Obj _35reg503 = primCons(_35val502, Nil);
+Obj _35reg504 = primCons(intern("%global"), _35reg503);
+__nargs = 2;
+__arg1 = _35reg504;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label9:
+{
+Obj _35val501 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1654) {
+if (True == _35val501) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3122) { goto fail; }
+if (co->ctx.pc.func != _35clofun1999) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
+pushCont(co, 8, _35clofun1999, 0);
 __nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#lookup-var-h"));
+__arg0 = globalRef(intern("cora/lib/toc#lookup-var"));
 __arg1 = x;
 __arg2 = ns;
 __arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label11:
+label10:
 {
-Obj _35cc1183 = makeNative(9, _35clofun3122, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc36 = makeNative(7, _35clofun1999, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj x = closureRef(co, 3);
-Obj _35reg1653 = primIsSymbol(x);
-if (True == _35reg1653) {
-pushCont(co, 10, _35clofun3122, 3, x, ns, import);
+Obj _35reg500 = primIsSymbol(x);
+if (True == _35reg500) {
+pushCont(co, 9, _35clofun1999, 3, x, ns, import);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#elem?"));
 __arg1 = x;
@@ -12159,245 +12216,245 @@ __arg2 = env;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1183;
+__arg0 = _35cc36;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label11:
+{
+Obj _35cc35 = makeNative(10, _35clofun1999, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj __ = closureRef(co, 0);
+__ = closureRef(co, 1);
+__ = closureRef(co, 2);
+Obj _35reg505 = primIsCons(closureRef(co, 3));
+if (True == _35reg505) {
+Obj _35reg506 = primCar(closureRef(co, 3));
+Obj _35reg507 = primEQ(intern("quote"), _35reg506);
+if (True == _35reg507) {
+Obj _35reg508 = primCdr(closureRef(co, 3));
+Obj _35reg509 = primIsCons(_35reg508);
+if (True == _35reg509) {
+Obj _35reg510 = primCdr(closureRef(co, 3));
+Obj _35reg511 = primCar(_35reg510);
+Obj x = _35reg511;
+Obj _35reg512 = primCdr(closureRef(co, 3));
+Obj _35reg513 = primCdr(_35reg512);
+Obj _35reg514 = primEQ(Nil, _35reg513);
+if (True == _35reg514) {
+Obj _35reg515 = primCons(x, Nil);
+Obj _35reg516 = primCons(intern("%const"), _35reg515);
+__nargs = 2;
+__arg1 = _35reg516;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc35;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc35;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc35;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc35;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj _35cc1182 = makeNative(11, _35clofun3122, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj __ = closureRef(co, 0);
-__ = closureRef(co, 1);
-__ = closureRef(co, 2);
-Obj _35reg1655 = primIsCons(closureRef(co, 3));
-if (True == _35reg1655) {
-Obj _35reg1656 = primCar(closureRef(co, 3));
-Obj _35reg1657 = primEQ(intern("quote"), _35reg1656);
-if (True == _35reg1657) {
-Obj _35reg1658 = primCdr(closureRef(co, 3));
-Obj _35reg1659 = primIsCons(_35reg1658);
-if (True == _35reg1659) {
-Obj _35reg1660 = primCdr(closureRef(co, 3));
-Obj _35reg1661 = primCar(_35reg1660);
-Obj x = _35reg1661;
-Obj _35reg1662 = primCdr(closureRef(co, 3));
-Obj _35reg1663 = primCdr(_35reg1662);
-Obj _35reg1664 = primEQ(Nil, _35reg1663);
-if (True == _35reg1664) {
-Obj _35reg1665 = primCons(x, Nil);
-Obj _35reg1666 = primCons(intern("%const"), _35reg1665);
+Obj _35val526 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc34= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val526) {
+if (True == True) {
+Obj _35reg527 = primCons(x, Nil);
+Obj _35reg528 = primCons(intern("%const"), _35reg527);
 __nargs = 2;
-__arg1 = _35reg1666;
+__arg1 = _35reg528;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3122) { goto fail; }
+if (co->ctx.pc.func != _35clofun1999) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1182;
+__arg0 = _35cc34;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-__nargs = 1;
-__arg0 = _35cc1182;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+if (True == False) {
+Obj _35reg529 = primCons(x, Nil);
+Obj _35reg530 = primCons(intern("%const"), _35reg529);
+__nargs = 2;
+__arg1 = _35reg530;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1182;
+__arg0 = _35cc34;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-} else {
-__nargs = 1;
-__arg0 = _35cc1182;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 }
 }
 
 label13:
 {
-Obj _35val1676 = __arg1;
+Obj _35val523 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1181= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1676) {
+Obj _35cc34= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val523) {
 if (True == True) {
-Obj _35reg1677 = primCons(x, Nil);
-Obj _35reg1678 = primCons(intern("%const"), _35reg1677);
+Obj _35reg524 = primCons(x, Nil);
+Obj _35reg525 = primCons(intern("%const"), _35reg524);
 __nargs = 2;
-__arg1 = _35reg1678;
+__arg1 = _35reg525;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3122) { goto fail; }
+if (co->ctx.pc.func != _35clofun1999) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1181;
+__arg0 = _35cc34;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-if (True == False) {
-Obj _35reg1679 = primCons(x, Nil);
-Obj _35reg1680 = primCons(intern("%const"), _35reg1679);
-__nargs = 2;
-__arg1 = _35reg1680;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3122) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1181;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label14:
-{
-Obj _35val1673 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1181= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1673) {
-if (True == True) {
-Obj _35reg1674 = primCons(x, Nil);
-Obj _35reg1675 = primCons(intern("%const"), _35reg1674);
-__nargs = 2;
-__arg1 = _35reg1675;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3122) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1181;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 13, _35clofun3122, 2, x, _35cc1181);
+pushCont(co, 12, _35clofun1999, 2, x, _35cc34);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label15:
+label14:
 {
-Obj _35val1667 = __arg1;
+Obj _35val517 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1181= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1667) {
+Obj _35cc34= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val517) {
 if (True == True) {
-Obj _35reg1668 = primCons(x, Nil);
-Obj _35reg1669 = primCons(intern("%const"), _35reg1668);
+Obj _35reg518 = primCons(x, Nil);
+Obj _35reg519 = primCons(intern("%const"), _35reg518);
 __nargs = 2;
-__arg1 = _35reg1669;
+__arg1 = _35reg519;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3122) { goto fail; }
+if (co->ctx.pc.func != _35clofun1999) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1181;
+__arg0 = _35cc34;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj _35reg1670 = primIsString(x);
-if (True == _35reg1670) {
+Obj _35reg520 = primIsString(x);
+if (True == _35reg520) {
 if (True == True) {
-Obj _35reg1671 = primCons(x, Nil);
-Obj _35reg1672 = primCons(intern("%const"), _35reg1671);
+Obj _35reg521 = primCons(x, Nil);
+Obj _35reg522 = primCons(intern("%const"), _35reg521);
 __nargs = 2;
-__arg1 = _35reg1672;
+__arg1 = _35reg522;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3122) { goto fail; }
+if (co->ctx.pc.func != _35clofun1999) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1181;
+__arg0 = _35cc34;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 14, _35clofun3122, 2, x, _35cc1181);
+pushCont(co, 13, _35clofun1999, 2, x, _35cc34);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#boolean?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 }
 
-label16:
+label15:
 {
-Obj _35p1177 = __arg1;
-Obj _35p1178 = __arg2;
-Obj _35p1179 = __arg3;
-Obj _35p1180 = co->args[4];
-Obj _35cc1181 = makeNative(12, _35clofun3122, 0, 4, _35p1177, _35p1178, _35p1179, _35p1180);
-Obj __ = _35p1177;
-__ = _35p1178;
-__ = _35p1179;
-Obj x = _35p1180;
-pushCont(co, 15, _35clofun3122, 2, x, _35cc1181);
+Obj _35p30 = __arg1;
+Obj _35p31 = __arg2;
+Obj _35p32 = __arg3;
+Obj _35p33 = co->args[4];
+Obj _35cc34 = makeNative(11, _35clofun1999, 0, 4, _35p30, _35p31, _35p32, _35p33);
+Obj __ = _35p30;
+__ = _35p31;
+__ = _35p32;
+Obj x = _35p33;
+pushCont(co, 14, _35clofun1999, 2, x, _35cc34);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#number?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label16:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -12405,33 +12462,33 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label17:
+{
+Obj _35val535 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg536 = primCons(x, _35val535);
+__nargs = 2;
+__arg1 = _35reg536;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label18:
 {
-Obj _35val1685 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1686 = primCons(x, _35val1685);
-__nargs = 2;
-__arg1 = _35reg1686;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3122) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label19:
-{
-Obj _35cc1196 = makeNative(17, _35clofun3122, 0, 0);
-Obj _35reg1682 = primIsCons(closureRef(co, 0));
-if (True == _35reg1682) {
-Obj _35reg1683 = primCar(closureRef(co, 0));
-Obj x = _35reg1683;
-Obj _35reg1684 = primCdr(closureRef(co, 0));
-Obj y = _35reg1684;
+Obj _35cc49 = makeNative(16, _35clofun1999, 0, 0);
+Obj _35reg532 = primIsCons(closureRef(co, 0));
+if (True == _35reg532) {
+Obj _35reg533 = primCar(closureRef(co, 0));
+Obj x = _35reg533;
+Obj _35reg534 = primCdr(closureRef(co, 0));
+Obj y = _35reg534;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 18, _35clofun3122, 1, x);
+pushCont(co, 17, _35clofun1999, 1, x);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#union"));
 __arg1 = y;
@@ -12439,42 +12496,73 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1196;
+__arg0 = _35cc49;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label19:
+{
+Obj _35val540 = __arg1;
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc48= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val540) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#union"));
+__arg1 = y;
+__arg2 = s2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc48;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label20:
 {
-Obj _35val1690 = __arg1;
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc1195= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1690) {
+Obj _35cc48 = makeNative(18, _35clofun1999, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg537 = primIsCons(closureRef(co, 0));
+if (True == _35reg537) {
+Obj _35reg538 = primCar(closureRef(co, 0));
+Obj x = _35reg538;
+Obj _35reg539 = primCdr(closureRef(co, 0));
+Obj y = _35reg539;
+Obj s2 = closureRef(co, 1);
+pushCont(co, 19, _35clofun1999, 3, y, s2, _35cc48);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#union"));
-__arg1 = y;
+__arg0 = globalRef(intern("cora/init#elem?"));
+__arg1 = x;
 __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1195;
+__arg0 = _35cc48;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12488,7 +12576,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3121(struct Cora* co){
+void _35clofun1998(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -12501,34 +12589,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1481 = __arg1;
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 20, _35clofun3120, 4, import, s, ns, more);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#intern"));
-__arg1 = _35val1481;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35cc1176 = makeNative(13, _35clofun3120, 0, 0);
+Obj _35cc29 = makeNative(13, _35clofun1997, 0, 0);
 Obj s = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
-Obj _35reg1478 = primIsCons(closureRef(co, 2));
-if (True == _35reg1478) {
-Obj _35reg1479 = primCar(closureRef(co, 2));
-Obj import = _35reg1479;
-Obj _35reg1480 = primCdr(closureRef(co, 2));
-Obj more = _35reg1480;
-pushCont(co, 0, _35clofun3121, 4, import, s, ns, more);
+Obj _35reg331 = primIsCons(closureRef(co, 2));
+if (True == _35reg331) {
+Obj _35reg332 = primCar(closureRef(co, 2));
+Obj import = _35reg332;
+Obj _35reg333 = primCdr(closureRef(co, 2));
+Obj more = _35reg333;
+pushCont(co, 20, _35clofun1997, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = import;
@@ -12536,42 +12606,29 @@ __arg2 = makeCString("#*ns-export*");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1176;
+__arg0 = _35cc29;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label2:
+label1:
 {
-Obj _35val1492 = __arg1;
-Obj _35reg1493 = primCons(_35val1492, Nil);
-Obj _35reg1494 = primCons(intern("%global"), _35reg1493);
-__nargs = 2;
-__arg1 = _35reg1494;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3121) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label3:
-{
-Obj _35p1172 = __arg1;
-Obj _35p1173 = __arg2;
-Obj _35p1174 = __arg3;
-Obj _35cc1175 = makeNative(1, _35clofun3121, 0, 3, _35p1172, _35p1173, _35p1174);
-Obj s = _35p1172;
-Obj ns = _35p1173;
-Obj _35reg1491 = primEQ(Nil, _35p1174);
-if (True == _35reg1491) {
-pushCont(co, 2, _35clofun3121, 0);
+Obj _35p25 = __arg1;
+Obj _35p26 = __arg2;
+Obj _35p27 = __arg3;
+Obj _35cc28 = makeNative(0, _35clofun1998, 0, 3, _35p25, _35p26, _35p27);
+Obj s = _35p25;
+Obj ns = _35p26;
+Obj _35reg341 = primEQ(Nil, _35p27);
+if (True == _35reg341) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#var-with-ns"));
 __arg1 = s;
@@ -12579,20 +12636,20 @@ __arg2 = ns;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1175;
+__arg0 = _35cc28;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label4:
+label2:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -12600,33 +12657,33 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label5:
+label3:
 {
-Obj _35val1496 = __arg1;
+Obj _35val343 = __arg1;
 Obj ls= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val1496;
+__arg1 = _35val343;
 __arg2 = ls;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label4:
 {
-Obj _35cc1191 = makeNative(4, _35clofun3121, 0, 0);
+Obj _35cc44 = makeNative(2, _35clofun1998, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj ls = closureRef(co, 3);
-pushCont(co, 5, _35clofun3121, 1, ls);
+pushCont(co, 3, _35clofun1998, 1, ls);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -12635,99 +12692,99 @@ __arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val354 = __arg1;
+Obj _35reg352= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg355 = primCons(_35reg352, _35val354);
+__nargs = 2;
+__arg1 = _35reg355;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun1998) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label6:
+{
+Obj _35val353 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg352= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 5, _35clofun1998, 1, _35reg352);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = _35val353;
+__arg2 = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val1507 = __arg1;
-Obj _35reg1505= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1508 = primCons(_35reg1505, _35val1507);
-__nargs = 2;
-__arg1 = _35reg1508;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3121) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label8:
-{
-Obj _35val1506 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1505= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun3121, 1, _35reg1505);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val1506;
-__arg2 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val1513 = __arg1;
+Obj _35val360 = __arg1;
 Obj tmp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1514 = primCons(_35val1513, Nil);
-Obj _35reg1515 = primCons(tmp, _35reg1514);
-Obj _35reg1516 = primCons(intern("lambda"), _35reg1515);
+Obj _35reg361 = primCons(_35val360, Nil);
+Obj _35reg362 = primCons(tmp, _35reg361);
+Obj _35reg363 = primCons(intern("lambda"), _35reg362);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
 __arg2 = ns;
 __arg3 = import;
-co->args[4] = _35reg1516;
+co->args[4] = _35reg363;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label10:
+label8:
 {
-Obj _35val1511 = __arg1;
+Obj _35val358 = __arg1;
 Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj tmp = _35val1511;
-Obj _35reg1512 = primCons(op, args);
-pushCont(co, 9, _35clofun3121, 4, tmp, env, ns, import);
+Obj tmp = _35val358;
+Obj _35reg359 = primCons(op, args);
+pushCont(co, 7, _35clofun1998, 4, tmp, env, ns, import);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#append"));
-__arg1 = _35reg1512;
+__arg1 = _35reg359;
 __arg2 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label9:
 {
-Obj _35val1502 = __arg1;
+Obj _35val349 = __arg1;
 Obj required= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj op= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj provided = _35val1502;
-Obj _35reg1503 = primEQ(required, provided);
-if (True == _35reg1503) {
-Obj _35reg1504 = primCons(op, Nil);
-Obj _35reg1505 = primCons(intern("%builtin"), _35reg1504);
-pushCont(co, 8, _35clofun3121, 2, args, _35reg1505);
+Obj provided = _35val349;
+Obj _35reg350 = primEQ(required, provided);
+if (True == _35reg350) {
+Obj _35reg351 = primCons(op, Nil);
+Obj _35reg352 = primCons(intern("%builtin"), _35reg351);
+pushCont(co, 6, _35clofun1998, 2, args, _35reg352);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -12736,21 +12793,21 @@ __arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1509 = primGT(required, provided);
-if (True == _35reg1509) {
-Obj _35reg1510 = primSub(required, provided);
-pushCont(co, 10, _35clofun3121, 5, op, args, env, ns, import);
+Obj _35reg356 = primGT(required, provided);
+if (True == _35reg356) {
+Obj _35reg357 = primSub(required, provided);
+pushCont(co, 8, _35clofun1998, 5, op, args, env, ns, import);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#temp-list"));
-__arg1 = _35reg1510;
+__arg1 = _35reg357;
 __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -12759,122 +12816,122 @@ __arg1 = makeCString("primitive call mismatch");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 }
 
-label12:
+label10:
 {
-Obj _35val1501 = __arg1;
+Obj _35val348 = __arg1;
 Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj required = _35val1501;
-pushCont(co, 11, _35clofun3121, 6, required, op, args, env, ns, import);
+Obj required = _35val348;
+pushCont(co, 9, _35clofun1998, 6, required, op, args, env, ns, import);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label11:
 {
-Obj _35val1500 = __arg1;
+Obj _35val347 = __arg1;
 Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35cc1190= co->ctx.stk.stack[co->ctx.stk.base + 5];
-if (True == _35val1500) {
-pushCont(co, 12, _35clofun3121, 5, op, args, env, ns, import);
+Obj _35cc43= co->ctx.stk.stack[co->ctx.stk.base + 5];
+if (True == _35val347) {
+pushCont(co, 10, _35clofun1998, 5, op, args, env, ns, import);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#builtin->args"));
 __arg1 = op;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1190;
+__arg0 = _35cc43;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label14:
+label12:
 {
-Obj _35cc1190 = makeNative(6, _35clofun3121, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc43 = makeNative(4, _35clofun1998, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj _35reg1497 = primIsCons(closureRef(co, 3));
-if (True == _35reg1497) {
-Obj _35reg1498 = primCar(closureRef(co, 3));
-Obj op = _35reg1498;
-Obj _35reg1499 = primCdr(closureRef(co, 3));
-Obj args = _35reg1499;
-pushCont(co, 13, _35clofun3121, 6, op, args, env, ns, import, _35cc1190);
+Obj _35reg344 = primIsCons(closureRef(co, 3));
+if (True == _35reg344) {
+Obj _35reg345 = primCar(closureRef(co, 3));
+Obj op = _35reg345;
+Obj _35reg346 = primCdr(closureRef(co, 3));
+Obj args = _35reg346;
+pushCont(co, 11, _35clofun1998, 6, op, args, env, ns, import, _35cc43);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#builtin?"));
 __arg1 = op;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1190;
+__arg0 = _35cc43;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label15:
+label13:
 {
-Obj _35val1539 = __arg1;
-Obj _35reg1538= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1536= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1540 = primCons(_35val1539, Nil);
-Obj _35reg1541 = primCons(_35reg1538, _35reg1540);
-Obj _35reg1542 = primCons(_35reg1536, _35reg1541);
+Obj _35val386 = __arg1;
+Obj _35reg385= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg383= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg387 = primCons(_35val386, Nil);
+Obj _35reg388 = primCons(_35reg385, _35reg387);
+Obj _35reg389 = primCons(_35reg383, _35reg388);
 __nargs = 2;
-__arg1 = _35reg1542;
+__arg1 = _35reg389;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3121) { goto fail; }
+if (co->ctx.pc.func != _35clofun1998) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label16:
+label14:
 {
-Obj _35val1534 = __arg1;
+Obj _35val381 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj var1 = _35val1534;
-Obj _35reg1535 = primCons(intern("set"), Nil);
-Obj _35reg1536 = primCons(intern("%builtin"), _35reg1535);
-Obj _35reg1537 = primCons(var1, Nil);
-Obj _35reg1538 = primCons(intern("%const"), _35reg1537);
-pushCont(co, 15, _35clofun3121, 2, _35reg1538, _35reg1536);
+Obj var1 = _35val381;
+Obj _35reg382 = primCons(intern("set"), Nil);
+Obj _35reg383 = primCons(intern("%builtin"), _35reg382);
+Obj _35reg384 = primCons(var1, Nil);
+Obj _35reg385 = primCons(intern("%const"), _35reg384);
+pushCont(co, 13, _35clofun1998, 2, _35reg385, _35reg383);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -12884,41 +12941,41 @@ co->args[4] = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label15:
 {
-Obj _35cc1189 = makeNative(14, _35clofun3121, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc42 = makeNative(12, _35clofun1998, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj _35reg1517 = primIsCons(closureRef(co, 3));
-if (True == _35reg1517) {
-Obj _35reg1518 = primCar(closureRef(co, 3));
-Obj _35reg1519 = primEQ(intern("def"), _35reg1518);
-if (True == _35reg1519) {
-Obj _35reg1520 = primCdr(closureRef(co, 3));
-Obj _35reg1521 = primIsCons(_35reg1520);
-if (True == _35reg1521) {
-Obj _35reg1522 = primCdr(closureRef(co, 3));
-Obj _35reg1523 = primCar(_35reg1522);
-Obj var = _35reg1523;
-Obj _35reg1524 = primCdr(closureRef(co, 3));
-Obj _35reg1525 = primCdr(_35reg1524);
-Obj _35reg1526 = primIsCons(_35reg1525);
-if (True == _35reg1526) {
-Obj _35reg1527 = primCdr(closureRef(co, 3));
-Obj _35reg1528 = primCdr(_35reg1527);
-Obj _35reg1529 = primCar(_35reg1528);
-Obj val = _35reg1529;
-Obj _35reg1530 = primCdr(closureRef(co, 3));
-Obj _35reg1531 = primCdr(_35reg1530);
-Obj _35reg1532 = primCdr(_35reg1531);
-Obj _35reg1533 = primEQ(Nil, _35reg1532);
-if (True == _35reg1533) {
-pushCont(co, 16, _35clofun3121, 4, env, ns, import, val);
+Obj _35reg364 = primIsCons(closureRef(co, 3));
+if (True == _35reg364) {
+Obj _35reg365 = primCar(closureRef(co, 3));
+Obj _35reg366 = primEQ(intern("def"), _35reg365);
+if (True == _35reg366) {
+Obj _35reg367 = primCdr(closureRef(co, 3));
+Obj _35reg368 = primIsCons(_35reg367);
+if (True == _35reg368) {
+Obj _35reg369 = primCdr(closureRef(co, 3));
+Obj _35reg370 = primCar(_35reg369);
+Obj var = _35reg370;
+Obj _35reg371 = primCdr(closureRef(co, 3));
+Obj _35reg372 = primCdr(_35reg371);
+Obj _35reg373 = primIsCons(_35reg372);
+if (True == _35reg373) {
+Obj _35reg374 = primCdr(closureRef(co, 3));
+Obj _35reg375 = primCdr(_35reg374);
+Obj _35reg376 = primCar(_35reg375);
+Obj val = _35reg376;
+Obj _35reg377 = primCdr(closureRef(co, 3));
+Obj _35reg378 = primCdr(_35reg377);
+Obj _35reg379 = primCdr(_35reg378);
+Obj _35reg380 = primEQ(Nil, _35reg379);
+if (True == _35reg380) {
+pushCont(co, 14, _35clofun1998, 4, env, ns, import, val);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#var-with-ns"));
 __arg1 = var;
@@ -12926,96 +12983,96 @@ __arg2 = ns;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1189;
+__arg0 = _35cc42;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1189;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1189;
+__arg0 = _35cc42;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1189;
+__arg0 = _35cc42;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1189;
+__arg0 = _35cc42;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc42;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label18:
+label16:
 {
-Obj _35cc1188 = makeNative(17, _35clofun3121, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc41 = makeNative(15, _35clofun1998, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
 __ = closureRef(co, 2);
-Obj _35reg1543 = primIsCons(closureRef(co, 3));
-if (True == _35reg1543) {
-Obj _35reg1544 = primCar(closureRef(co, 3));
-Obj _35reg1545 = primEQ(intern("ns"), _35reg1544);
-if (True == _35reg1545) {
-Obj _35reg1546 = primCdr(closureRef(co, 3));
-Obj _35reg1547 = primIsCons(_35reg1546);
-if (True == _35reg1547) {
-Obj _35reg1548 = primCdr(closureRef(co, 3));
-Obj _35reg1549 = primCar(_35reg1548);
-Obj path = _35reg1549;
-Obj _35reg1550 = primCdr(closureRef(co, 3));
-Obj _35reg1551 = primCdr(_35reg1550);
-Obj _35reg1552 = primIsCons(_35reg1551);
-if (True == _35reg1552) {
-Obj _35reg1553 = primCdr(closureRef(co, 3));
-Obj _35reg1554 = primCdr(_35reg1553);
-Obj _35reg1555 = primCar(_35reg1554);
-Obj import = _35reg1555;
-Obj _35reg1556 = primCdr(closureRef(co, 3));
-Obj _35reg1557 = primCdr(_35reg1556);
-Obj _35reg1558 = primCdr(_35reg1557);
-Obj _35reg1559 = primIsCons(_35reg1558);
-if (True == _35reg1559) {
-Obj _35reg1560 = primCdr(closureRef(co, 3));
-Obj _35reg1561 = primCdr(_35reg1560);
-Obj _35reg1562 = primCdr(_35reg1561);
-Obj _35reg1563 = primCar(_35reg1562);
-Obj body = _35reg1563;
-Obj _35reg1564 = primCdr(closureRef(co, 3));
-Obj _35reg1565 = primCdr(_35reg1564);
-Obj _35reg1566 = primCdr(_35reg1565);
-Obj _35reg1567 = primCdr(_35reg1566);
-Obj _35reg1568 = primEQ(Nil, _35reg1567);
-if (True == _35reg1568) {
+Obj _35reg390 = primIsCons(closureRef(co, 3));
+if (True == _35reg390) {
+Obj _35reg391 = primCar(closureRef(co, 3));
+Obj _35reg392 = primEQ(intern("ns"), _35reg391);
+if (True == _35reg392) {
+Obj _35reg393 = primCdr(closureRef(co, 3));
+Obj _35reg394 = primIsCons(_35reg393);
+if (True == _35reg394) {
+Obj _35reg395 = primCdr(closureRef(co, 3));
+Obj _35reg396 = primCar(_35reg395);
+Obj path = _35reg396;
+Obj _35reg397 = primCdr(closureRef(co, 3));
+Obj _35reg398 = primCdr(_35reg397);
+Obj _35reg399 = primIsCons(_35reg398);
+if (True == _35reg399) {
+Obj _35reg400 = primCdr(closureRef(co, 3));
+Obj _35reg401 = primCdr(_35reg400);
+Obj _35reg402 = primCar(_35reg401);
+Obj import = _35reg402;
+Obj _35reg403 = primCdr(closureRef(co, 3));
+Obj _35reg404 = primCdr(_35reg403);
+Obj _35reg405 = primCdr(_35reg404);
+Obj _35reg406 = primIsCons(_35reg405);
+if (True == _35reg406) {
+Obj _35reg407 = primCdr(closureRef(co, 3));
+Obj _35reg408 = primCdr(_35reg407);
+Obj _35reg409 = primCdr(_35reg408);
+Obj _35reg410 = primCar(_35reg409);
+Obj body = _35reg410;
+Obj _35reg411 = primCdr(closureRef(co, 3));
+Obj _35reg412 = primCdr(_35reg411);
+Obj _35reg413 = primCdr(_35reg412);
+Obj _35reg414 = primCdr(_35reg413);
+Obj _35reg415 = primEQ(Nil, _35reg414);
+if (True == _35reg415) {
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -13025,101 +13082,224 @@ co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1188;
+__arg0 = _35cc41;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1188;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1188;
+__arg0 = _35cc41;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1188;
+__arg0 = _35cc41;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1188;
+__arg0 = _35cc41;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1188;
+__arg0 = _35cc41;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc41;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label19:
+label17:
 {
-Obj _35val1597 = __arg1;
-Obj _35val1595= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val444 = __arg1;
+Obj _35val442= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1598 = primCons(_35val1597, Nil);
-Obj _35reg1599 = primCons(_35val1595, _35reg1598);
-Obj _35reg1600 = primCons(a, _35reg1599);
-Obj _35reg1601 = primCons(intern("let"), _35reg1600);
+Obj _35reg445 = primCons(_35val444, Nil);
+Obj _35reg446 = primCons(_35val442, _35reg445);
+Obj _35reg447 = primCons(a, _35reg446);
+Obj _35reg448 = primCons(intern("let"), _35reg447);
 __nargs = 2;
-__arg1 = _35reg1601;
+__arg1 = _35reg448;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3121) { goto fail; }
+if (co->ctx.pc.func != _35clofun1998) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label20:
+label18:
 {
-Obj _35val1595 = __arg1;
+Obj _35val442 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1596 = primCons(a, env);
-pushCont(co, 19, _35clofun3121, 2, _35val1595, a);
+Obj _35reg443 = primCons(a, env);
+pushCont(co, 17, _35clofun1998, 2, _35val442, a);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = _35reg1596;
+__arg1 = _35reg443;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label19:
+{
+Obj _35cc40 = makeNative(16, _35clofun1998, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj _35reg416 = primIsCons(closureRef(co, 3));
+if (True == _35reg416) {
+Obj _35reg417 = primCar(closureRef(co, 3));
+Obj _35reg418 = primEQ(intern("let"), _35reg417);
+if (True == _35reg418) {
+Obj _35reg419 = primCdr(closureRef(co, 3));
+Obj _35reg420 = primIsCons(_35reg419);
+if (True == _35reg420) {
+Obj _35reg421 = primCdr(closureRef(co, 3));
+Obj _35reg422 = primCar(_35reg421);
+Obj a = _35reg422;
+Obj _35reg423 = primCdr(closureRef(co, 3));
+Obj _35reg424 = primCdr(_35reg423);
+Obj _35reg425 = primIsCons(_35reg424);
+if (True == _35reg425) {
+Obj _35reg426 = primCdr(closureRef(co, 3));
+Obj _35reg427 = primCdr(_35reg426);
+Obj _35reg428 = primCar(_35reg427);
+Obj b = _35reg428;
+Obj _35reg429 = primCdr(closureRef(co, 3));
+Obj _35reg430 = primCdr(_35reg429);
+Obj _35reg431 = primCdr(_35reg430);
+Obj _35reg432 = primIsCons(_35reg431);
+if (True == _35reg432) {
+Obj _35reg433 = primCdr(closureRef(co, 3));
+Obj _35reg434 = primCdr(_35reg433);
+Obj _35reg435 = primCdr(_35reg434);
+Obj _35reg436 = primCar(_35reg435);
+Obj c = _35reg436;
+Obj _35reg437 = primCdr(closureRef(co, 3));
+Obj _35reg438 = primCdr(_35reg437);
+Obj _35reg439 = primCdr(_35reg438);
+Obj _35reg440 = primCdr(_35reg439);
+Obj _35reg441 = primEQ(Nil, _35reg440);
+if (True == _35reg441) {
+pushCont(co, 18, _35clofun1998, 5, env, ns, import, c, a);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#parse"));
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->args[4] = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc40;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc40;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc40;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc40;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc40;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc40;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label20:
+{
+Obj _35val467 = __arg1;
+Obj _35val466= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg468 = primCons(_35val467, Nil);
+Obj _35reg469 = primCons(_35val466, _35reg468);
+Obj _35reg470 = primCons(intern("do"), _35reg469);
+__nargs = 2;
+__arg1 = _35reg470;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun1998) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 fail:
@@ -13131,7 +13311,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3120(struct Cora* co){
+void _35clofun1997(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -13144,23 +13324,23 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1461 = __arg1;
-Obj find = _35val1461;
-pushCont(co, 20, _35clofun3119, 1, find);
+Obj _35val314 = __arg1;
+Obj find = _35val314;
+pushCont(co, 20, _35clofun1996, 1, find);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
 Obj x = __arg1;
-pushCont(co, 0, _35clofun3120, 0);
+pushCont(co, 0, _35clofun1997, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#assq"));
 __arg1 = x;
@@ -13168,19 +13348,19 @@ __arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1465 = __arg1;
+Obj _35val318 = __arg1;
 Obj find= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1465) {
+if (True == _35val318) {
 __nargs = 2;
 __arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3120) { goto fail; }
+if (co->ctx.pc.func != _35clofun1997) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
@@ -13189,30 +13369,30 @@ __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35val1464 = __arg1;
-Obj find = _35val1464;
-pushCont(co, 2, _35clofun3120, 1, find);
+Obj _35val317 = __arg1;
+Obj find = _35val317;
+pushCont(co, 2, _35clofun1997, 1, find);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
 Obj x = __arg1;
-pushCont(co, 3, _35clofun3120, 0);
+pushCont(co, 3, _35clofun1997, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#assq"));
 __arg1 = x;
@@ -13220,7 +13400,7 @@ __arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13232,118 +13412,118 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc1171 = makeNative(5, _35clofun3120, 0, 0);
+Obj _35cc24 = makeNative(5, _35clofun1997, 0, 0);
 Obj n = closureRef(co, 0);
 Obj res = closureRef(co, 1);
-Obj _35reg1467 = primSub(n, makeNumber(1));
-Obj _35reg1468 = primGenSym(intern("tmp"));
-Obj _35reg1469 = primCons(_35reg1468, res);
+Obj _35reg320 = primSub(n, makeNumber(1));
+Obj _35reg321 = primGenSym(intern("tmp"));
+Obj _35reg322 = primCons(_35reg321, res);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#temp-list"));
-__arg1 = _35reg1467;
-__arg2 = _35reg1469;
+__arg1 = _35reg320;
+__arg2 = _35reg322;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35p1168 = __arg1;
-Obj _35p1169 = __arg2;
-Obj _35cc1170 = makeNative(6, _35clofun3120, 0, 2, _35p1168, _35p1169);
-Obj _35reg1470 = primEQ(makeNumber(0), _35p1168);
-if (True == _35reg1470) {
-Obj res = _35p1169;
+Obj _35p21 = __arg1;
+Obj _35p22 = __arg2;
+Obj _35cc23 = makeNative(6, _35clofun1997, 0, 2, _35p21, _35p22);
+Obj _35reg323 = primEQ(makeNumber(0), _35p21);
+if (True == _35reg323) {
+Obj res = _35p22;
 __nargs = 2;
 __arg1 = res;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3120) { goto fail; }
+if (co->ctx.pc.func != _35clofun1997) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1170;
+__arg0 = _35cc23;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35val1476 = __arg1;
+Obj _35val329 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#intern"));
-__arg1 = _35val1476;
+__arg1 = _35val329;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val1475 = __arg1;
+Obj _35val328 = __arg1;
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 8, _35clofun3120, 0);
+pushCont(co, 8, _35clofun1997, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = ns;
-__arg2 = _35val1475;
+__arg2 = _35val328;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val1474 = __arg1;
+Obj _35val327 = __arg1;
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 9, _35clofun3120, 1, ns);
+pushCont(co, 9, _35clofun1997, 1, ns);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = makeCString("#");
-__arg2 = _35val1474;
+__arg2 = _35val327;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val1473 = __arg1;
+Obj _35val326 = __arg1;
 Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1473) {
+if (True == _35val326) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3120) { goto fail; }
+if (co->ctx.pc.func != _35clofun1997) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 10, _35clofun3120, 1, ns);
+pushCont(co, 10, _35clofun1997, 1, ns);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13352,22 +13532,22 @@ label12:
 {
 Obj var = __arg1;
 Obj ns = __arg2;
-Obj _35reg1472 = primEQ(ns, makeCString(""));
-if (True == _35reg1472) {
+Obj _35reg325 = primEQ(ns, makeCString(""));
+if (True == _35reg325) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3120) { goto fail; }
+if (co->ctx.pc.func != _35clofun1997) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 11, _35clofun3120, 2, var, ns);
+pushCont(co, 11, _35clofun1997, 2, var, ns);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol-cooked?"));
 __arg1 = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13380,108 +13560,95 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val1488 = __arg1;
-Obj _35reg1489 = primCons(_35val1488, Nil);
-Obj _35reg1490 = primCons(intern("%global"), _35reg1489);
+Obj _35val340 = __arg1;
 __nargs = 2;
-__arg1 = _35reg1490;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3120) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("cora/init#intern"));
+__arg1 = _35val340;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val1487 = __arg1;
-pushCont(co, 14, _35clofun3120, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#intern"));
-__arg1 = _35val1487;
+Obj _35val339 = __arg1;
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 14, _35clofun1997, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#string-append"));
+__arg1 = import;
+__arg2 = _35val339;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val1486 = __arg1;
+Obj _35val338 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 15, _35clofun3120, 0);
+pushCont(co, 15, _35clofun1997, 1, import);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
-__arg1 = import;
-__arg2 = _35val1486;
+__arg1 = makeCString("#");
+__arg2 = _35val338;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val1485 = __arg1;
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 16, _35clofun3120, 1, import);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#string-append"));
-__arg1 = makeCString("#");
-__arg2 = _35val1485;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val1484 = __arg1;
+Obj _35val337 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-if (True == _35val1484) {
-pushCont(co, 17, _35clofun3120, 1, import);
+if (True == _35val337) {
+pushCont(co, 16, _35clofun1997, 1, import);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = s;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#lookup-var-h"));
+__arg0 = globalRef(intern("cora/lib/toc#lookup-var"));
 __arg1 = s;
 __arg2 = ns;
 __arg3 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label19:
+label18:
 {
-Obj _35val1483 = __arg1;
+Obj _35val336 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj export = _35val1483;
-pushCont(co, 18, _35clofun3120, 4, import, s, ns, more);
+Obj export = _35val336;
+pushCont(co, 17, _35clofun1997, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#elem?"));
 __arg1 = s;
@@ -13489,26 +13656,44 @@ __arg2 = export;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label19:
+{
+Obj _35val335 = __arg1;
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 18, _35clofun1997, 4, import, s, ns, more);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#value-or"));
+__arg1 = _35val335;
+__arg2 = Nil;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1482 = __arg1;
+Obj _35val334 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun3120, 4, import, s, ns, more);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#value-or"));
-__arg1 = _35val1482;
-__arg2 = Nil;
+pushCont(co, 19, _35clofun1997, 4, import, s, ns, more);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#intern"));
+__arg1 = _35val334;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13521,7 +13706,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3119(struct Cora* co){
+void _35clofun1996(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -13540,20 +13725,20 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35cc1152 = makeNative(0, _35clofun3119, 0, 0);
+Obj _35cc5 = makeNative(0, _35clofun1996, 0, 0);
 Obj var = closureRef(co, 0);
-Obj _35reg1349 = primIsCons(closureRef(co, 1));
-if (True == _35reg1349) {
-Obj _35reg1350 = primCar(closureRef(co, 1));
-Obj __ = _35reg1350;
-Obj _35reg1351 = primCdr(closureRef(co, 1));
-Obj y = _35reg1351;
+Obj _35reg202 = primIsCons(closureRef(co, 1));
+if (True == _35reg202) {
+Obj _35reg203 = primCar(closureRef(co, 1));
+Obj __ = _35reg203;
+Obj _35reg204 = primCdr(closureRef(co, 1));
+Obj y = _35reg204;
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#assq"));
 __arg1 = var;
@@ -13561,93 +13746,93 @@ __arg2 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1152;
+__arg0 = _35cc5;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label2:
 {
-Obj _35cc1151 = makeNative(1, _35clofun3119, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc4 = makeNative(1, _35clofun1996, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
-Obj _35reg1352 = primIsCons(closureRef(co, 1));
-if (True == _35reg1352) {
-Obj _35reg1353 = primCar(closureRef(co, 1));
-Obj _35reg1354 = primIsCons(_35reg1353);
-if (True == _35reg1354) {
-Obj _35reg1355 = primCar(closureRef(co, 1));
-Obj _35reg1356 = primCar(_35reg1355);
-Obj x = _35reg1356;
-Obj _35reg1357 = primCar(closureRef(co, 1));
-Obj _35reg1358 = primCdr(_35reg1357);
-Obj y = _35reg1358;
-Obj _35reg1359 = primCdr(closureRef(co, 1));
-Obj __ = _35reg1359;
-Obj _35reg1360 = primEQ(var, x);
-if (True == _35reg1360) {
-Obj _35reg1361 = primCons(x, y);
+Obj _35reg205 = primIsCons(closureRef(co, 1));
+if (True == _35reg205) {
+Obj _35reg206 = primCar(closureRef(co, 1));
+Obj _35reg207 = primIsCons(_35reg206);
+if (True == _35reg207) {
+Obj _35reg208 = primCar(closureRef(co, 1));
+Obj _35reg209 = primCar(_35reg208);
+Obj x = _35reg209;
+Obj _35reg210 = primCar(closureRef(co, 1));
+Obj _35reg211 = primCdr(_35reg210);
+Obj y = _35reg211;
+Obj _35reg212 = primCdr(closureRef(co, 1));
+Obj __ = _35reg212;
+Obj _35reg213 = primEQ(var, x);
+if (True == _35reg213) {
+Obj _35reg214 = primCons(x, y);
 __nargs = 2;
-__arg1 = _35reg1361;
+__arg1 = _35reg214;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3119) { goto fail; }
+if (co->ctx.pc.func != _35clofun1996) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1151;
+__arg0 = _35cc4;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1151;
+__arg0 = _35cc4;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1151;
+__arg0 = _35cc4;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35p1148 = __arg1;
-Obj _35p1149 = __arg2;
-Obj _35cc1150 = makeNative(2, _35clofun3119, 0, 2, _35p1148, _35p1149);
-Obj var = _35p1148;
-Obj _35reg1362 = primEQ(Nil, _35p1149);
-if (True == _35reg1362) {
+Obj _35p1 = __arg1;
+Obj _35p2 = __arg2;
+Obj _35cc3 = makeNative(2, _35clofun1996, 0, 2, _35p1, _35p2);
+Obj var = _35p1;
+Obj _35reg215 = primEQ(Nil, _35p2);
+if (True == _35reg215) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3119) { goto fail; }
+if (co->ctx.pc.func != _35clofun1996) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1150;
+__arg0 = _35cc3;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13660,39 +13845,39 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1367 = __arg1;
+Obj _35val220 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#foldl"));
 __arg1 = f;
-__arg2 = _35val1367;
+__arg2 = _35val220;
 __arg3 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc1157 = makeNative(4, _35clofun3119, 0, 0);
+Obj _35cc10 = makeNative(4, _35clofun1996, 0, 0);
 Obj f = closureRef(co, 0);
 Obj acc = closureRef(co, 1);
-Obj _35reg1364 = primIsCons(closureRef(co, 2));
-if (True == _35reg1364) {
-Obj _35reg1365 = primCar(closureRef(co, 2));
-Obj x = _35reg1365;
-Obj _35reg1366 = primCdr(closureRef(co, 2));
-Obj y = _35reg1366;
-pushCont(co, 5, _35clofun3119, 2, f, y);
+Obj _35reg217 = primIsCons(closureRef(co, 2));
+if (True == _35reg217) {
+Obj _35reg218 = primCar(closureRef(co, 2));
+Obj x = _35reg218;
+Obj _35reg219 = primCdr(closureRef(co, 2));
+Obj y = _35reg219;
+pushCont(co, 5, _35clofun1996, 2, f, y);
 __nargs = 3;
 __arg0 = f;
 __arg1 = acc;
@@ -13700,41 +13885,41 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1157;
+__arg0 = _35cc10;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35p1153 = __arg1;
-Obj _35p1154 = __arg2;
-Obj _35p1155 = __arg3;
-Obj _35cc1156 = makeNative(6, _35clofun3119, 0, 3, _35p1153, _35p1154, _35p1155);
-Obj f = _35p1153;
-Obj acc = _35p1154;
-Obj _35reg1368 = primEQ(Nil, _35p1155);
-if (True == _35reg1368) {
+Obj _35p6 = __arg1;
+Obj _35p7 = __arg2;
+Obj _35p8 = __arg3;
+Obj _35cc9 = makeNative(6, _35clofun1996, 0, 3, _35p6, _35p7, _35p8);
+Obj f = _35p6;
+Obj acc = _35p7;
+Obj _35reg221 = primEQ(Nil, _35p8);
+if (True == _35reg221) {
 __nargs = 2;
 __arg1 = acc;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3119) { goto fail; }
+if (co->ctx.pc.func != _35clofun1996) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1156;
+__arg0 = _35cc9;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13747,103 +13932,103 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35cc1163 = makeNative(8, _35clofun3119, 0, 0);
+Obj _35cc16 = makeNative(8, _35clofun1996, 0, 0);
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1370 = primIsCons(closureRef(co, 2));
-if (True == _35reg1370) {
-Obj _35reg1371 = primCar(closureRef(co, 2));
-Obj a = _35reg1371;
-Obj _35reg1372 = primCdr(closureRef(co, 2));
-Obj b = _35reg1372;
-Obj _35reg1373 = primAdd(pos, makeNumber(1));
+Obj _35reg223 = primIsCons(closureRef(co, 2));
+if (True == _35reg223) {
+Obj _35reg224 = primCar(closureRef(co, 2));
+Obj a = _35reg224;
+Obj _35reg225 = primCdr(closureRef(co, 2));
+Obj b = _35reg225;
+Obj _35reg226 = primAdd(pos, makeNumber(1));
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#pos-in-list0"));
-__arg1 = _35reg1373;
+__arg1 = _35reg226;
 __arg2 = x;
 __arg3 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1163;
+__arg0 = _35cc16;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35cc1162 = makeNative(9, _35clofun3119, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc15 = makeNative(9, _35clofun1996, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1374 = primIsCons(closureRef(co, 2));
-if (True == _35reg1374) {
-Obj _35reg1375 = primCar(closureRef(co, 2));
-Obj a = _35reg1375;
-Obj _35reg1376 = primCdr(closureRef(co, 2));
-Obj b = _35reg1376;
-Obj _35reg1377 = primEQ(x, a);
-if (True == _35reg1377) {
+Obj _35reg227 = primIsCons(closureRef(co, 2));
+if (True == _35reg227) {
+Obj _35reg228 = primCar(closureRef(co, 2));
+Obj a = _35reg228;
+Obj _35reg229 = primCdr(closureRef(co, 2));
+Obj b = _35reg229;
+Obj _35reg230 = primEQ(x, a);
+if (True == _35reg230) {
 __nargs = 2;
 __arg1 = pos;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3119) { goto fail; }
+if (co->ctx.pc.func != _35clofun1996) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1162;
+__arg0 = _35cc15;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1162;
+__arg0 = _35cc15;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35p1158 = __arg1;
-Obj _35p1159 = __arg2;
-Obj _35p1160 = __arg3;
-Obj _35cc1161 = makeNative(10, _35clofun3119, 0, 3, _35p1158, _35p1159, _35p1160);
-Obj __ = _35p1158;
-Obj x = _35p1159;
-Obj _35reg1378 = primEQ(Nil, _35p1160);
-if (True == _35reg1378) {
+Obj _35p11 = __arg1;
+Obj _35p12 = __arg2;
+Obj _35p13 = __arg3;
+Obj _35cc14 = makeNative(10, _35clofun1996, 0, 3, _35p11, _35p12, _35p13);
+Obj __ = _35p11;
+Obj x = _35p12;
+Obj _35reg231 = primEQ(Nil, _35p13);
+if (True == _35reg231) {
 __nargs = 2;
 __arg1 = makeNumber(-1);
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3119) { goto fail; }
+if (co->ctx.pc.func != _35clofun1996) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1161;
+__arg0 = _35cc14;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13860,7 +14045,7 @@ __arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13872,17 +14057,17 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val1384 = __arg1;
+Obj _35val237 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj tl= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1385 = primLT(_35val1384, makeNumber(0));
-if (True == _35reg1385) {
+Obj _35reg238 = primLT(_35val237, makeNumber(0));
+if (True == _35reg238) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#exist-in-env"));
 __arg1 = x;
@@ -13890,28 +14075,28 @@ __arg2 = tl;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3119) { goto fail; }
+if (co->ctx.pc.func != _35clofun1996) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
 
 label15:
 {
-Obj _35cc1167 = makeNative(13, _35clofun3119, 0, 0);
+Obj _35cc20 = makeNative(13, _35clofun1996, 0, 0);
 Obj x = closureRef(co, 0);
-Obj _35reg1381 = primIsCons(closureRef(co, 1));
-if (True == _35reg1381) {
-Obj _35reg1382 = primCar(closureRef(co, 1));
-Obj hd = _35reg1382;
-Obj _35reg1383 = primCdr(closureRef(co, 1));
-Obj tl = _35reg1383;
-pushCont(co, 14, _35clofun3119, 2, x, tl);
+Obj _35reg234 = primIsCons(closureRef(co, 1));
+if (True == _35reg234) {
+Obj _35reg235 = primCar(closureRef(co, 1));
+Obj hd = _35reg235;
+Obj _35reg236 = primCdr(closureRef(co, 1));
+Obj tl = _35reg236;
+pushCont(co, 14, _35clofun1996, 2, x, tl);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#index"));
 __arg1 = x;
@@ -13919,72 +14104,72 @@ __arg2 = hd;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1167;
+__arg0 = _35cc20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label16:
 {
-Obj _35p1164 = __arg1;
-Obj _35p1165 = __arg2;
-Obj _35cc1166 = makeNative(15, _35clofun3119, 0, 2, _35p1164, _35p1165);
-Obj x = _35p1164;
-Obj _35reg1386 = primEQ(Nil, _35p1165);
-if (True == _35reg1386) {
+Obj _35p17 = __arg1;
+Obj _35p18 = __arg2;
+Obj _35cc19 = makeNative(15, _35clofun1996, 0, 2, _35p17, _35p18);
+Obj x = _35p17;
+Obj _35reg239 = primEQ(Nil, _35p18);
+if (True == _35reg239) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3119) { goto fail; }
+if (co->ctx.pc.func != _35clofun1996) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1166;
+__arg0 = _35cc19;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label17:
 {
-Obj _35val1458 = __arg1;
-Obj _35reg1459 = primNot(_35val1458);
+Obj _35val311 = __arg1;
+Obj _35reg312 = primNot(_35val311);
 __nargs = 2;
-__arg1 = _35reg1459;
+__arg1 = _35reg312;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3119) { goto fail; }
+if (co->ctx.pc.func != _35clofun1996) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label18:
 {
-Obj _35val1457 = __arg1;
-pushCont(co, 17, _35clofun3119, 0);
+Obj _35val310 = __arg1;
+pushCont(co, 17, _35clofun1996, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
-__arg1 = _35val1457;
+__arg1 = _35val310;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
 Obj x = __arg1;
-pushCont(co, 18, _35clofun3119, 0);
+pushCont(co, 18, _35clofun1996, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#assq"));
 __arg1 = x;
@@ -13992,19 +14177,19 @@ __arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1462 = __arg1;
+Obj _35val315 = __arg1;
 Obj find= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1462) {
+if (True == _35val315) {
 __nargs = 2;
 __arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3119) { goto fail; }
+if (co->ctx.pc.func != _35clofun1996) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
@@ -14013,7 +14198,7 @@ __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }

--- a/lib/toc.c
+++ b/lib/toc.c
@@ -2,30 +2,30 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun1992(struct Cora* co);
-void _35clofun1991(struct Cora* co);
-void _35clofun1990(struct Cora* co);
-void _35clofun1989(struct Cora* co);
-void _35clofun1988(struct Cora* co);
-void _35clofun1987(struct Cora* co);
-void _35clofun1986(struct Cora* co);
-void _35clofun1985(struct Cora* co);
-void _35clofun1984(struct Cora* co);
-void _35clofun1983(struct Cora* co);
-void _35clofun1982(struct Cora* co);
-void _35clofun1981(struct Cora* co);
-void _35clofun1980(struct Cora* co);
-void _35clofun1979(struct Cora* co);
-void _35clofun1978(struct Cora* co);
-void _35clofun1977(struct Cora* co);
-void _35clofun1976(struct Cora* co);
-void _35clofun1975(struct Cora* co);
-void _35clofun1974(struct Cora* co);
-void _35clofun1973(struct Cora* co);
-void _35clofun1972(struct Cora* co);
-void _35clofun1971(struct Cora* co);
-void _35clofun1970(struct Cora* co);
-void _35clofun1969(struct Cora* co);
+void _35clofun3135(struct Cora* co);
+void _35clofun3134(struct Cora* co);
+void _35clofun3133(struct Cora* co);
+void _35clofun3132(struct Cora* co);
+void _35clofun3131(struct Cora* co);
+void _35clofun3130(struct Cora* co);
+void _35clofun3129(struct Cora* co);
+void _35clofun3128(struct Cora* co);
+void _35clofun3127(struct Cora* co);
+void _35clofun3126(struct Cora* co);
+void _35clofun3125(struct Cora* co);
+void _35clofun3124(struct Cora* co);
+void _35clofun3123(struct Cora* co);
+void _35clofun3122(struct Cora* co);
+void _35clofun3121(struct Cora* co);
+void _35clofun3120(struct Cora* co);
+void _35clofun3119(struct Cora* co);
+void _35clofun3118(struct Cora* co);
+void _35clofun3117(struct Cora* co);
+void _35clofun3116(struct Cora* co);
+void _35clofun3115(struct Cora* co);
+void _35clofun3114(struct Cora* co);
+void _35clofun3113(struct Cora* co);
+void _35clofun3112(struct Cora* co);
 
 
 void entry(struct Cora* co){
@@ -41,7 +41,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-pushCont(co, 13, _35clofun1992, 0);
+pushCont(co, 14, _35clofun3135, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#import"));
 __arg1 = makeCString("cora/lib/toc/internal");
@@ -61,175 +61,178 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1992(struct Cora* co){
+void _35clofun3135(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1942 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1943 = primCdr(exp);
-pushCont(co, 20, _35clofun1991, 1, _35val1942);
+Obj _35val3090 = __arg1;
+Obj _35val3088= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg1943;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val3088;
+__arg2 = _35val3090;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val1952 = __arg1;
-Obj _35val1950= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val3088 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg3089 = primCdr(exp);
+pushCont(co, 0, _35clofun3135, 1, _35val3088);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val1950;
-__arg2 = _35val1952;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg3089;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1950 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1951 = primCdr(exp);
-pushCont(co, 1, _35clofun1992, 1, _35val1950);
+Obj _35val3097 = __arg1;
+Obj _35val3095= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg1951;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val3095;
+__arg2 = _35val3097;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val1960 = __arg1;
-Obj _35val1958= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val3095 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg3096 = primCdr(exp);
+pushCont(co, 2, _35clofun3135, 1, _35val3095);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val1958;
-__arg2 = _35val1960;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg3096;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val1958 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1959 = primCdr(exp);
-pushCont(co, 3, _35clofun1992, 1, _35val1958);
+Obj _35val3104 = __arg1;
+Obj _35val3102= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg1959;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val3102;
+__arg2 = _35val3104;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1967 = __arg1;
-Obj _35val1965= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val3102 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg3103 = primCdr(exp);
+pushCont(co, 4, _35clofun3135, 1, _35val3102);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val1965;
-__arg2 = _35val1967;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg3103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val1965 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1966 = primCdr(exp);
-pushCont(co, 5, _35clofun1992, 1, _35val1965);
+Obj _35val3110 = __arg1;
+Obj _35val3108= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg1966;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val3108;
+__arg2 = _35val3110;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val1953 = __arg1;
+Obj _35val3108 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1953) {
+Obj _35reg3109 = primCdr(exp);
+pushCont(co, 6, _35clofun3135, 1, _35val3108);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg3109;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label8:
+{
+Obj _35val3098 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val3098) {
 if (True == True) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1992) { goto fail; }
+if (co->ctx.pc.func != _35clofun3135) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg1954 = primIsCons(exp);
-if (True == _35reg1954) {
-Obj _35reg1955 = primCar(exp);
-Obj _35reg1956 = primEQ(_35reg1955, intern("quote"));
-if (True == _35reg1956) {
+Obj _35reg3099 = primCar(exp);
+Obj _35reg3100 = primEQ(_35reg3099, intern("quote"));
+if (True == _35reg3100) {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1957 = primCar(exp);
-pushCont(co, 4, _35clofun1992, 1, exp);
+Obj _35reg3101 = primCar(exp);
+pushCont(co, 5, _35clofun3135, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg1957;
+__arg1 = _35reg3101;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -238,415 +241,370 @@ if (True == False) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1992) { goto fail; }
+if (co->ctx.pc.func != _35clofun3135) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg1961 = primIsCons(exp);
-if (True == _35reg1961) {
-Obj _35reg1962 = primCar(exp);
-Obj _35reg1963 = primEQ(_35reg1962, intern("quote"));
-if (True == _35reg1963) {
+Obj _35reg3105 = primCar(exp);
+Obj _35reg3106 = primEQ(_35reg3105, intern("quote"));
+if (True == _35reg3106) {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1964 = primCar(exp);
-pushCont(co, 6, _35clofun1992, 1, exp);
+Obj _35reg3107 = primCar(exp);
+pushCont(co, 7, _35clofun3135, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg1964;
+__arg1 = _35reg3107;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 }
 }
 
-label8:
+label9:
 {
-Obj _35val1945 = __arg1;
+Obj _35val3091 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1945) {
+if (True == _35val3091) {
 if (True == True) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1992) { goto fail; }
+if (co->ctx.pc.func != _35clofun3135) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg1946 = primIsCons(exp);
-if (True == _35reg1946) {
-Obj _35reg1947 = primCar(exp);
-Obj _35reg1948 = primEQ(_35reg1947, intern("quote"));
-if (True == _35reg1948) {
+Obj _35reg3092 = primCar(exp);
+Obj _35reg3093 = primEQ(_35reg3092, intern("quote"));
+if (True == _35reg3093) {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1949 = primCar(exp);
-pushCont(co, 2, _35clofun1992, 1, exp);
+Obj _35reg3094 = primCar(exp);
+pushCont(co, 3, _35clofun3135, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg1949;
+__arg1 = _35reg3094;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 } else {
-pushCont(co, 7, _35clofun1992, 1, exp);
+pushCont(co, 8, _35clofun3135, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label9:
+label10:
 {
-Obj _35val1929 = __arg1;
+Obj _35val3077 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1929) {
+if (True == _35val3077) {
 if (True == True) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1992) { goto fail; }
+if (co->ctx.pc.func != _35clofun3135) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg1930 = primIsCons(exp);
-if (True == _35reg1930) {
-Obj _35reg1931 = primCar(exp);
-Obj _35reg1932 = primEQ(_35reg1931, intern("quote"));
-if (True == _35reg1932) {
+Obj _35reg3078 = primCar(exp);
+Obj _35reg3079 = primEQ(_35reg3078, intern("quote"));
+if (True == _35reg3079) {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1933 = primCar(exp);
-pushCont(co, 19, _35clofun1991, 1, exp);
+Obj _35reg3080 = primCar(exp);
+pushCont(co, 20, _35clofun3134, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg1933;
+__arg1 = _35reg3080;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 } else {
-Obj _35reg1937 = primIsString(exp);
-if (True == _35reg1937) {
+Obj _35reg3084 = primIsString(exp);
+if (True == _35reg3084) {
 if (True == True) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1992) { goto fail; }
+if (co->ctx.pc.func != _35clofun3135) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg1938 = primIsCons(exp);
-if (True == _35reg1938) {
-Obj _35reg1939 = primCar(exp);
-Obj _35reg1940 = primEQ(_35reg1939, intern("quote"));
-if (True == _35reg1940) {
+Obj _35reg3085 = primCar(exp);
+Obj _35reg3086 = primEQ(_35reg3085, intern("quote"));
+if (True == _35reg3086) {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1941 = primCar(exp);
-pushCont(co, 0, _35clofun1992, 1, exp);
+Obj _35reg3087 = primCar(exp);
+pushCont(co, 1, _35clofun3135, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg1941;
+__arg1 = _35reg3087;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 } else {
-pushCont(co, 8, _35clofun1992, 1, exp);
+pushCont(co, 9, _35clofun3135, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#boolean?"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 }
 
-label10:
+label11:
 {
 Obj exp = __arg1;
-Obj _35reg1928 = primIsSymbol(exp);
-if (True == _35reg1928) {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#value"));
+Obj _35reg3075 = primIsSymbol(exp);
+if (True == _35reg3075) {
+pushCont(co, 18, _35clofun3134, 0);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#lookup-var"));
 __arg1 = exp;
+__arg2 = makeCString("");
+__arg3 = globalRef(intern("cora/init#*imported*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 9, _35clofun1992, 1, exp);
+pushCont(co, 10, _35clofun3135, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#number?"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label11:
-{
-Obj _35val1768 = __arg1;
-Obj _35reg1773 = primSet(co, intern("cora/lib/toc#compile"), makeNative(4, _35clofun1988, 1, 0));
-Obj _35reg1779 = primSet(co, intern("cora/lib/toc#for-each"), makeNative(8, _35clofun1988, 2, 0));
-Obj _35reg1786 = primSet(co, intern("cora/lib/toc#generate-jumptable"), makeNative(12, _35clofun1988, 3, 0));
-Obj _35reg1807 = primSet(co, intern("cora/lib/toc#generate-toplevel-group"), makeNative(13, _35clofun1989, 2, 0));
-Obj _35reg1814 = primSet(co, intern("cora/lib/toc#generate-c"), makeNative(1, _35clofun1990, 2, 0));
-Obj _35reg1846 = primSet(co, intern("cora/lib/toc#handle-import-eagerly"), makeNative(7, _35clofun1990, 1, 0));
-Obj _35reg1887 = primSet(co, intern("cora/lib/toc#split-type-and-code"), makeNative(14, _35clofun1990, 4, 0));
-Obj _35reg1888 = primSet(co, intern("cora/lib/infer#*typecheck*"), False);
-Obj _35reg1891 = primSet(co, intern("cora/lib/toc#preprocess"), makeNative(17, _35clofun1990, 1, 0));
-Obj _35reg1897 = primSet(co, intern("cora/lib/toc#compile-to-c"), makeNative(2, _35clofun1991, 2, 0));
-Obj _35reg1899 = primSet(co, intern("set"), makeNative(3, _35clofun1991, 2, 0));
-Obj _35reg1901 = primSet(co, intern("car"), makeNative(4, _35clofun1991, 1, 0));
-Obj _35reg1903 = primSet(co, intern("cdr"), makeNative(5, _35clofun1991, 1, 0));
-Obj _35reg1905 = primSet(co, intern("cons"), makeNative(6, _35clofun1991, 2, 0));
-Obj _35reg1907 = primSet(co, intern("+"), makeNative(7, _35clofun1991, 2, 0));
-Obj _35reg1909 = primSet(co, intern("-"), makeNative(8, _35clofun1991, 2, 0));
-Obj _35reg1911 = primSet(co, intern("*"), makeNative(9, _35clofun1991, 2, 0));
-Obj _35reg1913 = primSet(co, intern("/"), makeNative(10, _35clofun1991, 2, 0));
-Obj _35reg1915 = primSet(co, intern("="), makeNative(11, _35clofun1991, 2, 0));
-Obj _35reg1917 = primSet(co, intern(">"), makeNative(12, _35clofun1991, 2, 0));
-Obj _35reg1919 = primSet(co, intern("<"), makeNative(13, _35clofun1991, 2, 0));
-Obj _35reg1921 = primSet(co, intern("gensym"), makeNative(14, _35clofun1991, 1, 0));
-Obj _35reg1923 = primSet(co, intern("symbol?"), makeNative(15, _35clofun1991, 1, 0));
-Obj _35reg1925 = primSet(co, intern("not"), makeNative(16, _35clofun1991, 1, 0));
-Obj _35reg1927 = primSet(co, intern("string?"), makeNative(17, _35clofun1991, 1, 0));
-Obj _35reg1968 = primSet(co, intern("cora/lib/toc#eval0"), makeNative(10, _35clofun1992, 1, 0));
-__nargs = 2;
-__arg1 = _35reg1968;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1992) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
 }
 
 label12:
 {
-Obj _35val200 = __arg1;
-Obj _35reg201 = primSet(co, intern("cora/lib/toc#*ns-export*"), Nil);
-Obj _35reg216 = primSet(co, intern("cora/lib/toc#assq"), makeNative(3, _35clofun1969, 2, 0));
-Obj _35reg222 = primSet(co, intern("cora/lib/toc#foldl"), makeNative(7, _35clofun1969, 3, 0));
-Obj _35reg232 = primSet(co, intern("cora/lib/toc#pos-in-list0"), makeNative(11, _35clofun1969, 3, 0));
-Obj _35reg233 = primSet(co, intern("cora/lib/toc#index"), makeNative(12, _35clofun1969, 2, 0));
-Obj _35reg240 = primSet(co, intern("cora/lib/toc#exist-in-env"), makeNative(16, _35clofun1969, 2, 0));
-Obj _35reg241 = primCons(intern("primSet"), Nil);
-Obj _35reg242 = primCons(makeNumber(2), _35reg241);
-Obj _35reg243 = primCons(intern("set"), _35reg242);
-Obj _35reg244 = primCons(intern("primCar"), Nil);
-Obj _35reg245 = primCons(makeNumber(1), _35reg244);
-Obj _35reg246 = primCons(intern("car"), _35reg245);
-Obj _35reg247 = primCons(intern("primCdr"), Nil);
-Obj _35reg248 = primCons(makeNumber(1), _35reg247);
-Obj _35reg249 = primCons(intern("cdr"), _35reg248);
-Obj _35reg250 = primCons(intern("primCons"), Nil);
-Obj _35reg251 = primCons(makeNumber(2), _35reg250);
-Obj _35reg252 = primCons(intern("cons"), _35reg251);
-Obj _35reg253 = primCons(intern("primIsCons"), Nil);
-Obj _35reg254 = primCons(makeNumber(1), _35reg253);
-Obj _35reg255 = primCons(intern("cons?"), _35reg254);
-Obj _35reg256 = primCons(intern("primAdd"), Nil);
-Obj _35reg257 = primCons(makeNumber(2), _35reg256);
-Obj _35reg258 = primCons(intern("+"), _35reg257);
-Obj _35reg259 = primCons(intern("primSub"), Nil);
-Obj _35reg260 = primCons(makeNumber(2), _35reg259);
-Obj _35reg261 = primCons(intern("-"), _35reg260);
-Obj _35reg262 = primCons(intern("primMul"), Nil);
-Obj _35reg263 = primCons(makeNumber(2), _35reg262);
-Obj _35reg264 = primCons(intern("*"), _35reg263);
-Obj _35reg265 = primCons(intern("primDiv"), Nil);
-Obj _35reg266 = primCons(makeNumber(2), _35reg265);
-Obj _35reg267 = primCons(intern("/"), _35reg266);
-Obj _35reg268 = primCons(intern("primEQ"), Nil);
-Obj _35reg269 = primCons(makeNumber(2), _35reg268);
-Obj _35reg270 = primCons(intern("="), _35reg269);
-Obj _35reg271 = primCons(intern("primGT"), Nil);
-Obj _35reg272 = primCons(makeNumber(2), _35reg271);
-Obj _35reg273 = primCons(intern(">"), _35reg272);
-Obj _35reg274 = primCons(intern("primLT"), Nil);
-Obj _35reg275 = primCons(makeNumber(2), _35reg274);
-Obj _35reg276 = primCons(intern("<"), _35reg275);
-Obj _35reg277 = primCons(intern("primGenSym"), Nil);
-Obj _35reg278 = primCons(makeNumber(1), _35reg277);
-Obj _35reg279 = primCons(intern("gensym"), _35reg278);
-Obj _35reg280 = primCons(intern("primIsSymbol"), Nil);
-Obj _35reg281 = primCons(makeNumber(1), _35reg280);
-Obj _35reg282 = primCons(intern("symbol?"), _35reg281);
-Obj _35reg283 = primCons(intern("primNot"), Nil);
-Obj _35reg284 = primCons(makeNumber(1), _35reg283);
-Obj _35reg285 = primCons(intern("not"), _35reg284);
-Obj _35reg286 = primCons(intern("primIsNumber"), Nil);
-Obj _35reg287 = primCons(makeNumber(1), _35reg286);
-Obj _35reg288 = primCons(intern("integer?"), _35reg287);
-Obj _35reg289 = primCons(intern("primIsString"), Nil);
-Obj _35reg290 = primCons(makeNumber(1), _35reg289);
-Obj _35reg291 = primCons(intern("string?"), _35reg290);
-Obj _35reg292 = primCons(_35reg291, Nil);
-Obj _35reg293 = primCons(_35reg288, _35reg292);
-Obj _35reg294 = primCons(_35reg285, _35reg293);
-Obj _35reg295 = primCons(_35reg282, _35reg294);
-Obj _35reg296 = primCons(_35reg279, _35reg295);
-Obj _35reg297 = primCons(_35reg276, _35reg296);
-Obj _35reg298 = primCons(_35reg273, _35reg297);
-Obj _35reg299 = primCons(_35reg270, _35reg298);
-Obj _35reg300 = primCons(_35reg267, _35reg299);
-Obj _35reg301 = primCons(_35reg264, _35reg300);
-Obj _35reg302 = primCons(_35reg261, _35reg301);
-Obj _35reg303 = primCons(_35reg258, _35reg302);
-Obj _35reg304 = primCons(_35reg255, _35reg303);
-Obj _35reg305 = primCons(_35reg252, _35reg304);
-Obj _35reg306 = primCons(_35reg249, _35reg305);
-Obj _35reg307 = primCons(_35reg246, _35reg306);
-Obj _35reg308 = primCons(_35reg243, _35reg307);
-Obj _35reg309 = primSet(co, intern("cora/lib/toc#*builtin-prims*"), _35reg308);
-Obj _35reg313 = primSet(co, intern("cora/lib/toc#builtin?"), makeNative(19, _35clofun1969, 1, 0));
-Obj _35reg316 = primSet(co, intern("cora/lib/toc#builtin->name"), makeNative(1, _35clofun1970, 1, 0));
-Obj _35reg319 = primSet(co, intern("cora/lib/toc#builtin->args"), makeNative(4, _35clofun1970, 1, 0));
-Obj _35reg324 = primSet(co, intern("cora/lib/toc#temp-list"), makeNative(7, _35clofun1970, 2, 0));
-Obj _35reg330 = primSet(co, intern("cora/lib/toc#var-with-ns"), makeNative(12, _35clofun1970, 2, 0));
-Obj _35reg342 = primSet(co, intern("cora/lib/toc#lookup-var"), makeNative(1, _35clofun1971, 3, 0));
-Obj _35reg531 = primSet(co, intern("cora/lib/toc#parse"), makeNative(15, _35clofun1972, 4, 0));
-Obj _35reg542 = primSet(co, intern("cora/lib/toc#union"), makeNative(0, _35clofun1973, 2, 0));
-Obj _35reg553 = primSet(co, intern("cora/lib/toc#diff"), makeNative(6, _35clofun1973, 2, 0));
-Obj _35reg604 = primSet(co, intern("cora/lib/toc#convert-protect?"), makeNative(13, _35clofun1973, 1, 0));
-Obj _35reg779 = primSet(co, intern("cora/lib/toc#free-vars"), makeNative(15, _35clofun1974, 1, 0));
-Obj _35reg852 = primSet(co, intern("cora/lib/toc#closure-convert"), makeNative(9, _35clofun1975, 2, 0));
-Obj _35reg855 = primSet(co, intern("cora/lib/toc#id"), makeNative(10, _35clofun1975, 1, 0));
-Obj _35reg992 = primSet(co, intern("cora/lib/toc#tailify"), makeNative(7, _35clofun1976, 2, 0));
-Obj _35reg1039 = primSet(co, intern("cora/lib/toc#tailify-list"), makeNative(17, _35clofun1976, 3, 0));
-Obj _35reg1118 = primSet(co, intern("cora/lib/toc#explicit-stack"), makeNative(14, _35clofun1977, 2, 0));
-Obj _35reg1294 = primSet(co, intern("cora/lib/toc#collect-lambda"), makeNative(7, _35clofun1979, 2, 0));
-Obj _35reg1307 = primSet(co, intern("cora/lib/toc#append-result"), makeNative(13, _35clofun1979, 5, 0));
-Obj _35reg1314 = primSet(co, intern("cora/lib/toc#wrap-var"), makeNative(15, _35clofun1979, 2, 0));
-Obj _35reg1334 = primSet(co, intern("cora/lib/toc#generate-call-list"), makeNative(8, _35clofun1980, 4, 0));
-Obj _35reg1604 = primSet(co, intern("cora/lib/toc#generate-inst"), makeNative(11, _35clofun1984, 4, 0));
-Obj _35reg1627 = primSet(co, intern("cora/lib/toc#generate-cont"), makeNative(3, _35clofun1985, 3, 0));
-Obj _35reg1636 = primSet(co, intern("cora/lib/toc#generate-inst-list-h"), makeNative(9, _35clofun1985, 5, 0));
-Obj _35reg1637 = primSet(co, intern("cora/lib/toc#generate-inst-list"), makeNative(10, _35clofun1985, 4, 0));
-Obj _35reg1642 = primSet(co, intern("cora/lib/toc#code-gen-func-declare"), makeNative(14, _35clofun1985, 2, 0));
-Obj _35reg1650 = primSet(co, intern("cora/lib/toc#local-from-params"), makeNative(0, _35clofun1986, 3, 0));
-Obj _35reg1655 = primSet(co, intern("cora/lib/toc#local-from-cont"), makeNative(5, _35clofun1986, 3, 0));
-Obj _35reg1662 = primSet(co, intern("cora/lib/toc#generate-call-args-reverse"), makeNative(9, _35clofun1986, 4, 0));
-Obj _35reg1724 = primSet(co, intern("cora/lib/toc#code-gen-toplevel"), makeNative(20, _35clofun1986, 2, 0));
-Obj _35reg1725 = primSet(co, intern("cora/lib/toc#parse-pass"), makeNative(0, _35clofun1987, 1, 0));
-Obj _35reg1726 = primSet(co, intern("cora/lib/toc#closure-convert-pass"), makeNative(1, _35clofun1987, 1, 0));
-Obj _35reg1727 = primSet(co, intern("cora/lib/toc#tailify-pass"), makeNative(2, _35clofun1987, 1, 0));
-Obj _35reg1728 = primSet(co, intern("cora/lib/toc#explicit-stack-pass"), makeNative(3, _35clofun1987, 1, 0));
-Obj _35reg1758 = primSet(co, intern("cora/lib/toc#collect-lambda-pass"), makeNative(14, _35clofun1987, 1, 0));
-Obj _35reg1765 = primSet(co, intern("cora/lib/toc#rewrite-->macro"), makeNative(17, _35clofun1987, 2, 0));
-pushCont(co, 11, _35clofun1992, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("->");
-__arg2 = makeNative(20, _35clofun1987, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj _35val2915 = __arg1;
+Obj _35reg2920 = primSet(co, intern("cora/lib/toc#compile"), makeNative(4, _35clofun3131, 1, 0));
+Obj _35reg2926 = primSet(co, intern("cora/lib/toc#for-each"), makeNative(8, _35clofun3131, 2, 0));
+Obj _35reg2933 = primSet(co, intern("cora/lib/toc#generate-jumptable"), makeNative(12, _35clofun3131, 3, 0));
+Obj _35reg2954 = primSet(co, intern("cora/lib/toc#generate-toplevel-group"), makeNative(13, _35clofun3132, 2, 0));
+Obj _35reg2961 = primSet(co, intern("cora/lib/toc#generate-c"), makeNative(1, _35clofun3133, 2, 0));
+Obj _35reg2993 = primSet(co, intern("cora/lib/toc#handle-import-eagerly"), makeNative(7, _35clofun3133, 1, 0));
+Obj _35reg3034 = primSet(co, intern("cora/lib/toc#split-type-and-code"), makeNative(14, _35clofun3133, 4, 0));
+Obj _35reg3035 = primSet(co, intern("cora/lib/infer#*typecheck*"), False);
+Obj _35reg3038 = primSet(co, intern("cora/lib/toc#preprocess"), makeNative(17, _35clofun3133, 1, 0));
+Obj _35reg3044 = primSet(co, intern("cora/lib/toc#compile-to-c"), makeNative(2, _35clofun3134, 2, 0));
+Obj _35reg3046 = primSet(co, intern("set"), makeNative(3, _35clofun3134, 2, 0));
+Obj _35reg3048 = primSet(co, intern("car"), makeNative(4, _35clofun3134, 1, 0));
+Obj _35reg3050 = primSet(co, intern("cdr"), makeNative(5, _35clofun3134, 1, 0));
+Obj _35reg3052 = primSet(co, intern("cons"), makeNative(6, _35clofun3134, 2, 0));
+Obj _35reg3054 = primSet(co, intern("+"), makeNative(7, _35clofun3134, 2, 0));
+Obj _35reg3056 = primSet(co, intern("-"), makeNative(8, _35clofun3134, 2, 0));
+Obj _35reg3058 = primSet(co, intern("*"), makeNative(9, _35clofun3134, 2, 0));
+Obj _35reg3060 = primSet(co, intern("/"), makeNative(10, _35clofun3134, 2, 0));
+Obj _35reg3062 = primSet(co, intern("="), makeNative(11, _35clofun3134, 2, 0));
+Obj _35reg3064 = primSet(co, intern(">"), makeNative(12, _35clofun3134, 2, 0));
+Obj _35reg3066 = primSet(co, intern("<"), makeNative(13, _35clofun3134, 2, 0));
+Obj _35reg3068 = primSet(co, intern("gensym"), makeNative(14, _35clofun3134, 1, 0));
+Obj _35reg3070 = primSet(co, intern("symbol?"), makeNative(15, _35clofun3134, 1, 0));
+Obj _35reg3072 = primSet(co, intern("not"), makeNative(16, _35clofun3134, 1, 0));
+Obj _35reg3074 = primSet(co, intern("string?"), makeNative(17, _35clofun3134, 1, 0));
+Obj _35reg3111 = primSet(co, intern("cora/lib/toc#eval0"), makeNative(11, _35clofun3135, 1, 0));
+__nargs = 2;
+__arg1 = _35reg3111;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun3135) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label13:
 {
-Obj _35val199 = __arg1;
-pushCont(co, 12, _35clofun1992, 0);
+Obj _35val1347 = __arg1;
+Obj _35reg1348 = primSet(co, intern("cora/lib/toc#*ns-export*"), Nil);
+Obj _35reg1363 = primSet(co, intern("cora/lib/toc#assq"), makeNative(3, _35clofun3112, 2, 0));
+Obj _35reg1369 = primSet(co, intern("cora/lib/toc#foldl"), makeNative(7, _35clofun3112, 3, 0));
+Obj _35reg1379 = primSet(co, intern("cora/lib/toc#pos-in-list0"), makeNative(11, _35clofun3112, 3, 0));
+Obj _35reg1380 = primSet(co, intern("cora/lib/toc#index"), makeNative(12, _35clofun3112, 2, 0));
+Obj _35reg1387 = primSet(co, intern("cora/lib/toc#exist-in-env"), makeNative(16, _35clofun3112, 2, 0));
+Obj _35reg1388 = primCons(intern("primSet"), Nil);
+Obj _35reg1389 = primCons(makeNumber(2), _35reg1388);
+Obj _35reg1390 = primCons(intern("set"), _35reg1389);
+Obj _35reg1391 = primCons(intern("primCar"), Nil);
+Obj _35reg1392 = primCons(makeNumber(1), _35reg1391);
+Obj _35reg1393 = primCons(intern("car"), _35reg1392);
+Obj _35reg1394 = primCons(intern("primCdr"), Nil);
+Obj _35reg1395 = primCons(makeNumber(1), _35reg1394);
+Obj _35reg1396 = primCons(intern("cdr"), _35reg1395);
+Obj _35reg1397 = primCons(intern("primCons"), Nil);
+Obj _35reg1398 = primCons(makeNumber(2), _35reg1397);
+Obj _35reg1399 = primCons(intern("cons"), _35reg1398);
+Obj _35reg1400 = primCons(intern("primIsCons"), Nil);
+Obj _35reg1401 = primCons(makeNumber(1), _35reg1400);
+Obj _35reg1402 = primCons(intern("cons?"), _35reg1401);
+Obj _35reg1403 = primCons(intern("primAdd"), Nil);
+Obj _35reg1404 = primCons(makeNumber(2), _35reg1403);
+Obj _35reg1405 = primCons(intern("+"), _35reg1404);
+Obj _35reg1406 = primCons(intern("primSub"), Nil);
+Obj _35reg1407 = primCons(makeNumber(2), _35reg1406);
+Obj _35reg1408 = primCons(intern("-"), _35reg1407);
+Obj _35reg1409 = primCons(intern("primMul"), Nil);
+Obj _35reg1410 = primCons(makeNumber(2), _35reg1409);
+Obj _35reg1411 = primCons(intern("*"), _35reg1410);
+Obj _35reg1412 = primCons(intern("primDiv"), Nil);
+Obj _35reg1413 = primCons(makeNumber(2), _35reg1412);
+Obj _35reg1414 = primCons(intern("/"), _35reg1413);
+Obj _35reg1415 = primCons(intern("primEQ"), Nil);
+Obj _35reg1416 = primCons(makeNumber(2), _35reg1415);
+Obj _35reg1417 = primCons(intern("="), _35reg1416);
+Obj _35reg1418 = primCons(intern("primGT"), Nil);
+Obj _35reg1419 = primCons(makeNumber(2), _35reg1418);
+Obj _35reg1420 = primCons(intern(">"), _35reg1419);
+Obj _35reg1421 = primCons(intern("primLT"), Nil);
+Obj _35reg1422 = primCons(makeNumber(2), _35reg1421);
+Obj _35reg1423 = primCons(intern("<"), _35reg1422);
+Obj _35reg1424 = primCons(intern("primGenSym"), Nil);
+Obj _35reg1425 = primCons(makeNumber(1), _35reg1424);
+Obj _35reg1426 = primCons(intern("gensym"), _35reg1425);
+Obj _35reg1427 = primCons(intern("primIsSymbol"), Nil);
+Obj _35reg1428 = primCons(makeNumber(1), _35reg1427);
+Obj _35reg1429 = primCons(intern("symbol?"), _35reg1428);
+Obj _35reg1430 = primCons(intern("primNot"), Nil);
+Obj _35reg1431 = primCons(makeNumber(1), _35reg1430);
+Obj _35reg1432 = primCons(intern("not"), _35reg1431);
+Obj _35reg1433 = primCons(intern("primIsNumber"), Nil);
+Obj _35reg1434 = primCons(makeNumber(1), _35reg1433);
+Obj _35reg1435 = primCons(intern("integer?"), _35reg1434);
+Obj _35reg1436 = primCons(intern("primIsString"), Nil);
+Obj _35reg1437 = primCons(makeNumber(1), _35reg1436);
+Obj _35reg1438 = primCons(intern("string?"), _35reg1437);
+Obj _35reg1439 = primCons(_35reg1438, Nil);
+Obj _35reg1440 = primCons(_35reg1435, _35reg1439);
+Obj _35reg1441 = primCons(_35reg1432, _35reg1440);
+Obj _35reg1442 = primCons(_35reg1429, _35reg1441);
+Obj _35reg1443 = primCons(_35reg1426, _35reg1442);
+Obj _35reg1444 = primCons(_35reg1423, _35reg1443);
+Obj _35reg1445 = primCons(_35reg1420, _35reg1444);
+Obj _35reg1446 = primCons(_35reg1417, _35reg1445);
+Obj _35reg1447 = primCons(_35reg1414, _35reg1446);
+Obj _35reg1448 = primCons(_35reg1411, _35reg1447);
+Obj _35reg1449 = primCons(_35reg1408, _35reg1448);
+Obj _35reg1450 = primCons(_35reg1405, _35reg1449);
+Obj _35reg1451 = primCons(_35reg1402, _35reg1450);
+Obj _35reg1452 = primCons(_35reg1399, _35reg1451);
+Obj _35reg1453 = primCons(_35reg1396, _35reg1452);
+Obj _35reg1454 = primCons(_35reg1393, _35reg1453);
+Obj _35reg1455 = primCons(_35reg1390, _35reg1454);
+Obj _35reg1456 = primSet(co, intern("cora/lib/toc#*builtin-prims*"), _35reg1455);
+Obj _35reg1460 = primSet(co, intern("cora/lib/toc#builtin?"), makeNative(19, _35clofun3112, 1, 0));
+Obj _35reg1463 = primSet(co, intern("cora/lib/toc#builtin->name"), makeNative(1, _35clofun3113, 1, 0));
+Obj _35reg1466 = primSet(co, intern("cora/lib/toc#builtin->args"), makeNative(4, _35clofun3113, 1, 0));
+Obj _35reg1471 = primSet(co, intern("cora/lib/toc#temp-list"), makeNative(7, _35clofun3113, 2, 0));
+Obj _35reg1477 = primSet(co, intern("cora/lib/toc#var-with-ns"), makeNative(12, _35clofun3113, 2, 0));
+Obj _35reg1489 = primSet(co, intern("cora/lib/toc#lookup-var"), makeNative(1, _35clofun3114, 3, 0));
+Obj _35reg1678 = primSet(co, intern("cora/lib/toc#parse"), makeNative(15, _35clofun3115, 4, 0));
+Obj _35reg1689 = primSet(co, intern("cora/lib/toc#union"), makeNative(0, _35clofun3116, 2, 0));
+Obj _35reg1700 = primSet(co, intern("cora/lib/toc#diff"), makeNative(6, _35clofun3116, 2, 0));
+Obj _35reg1751 = primSet(co, intern("cora/lib/toc#convert-protect?"), makeNative(13, _35clofun3116, 1, 0));
+Obj _35reg1926 = primSet(co, intern("cora/lib/toc#free-vars"), makeNative(15, _35clofun3117, 1, 0));
+Obj _35reg1999 = primSet(co, intern("cora/lib/toc#closure-convert"), makeNative(9, _35clofun3118, 2, 0));
+Obj _35reg2002 = primSet(co, intern("cora/lib/toc#id"), makeNative(10, _35clofun3118, 1, 0));
+Obj _35reg2139 = primSet(co, intern("cora/lib/toc#tailify"), makeNative(7, _35clofun3119, 2, 0));
+Obj _35reg2186 = primSet(co, intern("cora/lib/toc#tailify-list"), makeNative(17, _35clofun3119, 3, 0));
+Obj _35reg2265 = primSet(co, intern("cora/lib/toc#explicit-stack"), makeNative(14, _35clofun3120, 2, 0));
+Obj _35reg2441 = primSet(co, intern("cora/lib/toc#collect-lambda"), makeNative(7, _35clofun3122, 2, 0));
+Obj _35reg2454 = primSet(co, intern("cora/lib/toc#append-result"), makeNative(13, _35clofun3122, 5, 0));
+Obj _35reg2461 = primSet(co, intern("cora/lib/toc#wrap-var"), makeNative(15, _35clofun3122, 2, 0));
+Obj _35reg2481 = primSet(co, intern("cora/lib/toc#generate-call-list"), makeNative(8, _35clofun3123, 4, 0));
+Obj _35reg2751 = primSet(co, intern("cora/lib/toc#generate-inst"), makeNative(11, _35clofun3127, 4, 0));
+Obj _35reg2774 = primSet(co, intern("cora/lib/toc#generate-cont"), makeNative(3, _35clofun3128, 3, 0));
+Obj _35reg2783 = primSet(co, intern("cora/lib/toc#generate-inst-list-h"), makeNative(9, _35clofun3128, 5, 0));
+Obj _35reg2784 = primSet(co, intern("cora/lib/toc#generate-inst-list"), makeNative(10, _35clofun3128, 4, 0));
+Obj _35reg2789 = primSet(co, intern("cora/lib/toc#code-gen-func-declare"), makeNative(14, _35clofun3128, 2, 0));
+Obj _35reg2797 = primSet(co, intern("cora/lib/toc#local-from-params"), makeNative(0, _35clofun3129, 3, 0));
+Obj _35reg2802 = primSet(co, intern("cora/lib/toc#local-from-cont"), makeNative(5, _35clofun3129, 3, 0));
+Obj _35reg2809 = primSet(co, intern("cora/lib/toc#generate-call-args-reverse"), makeNative(9, _35clofun3129, 4, 0));
+Obj _35reg2871 = primSet(co, intern("cora/lib/toc#code-gen-toplevel"), makeNative(20, _35clofun3129, 2, 0));
+Obj _35reg2872 = primSet(co, intern("cora/lib/toc#parse-pass"), makeNative(0, _35clofun3130, 1, 0));
+Obj _35reg2873 = primSet(co, intern("cora/lib/toc#closure-convert-pass"), makeNative(1, _35clofun3130, 1, 0));
+Obj _35reg2874 = primSet(co, intern("cora/lib/toc#tailify-pass"), makeNative(2, _35clofun3130, 1, 0));
+Obj _35reg2875 = primSet(co, intern("cora/lib/toc#explicit-stack-pass"), makeNative(3, _35clofun3130, 1, 0));
+Obj _35reg2905 = primSet(co, intern("cora/lib/toc#collect-lambda-pass"), makeNative(14, _35clofun3130, 1, 0));
+Obj _35reg2912 = primSet(co, intern("cora/lib/toc#rewrite-->macro"), makeNative(17, _35clofun3130, 2, 0));
+pushCont(co, 12, _35clofun3135, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
+__arg1 = intern("->");
+__arg2 = makeNative(20, _35clofun3130, 1, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label14:
+{
+Obj _35val1346 = __arg1;
+pushCont(co, 13, _35clofun3135, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#import"));
 __arg1 = makeCString("cora/lib/io");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3135) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -659,7 +617,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1991(struct Cora* co){
+void _35clofun3134(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -672,31 +630,31 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1893 = __arg1;
+Obj _35val3040 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 20, _35clofun1990, 1, to);
+pushCont(co, 20, _35clofun3133, 1, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#compile"));
-__arg1 = _35val1893;
+__arg1 = _35val3040;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1991) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val1892 = __arg1;
+Obj _35val3039 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun1991, 1, to);
+pushCont(co, 0, _35clofun3134, 1, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#macroexpand"));
-__arg1 = _35val1892;
+__arg1 = _35val3039;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1991) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -704,235 +662,233 @@ label2:
 {
 Obj from = __arg1;
 Obj to = __arg2;
-pushCont(co, 1, _35clofun1991, 1, to);
+pushCont(co, 1, _35clofun3134, 1, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#preprocess"));
 __arg1 = from;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1991) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35tmp176 = __arg1;
-Obj _35tmp175 = __arg2;
-Obj _35reg1898 = primSet(co, _35tmp176, _35tmp175);
+Obj _35tmp1323 = __arg1;
+Obj _35tmp1322 = __arg2;
+Obj _35reg3045 = primSet(co, _35tmp1323, _35tmp1322);
 __nargs = 2;
-__arg1 = _35reg1898;
+__arg1 = _35reg3045;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label4:
 {
-Obj _35tmp177 = __arg1;
-Obj _35reg1900 = primCar(_35tmp177);
+Obj _35tmp1324 = __arg1;
+Obj _35reg3047 = primCar(_35tmp1324);
 __nargs = 2;
-__arg1 = _35reg1900;
+__arg1 = _35reg3047;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label5:
 {
-Obj _35tmp178 = __arg1;
-Obj _35reg1902 = primCdr(_35tmp178);
+Obj _35tmp1325 = __arg1;
+Obj _35reg3049 = primCdr(_35tmp1325);
 __nargs = 2;
-__arg1 = _35reg1902;
+__arg1 = _35reg3049;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label6:
 {
-Obj _35tmp180 = __arg1;
-Obj _35tmp179 = __arg2;
-Obj _35reg1904 = primCons(_35tmp180, _35tmp179);
+Obj _35tmp1327 = __arg1;
+Obj _35tmp1326 = __arg2;
+Obj _35reg3051 = primCons(_35tmp1327, _35tmp1326);
 __nargs = 2;
-__arg1 = _35reg1904;
+__arg1 = _35reg3051;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label7:
 {
-Obj _35tmp182 = __arg1;
-Obj _35tmp181 = __arg2;
-Obj _35reg1906 = primAdd(_35tmp182, _35tmp181);
+Obj _35tmp1329 = __arg1;
+Obj _35tmp1328 = __arg2;
+Obj _35reg3053 = primAdd(_35tmp1329, _35tmp1328);
 __nargs = 2;
-__arg1 = _35reg1906;
+__arg1 = _35reg3053;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label8:
 {
-Obj _35tmp184 = __arg1;
-Obj _35tmp183 = __arg2;
-Obj _35reg1908 = primSub(_35tmp184, _35tmp183);
+Obj _35tmp1331 = __arg1;
+Obj _35tmp1330 = __arg2;
+Obj _35reg3055 = primSub(_35tmp1331, _35tmp1330);
 __nargs = 2;
-__arg1 = _35reg1908;
+__arg1 = _35reg3055;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label9:
 {
-Obj _35tmp186 = __arg1;
-Obj _35tmp185 = __arg2;
-Obj _35reg1910 = primMul(_35tmp186, _35tmp185);
+Obj _35tmp1333 = __arg1;
+Obj _35tmp1332 = __arg2;
+Obj _35reg3057 = primMul(_35tmp1333, _35tmp1332);
 __nargs = 2;
-__arg1 = _35reg1910;
+__arg1 = _35reg3057;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label10:
 {
-Obj _35tmp188 = __arg1;
-Obj _35tmp187 = __arg2;
-Obj _35reg1912 = primDiv(_35tmp188, _35tmp187);
+Obj _35tmp1335 = __arg1;
+Obj _35tmp1334 = __arg2;
+Obj _35reg3059 = primDiv(_35tmp1335, _35tmp1334);
 __nargs = 2;
-__arg1 = _35reg1912;
+__arg1 = _35reg3059;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label11:
 {
-Obj _35tmp190 = __arg1;
-Obj _35tmp189 = __arg2;
-Obj _35reg1914 = primEQ(_35tmp190, _35tmp189);
+Obj _35tmp1337 = __arg1;
+Obj _35tmp1336 = __arg2;
+Obj _35reg3061 = primEQ(_35tmp1337, _35tmp1336);
 __nargs = 2;
-__arg1 = _35reg1914;
+__arg1 = _35reg3061;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label12:
 {
-Obj _35tmp192 = __arg1;
-Obj _35tmp191 = __arg2;
-Obj _35reg1916 = primGT(_35tmp192, _35tmp191);
+Obj _35tmp1339 = __arg1;
+Obj _35tmp1338 = __arg2;
+Obj _35reg3063 = primGT(_35tmp1339, _35tmp1338);
 __nargs = 2;
-__arg1 = _35reg1916;
+__arg1 = _35reg3063;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label13:
 {
-Obj _35tmp194 = __arg1;
-Obj _35tmp193 = __arg2;
-Obj _35reg1918 = primLT(_35tmp194, _35tmp193);
+Obj _35tmp1341 = __arg1;
+Obj _35tmp1340 = __arg2;
+Obj _35reg3065 = primLT(_35tmp1341, _35tmp1340);
 __nargs = 2;
-__arg1 = _35reg1918;
+__arg1 = _35reg3065;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label14:
 {
-Obj _35tmp195 = __arg1;
-Obj _35reg1920 = primGenSym(_35tmp195);
+Obj _35tmp1342 = __arg1;
+Obj _35reg3067 = primGenSym(_35tmp1342);
 __nargs = 2;
-__arg1 = _35reg1920;
+__arg1 = _35reg3067;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label15:
 {
-Obj _35tmp196 = __arg1;
-Obj _35reg1922 = primIsSymbol(_35tmp196);
+Obj _35tmp1343 = __arg1;
+Obj _35reg3069 = primIsSymbol(_35tmp1343);
 __nargs = 2;
-__arg1 = _35reg1922;
+__arg1 = _35reg3069;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label16:
 {
-Obj _35tmp197 = __arg1;
-Obj _35reg1924 = primNot(_35tmp197);
+Obj _35tmp1344 = __arg1;
+Obj _35reg3071 = primNot(_35tmp1344);
 __nargs = 2;
-__arg1 = _35reg1924;
+__arg1 = _35reg3071;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label17:
 {
-Obj _35tmp198 = __arg1;
-Obj _35reg1926 = primIsString(_35tmp198);
+Obj _35tmp1345 = __arg1;
+Obj _35reg3073 = primIsString(_35tmp1345);
 __nargs = 2;
-__arg1 = _35reg1926;
+__arg1 = _35reg3073;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1991) { goto fail; }
+if (co->ctx.pc.func != _35clofun3134) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label18:
 {
-Obj _35val1936 = __arg1;
-Obj _35val1934= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val1934;
-__arg2 = _35val1936;
+Obj _35val3076 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#value"));
+__arg1 = _35val3076;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1991) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1934 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1935 = primCdr(exp);
-pushCont(co, 18, _35clofun1991, 1, _35val1934);
+Obj _35val3083 = __arg1;
+Obj _35val3081= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg1935;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val3081;
+__arg2 = _35val3083;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1991) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1944 = __arg1;
-Obj _35val1942= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val3081 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg3082 = primCdr(exp);
+pushCont(co, 19, _35clofun3134, 1, _35val3081);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val1942;
-__arg2 = _35val1944;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg3082;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1991) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3134) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -945,7 +901,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1990(struct Cora* co){
+void _35clofun3133(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -958,10 +914,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1808 = __arg1;
+Obj _35val2955 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 20, _35clofun1989, 2, to, bc);
+pushCont(co, 20, _35clofun3132, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -969,7 +925,7 @@ __arg2 = makeCString("#include \"runtime.h\"\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -977,7 +933,7 @@ label1:
 {
 Obj to = __arg1;
 Obj bc = __arg2;
-pushCont(co, 0, _35clofun1990, 2, to, bc);
+pushCont(co, 0, _35clofun3133, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -985,7 +941,7 @@ __arg2 = makeCString("#include \"types.h\"\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -997,24 +953,24 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc166 = makeNative(2, _35clofun1990, 0, 0);
+Obj _35cc1313 = makeNative(2, _35clofun3133, 0, 0);
 Obj __ = closureRef(co, 0);
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1990) { goto fail; }
+if (co->ctx.pc.func != _35clofun3133) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label4:
 {
-Obj _35val1832 = __arg1;
+Obj _35val2979 = __arg1;
 Obj remain= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
@@ -1022,182 +978,182 @@ __arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35cc165 = makeNative(3, _35clofun1990, 0, 1, closureRef(co, 0));
-Obj _35reg1815 = primIsCons(closureRef(co, 0));
-if (True == _35reg1815) {
-Obj _35reg1816 = primCar(closureRef(co, 0));
-Obj _35reg1817 = primIsCons(_35reg1816);
-if (True == _35reg1817) {
-Obj _35reg1818 = primCar(closureRef(co, 0));
-Obj _35reg1819 = primCar(_35reg1818);
-Obj _35reg1820 = primEQ(intern("import"), _35reg1819);
-if (True == _35reg1820) {
-Obj _35reg1821 = primCar(closureRef(co, 0));
-Obj _35reg1822 = primCdr(_35reg1821);
-Obj _35reg1823 = primIsCons(_35reg1822);
-if (True == _35reg1823) {
-Obj _35reg1824 = primCar(closureRef(co, 0));
-Obj _35reg1825 = primCdr(_35reg1824);
-Obj _35reg1826 = primCar(_35reg1825);
-Obj pkg = _35reg1826;
-Obj _35reg1827 = primCar(closureRef(co, 0));
-Obj _35reg1828 = primCdr(_35reg1827);
-Obj _35reg1829 = primCdr(_35reg1828);
-Obj _35reg1830 = primEQ(Nil, _35reg1829);
-if (True == _35reg1830) {
-Obj _35reg1831 = primCdr(closureRef(co, 0));
-Obj remain = _35reg1831;
-pushCont(co, 4, _35clofun1990, 1, remain);
+Obj _35cc1312 = makeNative(3, _35clofun3133, 0, 1, closureRef(co, 0));
+Obj _35reg2962 = primIsCons(closureRef(co, 0));
+if (True == _35reg2962) {
+Obj _35reg2963 = primCar(closureRef(co, 0));
+Obj _35reg2964 = primIsCons(_35reg2963);
+if (True == _35reg2964) {
+Obj _35reg2965 = primCar(closureRef(co, 0));
+Obj _35reg2966 = primCar(_35reg2965);
+Obj _35reg2967 = primEQ(intern("import"), _35reg2966);
+if (True == _35reg2967) {
+Obj _35reg2968 = primCar(closureRef(co, 0));
+Obj _35reg2969 = primCdr(_35reg2968);
+Obj _35reg2970 = primIsCons(_35reg2969);
+if (True == _35reg2970) {
+Obj _35reg2971 = primCar(closureRef(co, 0));
+Obj _35reg2972 = primCdr(_35reg2971);
+Obj _35reg2973 = primCar(_35reg2972);
+Obj pkg = _35reg2973;
+Obj _35reg2974 = primCar(closureRef(co, 0));
+Obj _35reg2975 = primCdr(_35reg2974);
+Obj _35reg2976 = primCdr(_35reg2975);
+Obj _35reg2977 = primEQ(Nil, _35reg2976);
+if (True == _35reg2977) {
+Obj _35reg2978 = primCdr(closureRef(co, 0));
+Obj remain = _35reg2978;
+pushCont(co, 4, _35clofun3133, 1, remain);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#import"));
 __arg1 = pkg;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc165;
+__arg0 = _35cc1312;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc165;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc165;
+__arg0 = _35cc1312;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc165;
+__arg0 = _35cc1312;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc165;
+__arg0 = _35cc1312;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1312;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label6:
 {
-Obj _35cc164 = makeNative(5, _35clofun1990, 0, 1, closureRef(co, 0));
-Obj _35reg1833 = primIsCons(closureRef(co, 0));
-if (True == _35reg1833) {
-Obj _35reg1834 = primCar(closureRef(co, 0));
-Obj _35reg1835 = primEQ(intern("begin"), _35reg1834);
-if (True == _35reg1835) {
-Obj _35reg1836 = primCdr(closureRef(co, 0));
-Obj remain = _35reg1836;
+Obj _35cc1311 = makeNative(5, _35clofun3133, 0, 1, closureRef(co, 0));
+Obj _35reg2980 = primIsCons(closureRef(co, 0));
+if (True == _35reg2980) {
+Obj _35reg2981 = primCar(closureRef(co, 0));
+Obj _35reg2982 = primEQ(intern("begin"), _35reg2981);
+if (True == _35reg2982) {
+Obj _35reg2983 = primCdr(closureRef(co, 0));
+Obj remain = _35reg2983;
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
 __arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc164;
+__arg0 = _35cc1311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc164;
+__arg0 = _35cc1311;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35p162 = __arg1;
-Obj _35cc163 = makeNative(6, _35clofun1990, 0, 1, _35p162);
-Obj _35reg1837 = primIsCons(_35p162);
-if (True == _35reg1837) {
-Obj _35reg1838 = primCar(_35p162);
-Obj _35reg1839 = primEQ(intern("define-library"), _35reg1838);
-if (True == _35reg1839) {
-Obj _35reg1840 = primCdr(_35p162);
-Obj _35reg1841 = primIsCons(_35reg1840);
-if (True == _35reg1841) {
-Obj _35reg1842 = primCdr(_35p162);
-Obj _35reg1843 = primCar(_35reg1842);
-Obj __ = _35reg1843;
-Obj _35reg1844 = primCdr(_35p162);
-Obj _35reg1845 = primCdr(_35reg1844);
-Obj remain = _35reg1845;
+Obj _35p1309 = __arg1;
+Obj _35cc1310 = makeNative(6, _35clofun3133, 0, 1, _35p1309);
+Obj _35reg2984 = primIsCons(_35p1309);
+if (True == _35reg2984) {
+Obj _35reg2985 = primCar(_35p1309);
+Obj _35reg2986 = primEQ(intern("define-library"), _35reg2985);
+if (True == _35reg2986) {
+Obj _35reg2987 = primCdr(_35p1309);
+Obj _35reg2988 = primIsCons(_35reg2987);
+if (True == _35reg2988) {
+Obj _35reg2989 = primCdr(_35p1309);
+Obj _35reg2990 = primCar(_35reg2989);
+Obj __ = _35reg2990;
+Obj _35reg2991 = primCdr(_35p1309);
+Obj _35reg2992 = primCdr(_35reg2991);
+Obj remain = _35reg2992;
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
 __arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc163;
+__arg0 = _35cc1310;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc163;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc163;
+__arg0 = _35cc1310;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1310;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -1210,287 +1166,287 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35cc174 = makeNative(8, _35clofun1990, 0, 0);
-Obj _35reg1847 = primIsCons(closureRef(co, 0));
-if (True == _35reg1847) {
-Obj _35reg1848 = primCar(closureRef(co, 0));
-Obj exp = _35reg1848;
-Obj _35reg1849 = primCdr(closureRef(co, 0));
-Obj more = _35reg1849;
+Obj _35cc1321 = makeNative(8, _35clofun3133, 0, 0);
+Obj _35reg2994 = primIsCons(closureRef(co, 0));
+if (True == _35reg2994) {
+Obj _35reg2995 = primCar(closureRef(co, 0));
+Obj exp = _35reg2995;
+Obj _35reg2996 = primCdr(closureRef(co, 0));
+Obj more = _35reg2996;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj _35reg1850 = primCons(exp, Nil);
-Obj _35reg1851 = primCons(intern("backquote"), _35reg1850);
-Obj _35reg1852 = primCons(_35reg1851, Nil);
-Obj _35reg1853 = primCons(intern("macroexpand"), _35reg1852);
-Obj _35reg1854 = primCons(intern("tvar"), Nil);
-Obj _35reg1855 = primCons(Nil, Nil);
-Obj _35reg1856 = primCons(Nil, _35reg1855);
-Obj _35reg1857 = primCons(_35reg1854, _35reg1856);
-Obj _35reg1858 = primCons(_35reg1853, _35reg1857);
-Obj _35reg1859 = primCons(intern("cora/lib/infer#check-type"), _35reg1858);
-Obj _35reg1860 = primCons(_35reg1859, type);
-Obj _35reg1861 = primCons(exp, code);
+Obj _35reg2997 = primCons(exp, Nil);
+Obj _35reg2998 = primCons(intern("backquote"), _35reg2997);
+Obj _35reg2999 = primCons(_35reg2998, Nil);
+Obj _35reg3000 = primCons(intern("macroexpand"), _35reg2999);
+Obj _35reg3001 = primCons(intern("tvar"), Nil);
+Obj _35reg3002 = primCons(Nil, Nil);
+Obj _35reg3003 = primCons(Nil, _35reg3002);
+Obj _35reg3004 = primCons(_35reg3001, _35reg3003);
+Obj _35reg3005 = primCons(_35reg3000, _35reg3004);
+Obj _35reg3006 = primCons(intern("cora/lib/infer#check-type"), _35reg3005);
+Obj _35reg3007 = primCons(_35reg3006, type);
+Obj _35reg3008 = primCons(exp, code);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
 __arg1 = more;
-__arg2 = _35reg1860;
-__arg3 = _35reg1861;
+__arg2 = _35reg3007;
+__arg3 = _35reg3008;
 co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc174;
+__arg0 = _35cc1321;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35cc173 = makeNative(9, _35clofun1990, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg1862 = primIsCons(closureRef(co, 0));
-if (True == _35reg1862) {
-Obj _35reg1863 = primCar(closureRef(co, 0));
-Obj _35reg1864 = primIsCons(_35reg1863);
-if (True == _35reg1864) {
-Obj _35reg1865 = primCar(closureRef(co, 0));
-Obj _35reg1866 = primCar(_35reg1865);
-Obj _35reg1867 = primEQ(intern(":declare"), _35reg1866);
-if (True == _35reg1867) {
-Obj _35reg1868 = primCar(closureRef(co, 0));
-Obj _35reg1869 = primCdr(_35reg1868);
-Obj exp = _35reg1869;
-Obj _35reg1870 = primCdr(closureRef(co, 0));
-Obj more = _35reg1870;
+Obj _35cc1320 = makeNative(9, _35clofun3133, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35reg3009 = primIsCons(closureRef(co, 0));
+if (True == _35reg3009) {
+Obj _35reg3010 = primCar(closureRef(co, 0));
+Obj _35reg3011 = primIsCons(_35reg3010);
+if (True == _35reg3011) {
+Obj _35reg3012 = primCar(closureRef(co, 0));
+Obj _35reg3013 = primCar(_35reg3012);
+Obj _35reg3014 = primEQ(intern(":declare"), _35reg3013);
+if (True == _35reg3014) {
+Obj _35reg3015 = primCar(closureRef(co, 0));
+Obj _35reg3016 = primCdr(_35reg3015);
+Obj exp = _35reg3016;
+Obj _35reg3017 = primCdr(closureRef(co, 0));
+Obj more = _35reg3017;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj _35reg1871 = primCons(intern("declare"), exp);
-Obj _35reg1872 = primCons(_35reg1871, type);
+Obj _35reg3018 = primCons(intern("declare"), exp);
+Obj _35reg3019 = primCons(_35reg3018, type);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
 __arg1 = more;
-__arg2 = _35reg1872;
+__arg2 = _35reg3019;
 __arg3 = code;
 co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc173;
+__arg0 = _35cc1320;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc173;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc173;
+__arg0 = _35cc1320;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1320;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35cc172 = makeNative(10, _35clofun1990, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg1873 = primIsCons(closureRef(co, 0));
-if (True == _35reg1873) {
-Obj _35reg1874 = primCar(closureRef(co, 0));
-Obj _35reg1875 = primIsCons(_35reg1874);
-if (True == _35reg1875) {
-Obj _35reg1876 = primCar(closureRef(co, 0));
-Obj _35reg1877 = primCar(_35reg1876);
-Obj _35reg1878 = primEQ(intern(":type"), _35reg1877);
-if (True == _35reg1878) {
-Obj _35reg1879 = primCar(closureRef(co, 0));
-Obj _35reg1880 = primCdr(_35reg1879);
-Obj exp = _35reg1880;
-Obj _35reg1881 = primCdr(closureRef(co, 0));
-Obj more = _35reg1881;
+Obj _35cc1319 = makeNative(10, _35clofun3133, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35reg3020 = primIsCons(closureRef(co, 0));
+if (True == _35reg3020) {
+Obj _35reg3021 = primCar(closureRef(co, 0));
+Obj _35reg3022 = primIsCons(_35reg3021);
+if (True == _35reg3022) {
+Obj _35reg3023 = primCar(closureRef(co, 0));
+Obj _35reg3024 = primCar(_35reg3023);
+Obj _35reg3025 = primEQ(intern(":type"), _35reg3024);
+if (True == _35reg3025) {
+Obj _35reg3026 = primCar(closureRef(co, 0));
+Obj _35reg3027 = primCdr(_35reg3026);
+Obj exp = _35reg3027;
+Obj _35reg3028 = primCdr(closureRef(co, 0));
+Obj more = _35reg3028;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj _35reg1882 = primCons(intern("begin"), exp);
-Obj _35reg1883 = primCons(_35reg1882, type);
+Obj _35reg3029 = primCons(intern("begin"), exp);
+Obj _35reg3030 = primCons(_35reg3029, type);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
 __arg1 = more;
-__arg2 = _35reg1883;
+__arg2 = _35reg3030;
 __arg3 = code;
 co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc172;
+__arg0 = _35cc1319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc172;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc172;
+__arg0 = _35cc1319;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1319;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj _35val1886 = __arg1;
+Obj _35val3033 = __arg1;
 Obj k= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val1885= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35val3032= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 3;
 __arg0 = k;
-__arg1 = _35val1885;
-__arg2 = _35val1886;
+__arg1 = _35val3032;
+__arg2 = _35val3033;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val1885 = __arg1;
+Obj _35val3032 = __arg1;
 Obj code= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj k= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun1990, 2, k, _35val1885);
+pushCont(co, 12, _35clofun3133, 2, k, _35val3032);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = code;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35p167 = __arg1;
-Obj _35p168 = __arg2;
-Obj _35p169 = __arg3;
-Obj _35p170 = co->args[4];
-Obj _35cc171 = makeNative(11, _35clofun1990, 0, 4, _35p167, _35p168, _35p169, _35p170);
-Obj _35reg1884 = primEQ(Nil, _35p167);
-if (True == _35reg1884) {
-Obj type = _35p168;
-Obj code = _35p169;
-Obj k = _35p170;
-pushCont(co, 13, _35clofun1990, 2, code, k);
+Obj _35p1314 = __arg1;
+Obj _35p1315 = __arg2;
+Obj _35p1316 = __arg3;
+Obj _35p1317 = co->args[4];
+Obj _35cc1318 = makeNative(11, _35clofun3133, 0, 4, _35p1314, _35p1315, _35p1316, _35p1317);
+Obj _35reg3031 = primEQ(Nil, _35p1314);
+if (True == _35reg3031) {
+Obj type = _35p1315;
+Obj code = _35p1316;
+Obj k = _35p1317;
+pushCont(co, 13, _35clofun3133, 2, code, k);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = type;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc171;
+__arg0 = _35cc1318;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label15:
 {
-Obj _35val1890 = __arg1;
+Obj _35val3037 = __arg1;
 Obj sexp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg1 = sexp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1990) { goto fail; }
+if (co->ctx.pc.func != _35clofun3133) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label16:
 {
-Obj _35val1889 = __arg1;
-Obj sexp = _35val1889;
-pushCont(co, 15, _35clofun1990, 1, sexp);
+Obj _35val3036 = __arg1;
+Obj sexp = _35val3036;
+pushCont(co, 15, _35clofun3133, 1, sexp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
 Obj file_45path = __arg1;
-pushCont(co, 16, _35clofun1990, 0);
+pushCont(co, 16, _35clofun3133, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#read-file-as-sexp"));
 __arg1 = file_45path;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1896 = __arg1;
+Obj _35val3043 = __arg1;
 Obj stream= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io#close-output-file"));
@@ -1498,16 +1454,16 @@ __arg1 = stream;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1895 = __arg1;
+Obj _35val3042 = __arg1;
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stream = _35val1895;
-pushCont(co, 18, _35clofun1990, 1, stream);
+Obj stream = _35val3042;
+pushCont(co, 18, _35clofun3133, 1, stream);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#generate-c"));
 __arg1 = stream;
@@ -1515,23 +1471,23 @@ __arg2 = bc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1894 = __arg1;
+Obj _35val3041 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc = _35val1894;
-pushCont(co, 19, _35clofun1990, 1, bc);
+Obj bc = _35val3041;
+pushCont(co, 19, _35clofun3133, 1, bc);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io#open-output-file"));
 __arg1 = to;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3133) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1544,7 +1500,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1989(struct Cora* co){
+void _35clofun3132(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -1557,27 +1513,27 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1799 = __arg1;
+Obj _35val2946 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 20, _35clofun1988, 1, to);
+pushCont(co, 20, _35clofun3131, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(13, _35clofun1988, 1, 1, to);
+__arg1 = makeNative(13, _35clofun3131, 1, 1, to);
 __arg2 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val1798 = __arg1;
+Obj _35val2945 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun1989, 2, group, to);
+pushCont(co, 0, _35clofun3132, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1585,16 +1541,16 @@ __arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1797 = __arg1;
+Obj _35val2944 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun1989, 2, group, to);
+pushCont(co, 1, _35clofun3132, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1602,50 +1558,50 @@ __arg2 = makeCString("};\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val1796 = __arg1;
+Obj _35val2943 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun1989, 2, group, to);
+pushCont(co, 2, _35clofun3132, 2, group, to);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#generate-jumptable"));
 __arg1 = to;
 __arg2 = makeNumber(0);
-__arg3 = _35val1796;
+__arg3 = _35val2943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val1795 = __arg1;
+Obj _35val2942 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 3, _35clofun1989, 2, group, to);
+pushCont(co, 3, _35clofun3132, 2, group, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1794 = __arg1;
+Obj _35val2941 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun1989, 2, group, to);
+pushCont(co, 4, _35clofun3132, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1653,16 +1609,16 @@ __arg2 = makeCString("static void* jumpTable[] = {");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val1793 = __arg1;
+Obj _35val2940 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun1989, 2, group, to);
+pushCont(co, 5, _35clofun3132, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1670,16 +1626,16 @@ __arg2 = makeCString("Obj __arg3 = co->args[3];\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val1792 = __arg1;
+Obj _35val2939 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 6, _35clofun1989, 2, group, to);
+pushCont(co, 6, _35clofun3132, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1687,16 +1643,16 @@ __arg2 = makeCString("Obj __arg2 = co->args[2];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val1791 = __arg1;
+Obj _35val2938 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun1989, 2, group, to);
+pushCont(co, 7, _35clofun3132, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1704,16 +1660,16 @@ __arg2 = makeCString("Obj __arg1 = co->args[1];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val1790 = __arg1;
+Obj _35val2937 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun1989, 2, group, to);
+pushCont(co, 8, _35clofun3132, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1721,16 +1677,16 @@ __arg2 = makeCString("Obj __arg0 = co->args[0];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val1789 = __arg1;
+Obj _35val2936 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun1989, 2, group, to);
+pushCont(co, 9, _35clofun3132, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1738,16 +1694,16 @@ __arg2 = makeCString("int __nargs = co->nargs;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val1788 = __arg1;
+Obj _35val2935 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun1989, 2, group, to);
+pushCont(co, 10, _35clofun3132, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1755,24 +1711,24 @@ __arg2 = makeCString("{\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val1787 = __arg1;
+Obj _35val2934 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun1989, 2, group, to);
+pushCont(co, 11, _35clofun3132, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#code-gen-func-declare"));
 __arg1 = to;
-__arg2 = _35val1787;
+__arg2 = _35val2934;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1780,20 +1736,20 @@ label13:
 {
 Obj to = __arg1;
 Obj group = __arg2;
-pushCont(co, 12, _35clofun1989, 2, group, to);
+pushCont(co, 12, _35clofun3132, 2, group, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val1811 = __arg1;
+Obj _35val2958 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = closureRef(co, 0);
@@ -1801,36 +1757,36 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val1810 = __arg1;
-pushCont(co, 14, _35clofun1989, 0);
+Obj _35val2957 = __arg1;
+pushCont(co, 14, _35clofun3132, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#code-gen-func-declare"));
 __arg1 = closureRef(co, 0);
-__arg2 = _35val1810;
+__arg2 = _35val2957;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
 Obj group = __arg1;
-pushCont(co, 15, _35clofun1989, 0);
+pushCont(co, 15, _35clofun3132, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1844,32 +1800,32 @@ __arg2 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1813 = __arg1;
+Obj _35val2960 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(17, _35clofun1989, 1, 1, to);
+__arg1 = makeNative(17, _35clofun3132, 1, 1, to);
 __arg2 = bc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1812 = __arg1;
+Obj _35val2959 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 18, _35clofun1989, 2, to, bc);
+pushCont(co, 18, _35clofun3132, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1877,24 +1833,24 @@ __arg2 = makeCString("\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1809 = __arg1;
+Obj _35val2956 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 19, _35clofun1989, 2, to, bc);
+pushCont(co, 19, _35clofun3132, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(16, _35clofun1989, 1, 1, to);
+__arg1 = makeNative(16, _35clofun3132, 1, 1, to);
 __arg2 = bc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3132) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1907,7 +1863,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1988(struct Cora* co){
+void _35clofun3131(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -1920,70 +1876,70 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1772 = __arg1;
+Obj _35val2919 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda-pass"));
-__arg1 = _35val1772;
+__arg1 = _35val2919;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val1771 = __arg1;
-pushCont(co, 0, _35clofun1988, 0);
+Obj _35val2918 = __arg1;
+pushCont(co, 0, _35clofun3131, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack-pass"));
-__arg1 = _35val1771;
+__arg1 = _35val2918;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1770 = __arg1;
-pushCont(co, 1, _35clofun1988, 0);
+Obj _35val2917 = __arg1;
+pushCont(co, 1, _35clofun3131, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#tailify-pass"));
-__arg1 = _35val1770;
+__arg1 = _35val2917;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val1769 = __arg1;
-pushCont(co, 2, _35clofun1988, 0);
+Obj _35val2916 = __arg1;
+pushCont(co, 2, _35clofun3131, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert-pass"));
-__arg1 = _35val1769;
+__arg1 = _35val2916;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
 Obj exp = __arg1;
-pushCont(co, 3, _35clofun1988, 0);
+pushCont(co, 3, _35clofun3131, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#parse-pass"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1995,13 +1951,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val1777 = __arg1;
+Obj _35val2924 = __arg1;
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 3;
@@ -2011,67 +1967,67 @@ __arg2 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35cc161 = makeNative(5, _35clofun1988, 0, 0);
+Obj _35cc1308 = makeNative(5, _35clofun3131, 0, 0);
 Obj fn = closureRef(co, 0);
-Obj _35reg1774 = primIsCons(closureRef(co, 1));
-if (True == _35reg1774) {
-Obj _35reg1775 = primCar(closureRef(co, 1));
-Obj x = _35reg1775;
-Obj _35reg1776 = primCdr(closureRef(co, 1));
-Obj y = _35reg1776;
-pushCont(co, 6, _35clofun1988, 2, fn, y);
+Obj _35reg2921 = primIsCons(closureRef(co, 1));
+if (True == _35reg2921) {
+Obj _35reg2922 = primCar(closureRef(co, 1));
+Obj x = _35reg2922;
+Obj _35reg2923 = primCdr(closureRef(co, 1));
+Obj y = _35reg2923;
+pushCont(co, 6, _35clofun3131, 2, fn, y);
 __nargs = 2;
 __arg0 = fn;
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc161;
+__arg0 = _35cc1308;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35p158 = __arg1;
-Obj _35p159 = __arg2;
-Obj _35cc160 = makeNative(7, _35clofun1988, 0, 2, _35p158, _35p159);
-Obj fn = _35p158;
-Obj _35reg1778 = primEQ(Nil, _35p159);
-if (True == _35reg1778) {
+Obj _35p1305 = __arg1;
+Obj _35p1306 = __arg2;
+Obj _35cc1307 = makeNative(7, _35clofun3131, 0, 2, _35p1305, _35p1306);
+Obj fn = _35p1305;
+Obj _35reg2925 = primEQ(Nil, _35p1306);
+if (True == _35reg2925) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1988) { goto fail; }
+if (co->ctx.pc.func != _35clofun3131) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc160;
+__arg0 = _35cc1307;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label9:
 {
-Obj _35val1781 = __arg1;
+Obj _35val2928 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj n= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -2082,36 +2038,36 @@ __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val1784 = __arg1;
+Obj _35val2931 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj n= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1785 = primAdd(i, makeNumber(1));
+Obj _35reg2932 = primAdd(i, makeNumber(1));
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#generate-jumptable"));
 __arg1 = to;
-__arg2 = _35reg1785;
+__arg2 = _35reg2932;
 __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val1783 = __arg1;
+Obj _35val2930 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj n= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 10, _35clofun1988, 3, i, to, n);
+pushCont(co, 10, _35clofun3131, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = to;
@@ -2119,7 +2075,7 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2128,9 +2084,9 @@ label12:
 Obj to = __arg1;
 Obj i = __arg2;
 Obj n = __arg3;
-Obj _35reg1780 = primEQ(i, makeNumber(0));
-if (True == _35reg1780) {
-pushCont(co, 9, _35clofun1988, 2, to, n);
+Obj _35reg2927 = primEQ(i, makeNumber(0));
+if (True == _35reg2927) {
+pushCont(co, 9, _35clofun3131, 2, to, n);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2138,12 +2094,12 @@ __arg2 = makeCString("&&label0");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1782 = primLT(i, n);
-if (True == _35reg1782) {
-pushCont(co, 11, _35clofun1988, 3, i, to, n);
+Obj _35reg2929 = primLT(i, n);
+if (True == _35reg2929) {
+pushCont(co, 11, _35clofun3131, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2151,13 +2107,13 @@ __arg2 = makeCString(", &&label");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1988) { goto fail; }
+if (co->ctx.pc.func != _35clofun3131) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -2173,13 +2129,13 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val1806 = __arg1;
+Obj _35val2953 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -2188,15 +2144,15 @@ __arg2 = makeCString("\n}\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val1805 = __arg1;
+Obj _35val2952 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 14, _35clofun1988, 1, to);
+pushCont(co, 14, _35clofun3131, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2204,15 +2160,15 @@ __arg2 = makeCString("co->args[3] = __arg3;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val1804 = __arg1;
+Obj _35val2951 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 15, _35clofun1988, 1, to);
+pushCont(co, 15, _35clofun3131, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2220,15 +2176,15 @@ __arg2 = makeCString("co->args[2] = __arg2;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val1803 = __arg1;
+Obj _35val2950 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 16, _35clofun1988, 1, to);
+pushCont(co, 16, _35clofun3131, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2236,15 +2192,15 @@ __arg2 = makeCString("co->args[1] = __arg1;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1802 = __arg1;
+Obj _35val2949 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 17, _35clofun1988, 1, to);
+pushCont(co, 17, _35clofun3131, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2252,15 +2208,15 @@ __arg2 = makeCString("co->args[0] = __arg0;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1801 = __arg1;
+Obj _35val2948 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 18, _35clofun1988, 1, to);
+pushCont(co, 18, _35clofun3131, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2268,15 +2224,15 @@ __arg2 = makeCString("co->nargs = __nargs;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1800 = __arg1;
+Obj _35val2947 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 19, _35clofun1988, 1, to);
+pushCont(co, 19, _35clofun3131, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2284,7 +2240,7 @@ __arg2 = makeCString("fail:\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3131) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2297,7 +2253,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1987(struct Cora* co){
+void _35clofun3130(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -2320,7 +2276,7 @@ co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2334,7 +2290,7 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2348,7 +2304,7 @@ __arg2 = globalRef(intern("cora/lib/toc#id"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2362,60 +2318,60 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val1736 = __arg1;
+Obj _35val2883 = __arg1;
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj res = _35val1736;
-Obj _35reg1737 = primCons(intern("entry"), makeNumber(0));
-Obj _35reg1738 = primCons(e1, Nil);
-Obj _35reg1739 = primCons(Nil, _35reg1738);
-Obj _35reg1740 = primCons(Nil, _35reg1739);
-Obj _35reg1741 = primCons(intern("lambda"), _35reg1740);
-Obj _35reg1742 = primCons(_35reg1741, Nil);
-Obj _35reg1743 = primCons(_35reg1737, _35reg1742);
-Obj _35reg1744 = primCons(_35reg1743, Nil);
-Obj _35reg1745 = primCons(_35reg1744, res);
+Obj res = _35val2883;
+Obj _35reg2884 = primCons(intern("entry"), makeNumber(0));
+Obj _35reg2885 = primCons(e1, Nil);
+Obj _35reg2886 = primCons(Nil, _35reg2885);
+Obj _35reg2887 = primCons(Nil, _35reg2886);
+Obj _35reg2888 = primCons(intern("lambda"), _35reg2887);
+Obj _35reg2889 = primCons(_35reg2888, Nil);
+Obj _35reg2890 = primCons(_35reg2884, _35reg2889);
+Obj _35reg2891 = primCons(_35reg2890, Nil);
+Obj _35reg2892 = primCons(_35reg2891, res);
 __nargs = 2;
-__arg1 = _35reg1745;
+__arg1 = _35reg2892;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1987) { goto fail; }
+if (co->ctx.pc.func != _35clofun3130) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label5:
 {
-Obj _35val1747 = __arg1;
-Obj _35val1746= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2894 = __arg1;
+Obj _35val2893= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1748 = primCons(_35val1746, _35val1747);
-Obj res = _35reg1748;
-Obj _35reg1749 = primCons(intern("entry"), makeNumber(0));
-Obj _35reg1750 = primCons(e1, Nil);
-Obj _35reg1751 = primCons(Nil, _35reg1750);
-Obj _35reg1752 = primCons(Nil, _35reg1751);
-Obj _35reg1753 = primCons(intern("lambda"), _35reg1752);
-Obj _35reg1754 = primCons(_35reg1753, Nil);
-Obj _35reg1755 = primCons(_35reg1749, _35reg1754);
-Obj _35reg1756 = primCons(_35reg1755, Nil);
-Obj _35reg1757 = primCons(_35reg1756, res);
+Obj _35reg2895 = primCons(_35val2893, _35val2894);
+Obj res = _35reg2895;
+Obj _35reg2896 = primCons(intern("entry"), makeNumber(0));
+Obj _35reg2897 = primCons(e1, Nil);
+Obj _35reg2898 = primCons(Nil, _35reg2897);
+Obj _35reg2899 = primCons(Nil, _35reg2898);
+Obj _35reg2900 = primCons(intern("lambda"), _35reg2899);
+Obj _35reg2901 = primCons(_35reg2900, Nil);
+Obj _35reg2902 = primCons(_35reg2896, _35reg2901);
+Obj _35reg2903 = primCons(_35reg2902, Nil);
+Obj _35reg2904 = primCons(_35reg2903, res);
 __nargs = 2;
-__arg1 = _35reg1757;
+__arg1 = _35reg2904;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1987) { goto fail; }
+if (co->ctx.pc.func != _35clofun3130) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label6:
 {
-Obj _35val1746 = __arg1;
+Obj _35val2893 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun1987, 2, _35val1746, e1);
+pushCont(co, 5, _35clofun3130, 2, _35val2893, e1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -2423,18 +2379,18 @@ __arg2 = makeNumber(2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val1735 = __arg1;
+Obj _35val2882 = __arg1;
 Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1735) {
-pushCont(co, 4, _35clofun1987, 1, e1);
+if (True == _35val2882) {
+pushCont(co, 4, _35clofun3130, 1, e1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -2442,44 +2398,44 @@ __arg2 = makeNumber(2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 6, _35clofun1987, 2, v, e1);
+pushCont(co, 6, _35clofun3130, 2, v, e1);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35val1734 = __arg1;
+Obj _35val2881 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cur = _35val1734;
-pushCont(co, 7, _35clofun1987, 3, cur, v, e1);
+Obj cur = _35val2881;
+pushCont(co, 7, _35clofun3130, 3, cur, v, e1);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val1733 = __arg1;
+Obj _35val2880 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj e1 = _35val1733;
-pushCont(co, 8, _35clofun1987, 2, v, e1);
+Obj e1 = _35val2880;
+pushCont(co, 8, _35clofun3130, 2, v, e1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -2487,16 +2443,16 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val1732 = __arg1;
+Obj _35val2879 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun1987, 1, v);
+pushCont(co, 9, _35clofun3130, 1, v);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
 __arg1 = v;
@@ -2504,16 +2460,16 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val1731 = __arg1;
+Obj _35val2878 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun1987, 2, exp, v);
+pushCont(co, 10, _35clofun3130, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -2522,16 +2478,16 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val1730 = __arg1;
+Obj _35val2877 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun1987, 2, exp, v);
+pushCont(co, 11, _35clofun3130, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -2540,16 +2496,16 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val1729 = __arg1;
+Obj _35val2876 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v = _35val1729;
-pushCont(co, 12, _35clofun1987, 2, exp, v);
+Obj v = _35val2876;
+pushCont(co, 12, _35clofun3130, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -2558,21 +2514,21 @@ __arg3 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
 Obj exp = __arg1;
-pushCont(co, 13, _35clofun1987, 1, exp);
+pushCont(co, 13, _35clofun3130, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#vector"));
 __arg1 = makeNumber(3);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2584,71 +2540,71 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35cc157 = makeNative(15, _35clofun1987, 0, 0);
+Obj _35cc1304 = makeNative(15, _35clofun3130, 0, 0);
 Obj obj = closureRef(co, 0);
-Obj _35reg1759 = primIsCons(closureRef(co, 1));
-if (True == _35reg1759) {
-Obj _35reg1760 = primCar(closureRef(co, 1));
-Obj hd = _35reg1760;
-Obj _35reg1761 = primCdr(closureRef(co, 1));
-Obj more = _35reg1761;
-Obj _35reg1762 = primCons(obj, Nil);
-Obj _35reg1763 = primCons(hd, _35reg1762);
+Obj _35reg2906 = primIsCons(closureRef(co, 1));
+if (True == _35reg2906) {
+Obj _35reg2907 = primCar(closureRef(co, 1));
+Obj hd = _35reg2907;
+Obj _35reg2908 = primCdr(closureRef(co, 1));
+Obj more = _35reg2908;
+Obj _35reg2909 = primCons(obj, Nil);
+Obj _35reg2910 = primCons(hd, _35reg2909);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#rewrite-->macro"));
-__arg1 = _35reg1763;
+__arg1 = _35reg2910;
 __arg2 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc157;
+__arg0 = _35cc1304;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label17:
 {
-Obj _35p154 = __arg1;
-Obj _35p155 = __arg2;
-Obj _35cc156 = makeNative(16, _35clofun1987, 0, 2, _35p154, _35p155);
-Obj obj = _35p154;
-Obj _35reg1764 = primEQ(Nil, _35p155);
-if (True == _35reg1764) {
+Obj _35p1301 = __arg1;
+Obj _35p1302 = __arg2;
+Obj _35cc1303 = makeNative(16, _35clofun3130, 0, 2, _35p1301, _35p1302);
+Obj obj = _35p1301;
+Obj _35reg2911 = primEQ(Nil, _35p1302);
+if (True == _35reg2911) {
 __nargs = 2;
 __arg1 = obj;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1987) { goto fail; }
+if (co->ctx.pc.func != _35clofun3130) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc156;
+__arg0 = _35cc1303;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label18:
 {
-Obj _35val1767 = __arg1;
+Obj _35val2914 = __arg1;
 Obj obj= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fns = _35val1767;
+Obj fns = _35val2914;
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#rewrite-->macro"));
 __arg1 = obj;
@@ -2656,37 +2612,37 @@ __arg2 = fns;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1766 = __arg1;
+Obj _35val2913 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj obj = _35val1766;
-pushCont(co, 18, _35clofun1987, 1, obj);
+Obj obj = _35val2913;
+pushCont(co, 18, _35clofun3130, 1, obj);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
 Obj exp = __arg1;
-pushCont(co, 19, _35clofun1987, 1, exp);
+pushCont(co, 19, _35clofun3130, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3130) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2699,7 +2655,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1986(struct Cora* co){
+void _35clofun3129(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -2715,7 +2671,7 @@ label0:
 Obj w = __arg1;
 Obj i = __arg2;
 Obj var = __arg3;
-pushCont(co, 20, _35clofun1985, 3, var, i, w);
+pushCont(co, 20, _35clofun3128, 3, var, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -2723,13 +2679,13 @@ __arg2 = makeCString("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val1654 = __arg1;
+Obj _35val2801 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -2738,16 +2694,16 @@ __arg2 = makeCString("];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1653 = __arg1;
+Obj _35val2800 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun1986, 1, w);
+pushCont(co, 1, _35clofun3129, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -2755,16 +2711,16 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val1652 = __arg1;
+Obj _35val2799 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun1986, 2, i, w);
+pushCont(co, 2, _35clofun3129, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -2772,17 +2728,17 @@ __arg2 = makeCString("= co->ctx.stk.stack[co->ctx.stk.base + ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val1651 = __arg1;
+Obj _35val2798 = __arg1;
 Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 3, _35clofun1986, 2, i, w);
+pushCont(co, 3, _35clofun3129, 2, i, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = intern("ignore");
@@ -2792,7 +2748,7 @@ co->args[4] = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2801,7 +2757,7 @@ label5:
 Obj w = __arg1;
 Obj i = __arg2;
 Obj var = __arg3;
-pushCont(co, 4, _35clofun1986, 3, var, i, w);
+pushCont(co, 4, _35clofun3129, 3, var, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -2809,7 +2765,7 @@ __arg2 = makeCString("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2821,44 +2777,44 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val1659 = __arg1;
+Obj _35val2806 = __arg1;
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1660 = primAdd(idx, makeNumber(1));
+Obj _35reg2807 = primAdd(idx, makeNumber(1));
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
 __arg1 = fn;
 __arg2 = w;
-__arg3 = _35reg1660;
+__arg3 = _35reg2807;
 co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35cc149 = makeNative(6, _35clofun1986, 0, 0);
+Obj _35cc1296 = makeNative(6, _35clofun3129, 0, 0);
 Obj fn = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj idx = closureRef(co, 2);
-Obj _35reg1656 = primIsCons(closureRef(co, 3));
-if (True == _35reg1656) {
-Obj _35reg1657 = primCar(closureRef(co, 3));
-Obj a = _35reg1657;
-Obj _35reg1658 = primCdr(closureRef(co, 3));
-Obj b = _35reg1658;
-pushCont(co, 7, _35clofun1986, 4, idx, fn, w, b);
+Obj _35reg2803 = primIsCons(closureRef(co, 3));
+if (True == _35reg2803) {
+Obj _35reg2804 = primCar(closureRef(co, 3));
+Obj a = _35reg2804;
+Obj _35reg2805 = primCdr(closureRef(co, 3));
+Obj b = _35reg2805;
+pushCont(co, 7, _35clofun3129, 4, idx, fn, w, b);
 __nargs = 4;
 __arg0 = fn;
 __arg1 = w;
@@ -2867,43 +2823,43 @@ __arg3 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc149;
+__arg0 = _35cc1296;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label9:
 {
-Obj _35p144 = __arg1;
-Obj _35p145 = __arg2;
-Obj _35p146 = __arg3;
-Obj _35p147 = co->args[4];
-Obj _35cc148 = makeNative(8, _35clofun1986, 0, 4, _35p144, _35p145, _35p146, _35p147);
-Obj fn = _35p144;
-Obj w = _35p145;
-Obj idx = _35p146;
-Obj _35reg1661 = primEQ(Nil, _35p147);
-if (True == _35reg1661) {
+Obj _35p1291 = __arg1;
+Obj _35p1292 = __arg2;
+Obj _35p1293 = __arg3;
+Obj _35p1294 = co->args[4];
+Obj _35cc1295 = makeNative(8, _35clofun3129, 0, 4, _35p1291, _35p1292, _35p1293, _35p1294);
+Obj fn = _35p1291;
+Obj w = _35p1292;
+Obj idx = _35p1293;
+Obj _35reg2808 = primEQ(Nil, _35p1294);
+if (True == _35reg2808) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1986) { goto fail; }
+if (co->ctx.pc.func != _35clofun3129) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc148;
+__arg0 = _35cc1295;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2916,57 +2872,57 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val1664 = __arg1;
+Obj _35val2811 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io#display"));
 __arg1 = makeCString("\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val1663 = __arg1;
+Obj _35val2810 = __arg1;
 Obj other= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 11, _35clofun1986, 0);
+pushCont(co, 11, _35clofun3129, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io#display"));
 __arg1 = other;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35cc153 = makeNative(10, _35clofun1986, 0, 0);
+Obj _35cc1300 = makeNative(10, _35clofun3129, 0, 0);
 Obj w = closureRef(co, 0);
 Obj other = closureRef(co, 1);
-pushCont(co, 12, _35clofun1986, 1, other);
+pushCont(co, 12, _35clofun3129, 1, other);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io#display"));
 __arg1 = makeCString("wrong format of toplevel\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val1723 = __arg1;
+Obj _35val2870 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -2975,41 +2931,41 @@ __arg2 = makeCString("}\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val1721 = __arg1;
+Obj _35val2868 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1722 = primCar(label);
-pushCont(co, 14, _35clofun1986, 1, w);
+Obj _35reg2869 = primCar(label);
+pushCont(co, 14, _35clofun3129, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = _35reg1722;
+__arg1 = _35reg2869;
 __arg2 = params;
 __arg3 = w;
 co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val1720 = __arg1;
+Obj _35val2867 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 15, _35clofun1986, 4, label, params, body, w);
+pushCont(co, 15, _35clofun3129, 4, label, params, body, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
 __arg1 = globalRef(intern("cora/lib/toc#local-from-cont"));
@@ -3019,19 +2975,19 @@ co->args[4] = actives;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val1719 = __arg1;
+Obj _35val2866 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 16, _35clofun1986, 5, actives, label, params, body, w);
+pushCont(co, 16, _35clofun3129, 5, actives, label, params, body, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
 __arg1 = globalRef(intern("cora/lib/toc#local-from-params"));
@@ -3041,19 +2997,19 @@ co->args[4] = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1718 = __arg1;
+Obj _35val2865 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 17, _35clofun1986, 5, actives, label, params, body, w);
+pushCont(co, 17, _35clofun3129, 5, actives, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3061,102 +3017,102 @@ __arg2 = makeCString(":\n{\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1716 = __arg1;
+Obj _35val2863 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1717 = primCdr(label);
-pushCont(co, 18, _35clofun1986, 5, actives, label, params, body, w);
+Obj _35reg2864 = primCdr(label);
+pushCont(co, 18, _35clofun3129, 5, actives, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = _35reg1717;
+__arg2 = _35reg2864;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35p150 = __arg1;
-Obj _35p151 = __arg2;
-Obj _35cc152 = makeNative(13, _35clofun1986, 0, 2, _35p150, _35p151);
-Obj w = _35p150;
-Obj _35reg1665 = primIsCons(_35p151);
-if (True == _35reg1665) {
-Obj _35reg1666 = primCar(_35p151);
-Obj label = _35reg1666;
-Obj _35reg1667 = primCdr(_35p151);
-Obj _35reg1668 = primIsCons(_35reg1667);
-if (True == _35reg1668) {
-Obj _35reg1669 = primCdr(_35p151);
-Obj _35reg1670 = primCar(_35reg1669);
-Obj _35reg1671 = primIsCons(_35reg1670);
-if (True == _35reg1671) {
-Obj _35reg1672 = primCdr(_35p151);
-Obj _35reg1673 = primCar(_35reg1672);
-Obj _35reg1674 = primCar(_35reg1673);
-Obj _35reg1675 = primEQ(intern("lambda"), _35reg1674);
-if (True == _35reg1675) {
-Obj _35reg1676 = primCdr(_35p151);
-Obj _35reg1677 = primCar(_35reg1676);
-Obj _35reg1678 = primCdr(_35reg1677);
-Obj _35reg1679 = primIsCons(_35reg1678);
-if (True == _35reg1679) {
-Obj _35reg1680 = primCdr(_35p151);
-Obj _35reg1681 = primCar(_35reg1680);
-Obj _35reg1682 = primCdr(_35reg1681);
-Obj _35reg1683 = primCar(_35reg1682);
-Obj params = _35reg1683;
-Obj _35reg1684 = primCdr(_35p151);
-Obj _35reg1685 = primCar(_35reg1684);
-Obj _35reg1686 = primCdr(_35reg1685);
-Obj _35reg1687 = primCdr(_35reg1686);
-Obj _35reg1688 = primIsCons(_35reg1687);
-if (True == _35reg1688) {
-Obj _35reg1689 = primCdr(_35p151);
-Obj _35reg1690 = primCar(_35reg1689);
-Obj _35reg1691 = primCdr(_35reg1690);
-Obj _35reg1692 = primCdr(_35reg1691);
-Obj _35reg1693 = primCar(_35reg1692);
-Obj actives = _35reg1693;
-Obj _35reg1694 = primCdr(_35p151);
-Obj _35reg1695 = primCar(_35reg1694);
-Obj _35reg1696 = primCdr(_35reg1695);
-Obj _35reg1697 = primCdr(_35reg1696);
-Obj _35reg1698 = primCdr(_35reg1697);
-Obj _35reg1699 = primIsCons(_35reg1698);
-if (True == _35reg1699) {
-Obj _35reg1700 = primCdr(_35p151);
-Obj _35reg1701 = primCar(_35reg1700);
-Obj _35reg1702 = primCdr(_35reg1701);
-Obj _35reg1703 = primCdr(_35reg1702);
-Obj _35reg1704 = primCdr(_35reg1703);
-Obj _35reg1705 = primCar(_35reg1704);
-Obj body = _35reg1705;
-Obj _35reg1706 = primCdr(_35p151);
-Obj _35reg1707 = primCar(_35reg1706);
-Obj _35reg1708 = primCdr(_35reg1707);
-Obj _35reg1709 = primCdr(_35reg1708);
-Obj _35reg1710 = primCdr(_35reg1709);
-Obj _35reg1711 = primCdr(_35reg1710);
-Obj _35reg1712 = primEQ(Nil, _35reg1711);
-if (True == _35reg1712) {
-Obj _35reg1713 = primCdr(_35p151);
-Obj _35reg1714 = primCdr(_35reg1713);
-Obj _35reg1715 = primEQ(Nil, _35reg1714);
-if (True == _35reg1715) {
-pushCont(co, 19, _35clofun1986, 5, actives, label, params, body, w);
+Obj _35p1297 = __arg1;
+Obj _35p1298 = __arg2;
+Obj _35cc1299 = makeNative(13, _35clofun3129, 0, 2, _35p1297, _35p1298);
+Obj w = _35p1297;
+Obj _35reg2812 = primIsCons(_35p1298);
+if (True == _35reg2812) {
+Obj _35reg2813 = primCar(_35p1298);
+Obj label = _35reg2813;
+Obj _35reg2814 = primCdr(_35p1298);
+Obj _35reg2815 = primIsCons(_35reg2814);
+if (True == _35reg2815) {
+Obj _35reg2816 = primCdr(_35p1298);
+Obj _35reg2817 = primCar(_35reg2816);
+Obj _35reg2818 = primIsCons(_35reg2817);
+if (True == _35reg2818) {
+Obj _35reg2819 = primCdr(_35p1298);
+Obj _35reg2820 = primCar(_35reg2819);
+Obj _35reg2821 = primCar(_35reg2820);
+Obj _35reg2822 = primEQ(intern("lambda"), _35reg2821);
+if (True == _35reg2822) {
+Obj _35reg2823 = primCdr(_35p1298);
+Obj _35reg2824 = primCar(_35reg2823);
+Obj _35reg2825 = primCdr(_35reg2824);
+Obj _35reg2826 = primIsCons(_35reg2825);
+if (True == _35reg2826) {
+Obj _35reg2827 = primCdr(_35p1298);
+Obj _35reg2828 = primCar(_35reg2827);
+Obj _35reg2829 = primCdr(_35reg2828);
+Obj _35reg2830 = primCar(_35reg2829);
+Obj params = _35reg2830;
+Obj _35reg2831 = primCdr(_35p1298);
+Obj _35reg2832 = primCar(_35reg2831);
+Obj _35reg2833 = primCdr(_35reg2832);
+Obj _35reg2834 = primCdr(_35reg2833);
+Obj _35reg2835 = primIsCons(_35reg2834);
+if (True == _35reg2835) {
+Obj _35reg2836 = primCdr(_35p1298);
+Obj _35reg2837 = primCar(_35reg2836);
+Obj _35reg2838 = primCdr(_35reg2837);
+Obj _35reg2839 = primCdr(_35reg2838);
+Obj _35reg2840 = primCar(_35reg2839);
+Obj actives = _35reg2840;
+Obj _35reg2841 = primCdr(_35p1298);
+Obj _35reg2842 = primCar(_35reg2841);
+Obj _35reg2843 = primCdr(_35reg2842);
+Obj _35reg2844 = primCdr(_35reg2843);
+Obj _35reg2845 = primCdr(_35reg2844);
+Obj _35reg2846 = primIsCons(_35reg2845);
+if (True == _35reg2846) {
+Obj _35reg2847 = primCdr(_35p1298);
+Obj _35reg2848 = primCar(_35reg2847);
+Obj _35reg2849 = primCdr(_35reg2848);
+Obj _35reg2850 = primCdr(_35reg2849);
+Obj _35reg2851 = primCdr(_35reg2850);
+Obj _35reg2852 = primCar(_35reg2851);
+Obj body = _35reg2852;
+Obj _35reg2853 = primCdr(_35p1298);
+Obj _35reg2854 = primCar(_35reg2853);
+Obj _35reg2855 = primCdr(_35reg2854);
+Obj _35reg2856 = primCdr(_35reg2855);
+Obj _35reg2857 = primCdr(_35reg2856);
+Obj _35reg2858 = primCdr(_35reg2857);
+Obj _35reg2859 = primEQ(Nil, _35reg2858);
+if (True == _35reg2859) {
+Obj _35reg2860 = primCdr(_35p1298);
+Obj _35reg2861 = primCdr(_35reg2860);
+Obj _35reg2862 = primEQ(Nil, _35reg2861);
+if (True == _35reg2862) {
+pushCont(co, 19, _35clofun3129, 5, actives, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3164,87 +3120,87 @@ __arg2 = makeCString("label");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc152;
+__arg0 = _35cc1299;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc152;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc152;
+__arg0 = _35cc1299;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc152;
+__arg0 = _35cc1299;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc152;
+__arg0 = _35cc1299;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc152;
+__arg0 = _35cc1299;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc152;
+__arg0 = _35cc1299;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc152;
+__arg0 = _35cc1299;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc152;
+__arg0 = _35cc1299;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1299;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3129) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3258,7 +3214,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1985(struct Cora* co){
+void _35clofun3128(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -3271,32 +3227,32 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1617 = __arg1;
+Obj _35val2764 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1618 = primCar(label);
-pushCont(co, 20, _35clofun1984, 3, self, stacks, w);
+Obj _35reg2765 = primCar(label);
+pushCont(co, 20, _35clofun3127, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
-__arg2 = _35reg1618;
+__arg2 = _35reg2765;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val1616 = __arg1;
+Obj _35val2763 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun1985, 4, label, self, stacks, w);
+pushCont(co, 0, _35clofun3128, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3304,53 +3260,53 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1614 = __arg1;
+Obj _35val2761 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1615 = primCdr(label);
-pushCont(co, 1, _35clofun1985, 4, label, self, stacks, w);
+Obj _35reg2762 = primCdr(label);
+pushCont(co, 1, _35clofun3128, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = _35reg1615;
+__arg2 = _35reg2762;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35p133 = __arg1;
-Obj _35p134 = __arg2;
-Obj _35p135 = __arg3;
-Obj _35cc136 = makeNative(12, _35clofun1984, 0, 0);
-Obj self = _35p133;
-Obj w = _35p134;
-Obj _35reg1605 = primIsCons(_35p135);
-if (True == _35reg1605) {
-Obj _35reg1606 = primCar(_35p135);
-Obj _35reg1607 = primEQ(intern("%continuation"), _35reg1606);
-if (True == _35reg1607) {
-Obj _35reg1608 = primCdr(_35p135);
-Obj _35reg1609 = primIsCons(_35reg1608);
-if (True == _35reg1609) {
-Obj _35reg1610 = primCdr(_35p135);
-Obj _35reg1611 = primCar(_35reg1610);
-Obj label = _35reg1611;
-Obj _35reg1612 = primCdr(_35p135);
-Obj _35reg1613 = primCdr(_35reg1612);
-Obj stacks = _35reg1613;
-pushCont(co, 2, _35clofun1985, 4, label, self, stacks, w);
+Obj _35p1280 = __arg1;
+Obj _35p1281 = __arg2;
+Obj _35p1282 = __arg3;
+Obj _35cc1283 = makeNative(12, _35clofun3127, 0, 0);
+Obj self = _35p1280;
+Obj w = _35p1281;
+Obj _35reg2752 = primIsCons(_35p1282);
+if (True == _35reg2752) {
+Obj _35reg2753 = primCar(_35p1282);
+Obj _35reg2754 = primEQ(intern("%continuation"), _35reg2753);
+if (True == _35reg2754) {
+Obj _35reg2755 = primCdr(_35p1282);
+Obj _35reg2756 = primIsCons(_35reg2755);
+if (True == _35reg2756) {
+Obj _35reg2757 = primCdr(_35p1282);
+Obj _35reg2758 = primCar(_35reg2757);
+Obj label = _35reg2758;
+Obj _35reg2759 = primCdr(_35p1282);
+Obj _35reg2760 = primCdr(_35reg2759);
+Obj stacks = _35reg2760;
+pushCont(co, 2, _35clofun3128, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3358,33 +3314,33 @@ __arg2 = makeCString("pushCont(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc136;
+__arg0 = _35cc1283;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc136;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc136;
+__arg0 = _35cc1283;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1283;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3397,13 +3353,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1634 = __arg1;
+Obj _35val2781 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -3419,21 +3375,21 @@ co->args[5] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val1632 = __arg1;
+Obj _35val2779 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1633 = primNot(_35val1632);
-if (True == _35reg1633) {
-pushCont(co, 5, _35clofun1985, 5, self, env, fn, w, b);
+Obj _35reg2780 = primNot(_35val2779);
+if (True == _35reg2780) {
+pushCont(co, 5, _35clofun3128, 5, self, env, fn, w, b);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3441,7 +3397,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
@@ -3455,44 +3411,44 @@ co->args[5] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35val1631 = __arg1;
+Obj _35val2778 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 6, _35clofun1985, 5, self, env, fn, w, b);
+pushCont(co, 6, _35clofun3128, 5, self, env, fn, w, b);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35cc143 = makeNative(4, _35clofun1985, 0, 0);
+Obj _35cc1290 = makeNative(4, _35clofun3128, 0, 0);
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj fn = closureRef(co, 2);
 Obj w = closureRef(co, 3);
-Obj _35reg1628 = primIsCons(closureRef(co, 4));
-if (True == _35reg1628) {
-Obj _35reg1629 = primCar(closureRef(co, 4));
-Obj a = _35reg1629;
-Obj _35reg1630 = primCdr(closureRef(co, 4));
-Obj b = _35reg1630;
-pushCont(co, 7, _35clofun1985, 5, self, env, fn, w, b);
+Obj _35reg2775 = primIsCons(closureRef(co, 4));
+if (True == _35reg2775) {
+Obj _35reg2776 = primCar(closureRef(co, 4));
+Obj a = _35reg2776;
+Obj _35reg2777 = primCdr(closureRef(co, 4));
+Obj b = _35reg2777;
+pushCont(co, 7, _35clofun3128, 5, self, env, fn, w, b);
 __nargs = 5;
 __arg0 = fn;
 __arg1 = self;
@@ -3502,45 +3458,45 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc143;
+__arg0 = _35cc1290;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label9:
 {
-Obj _35p137 = __arg1;
-Obj _35p138 = __arg2;
-Obj _35p139 = __arg3;
-Obj _35p140 = co->args[4];
-Obj _35p141 = co->args[5];
-Obj _35cc142 = makeNative(8, _35clofun1985, 0, 5, _35p137, _35p138, _35p139, _35p140, _35p141);
-Obj self = _35p137;
-Obj env = _35p138;
-Obj fn = _35p139;
-Obj w = _35p140;
-Obj _35reg1635 = primEQ(Nil, _35p141);
-if (True == _35reg1635) {
+Obj _35p1284 = __arg1;
+Obj _35p1285 = __arg2;
+Obj _35p1286 = __arg3;
+Obj _35p1287 = co->args[4];
+Obj _35p1288 = co->args[5];
+Obj _35cc1289 = makeNative(8, _35clofun3128, 0, 5, _35p1284, _35p1285, _35p1286, _35p1287, _35p1288);
+Obj self = _35p1284;
+Obj env = _35p1285;
+Obj fn = _35p1286;
+Obj w = _35p1287;
+Obj _35reg2782 = primEQ(Nil, _35p1288);
+if (True == _35reg2782) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1985) { goto fail; }
+if (co->ctx.pc.func != _35clofun3128) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc142;
+__arg0 = _35cc1289;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3561,13 +3517,13 @@ co->args[5] = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val1641 = __arg1;
+Obj _35val2788 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -3576,15 +3532,15 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val1640 = __arg1;
+Obj _35val2787 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 11, _35clofun1985, 1, w);
+pushCont(co, 11, _35clofun3128, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3592,25 +3548,25 @@ __arg2 = makeCString("(struct Cora* co");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val1638 = __arg1;
+Obj _35val2785 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1639 = primCar(label);
-pushCont(co, 12, _35clofun1985, 1, w);
+Obj _35reg2786 = primCar(label);
+pushCont(co, 12, _35clofun3128, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
-__arg2 = _35reg1639;
+__arg2 = _35reg2786;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3618,7 +3574,7 @@ label14:
 {
 Obj w = __arg1;
 Obj label = __arg2;
-pushCont(co, 13, _35clofun1985, 2, label, w);
+pushCont(co, 13, _35clofun3128, 2, label, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3626,13 +3582,13 @@ __arg2 = makeCString("void ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val1647 = __arg1;
+Obj _35val2794 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -3641,16 +3597,16 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val1646 = __arg1;
+Obj _35val2793 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 15, _35clofun1985, 1, w);
+pushCont(co, 15, _35clofun3128, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -3658,13 +3614,13 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val1649 = __arg1;
+Obj _35val2796 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -3673,16 +3629,16 @@ __arg2 = makeCString("];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1648 = __arg1;
+Obj _35val2795 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 17, _35clofun1985, 1, w);
+pushCont(co, 17, _35clofun3128, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -3690,18 +3646,18 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1644 = __arg1;
+Obj _35val2791 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1645 = primLT(i, makeNumber(4));
-if (True == _35reg1645) {
-pushCont(co, 16, _35clofun1985, 2, i, w);
+Obj _35reg2792 = primLT(i, makeNumber(4));
+if (True == _35reg2792) {
+pushCont(co, 16, _35clofun3128, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3709,10 +3665,10 @@ __arg2 = makeCString(" = __arg");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 18, _35clofun1985, 2, i, w);
+pushCont(co, 18, _35clofun3128, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3720,18 +3676,18 @@ __arg2 = makeCString(" = co->args[");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label20:
 {
-Obj _35val1643 = __arg1;
+Obj _35val2790 = __arg1;
 Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 19, _35clofun1985, 2, i, w);
+pushCont(co, 19, _35clofun3128, 2, i, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = intern("ignore");
@@ -3741,7 +3697,7 @@ co->args[4] = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3128) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3754,7 +3710,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1984(struct Cora* co){
+void _35clofun3127(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -3767,28 +3723,28 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc123 = makeNative(11, _35clofun1983, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1270 = makeNative(11, _35clofun3126, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1542 = primIsCons(closureRef(co, 3));
-if (True == _35reg1542) {
-Obj _35reg1543 = primCar(closureRef(co, 3));
-Obj _35reg1544 = primEQ(intern("%const"), _35reg1543);
-if (True == _35reg1544) {
-Obj _35reg1545 = primCdr(closureRef(co, 3));
-Obj _35reg1546 = primIsCons(_35reg1545);
-if (True == _35reg1546) {
-Obj _35reg1547 = primCdr(closureRef(co, 3));
-Obj _35reg1548 = primCar(_35reg1547);
-Obj x = _35reg1548;
-Obj _35reg1549 = primCdr(closureRef(co, 3));
-Obj _35reg1550 = primCdr(_35reg1549);
-Obj _35reg1551 = primEQ(Nil, _35reg1550);
-if (True == _35reg1551) {
-Obj _35reg1552 = primIsSymbol(x);
-if (True == _35reg1552) {
-pushCont(co, 14, _35clofun1983, 2, x, w);
+Obj _35reg2689 = primIsCons(closureRef(co, 3));
+if (True == _35reg2689) {
+Obj _35reg2690 = primCar(closureRef(co, 3));
+Obj _35reg2691 = primEQ(intern("%const"), _35reg2690);
+if (True == _35reg2691) {
+Obj _35reg2692 = primCdr(closureRef(co, 3));
+Obj _35reg2693 = primIsCons(_35reg2692);
+if (True == _35reg2693) {
+Obj _35reg2694 = primCdr(closureRef(co, 3));
+Obj _35reg2695 = primCar(_35reg2694);
+Obj x = _35reg2695;
+Obj _35reg2696 = primCdr(closureRef(co, 3));
+Obj _35reg2697 = primCdr(_35reg2696);
+Obj _35reg2698 = primEQ(Nil, _35reg2697);
+if (True == _35reg2698) {
+Obj _35reg2699 = primIsSymbol(x);
+if (True == _35reg2699) {
+pushCont(co, 14, _35clofun3126, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3796,60 +3752,60 @@ __arg2 = makeCString("intern(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 20, _35clofun1983, 2, x, w);
+pushCont(co, 20, _35clofun3126, 2, x, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#number?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc123;
+__arg0 = _35cc1270;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc123;
+__arg0 = _35cc1270;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc123;
+__arg0 = _35cc1270;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc123;
+__arg0 = _35cc1270;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35val1577 = __arg1;
+Obj _35val2724 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -3858,16 +3814,16 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1576 = __arg1;
+Obj _35val2723 = __arg1;
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun1984, 1, w);
+pushCont(co, 1, _35clofun3127, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -3875,32 +3831,32 @@ __arg2 = idx;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc122 = makeNative(0, _35clofun1984, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1269 = makeNative(0, _35clofun3127, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1566 = primIsCons(closureRef(co, 3));
-if (True == _35reg1566) {
-Obj _35reg1567 = primCar(closureRef(co, 3));
-Obj _35reg1568 = primEQ(intern("%stack-ref"), _35reg1567);
-if (True == _35reg1568) {
-Obj _35reg1569 = primCdr(closureRef(co, 3));
-Obj _35reg1570 = primIsCons(_35reg1569);
-if (True == _35reg1570) {
-Obj _35reg1571 = primCdr(closureRef(co, 3));
-Obj _35reg1572 = primCar(_35reg1571);
-Obj idx = _35reg1572;
-Obj _35reg1573 = primCdr(closureRef(co, 3));
-Obj _35reg1574 = primCdr(_35reg1573);
-Obj _35reg1575 = primEQ(Nil, _35reg1574);
-if (True == _35reg1575) {
-pushCont(co, 2, _35clofun1984, 2, idx, w);
+Obj _35reg2713 = primIsCons(closureRef(co, 3));
+if (True == _35reg2713) {
+Obj _35reg2714 = primCar(closureRef(co, 3));
+Obj _35reg2715 = primEQ(intern("%stack-ref"), _35reg2714);
+if (True == _35reg2715) {
+Obj _35reg2716 = primCdr(closureRef(co, 3));
+Obj _35reg2717 = primIsCons(_35reg2716);
+if (True == _35reg2717) {
+Obj _35reg2718 = primCdr(closureRef(co, 3));
+Obj _35reg2719 = primCar(_35reg2718);
+Obj idx = _35reg2719;
+Obj _35reg2720 = primCdr(closureRef(co, 3));
+Obj _35reg2721 = primCdr(_35reg2720);
+Obj _35reg2722 = primEQ(Nil, _35reg2721);
+if (True == _35reg2722) {
+pushCont(co, 2, _35clofun3127, 2, idx, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3908,49 +3864,49 @@ __arg2 = makeCString("stackRef(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc122;
+__arg0 = _35cc1269;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc122;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc122;
+__arg0 = _35cc1269;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc122;
+__arg0 = _35cc1269;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1269;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35val1589 = __arg1;
+Obj _35val2736 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -3959,16 +3915,16 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1588 = __arg1;
+Obj _35val2735 = __arg1;
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun1984, 1, w);
+pushCont(co, 4, _35clofun3127, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -3976,32 +3932,32 @@ __arg2 = idx;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc121 = makeNative(3, _35clofun1984, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1268 = makeNative(3, _35clofun3127, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1578 = primIsCons(closureRef(co, 3));
-if (True == _35reg1578) {
-Obj _35reg1579 = primCar(closureRef(co, 3));
-Obj _35reg1580 = primEQ(intern("%closure-ref"), _35reg1579);
-if (True == _35reg1580) {
-Obj _35reg1581 = primCdr(closureRef(co, 3));
-Obj _35reg1582 = primIsCons(_35reg1581);
-if (True == _35reg1582) {
-Obj _35reg1583 = primCdr(closureRef(co, 3));
-Obj _35reg1584 = primCar(_35reg1583);
-Obj idx = _35reg1584;
-Obj _35reg1585 = primCdr(closureRef(co, 3));
-Obj _35reg1586 = primCdr(_35reg1585);
-Obj _35reg1587 = primEQ(Nil, _35reg1586);
-if (True == _35reg1587) {
-pushCont(co, 5, _35clofun1984, 2, idx, w);
+Obj _35reg2725 = primIsCons(closureRef(co, 3));
+if (True == _35reg2725) {
+Obj _35reg2726 = primCar(closureRef(co, 3));
+Obj _35reg2727 = primEQ(intern("%closure-ref"), _35reg2726);
+if (True == _35reg2727) {
+Obj _35reg2728 = primCdr(closureRef(co, 3));
+Obj _35reg2729 = primIsCons(_35reg2728);
+if (True == _35reg2729) {
+Obj _35reg2730 = primCdr(closureRef(co, 3));
+Obj _35reg2731 = primCar(_35reg2730);
+Obj idx = _35reg2731;
+Obj _35reg2732 = primCdr(closureRef(co, 3));
+Obj _35reg2733 = primCdr(_35reg2732);
+Obj _35reg2734 = primEQ(Nil, _35reg2733);
+if (True == _35reg2734) {
+pushCont(co, 5, _35clofun3127, 2, idx, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4009,49 +3965,49 @@ __arg2 = makeCString("closureRef(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc121;
+__arg0 = _35cc1268;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc121;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc121;
+__arg0 = _35cc1268;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc121;
+__arg0 = _35cc1268;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1268;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35val1602 = __arg1;
+Obj _35val2749 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -4060,64 +4016,64 @@ __arg2 = makeCString("\"))");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val1601 = __arg1;
+Obj _35val2748 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 7, _35clofun1984, 1, w);
+pushCont(co, 7, _35clofun3127, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = _35val1601;
+__arg2 = _35val2748;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val1600 = __arg1;
+Obj _35val2747 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun1984, 1, w);
+pushCont(co, 8, _35clofun3127, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35cc120 = makeNative(6, _35clofun1984, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1267 = makeNative(6, _35clofun3127, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1590 = primIsCons(closureRef(co, 3));
-if (True == _35reg1590) {
-Obj _35reg1591 = primCar(closureRef(co, 3));
-Obj _35reg1592 = primEQ(intern("%global"), _35reg1591);
-if (True == _35reg1592) {
-Obj _35reg1593 = primCdr(closureRef(co, 3));
-Obj _35reg1594 = primIsCons(_35reg1593);
-if (True == _35reg1594) {
-Obj _35reg1595 = primCdr(closureRef(co, 3));
-Obj _35reg1596 = primCar(_35reg1595);
-Obj x = _35reg1596;
-Obj _35reg1597 = primCdr(closureRef(co, 3));
-Obj _35reg1598 = primCdr(_35reg1597);
-Obj _35reg1599 = primEQ(Nil, _35reg1598);
-if (True == _35reg1599) {
-pushCont(co, 9, _35clofun1984, 2, x, w);
+Obj _35reg2737 = primIsCons(closureRef(co, 3));
+if (True == _35reg2737) {
+Obj _35reg2738 = primCar(closureRef(co, 3));
+Obj _35reg2739 = primEQ(intern("%global"), _35reg2738);
+if (True == _35reg2739) {
+Obj _35reg2740 = primCdr(closureRef(co, 3));
+Obj _35reg2741 = primIsCons(_35reg2740);
+if (True == _35reg2741) {
+Obj _35reg2742 = primCdr(closureRef(co, 3));
+Obj _35reg2743 = primCar(_35reg2742);
+Obj x = _35reg2743;
+Obj _35reg2744 = primCdr(closureRef(co, 3));
+Obj _35reg2745 = primCdr(_35reg2744);
+Obj _35reg2746 = primEQ(Nil, _35reg2745);
+if (True == _35reg2746) {
+pushCont(co, 9, _35clofun3127, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4125,59 +4081,59 @@ __arg2 = makeCString("globalRef(intern(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc120;
+__arg0 = _35cc1267;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc120;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc120;
+__arg0 = _35cc1267;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc120;
+__arg0 = _35cc1267;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1267;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35p115 = __arg1;
-Obj _35p116 = __arg2;
-Obj _35p117 = __arg3;
-Obj _35p118 = co->args[4];
-Obj _35cc119 = makeNative(10, _35clofun1984, 0, 4, _35p115, _35p116, _35p117, _35p118);
-Obj self = _35p115;
-Obj env = _35p116;
-Obj w = _35p117;
-Obj x = _35p118;
-Obj _35reg1603 = primIsSymbol(x);
-if (True == _35reg1603) {
+Obj _35p1262 = __arg1;
+Obj _35p1263 = __arg2;
+Obj _35p1264 = __arg3;
+Obj _35p1265 = co->args[4];
+Obj _35cc1266 = makeNative(10, _35clofun3127, 0, 4, _35p1262, _35p1263, _35p1264, _35p1265);
+Obj self = _35p1262;
+Obj env = _35p1263;
+Obj w = _35p1264;
+Obj x = _35p1265;
+Obj _35reg2750 = primIsSymbol(x);
+if (True == _35reg2750) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -4185,15 +4141,15 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc119;
+__arg0 = _35cc1266;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4206,13 +4162,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val1625 = __arg1;
+Obj _35val2772 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
@@ -4223,14 +4179,14 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
 Obj x = __arg1;
-pushCont(co, 13, _35clofun1984, 1, x);
+pushCont(co, 13, _35clofun3127, 1, x);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = closureRef(co, 1);
@@ -4238,13 +4194,13 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val1626 = __arg1;
+Obj _35val2773 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -4253,27 +4209,27 @@ __arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val1623 = __arg1;
+Obj _35val2770 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1624 = primNot(_35val1623);
-if (True == _35reg1624) {
-pushCont(co, 15, _35clofun1984, 1, w);
+Obj _35reg2771 = primNot(_35val2770);
+if (True == _35reg2771) {
+pushCont(co, 15, _35clofun3127, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(14, _35clofun1984, 1, 2, self, w);
+__arg1 = makeNative(14, _35clofun3127, 1, 2, self, w);
 __arg2 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
@@ -4284,70 +4240,70 @@ __arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label17:
 {
-Obj _35val1622 = __arg1;
+Obj _35val2769 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 16, _35clofun1984, 3, self, stacks, w);
+pushCont(co, 16, _35clofun3127, 3, self, stacks, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1621 = __arg1;
+Obj _35val2768 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 17, _35clofun1984, 3, self, stacks, w);
+pushCont(co, 17, _35clofun3127, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = _35val1621;
+__arg2 = _35val2768;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1620 = __arg1;
+Obj _35val2767 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 18, _35clofun1984, 3, self, stacks, w);
+pushCont(co, 18, _35clofun3127, 3, self, stacks, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1619 = __arg1;
+Obj _35val2766 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 19, _35clofun1984, 3, self, stacks, w);
+pushCont(co, 19, _35clofun3127, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4355,7 +4311,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3127) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4368,7 +4324,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1983(struct Cora* co){
+void _35clofun3126(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -4381,121 +4337,121 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc125 = makeNative(14, _35clofun1982, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1272 = makeNative(14, _35clofun3125, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1479 = primIsCons(closureRef(co, 3));
-if (True == _35reg1479) {
-Obj _35reg1480 = primCar(closureRef(co, 3));
-Obj _35reg1481 = primIsCons(_35reg1480);
-if (True == _35reg1481) {
-Obj _35reg1482 = primCar(closureRef(co, 3));
-Obj _35reg1483 = primCar(_35reg1482);
-Obj _35reg1484 = primEQ(intern("%builtin"), _35reg1483);
-if (True == _35reg1484) {
-Obj _35reg1485 = primCar(closureRef(co, 3));
-Obj _35reg1486 = primCdr(_35reg1485);
-Obj _35reg1487 = primIsCons(_35reg1486);
-if (True == _35reg1487) {
-Obj _35reg1488 = primCar(closureRef(co, 3));
-Obj _35reg1489 = primCdr(_35reg1488);
-Obj _35reg1490 = primCar(_35reg1489);
-Obj f = _35reg1490;
-Obj _35reg1491 = primCar(closureRef(co, 3));
-Obj _35reg1492 = primCdr(_35reg1491);
-Obj _35reg1493 = primCdr(_35reg1492);
-Obj _35reg1494 = primEQ(Nil, _35reg1493);
-if (True == _35reg1494) {
-Obj _35reg1495 = primCdr(closureRef(co, 3));
-Obj args = _35reg1495;
-pushCont(co, 20, _35clofun1982, 5, f, self, env, args, w);
+Obj _35reg2626 = primIsCons(closureRef(co, 3));
+if (True == _35reg2626) {
+Obj _35reg2627 = primCar(closureRef(co, 3));
+Obj _35reg2628 = primIsCons(_35reg2627);
+if (True == _35reg2628) {
+Obj _35reg2629 = primCar(closureRef(co, 3));
+Obj _35reg2630 = primCar(_35reg2629);
+Obj _35reg2631 = primEQ(intern("%builtin"), _35reg2630);
+if (True == _35reg2631) {
+Obj _35reg2632 = primCar(closureRef(co, 3));
+Obj _35reg2633 = primCdr(_35reg2632);
+Obj _35reg2634 = primIsCons(_35reg2633);
+if (True == _35reg2634) {
+Obj _35reg2635 = primCar(closureRef(co, 3));
+Obj _35reg2636 = primCdr(_35reg2635);
+Obj _35reg2637 = primCar(_35reg2636);
+Obj f = _35reg2637;
+Obj _35reg2638 = primCar(closureRef(co, 3));
+Obj _35reg2639 = primCdr(_35reg2638);
+Obj _35reg2640 = primCdr(_35reg2639);
+Obj _35reg2641 = primEQ(Nil, _35reg2640);
+if (True == _35reg2641) {
+Obj _35reg2642 = primCdr(closureRef(co, 3));
+Obj args = _35reg2642;
+pushCont(co, 20, _35clofun3125, 5, f, self, env, args, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#builtin->name"));
 __arg1 = f;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc125;
+__arg0 = _35cc1272;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc125;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc125;
+__arg0 = _35cc1272;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc125;
+__arg0 = _35cc1272;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc125;
+__arg0 = _35cc1272;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1272;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35val1535 = __arg1;
+Obj _35val2682 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1536 = primCons(a, env);
+Obj _35reg2683 = primCons(a, env);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
-__arg2 = _35reg1536;
+__arg2 = _35reg2683;
 __arg3 = w;
 co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1534 = __arg1;
+Obj _35val2681 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 1, _35clofun1983, 5, a, env, self, w, c);
+pushCont(co, 1, _35clofun3126, 5, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4503,20 +4459,20 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val1533 = __arg1;
+Obj _35val2680 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 2, _35clofun1983, 5, a, env, self, w, c);
+pushCont(co, 2, _35clofun3126, 5, a, env, self, w, c);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -4526,20 +4482,20 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val1532 = __arg1;
+Obj _35val2679 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 3, _35clofun1983, 6, b, a, env, self, w, c);
+pushCont(co, 3, _35clofun3126, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4547,20 +4503,20 @@ __arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1531 = __arg1;
+Obj _35val2678 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 4, _35clofun1983, 6, b, a, env, self, w, c);
+pushCont(co, 4, _35clofun3126, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -4568,41 +4524,41 @@ __arg2 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val1540 = __arg1;
+Obj _35val2687 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1541 = primCons(a, env);
+Obj _35reg2688 = primCons(a, env);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
-__arg2 = _35reg1541;
+__arg2 = _35reg2688;
 __arg3 = w;
 co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val1539 = __arg1;
+Obj _35val2686 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 6, _35clofun1983, 5, a, env, self, w, c);
+pushCont(co, 6, _35clofun3126, 5, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4610,20 +4566,20 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val1538 = __arg1;
+Obj _35val2685 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 7, _35clofun1983, 5, a, env, self, w, c);
+pushCont(co, 7, _35clofun3126, 5, a, env, self, w, c);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -4633,20 +4589,20 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val1537 = __arg1;
+Obj _35val2684 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 8, _35clofun1983, 6, b, a, env, self, w, c);
+pushCont(co, 8, _35clofun3126, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4654,23 +4610,23 @@ __arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val1529 = __arg1;
+Obj _35val2676 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj idx = _35val1529;
-Obj _35reg1530 = primLT(idx, makeNumber(0));
-if (True == _35reg1530) {
-pushCont(co, 5, _35clofun1983, 6, b, a, env, self, w, c);
+Obj idx = _35val2676;
+Obj _35reg2677 = primLT(idx, makeNumber(0));
+if (True == _35reg2677) {
+pushCont(co, 5, _35clofun3126, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4678,11 +4634,11 @@ __arg2 = makeCString("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
-pushCont(co, 9, _35clofun1983, 6, b, a, env, self, w, c);
+pushCont(co, 9, _35clofun3126, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -4690,53 +4646,53 @@ __arg2 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35cc124 = makeNative(0, _35clofun1983, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1271 = makeNative(0, _35clofun3126, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1503 = primIsCons(closureRef(co, 3));
-if (True == _35reg1503) {
-Obj _35reg1504 = primCar(closureRef(co, 3));
-Obj _35reg1505 = primEQ(intern("let"), _35reg1504);
-if (True == _35reg1505) {
-Obj _35reg1506 = primCdr(closureRef(co, 3));
-Obj _35reg1507 = primIsCons(_35reg1506);
-if (True == _35reg1507) {
-Obj _35reg1508 = primCdr(closureRef(co, 3));
-Obj _35reg1509 = primCar(_35reg1508);
-Obj a = _35reg1509;
-Obj _35reg1510 = primCdr(closureRef(co, 3));
-Obj _35reg1511 = primCdr(_35reg1510);
-Obj _35reg1512 = primIsCons(_35reg1511);
-if (True == _35reg1512) {
-Obj _35reg1513 = primCdr(closureRef(co, 3));
-Obj _35reg1514 = primCdr(_35reg1513);
-Obj _35reg1515 = primCar(_35reg1514);
-Obj b = _35reg1515;
-Obj _35reg1516 = primCdr(closureRef(co, 3));
-Obj _35reg1517 = primCdr(_35reg1516);
-Obj _35reg1518 = primCdr(_35reg1517);
-Obj _35reg1519 = primIsCons(_35reg1518);
-if (True == _35reg1519) {
-Obj _35reg1520 = primCdr(closureRef(co, 3));
-Obj _35reg1521 = primCdr(_35reg1520);
-Obj _35reg1522 = primCdr(_35reg1521);
-Obj _35reg1523 = primCar(_35reg1522);
-Obj c = _35reg1523;
-Obj _35reg1524 = primCdr(closureRef(co, 3));
-Obj _35reg1525 = primCdr(_35reg1524);
-Obj _35reg1526 = primCdr(_35reg1525);
-Obj _35reg1527 = primCdr(_35reg1526);
-Obj _35reg1528 = primEQ(Nil, _35reg1527);
-if (True == _35reg1528) {
-pushCont(co, 10, _35clofun1983, 6, b, a, env, self, w, c);
+Obj _35reg2650 = primIsCons(closureRef(co, 3));
+if (True == _35reg2650) {
+Obj _35reg2651 = primCar(closureRef(co, 3));
+Obj _35reg2652 = primEQ(intern("let"), _35reg2651);
+if (True == _35reg2652) {
+Obj _35reg2653 = primCdr(closureRef(co, 3));
+Obj _35reg2654 = primIsCons(_35reg2653);
+if (True == _35reg2654) {
+Obj _35reg2655 = primCdr(closureRef(co, 3));
+Obj _35reg2656 = primCar(_35reg2655);
+Obj a = _35reg2656;
+Obj _35reg2657 = primCdr(closureRef(co, 3));
+Obj _35reg2658 = primCdr(_35reg2657);
+Obj _35reg2659 = primIsCons(_35reg2658);
+if (True == _35reg2659) {
+Obj _35reg2660 = primCdr(closureRef(co, 3));
+Obj _35reg2661 = primCdr(_35reg2660);
+Obj _35reg2662 = primCar(_35reg2661);
+Obj b = _35reg2662;
+Obj _35reg2663 = primCdr(closureRef(co, 3));
+Obj _35reg2664 = primCdr(_35reg2663);
+Obj _35reg2665 = primCdr(_35reg2664);
+Obj _35reg2666 = primIsCons(_35reg2665);
+if (True == _35reg2666) {
+Obj _35reg2667 = primCdr(closureRef(co, 3));
+Obj _35reg2668 = primCdr(_35reg2667);
+Obj _35reg2669 = primCdr(_35reg2668);
+Obj _35reg2670 = primCar(_35reg2669);
+Obj c = _35reg2670;
+Obj _35reg2671 = primCdr(closureRef(co, 3));
+Obj _35reg2672 = primCdr(_35reg2671);
+Obj _35reg2673 = primCdr(_35reg2672);
+Obj _35reg2674 = primCdr(_35reg2673);
+Obj _35reg2675 = primEQ(Nil, _35reg2674);
+if (True == _35reg2675) {
+pushCont(co, 10, _35clofun3126, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#index"));
 __arg1 = a;
@@ -4744,67 +4700,67 @@ __arg2 = env;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc124;
+__arg0 = _35cc1271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc124;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc124;
+__arg0 = _35cc1271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc124;
+__arg0 = _35cc1271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc124;
+__arg0 = _35cc1271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc124;
+__arg0 = _35cc1271;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1271;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj _35val1555 = __arg1;
+Obj _35val2702 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -4813,45 +4769,45 @@ __arg2 = makeCString("\")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val1554 = __arg1;
+Obj _35val2701 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 12, _35clofun1983, 1, w);
+pushCont(co, 12, _35clofun3126, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = _35val1554;
+__arg2 = _35val2701;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val1553 = __arg1;
+Obj _35val2700 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 13, _35clofun1983, 1, w);
+pushCont(co, 13, _35clofun3126, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val1558 = __arg1;
+Obj _35val2705 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -4860,16 +4816,16 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val1557 = __arg1;
+Obj _35val2704 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 15, _35clofun1983, 1, w);
+pushCont(co, 15, _35clofun3126, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -4877,13 +4833,13 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val1562 = __arg1;
+Obj _35val2709 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -4892,49 +4848,49 @@ __arg2 = makeCString("\")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1561 = __arg1;
+Obj _35val2708 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 17, _35clofun1983, 1, w);
+pushCont(co, 17, _35clofun3126, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = _35val1561;
+__arg2 = _35val2708;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1560 = __arg1;
+Obj _35val2707 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 18, _35clofun1983, 1, w);
+pushCont(co, 18, _35clofun3126, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc/internal#escape-str"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1556 = __arg1;
+Obj _35val2703 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1556) {
-pushCont(co, 16, _35clofun1983, 2, x, w);
+if (True == _35val2703) {
+pushCont(co, 16, _35clofun3126, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4942,12 +4898,12 @@ __arg2 = makeCString("makeNumber(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1559 = primIsString(x);
-if (True == _35reg1559) {
-pushCont(co, 19, _35clofun1983, 2, x, w);
+Obj _35reg2706 = primIsString(x);
+if (True == _35reg2706) {
+pushCont(co, 19, _35clofun3126, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4955,11 +4911,11 @@ __arg2 = makeCString("makeCString(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1563 = primEQ(x, Nil);
-if (True == _35reg1563) {
+Obj _35reg2710 = primEQ(x, Nil);
+if (True == _35reg2710) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4967,11 +4923,11 @@ __arg2 = makeCString("Nil");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1564 = primEQ(x, True);
-if (True == _35reg1564) {
+Obj _35reg2711 = primEQ(x, True);
+if (True == _35reg2711) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4979,11 +4935,11 @@ __arg2 = makeCString("True");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1565 = primEQ(x, False);
-if (True == _35reg1565) {
+Obj _35reg2712 = primEQ(x, False);
+if (True == _35reg2712) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4991,7 +4947,7 @@ __arg2 = makeCString("False");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -5000,7 +4956,7 @@ __arg1 = makeCString("no cond match");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3126) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5018,7 +4974,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1982(struct Cora* co){
+void _35clofun3125(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -5031,30 +4987,30 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1440 = __arg1;
+Obj _35val2587 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 20, _35clofun1981, 4, self, env, frees, w);
+pushCont(co, 20, _35clofun3124, 4, self, env, frees, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val1439 = __arg1;
+Obj _35val2586 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun1982, 4, self, env, frees, w);
+pushCont(co, 0, _35clofun3125, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5062,19 +5018,19 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1438 = __arg1;
+Obj _35val2585 = __arg1;
 Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 1, _35clofun1982, 4, self, env, frees, w);
+pushCont(co, 1, _35clofun3125, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -5082,19 +5038,19 @@ __arg2 = nargs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val1437 = __arg1;
+Obj _35val2584 = __arg1;
 Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 2, _35clofun1982, 5, nargs, self, env, frees, w);
+pushCont(co, 2, _35clofun3125, 5, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5102,42 +5058,42 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val1435 = __arg1;
+Obj _35val2582 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj _35reg1436 = primCar(label);
-pushCont(co, 3, _35clofun1982, 5, nargs, self, env, frees, w);
+Obj _35reg2583 = primCar(label);
+pushCont(co, 3, _35clofun3125, 5, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
-__arg2 = _35reg1436;
+__arg2 = _35reg2583;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1434 = __arg1;
+Obj _35val2581 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 4, _35clofun1982, 6, label, nargs, self, env, frees, w);
+pushCont(co, 4, _35clofun3125, 6, label, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5145,62 +5101,62 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val1432 = __arg1;
+Obj _35val2579 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj _35reg1433 = primCdr(label);
-pushCont(co, 5, _35clofun1982, 6, label, nargs, self, env, frees, w);
+Obj _35reg2580 = primCdr(label);
+pushCont(co, 5, _35clofun3125, 6, label, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = _35reg1433;
+__arg2 = _35reg2580;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35cc127 = makeNative(15, _35clofun1981, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1274 = makeNative(15, _35clofun3124, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1416 = primIsCons(closureRef(co, 3));
-if (True == _35reg1416) {
-Obj _35reg1417 = primCar(closureRef(co, 3));
-Obj _35reg1418 = primEQ(intern("%closure"), _35reg1417);
-if (True == _35reg1418) {
-Obj _35reg1419 = primCdr(closureRef(co, 3));
-Obj _35reg1420 = primIsCons(_35reg1419);
-if (True == _35reg1420) {
-Obj _35reg1421 = primCdr(closureRef(co, 3));
-Obj _35reg1422 = primCar(_35reg1421);
-Obj label = _35reg1422;
-Obj _35reg1423 = primCdr(closureRef(co, 3));
-Obj _35reg1424 = primCdr(_35reg1423);
-Obj _35reg1425 = primIsCons(_35reg1424);
-if (True == _35reg1425) {
-Obj _35reg1426 = primCdr(closureRef(co, 3));
-Obj _35reg1427 = primCdr(_35reg1426);
-Obj _35reg1428 = primCar(_35reg1427);
-Obj nargs = _35reg1428;
-Obj _35reg1429 = primCdr(closureRef(co, 3));
-Obj _35reg1430 = primCdr(_35reg1429);
-Obj _35reg1431 = primCdr(_35reg1430);
-Obj frees = _35reg1431;
-pushCont(co, 6, _35clofun1982, 6, label, nargs, self, env, frees, w);
+Obj _35reg2563 = primIsCons(closureRef(co, 3));
+if (True == _35reg2563) {
+Obj _35reg2564 = primCar(closureRef(co, 3));
+Obj _35reg2565 = primEQ(intern("%closure"), _35reg2564);
+if (True == _35reg2565) {
+Obj _35reg2566 = primCdr(closureRef(co, 3));
+Obj _35reg2567 = primIsCons(_35reg2566);
+if (True == _35reg2567) {
+Obj _35reg2568 = primCdr(closureRef(co, 3));
+Obj _35reg2569 = primCar(_35reg2568);
+Obj label = _35reg2569;
+Obj _35reg2570 = primCdr(closureRef(co, 3));
+Obj _35reg2571 = primCdr(_35reg2570);
+Obj _35reg2572 = primIsCons(_35reg2571);
+if (True == _35reg2572) {
+Obj _35reg2573 = primCdr(closureRef(co, 3));
+Obj _35reg2574 = primCdr(_35reg2573);
+Obj _35reg2575 = primCar(_35reg2574);
+Obj nargs = _35reg2575;
+Obj _35reg2576 = primCdr(closureRef(co, 3));
+Obj _35reg2577 = primCdr(_35reg2576);
+Obj _35reg2578 = primCdr(_35reg2577);
+Obj frees = _35reg2578;
+pushCont(co, 6, _35clofun3125, 6, label, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5208,49 +5164,49 @@ __arg2 = makeCString("makeNative(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc127;
+__arg0 = _35cc1274;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc127;
+__arg0 = _35cc1274;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc127;
+__arg0 = _35cc1274;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1274;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35val1478 = __arg1;
+Obj _35val2625 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -5259,18 +5215,18 @@ __arg2 = makeCString("}\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val1477 = __arg1;
+Obj _35val2624 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 8, _35clofun1982, 1, w);
+pushCont(co, 8, _35clofun3125, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5280,18 +5236,18 @@ co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val1476 = __arg1;
+Obj _35val2623 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 9, _35clofun1982, 4, self, env, c, w);
+pushCont(co, 9, _35clofun3125, 4, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5299,19 +5255,19 @@ __arg2 = makeCString("} else {\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val1475 = __arg1;
+Obj _35val2622 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 10, _35clofun1982, 4, self, env, c, w);
+pushCont(co, 10, _35clofun3125, 4, self, env, c, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5321,19 +5277,19 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val1474 = __arg1;
+Obj _35val2621 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 11, _35clofun1982, 5, b, self, env, c, w);
+pushCont(co, 11, _35clofun3125, 5, b, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5341,20 +5297,20 @@ __arg2 = makeCString(") {\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val1473 = __arg1;
+Obj _35val2620 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 12, _35clofun1982, 5, b, self, env, c, w);
+pushCont(co, 12, _35clofun3125, 5, b, self, env, c, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5364,52 +5320,52 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35cc126 = makeNative(7, _35clofun1982, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1273 = makeNative(7, _35clofun3125, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1447 = primIsCons(closureRef(co, 3));
-if (True == _35reg1447) {
-Obj _35reg1448 = primCar(closureRef(co, 3));
-Obj _35reg1449 = primEQ(intern("if"), _35reg1448);
-if (True == _35reg1449) {
-Obj _35reg1450 = primCdr(closureRef(co, 3));
-Obj _35reg1451 = primIsCons(_35reg1450);
-if (True == _35reg1451) {
-Obj _35reg1452 = primCdr(closureRef(co, 3));
-Obj _35reg1453 = primCar(_35reg1452);
-Obj a = _35reg1453;
-Obj _35reg1454 = primCdr(closureRef(co, 3));
-Obj _35reg1455 = primCdr(_35reg1454);
-Obj _35reg1456 = primIsCons(_35reg1455);
-if (True == _35reg1456) {
-Obj _35reg1457 = primCdr(closureRef(co, 3));
-Obj _35reg1458 = primCdr(_35reg1457);
-Obj _35reg1459 = primCar(_35reg1458);
-Obj b = _35reg1459;
-Obj _35reg1460 = primCdr(closureRef(co, 3));
-Obj _35reg1461 = primCdr(_35reg1460);
-Obj _35reg1462 = primCdr(_35reg1461);
-Obj _35reg1463 = primIsCons(_35reg1462);
-if (True == _35reg1463) {
-Obj _35reg1464 = primCdr(closureRef(co, 3));
-Obj _35reg1465 = primCdr(_35reg1464);
-Obj _35reg1466 = primCdr(_35reg1465);
-Obj _35reg1467 = primCar(_35reg1466);
-Obj c = _35reg1467;
-Obj _35reg1468 = primCdr(closureRef(co, 3));
-Obj _35reg1469 = primCdr(_35reg1468);
-Obj _35reg1470 = primCdr(_35reg1469);
-Obj _35reg1471 = primCdr(_35reg1470);
-Obj _35reg1472 = primEQ(Nil, _35reg1471);
-if (True == _35reg1472) {
-pushCont(co, 13, _35clofun1982, 6, a, b, self, env, c, w);
+Obj _35reg2594 = primIsCons(closureRef(co, 3));
+if (True == _35reg2594) {
+Obj _35reg2595 = primCar(closureRef(co, 3));
+Obj _35reg2596 = primEQ(intern("if"), _35reg2595);
+if (True == _35reg2596) {
+Obj _35reg2597 = primCdr(closureRef(co, 3));
+Obj _35reg2598 = primIsCons(_35reg2597);
+if (True == _35reg2598) {
+Obj _35reg2599 = primCdr(closureRef(co, 3));
+Obj _35reg2600 = primCar(_35reg2599);
+Obj a = _35reg2600;
+Obj _35reg2601 = primCdr(closureRef(co, 3));
+Obj _35reg2602 = primCdr(_35reg2601);
+Obj _35reg2603 = primIsCons(_35reg2602);
+if (True == _35reg2603) {
+Obj _35reg2604 = primCdr(closureRef(co, 3));
+Obj _35reg2605 = primCdr(_35reg2604);
+Obj _35reg2606 = primCar(_35reg2605);
+Obj b = _35reg2606;
+Obj _35reg2607 = primCdr(closureRef(co, 3));
+Obj _35reg2608 = primCdr(_35reg2607);
+Obj _35reg2609 = primCdr(_35reg2608);
+Obj _35reg2610 = primIsCons(_35reg2609);
+if (True == _35reg2610) {
+Obj _35reg2611 = primCdr(closureRef(co, 3));
+Obj _35reg2612 = primCdr(_35reg2611);
+Obj _35reg2613 = primCdr(_35reg2612);
+Obj _35reg2614 = primCar(_35reg2613);
+Obj c = _35reg2614;
+Obj _35reg2615 = primCdr(closureRef(co, 3));
+Obj _35reg2616 = primCdr(_35reg2615);
+Obj _35reg2617 = primCdr(_35reg2616);
+Obj _35reg2618 = primCdr(_35reg2617);
+Obj _35reg2619 = primEQ(Nil, _35reg2618);
+if (True == _35reg2619) {
+pushCont(co, 13, _35clofun3125, 6, a, b, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5417,67 +5373,67 @@ __arg2 = makeCString("if (True == ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc126;
+__arg0 = _35cc1273;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc126;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc126;
+__arg0 = _35cc1273;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc126;
+__arg0 = _35cc1273;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc126;
+__arg0 = _35cc1273;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc126;
+__arg0 = _35cc1273;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1273;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label15:
 {
-Obj _35val1500 = __arg1;
+Obj _35val2647 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -5486,18 +5442,18 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val1499 = __arg1;
+Obj _35val2646 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 15, _35clofun1982, 1, w);
+pushCont(co, 15, _35clofun3125, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
 __arg1 = self;
@@ -5507,13 +5463,13 @@ co->args[4] = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val1502 = __arg1;
+Obj _35val2649 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -5522,18 +5478,18 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1501 = __arg1;
+Obj _35val2648 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 17, _35clofun1982, 1, w);
+pushCont(co, 17, _35clofun3125, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
 __arg1 = self;
@@ -5543,21 +5499,21 @@ co->args[4] = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1497 = __arg1;
+Obj _35val2644 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1498 = primEQ(f, intern("set"));
-if (True == _35reg1498) {
-pushCont(co, 16, _35clofun1982, 4, self, env, args, w);
+Obj _35reg2645 = primEQ(f, intern("set"));
+if (True == _35reg2645) {
+pushCont(co, 16, _35clofun3125, 4, self, env, args, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5565,10 +5521,10 @@ __arg2 = makeCString("(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 18, _35clofun1982, 4, self, env, args, w);
+pushCont(co, 18, _35clofun3125, 4, self, env, args, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5576,28 +5532,28 @@ __arg2 = makeCString("(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label20:
 {
-Obj _35val1496 = __arg1;
+Obj _35val2643 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 19, _35clofun1982, 5, f, self, env, args, w);
+pushCont(co, 19, _35clofun3125, 5, f, self, env, args, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
-__arg2 = _35val1496;
+__arg2 = _35val2643;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3125) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5610,7 +5566,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1981(struct Cora* co){
+void _35clofun3124(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -5623,17 +5579,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc132 = makeNative(9, _35clofun1980, 0, 0);
+Obj _35cc1279 = makeNative(9, _35clofun3123, 0, 0);
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1335 = primIsCons(closureRef(co, 3));
-if (True == _35reg1335) {
-Obj _35reg1336 = primCar(closureRef(co, 3));
-Obj f = _35reg1336;
-Obj _35reg1337 = primCdr(closureRef(co, 3));
-Obj args = _35reg1337;
-pushCont(co, 20, _35clofun1980, 4, f, args, self, w);
+Obj _35reg2482 = primIsCons(closureRef(co, 3));
+if (True == _35reg2482) {
+Obj _35reg2483 = primCar(closureRef(co, 3));
+Obj f = _35reg2483;
+Obj _35reg2484 = primCdr(closureRef(co, 3));
+Obj args = _35reg2484;
+pushCont(co, 20, _35clofun3123, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5641,22 +5597,22 @@ __arg2 = makeCString("__nargs = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc132;
+__arg0 = _35cc1279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35val1368 = __arg1;
+Obj _35val2515 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -5670,41 +5626,41 @@ co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35cc131 = makeNative(0, _35clofun1981, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1278 = makeNative(0, _35clofun3124, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1351 = primIsCons(closureRef(co, 3));
-if (True == _35reg1351) {
-Obj _35reg1352 = primCar(closureRef(co, 3));
-Obj _35reg1353 = primEQ(intern("call"), _35reg1352);
-if (True == _35reg1353) {
-Obj _35reg1354 = primCdr(closureRef(co, 3));
-Obj _35reg1355 = primIsCons(_35reg1354);
-if (True == _35reg1355) {
-Obj _35reg1356 = primCdr(closureRef(co, 3));
-Obj _35reg1357 = primCar(_35reg1356);
-Obj exp = _35reg1357;
-Obj _35reg1358 = primCdr(closureRef(co, 3));
-Obj _35reg1359 = primCdr(_35reg1358);
-Obj _35reg1360 = primIsCons(_35reg1359);
-if (True == _35reg1360) {
-Obj _35reg1361 = primCdr(closureRef(co, 3));
-Obj _35reg1362 = primCdr(_35reg1361);
-Obj _35reg1363 = primCar(_35reg1362);
-Obj cont = _35reg1363;
-Obj _35reg1364 = primCdr(closureRef(co, 3));
-Obj _35reg1365 = primCdr(_35reg1364);
-Obj _35reg1366 = primCdr(_35reg1365);
-Obj _35reg1367 = primEQ(Nil, _35reg1366);
-if (True == _35reg1367) {
-pushCont(co, 1, _35clofun1981, 4, self, env, w, exp);
+Obj _35reg2498 = primIsCons(closureRef(co, 3));
+if (True == _35reg2498) {
+Obj _35reg2499 = primCar(closureRef(co, 3));
+Obj _35reg2500 = primEQ(intern("call"), _35reg2499);
+if (True == _35reg2500) {
+Obj _35reg2501 = primCdr(closureRef(co, 3));
+Obj _35reg2502 = primIsCons(_35reg2501);
+if (True == _35reg2502) {
+Obj _35reg2503 = primCdr(closureRef(co, 3));
+Obj _35reg2504 = primCar(_35reg2503);
+Obj exp = _35reg2504;
+Obj _35reg2505 = primCdr(closureRef(co, 3));
+Obj _35reg2506 = primCdr(_35reg2505);
+Obj _35reg2507 = primIsCons(_35reg2506);
+if (True == _35reg2507) {
+Obj _35reg2508 = primCdr(closureRef(co, 3));
+Obj _35reg2509 = primCdr(_35reg2508);
+Obj _35reg2510 = primCar(_35reg2509);
+Obj cont = _35reg2510;
+Obj _35reg2511 = primCdr(closureRef(co, 3));
+Obj _35reg2512 = primCdr(_35reg2511);
+Obj _35reg2513 = primCdr(_35reg2512);
+Obj _35reg2514 = primEQ(Nil, _35reg2513);
+if (True == _35reg2514) {
+pushCont(co, 1, _35clofun3124, 4, self, env, w, exp);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#generate-cont"));
 __arg1 = self;
@@ -5713,76 +5669,76 @@ __arg3 = cont;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc131;
+__arg0 = _35cc1278;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc131;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc131;
+__arg0 = _35cc1278;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc131;
+__arg0 = _35cc1278;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc131;
+__arg0 = _35cc1278;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1278;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35cc130 = makeNative(2, _35clofun1981, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1277 = makeNative(2, _35clofun3124, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1369 = primIsCons(closureRef(co, 3));
-if (True == _35reg1369) {
-Obj _35reg1370 = primCar(closureRef(co, 3));
-Obj _35reg1371 = primEQ(intern("tailcall"), _35reg1370);
-if (True == _35reg1371) {
-Obj _35reg1372 = primCdr(closureRef(co, 3));
-Obj _35reg1373 = primIsCons(_35reg1372);
-if (True == _35reg1373) {
-Obj _35reg1374 = primCdr(closureRef(co, 3));
-Obj _35reg1375 = primCar(_35reg1374);
-Obj exp = _35reg1375;
-Obj _35reg1376 = primCdr(closureRef(co, 3));
-Obj _35reg1377 = primCdr(_35reg1376);
-Obj _35reg1378 = primEQ(Nil, _35reg1377);
-if (True == _35reg1378) {
+Obj _35reg2516 = primIsCons(closureRef(co, 3));
+if (True == _35reg2516) {
+Obj _35reg2517 = primCar(closureRef(co, 3));
+Obj _35reg2518 = primEQ(intern("tailcall"), _35reg2517);
+if (True == _35reg2518) {
+Obj _35reg2519 = primCdr(closureRef(co, 3));
+Obj _35reg2520 = primIsCons(_35reg2519);
+if (True == _35reg2520) {
+Obj _35reg2521 = primCdr(closureRef(co, 3));
+Obj _35reg2522 = primCar(_35reg2521);
+Obj exp = _35reg2522;
+Obj _35reg2523 = primCdr(closureRef(co, 3));
+Obj _35reg2524 = primCdr(_35reg2523);
+Obj _35reg2525 = primEQ(Nil, _35reg2524);
+if (True == _35reg2525) {
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5792,49 +5748,49 @@ co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc130;
+__arg0 = _35cc1277;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc130;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc130;
+__arg0 = _35cc1277;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc130;
+__arg0 = _35cc1277;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1277;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35val1396 = __arg1;
+Obj _35val2543 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -5843,15 +5799,15 @@ __arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1395 = __arg1;
+Obj _35val2542 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 4, _35clofun1981, 1, w);
+pushCont(co, 4, _35clofun3124, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5859,16 +5815,16 @@ __arg2 = makeCString(") { goto fail; }\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val1394 = __arg1;
+Obj _35val2541 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun1981, 1, w);
+pushCont(co, 5, _35clofun3124, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -5876,16 +5832,16 @@ __arg2 = self;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val1393 = __arg1;
+Obj _35val2540 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 6, _35clofun1981, 2, self, w);
+pushCont(co, 6, _35clofun3124, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5893,16 +5849,16 @@ __arg2 = makeCString("if (co->ctx.pc.func != ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val1392 = __arg1;
+Obj _35val2539 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun1981, 2, self, w);
+pushCont(co, 7, _35clofun3124, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5910,16 +5866,16 @@ __arg2 = makeCString("co->ctx = co->callstack.data[--co->callstack.len];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val1391 = __arg1;
+Obj _35val2538 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun1981, 2, self, w);
+pushCont(co, 8, _35clofun3124, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5927,18 +5883,18 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val1390 = __arg1;
+Obj _35val2537 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 9, _35clofun1981, 2, self, w);
+pushCont(co, 9, _35clofun3124, 2, self, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5948,18 +5904,18 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val1389 = __arg1;
+Obj _35val2536 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 10, _35clofun1981, 4, env, x, self, w);
+pushCont(co, 10, _35clofun3124, 4, env, x, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5967,32 +5923,32 @@ __arg2 = makeCString("__arg1 = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35cc129 = makeNative(3, _35clofun1981, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1276 = makeNative(3, _35clofun3124, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1379 = primIsCons(closureRef(co, 3));
-if (True == _35reg1379) {
-Obj _35reg1380 = primCar(closureRef(co, 3));
-Obj _35reg1381 = primEQ(intern("return"), _35reg1380);
-if (True == _35reg1381) {
-Obj _35reg1382 = primCdr(closureRef(co, 3));
-Obj _35reg1383 = primIsCons(_35reg1382);
-if (True == _35reg1383) {
-Obj _35reg1384 = primCdr(closureRef(co, 3));
-Obj _35reg1385 = primCar(_35reg1384);
-Obj x = _35reg1385;
-Obj _35reg1386 = primCdr(closureRef(co, 3));
-Obj _35reg1387 = primCdr(_35reg1386);
-Obj _35reg1388 = primEQ(Nil, _35reg1387);
-if (True == _35reg1388) {
-pushCont(co, 11, _35clofun1981, 4, env, x, self, w);
+Obj _35reg2526 = primIsCons(closureRef(co, 3));
+if (True == _35reg2526) {
+Obj _35reg2527 = primCar(closureRef(co, 3));
+Obj _35reg2528 = primEQ(intern("return"), _35reg2527);
+if (True == _35reg2528) {
+Obj _35reg2529 = primCdr(closureRef(co, 3));
+Obj _35reg2530 = primIsCons(_35reg2529);
+if (True == _35reg2530) {
+Obj _35reg2531 = primCdr(closureRef(co, 3));
+Obj _35reg2532 = primCar(_35reg2531);
+Obj x = _35reg2532;
+Obj _35reg2533 = primCdr(closureRef(co, 3));
+Obj _35reg2534 = primCdr(_35reg2533);
+Obj _35reg2535 = primEQ(Nil, _35reg2534);
+if (True == _35reg2535) {
+pushCont(co, 11, _35clofun3124, 4, env, x, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6000,49 +5956,49 @@ __arg2 = makeCString("__nargs = 2;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc129;
+__arg0 = _35cc1276;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc129;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc129;
+__arg0 = _35cc1276;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc129;
+__arg0 = _35cc1276;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1276;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label13:
 {
-Obj _35val1415 = __arg1;
+Obj _35val2562 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -6056,18 +6012,18 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val1414 = __arg1;
+Obj _35val2561 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 13, _35clofun1981, 4, self, env, w, b);
+pushCont(co, 13, _35clofun3124, 4, self, env, w, b);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6075,41 +6031,41 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35cc128 = makeNative(12, _35clofun1981, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1275 = makeNative(12, _35clofun3124, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg1397 = primIsCons(closureRef(co, 3));
-if (True == _35reg1397) {
-Obj _35reg1398 = primCar(closureRef(co, 3));
-Obj _35reg1399 = primEQ(intern("do"), _35reg1398);
-if (True == _35reg1399) {
-Obj _35reg1400 = primCdr(closureRef(co, 3));
-Obj _35reg1401 = primIsCons(_35reg1400);
-if (True == _35reg1401) {
-Obj _35reg1402 = primCdr(closureRef(co, 3));
-Obj _35reg1403 = primCar(_35reg1402);
-Obj a = _35reg1403;
-Obj _35reg1404 = primCdr(closureRef(co, 3));
-Obj _35reg1405 = primCdr(_35reg1404);
-Obj _35reg1406 = primIsCons(_35reg1405);
-if (True == _35reg1406) {
-Obj _35reg1407 = primCdr(closureRef(co, 3));
-Obj _35reg1408 = primCdr(_35reg1407);
-Obj _35reg1409 = primCar(_35reg1408);
-Obj b = _35reg1409;
-Obj _35reg1410 = primCdr(closureRef(co, 3));
-Obj _35reg1411 = primCdr(_35reg1410);
-Obj _35reg1412 = primCdr(_35reg1411);
-Obj _35reg1413 = primEQ(Nil, _35reg1412);
-if (True == _35reg1413) {
-pushCont(co, 14, _35clofun1981, 4, self, env, w, b);
+Obj _35reg2544 = primIsCons(closureRef(co, 3));
+if (True == _35reg2544) {
+Obj _35reg2545 = primCar(closureRef(co, 3));
+Obj _35reg2546 = primEQ(intern("do"), _35reg2545);
+if (True == _35reg2546) {
+Obj _35reg2547 = primCdr(closureRef(co, 3));
+Obj _35reg2548 = primIsCons(_35reg2547);
+if (True == _35reg2548) {
+Obj _35reg2549 = primCdr(closureRef(co, 3));
+Obj _35reg2550 = primCar(_35reg2549);
+Obj a = _35reg2550;
+Obj _35reg2551 = primCdr(closureRef(co, 3));
+Obj _35reg2552 = primCdr(_35reg2551);
+Obj _35reg2553 = primIsCons(_35reg2552);
+if (True == _35reg2553) {
+Obj _35reg2554 = primCdr(closureRef(co, 3));
+Obj _35reg2555 = primCdr(_35reg2554);
+Obj _35reg2556 = primCar(_35reg2555);
+Obj b = _35reg2556;
+Obj _35reg2557 = primCdr(closureRef(co, 3));
+Obj _35reg2558 = primCdr(_35reg2557);
+Obj _35reg2559 = primCdr(_35reg2558);
+Obj _35reg2560 = primEQ(Nil, _35reg2559);
+if (True == _35reg2560) {
+pushCont(co, 14, _35clofun3124, 4, self, env, w, b);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -6119,58 +6075,58 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc128;
+__arg0 = _35cc1275;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc128;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc128;
+__arg0 = _35cc1275;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc128;
+__arg0 = _35cc1275;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc128;
+__arg0 = _35cc1275;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1275;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label16:
 {
-Obj _35val1446 = __arg1;
+Obj _35val2593 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -6179,18 +6135,18 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val1445 = __arg1;
+Obj _35val2592 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 16, _35clofun1981, 1, w);
+pushCont(co, 16, _35clofun3124, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
 __arg1 = self;
@@ -6200,20 +6156,20 @@ co->args[4] = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1443 = __arg1;
+Obj _35val2590 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1444 = primNot(_35val1443);
-if (True == _35reg1444) {
-pushCont(co, 17, _35clofun1981, 4, self, env, frees, w);
+Obj _35reg2591 = primNot(_35val2590);
+if (True == _35reg2591) {
+pushCont(co, 17, _35clofun3124, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6221,7 +6177,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
@@ -6232,45 +6188,45 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label19:
 {
-Obj _35val1442 = __arg1;
+Obj _35val2589 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun1981, 4, self, env, frees, w);
+pushCont(co, 18, _35clofun3124, 4, self, env, frees, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1441 = __arg1;
+Obj _35val2588 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun1981, 4, self, env, frees, w);
+pushCont(co, 19, _35clofun3124, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = _35val1441;
+__arg2 = _35val2588;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3124) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6283,7 +6239,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1980(struct Cora* co){
+void _35clofun3123(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -6296,13 +6252,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1320 = __arg1;
+Obj _35val2467 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 20, _35clofun1979, 5, x, i, self, w, more);
+pushCont(co, 20, _35clofun3122, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -6310,39 +6266,39 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val1331 = __arg1;
+Obj _35val2478 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1332 = primAdd(i, makeNumber(1));
+Obj _35reg2479 = primAdd(i, makeNumber(1));
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
 __arg1 = self;
 __arg2 = w;
-__arg3 = _35reg1332;
+__arg3 = _35reg2479;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1330 = __arg1;
+Obj _35val2477 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 1, _35clofun1980, 4, i, self, w, more);
+pushCont(co, 1, _35clofun3123, 4, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6350,19 +6306,19 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val1329 = __arg1;
+Obj _35val2476 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 2, _35clofun1980, 4, i, self, w, more);
+pushCont(co, 2, _35clofun3123, 4, i, self, w, more);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -6372,19 +6328,19 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val1328 = __arg1;
+Obj _35val2475 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 3, _35clofun1980, 5, x, i, self, w, more);
+pushCont(co, 3, _35clofun3123, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6392,19 +6348,19 @@ __arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1327 = __arg1;
+Obj _35val2474 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 4, _35clofun1980, 5, x, i, self, w, more);
+pushCont(co, 4, _35clofun3123, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6412,19 +6368,19 @@ __arg2 = makeCString("]");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val1326 = __arg1;
+Obj _35val2473 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 5, _35clofun1980, 5, x, i, self, w, more);
+pushCont(co, 5, _35clofun3123, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -6432,26 +6388,26 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35cc114 = makeNative(16, _35clofun1979, 0, 0);
+Obj _35cc1261 = makeNative(16, _35clofun3122, 0, 0);
 Obj self = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj i = closureRef(co, 2);
-Obj _35reg1315 = primIsCons(closureRef(co, 3));
-if (True == _35reg1315) {
-Obj _35reg1316 = primCar(closureRef(co, 3));
-Obj x = _35reg1316;
-Obj _35reg1317 = primCdr(closureRef(co, 3));
-Obj more = _35reg1317;
-Obj _35reg1318 = primGT(i, makeNumber(3));
-Obj _35reg1319 = primNot(_35reg1318);
-if (True == _35reg1319) {
-pushCont(co, 0, _35clofun1980, 5, x, i, self, w, more);
+Obj _35reg2462 = primIsCons(closureRef(co, 3));
+if (True == _35reg2462) {
+Obj _35reg2463 = primCar(closureRef(co, 3));
+Obj x = _35reg2463;
+Obj _35reg2464 = primCdr(closureRef(co, 3));
+Obj more = _35reg2464;
+Obj _35reg2465 = primGT(i, makeNumber(3));
+Obj _35reg2466 = primNot(_35reg2465);
+if (True == _35reg2466) {
+pushCont(co, 0, _35clofun3123, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6459,10 +6415,10 @@ __arg2 = makeCString("__arg");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 6, _35clofun1980, 5, x, i, self, w, more);
+pushCont(co, 6, _35clofun3123, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6470,44 +6426,44 @@ __arg2 = makeCString("co->args[");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc114;
+__arg0 = _35cc1261;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35p109 = __arg1;
-Obj _35p110 = __arg2;
-Obj _35p111 = __arg3;
-Obj _35p112 = co->args[4];
-Obj _35cc113 = makeNative(7, _35clofun1980, 0, 4, _35p109, _35p110, _35p111, _35p112);
-Obj self = _35p109;
-Obj w = _35p110;
-Obj i = _35p111;
-Obj _35reg1333 = primEQ(Nil, _35p112);
-if (True == _35reg1333) {
+Obj _35p1256 = __arg1;
+Obj _35p1257 = __arg2;
+Obj _35p1258 = __arg3;
+Obj _35p1259 = co->args[4];
+Obj _35cc1260 = makeNative(7, _35clofun3123, 0, 4, _35p1256, _35p1257, _35p1258, _35p1259);
+Obj self = _35p1256;
+Obj w = _35p1257;
+Obj i = _35p1258;
+Obj _35reg2480 = primEQ(Nil, _35p1259);
+if (True == _35reg2480) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1980) { goto fail; }
+if (co->ctx.pc.func != _35clofun3123) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc113;
+__arg0 = _35cc1260;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -6520,13 +6476,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val1350 = __arg1;
+Obj _35val2497 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -6535,15 +6491,15 @@ __arg2 = makeCString("goto *jumpTable[ps.label];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val1349 = __arg1;
+Obj _35val2496 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 10, _35clofun1980, 1, w);
+pushCont(co, 10, _35clofun3123, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6551,16 +6507,16 @@ __arg2 = makeCString(") { co->ctx.pc = ps; goto fail; };\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val1348 = __arg1;
+Obj _35val2495 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun1980, 1, w);
+pushCont(co, 11, _35clofun3123, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -6568,16 +6524,16 @@ __arg2 = self;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val1347 = __arg1;
+Obj _35val2494 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun1980, 2, self, w);
+pushCont(co, 12, _35clofun3123, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6585,16 +6541,16 @@ __arg2 = makeCString("if (ps.func != ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val1346 = __arg1;
+Obj _35val2493 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 13, _35clofun1980, 2, self, w);
+pushCont(co, 13, _35clofun3123, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6602,16 +6558,16 @@ __arg2 = makeCString("if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) {
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val1345 = __arg1;
+Obj _35val2492 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 14, _35clofun1980, 2, self, w);
+pushCont(co, 14, _35clofun3123, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6619,16 +6575,16 @@ __arg2 = makeCString("struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n"
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val1344 = __arg1;
+Obj _35val2491 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 15, _35clofun1980, 2, self, w);
+pushCont(co, 15, _35clofun3123, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6636,40 +6592,40 @@ __arg2 = makeCString("co->ctx.frees = __arg0;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val1342 = __arg1;
+Obj _35val2489 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1343 = primCons(f, args);
-pushCont(co, 16, _35clofun1980, 2, self, w);
+Obj _35reg2490 = primCons(f, args);
+pushCont(co, 16, _35clofun3123, 2, self, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
 __arg1 = self;
 __arg2 = w;
 __arg3 = makeNumber(0);
-co->args[4] = _35reg1343;
+co->args[4] = _35reg2490;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1341 = __arg1;
+Obj _35val2488 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 17, _35clofun1980, 4, f, args, self, w);
+pushCont(co, 17, _35clofun3123, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6677,45 +6633,45 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1339 = __arg1;
+Obj _35val2486 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1340 = primAdd(makeNumber(1), _35val1339);
-pushCont(co, 18, _35clofun1980, 4, f, args, self, w);
+Obj _35reg2487 = primAdd(makeNumber(1), _35val2486);
+pushCont(co, 18, _35clofun3123, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = _35reg1340;
+__arg2 = _35reg2487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1338 = __arg1;
+Obj _35val2485 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun1980, 4, f, args, self, w);
+pushCont(co, 19, _35clofun3123, 4, f, args, self, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3123) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6728,7 +6684,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1979(struct Cora* co){
+void _35clofun3122(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -6741,60 +6697,60 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1282 = __arg1;
+Obj _35val2429 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1281= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2428= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1283 = primCons(_35val1282, fvs);
-Obj _35reg1284 = primCons(_35reg1281, _35reg1283);
-Obj _35reg1285 = primCons(clo_45or_45cont, _35reg1284);
+Obj _35reg2430 = primCons(_35val2429, fvs);
+Obj _35reg2431 = primCons(_35reg2428, _35reg2430);
+Obj _35reg2432 = primCons(clo_45or_45cont, _35reg2431);
 __nargs = 2;
-__arg1 = _35reg1285;
+__arg1 = _35reg2432;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1979) { goto fail; }
+if (co->ctx.pc.func != _35clofun3122) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj _35val1280 = __arg1;
+Obj _35val2427 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1281 = primCons(name, idx);
-pushCont(co, 0, _35clofun1979, 3, fvs, _35reg1281, clo_45or_45cont);
+Obj _35reg2428 = primCons(name, idx);
+pushCont(co, 0, _35clofun3122, 3, fvs, _35reg2428, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1290 = __arg1;
+Obj _35val2437 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1291 = primCons(name, idx);
-Obj _35reg1292 = primCons(_35reg1291, fvs);
-Obj _35reg1293 = primCons(clo_45or_45cont, _35reg1292);
+Obj _35reg2438 = primCons(name, idx);
+Obj _35reg2439 = primCons(_35reg2438, fvs);
+Obj _35reg2440 = primCons(clo_45or_45cont, _35reg2439);
 __nargs = 2;
-__arg1 = _35reg1293;
+__arg1 = _35reg2440;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1979) { goto fail; }
+if (co->ctx.pc.func != _35clofun3122) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label3:
 {
-Obj _35val1273 = __arg1;
+Obj _35val2420 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -6802,123 +6758,123 @@ Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 5];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 6];
-Obj _35reg1274 = primCar(_35val1273);
-Obj name = _35reg1274;
-Obj _35reg1275 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg1275) {
-Obj _35reg1276 = primCons(body1, Nil);
-Obj _35reg1277 = primCons(Nil, _35reg1276);
-Obj _35reg1278 = primCons(params, _35reg1277);
-Obj _35reg1279 = primCons(intern("lambda"), _35reg1278);
-pushCont(co, 1, _35clofun1979, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj _35reg2421 = primCar(_35val2420);
+Obj name = _35reg2421;
+Obj _35reg2422 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2422) {
+Obj _35reg2423 = primCons(body1, Nil);
+Obj _35reg2424 = primCons(Nil, _35reg2423);
+Obj _35reg2425 = primCons(params, _35reg2424);
+Obj _35reg2426 = primCons(intern("lambda"), _35reg2425);
+pushCont(co, 1, _35clofun3122, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg1279;
+co->args[5] = _35reg2426;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1286 = primCons(body1, Nil);
-Obj _35reg1287 = primCons(fvs, _35reg1286);
-Obj _35reg1288 = primCons(params, _35reg1287);
-Obj _35reg1289 = primCons(intern("lambda"), _35reg1288);
-pushCont(co, 2, _35clofun1979, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg2433 = primCons(body1, Nil);
+Obj _35reg2434 = primCons(fvs, _35reg2433);
+Obj _35reg2435 = primCons(params, _35reg2434);
+Obj _35reg2436 = primCons(intern("lambda"), _35reg2435);
+pushCont(co, 2, _35clofun3122, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg1289;
+co->args[5] = _35reg2436;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35val1251 = __arg1;
+Obj _35val2398 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj cur = _35val1251;
-Obj _35reg1252 = primEQ(idx, makeNumber(0));
-if (True == _35reg1252) {
-Obj _35reg1253 = primGenSym(intern("clofun"));
-Obj name = _35reg1253;
-Obj _35reg1254 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg1254) {
-Obj _35reg1255 = primCons(body1, Nil);
-Obj _35reg1256 = primCons(Nil, _35reg1255);
-Obj _35reg1257 = primCons(params, _35reg1256);
-Obj _35reg1258 = primCons(intern("lambda"), _35reg1257);
-pushCont(co, 19, _35clofun1978, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj cur = _35val2398;
+Obj _35reg2399 = primEQ(idx, makeNumber(0));
+if (True == _35reg2399) {
+Obj _35reg2400 = primGenSym(intern("clofun"));
+Obj name = _35reg2400;
+Obj _35reg2401 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2401) {
+Obj _35reg2402 = primCons(body1, Nil);
+Obj _35reg2403 = primCons(Nil, _35reg2402);
+Obj _35reg2404 = primCons(params, _35reg2403);
+Obj _35reg2405 = primCons(intern("lambda"), _35reg2404);
+pushCont(co, 19, _35clofun3121, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg1258;
+co->args[5] = _35reg2405;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1265 = primCons(body1, Nil);
-Obj _35reg1266 = primCons(fvs, _35reg1265);
-Obj _35reg1267 = primCons(params, _35reg1266);
-Obj _35reg1268 = primCons(intern("lambda"), _35reg1267);
-pushCont(co, 20, _35clofun1978, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg2412 = primCons(body1, Nil);
+Obj _35reg2413 = primCons(fvs, _35reg2412);
+Obj _35reg2414 = primCons(params, _35reg2413);
+Obj _35reg2415 = primCons(intern("lambda"), _35reg2414);
+pushCont(co, 20, _35clofun3121, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg1268;
+co->args[5] = _35reg2415;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 3, _35clofun1979, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
+pushCont(co, 3, _35clofun3122, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35val1250 = __arg1;
+Obj _35val2397 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val1250;
-pushCont(co, 4, _35clofun1979, 6, body1, params, v, idx, fvs, clo_45or_45cont);
+Obj idx = _35val2397;
+pushCont(co, 4, _35clofun3122, 6, body1, params, v, idx, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -6926,19 +6882,19 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val1249 = __arg1;
+Obj _35val2396 = __arg1;
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj body1 = _35val1249;
-pushCont(co, 5, _35clofun1979, 5, body1, params, v, fvs, clo_45or_45cont);
+Obj body1 = _35val2396;
+pushCont(co, 5, _35clofun3122, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -6946,68 +6902,68 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35p104 = __arg1;
-Obj _35p105 = __arg2;
-Obj _35cc106 = makeNative(18, _35clofun1977, 0, 2, _35p104, _35p105);
-Obj v = _35p104;
-Obj _35reg1120 = primIsCons(_35p105);
-if (True == _35reg1120) {
-Obj _35reg1121 = primCar(_35p105);
-Obj clo_45or_45cont = _35reg1121;
-Obj _35reg1122 = primCdr(_35p105);
-Obj _35reg1123 = primIsCons(_35reg1122);
-if (True == _35reg1123) {
-Obj _35reg1124 = primCdr(_35p105);
-Obj _35reg1125 = primCar(_35reg1124);
-Obj _35reg1126 = primIsCons(_35reg1125);
-if (True == _35reg1126) {
-Obj _35reg1127 = primCdr(_35p105);
-Obj _35reg1128 = primCar(_35reg1127);
-Obj _35reg1129 = primCar(_35reg1128);
-Obj _35reg1130 = primEQ(intern("lambda"), _35reg1129);
-if (True == _35reg1130) {
-Obj _35reg1131 = primCdr(_35p105);
-Obj _35reg1132 = primCar(_35reg1131);
-Obj _35reg1133 = primCdr(_35reg1132);
-Obj _35reg1134 = primIsCons(_35reg1133);
-if (True == _35reg1134) {
-Obj _35reg1135 = primCdr(_35p105);
-Obj _35reg1136 = primCar(_35reg1135);
-Obj _35reg1137 = primCdr(_35reg1136);
-Obj _35reg1138 = primCar(_35reg1137);
-Obj params = _35reg1138;
-Obj _35reg1139 = primCdr(_35p105);
-Obj _35reg1140 = primCar(_35reg1139);
-Obj _35reg1141 = primCdr(_35reg1140);
-Obj _35reg1142 = primCdr(_35reg1141);
-Obj _35reg1143 = primIsCons(_35reg1142);
-if (True == _35reg1143) {
-Obj _35reg1144 = primCdr(_35p105);
-Obj _35reg1145 = primCar(_35reg1144);
-Obj _35reg1146 = primCdr(_35reg1145);
-Obj _35reg1147 = primCdr(_35reg1146);
-Obj _35reg1148 = primCar(_35reg1147);
-Obj body = _35reg1148;
-Obj _35reg1149 = primCdr(_35p105);
-Obj _35reg1150 = primCar(_35reg1149);
-Obj _35reg1151 = primCdr(_35reg1150);
-Obj _35reg1152 = primCdr(_35reg1151);
-Obj _35reg1153 = primCdr(_35reg1152);
-Obj _35reg1154 = primEQ(Nil, _35reg1153);
-if (True == _35reg1154) {
-Obj _35reg1155 = primCdr(_35p105);
-Obj _35reg1156 = primCdr(_35reg1155);
-Obj fvs = _35reg1156;
-Obj _35reg1157 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg1157) {
+Obj _35p1251 = __arg1;
+Obj _35p1252 = __arg2;
+Obj _35cc1253 = makeNative(18, _35clofun3120, 0, 2, _35p1251, _35p1252);
+Obj v = _35p1251;
+Obj _35reg2267 = primIsCons(_35p1252);
+if (True == _35reg2267) {
+Obj _35reg2268 = primCar(_35p1252);
+Obj clo_45or_45cont = _35reg2268;
+Obj _35reg2269 = primCdr(_35p1252);
+Obj _35reg2270 = primIsCons(_35reg2269);
+if (True == _35reg2270) {
+Obj _35reg2271 = primCdr(_35p1252);
+Obj _35reg2272 = primCar(_35reg2271);
+Obj _35reg2273 = primIsCons(_35reg2272);
+if (True == _35reg2273) {
+Obj _35reg2274 = primCdr(_35p1252);
+Obj _35reg2275 = primCar(_35reg2274);
+Obj _35reg2276 = primCar(_35reg2275);
+Obj _35reg2277 = primEQ(intern("lambda"), _35reg2276);
+if (True == _35reg2277) {
+Obj _35reg2278 = primCdr(_35p1252);
+Obj _35reg2279 = primCar(_35reg2278);
+Obj _35reg2280 = primCdr(_35reg2279);
+Obj _35reg2281 = primIsCons(_35reg2280);
+if (True == _35reg2281) {
+Obj _35reg2282 = primCdr(_35p1252);
+Obj _35reg2283 = primCar(_35reg2282);
+Obj _35reg2284 = primCdr(_35reg2283);
+Obj _35reg2285 = primCar(_35reg2284);
+Obj params = _35reg2285;
+Obj _35reg2286 = primCdr(_35p1252);
+Obj _35reg2287 = primCar(_35reg2286);
+Obj _35reg2288 = primCdr(_35reg2287);
+Obj _35reg2289 = primCdr(_35reg2288);
+Obj _35reg2290 = primIsCons(_35reg2289);
+if (True == _35reg2290) {
+Obj _35reg2291 = primCdr(_35p1252);
+Obj _35reg2292 = primCar(_35reg2291);
+Obj _35reg2293 = primCdr(_35reg2292);
+Obj _35reg2294 = primCdr(_35reg2293);
+Obj _35reg2295 = primCar(_35reg2294);
+Obj body = _35reg2295;
+Obj _35reg2296 = primCdr(_35p1252);
+Obj _35reg2297 = primCar(_35reg2296);
+Obj _35reg2298 = primCdr(_35reg2297);
+Obj _35reg2299 = primCdr(_35reg2298);
+Obj _35reg2300 = primCdr(_35reg2299);
+Obj _35reg2301 = primEQ(Nil, _35reg2300);
+if (True == _35reg2301) {
+Obj _35reg2302 = primCdr(_35p1252);
+Obj _35reg2303 = primCdr(_35reg2302);
+Obj fvs = _35reg2303;
+Obj _35reg2304 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2304) {
 if (True == True) {
-pushCont(co, 7, _35clofun1978, 4, params, v, fvs, clo_45or_45cont);
+pushCont(co, 7, _35clofun3121, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
 __arg1 = v;
@@ -7015,22 +6971,22 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc106;
+__arg0 = _35cc1253;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj _35reg1203 = primEQ(clo_45or_45cont, intern("%continuation"));
-if (True == _35reg1203) {
+Obj _35reg2350 = primEQ(clo_45or_45cont, intern("%continuation"));
+if (True == _35reg2350) {
 if (True == True) {
-pushCont(co, 17, _35clofun1978, 4, params, v, fvs, clo_45or_45cont);
+pushCont(co, 17, _35clofun3121, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
 __arg1 = v;
@@ -7038,20 +6994,20 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc106;
+__arg0 = _35cc1253;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-pushCont(co, 6, _35clofun1979, 4, params, v, fvs, clo_45or_45cont);
+pushCont(co, 6, _35clofun3122, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
 __arg1 = v;
@@ -7059,87 +7015,87 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc106;
+__arg0 = _35cc1253;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc106;
+__arg0 = _35cc1253;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc106;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc106;
+__arg0 = _35cc1253;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc106;
+__arg0 = _35cc1253;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc106;
+__arg0 = _35cc1253;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc106;
+__arg0 = _35cc1253;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc106;
+__arg0 = _35cc1253;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1253;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35val1301 = __arg1;
+Obj _35val2448 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -7150,51 +7106,51 @@ __arg3 = cur1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val1305 = __arg1;
+Obj _35val2452 = __arg1;
 Obj res= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1306 = primCons(_35val1305, res);
+Obj _35reg2453 = primCons(_35val2452, res);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
 __arg2 = makeNumber(2);
-__arg3 = _35reg1306;
+__arg3 = _35reg2453;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val1304 = __arg1;
+Obj _35val2451 = __arg1;
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj res = _35val1304;
-pushCont(co, 9, _35clofun1979, 2, res, v);
+Obj res = _35val2451;
+pushCont(co, 9, _35clofun3122, 2, res, v);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = cur1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val1303 = __arg1;
+Obj _35val2450 = __arg1;
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun1979, 2, cur1, v);
+pushCont(co, 10, _35clofun3122, 2, cur1, v);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7202,16 +7158,16 @@ __arg2 = makeNumber(2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35val1302 = __arg1;
+Obj _35val2449 = __arg1;
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun1979, 2, cur1, v);
+pushCont(co, 11, _35clofun3122, 2, cur1, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -7220,7 +7176,7 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7231,27 +7187,27 @@ Obj idx = __arg2;
 Obj cur = __arg3;
 Obj name = co->args[4];
 Obj val = co->args[5];
-Obj _35reg1295 = primCons(name, idx);
-Obj _35reg1296 = primCons(val, Nil);
-Obj _35reg1297 = primCons(_35reg1295, _35reg1296);
-Obj _35reg1298 = primCons(_35reg1297, cur);
-Obj cur1 = _35reg1298;
-Obj _35reg1299 = primLT(idx, makeNumber(20));
-if (True == _35reg1299) {
-Obj _35reg1300 = primAdd(idx, makeNumber(1));
-pushCont(co, 8, _35clofun1979, 2, v, cur1);
+Obj _35reg2442 = primCons(name, idx);
+Obj _35reg2443 = primCons(val, Nil);
+Obj _35reg2444 = primCons(_35reg2442, _35reg2443);
+Obj _35reg2445 = primCons(_35reg2444, cur);
+Obj cur1 = _35reg2445;
+Obj _35reg2446 = primLT(idx, makeNumber(20));
+if (True == _35reg2446) {
+Obj _35reg2447 = primAdd(idx, makeNumber(1));
+pushCont(co, 8, _35clofun3122, 2, v, cur1);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
 __arg2 = makeNumber(0);
-__arg3 = _35reg1300;
+__arg3 = _35reg2447;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 12, _35clofun1979, 2, cur1, v);
+pushCont(co, 12, _35clofun3122, 2, cur1, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -7260,24 +7216,24 @@ __arg3 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label14:
 {
-Obj _35val1309 = __arg1;
+Obj _35val2456 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj tmp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1310 = primCons(_35val1309, Nil);
-Obj _35reg1311 = primCons(x, _35reg1310);
-Obj _35reg1312 = primCons(tmp, _35reg1311);
-Obj _35reg1313 = primCons(intern("let"), _35reg1312);
+Obj _35reg2457 = primCons(_35val2456, Nil);
+Obj _35reg2458 = primCons(x, _35reg2457);
+Obj _35reg2459 = primCons(tmp, _35reg2458);
+Obj _35reg2460 = primCons(intern("let"), _35reg2459);
 __nargs = 2;
-__arg1 = _35reg1313;
+__arg1 = _35reg2460;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1979) { goto fail; }
+if (co->ctx.pc.func != _35clofun3122) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -7285,16 +7241,16 @@ label15:
 {
 Obj x = __arg1;
 Obj k = __arg2;
-Obj _35reg1308 = primGenSym(intern("reg"));
-Obj tmp = _35reg1308;
-pushCont(co, 14, _35clofun1979, 2, x, tmp);
+Obj _35reg2455 = primGenSym(intern("reg"));
+Obj tmp = _35reg2455;
+pushCont(co, 14, _35clofun3122, 2, x, tmp);
 __nargs = 2;
 __arg0 = k;
 __arg1 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7306,39 +7262,39 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val1324 = __arg1;
+Obj _35val2471 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1325 = primAdd(i, makeNumber(1));
+Obj _35reg2472 = primAdd(i, makeNumber(1));
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
 __arg1 = self;
 __arg2 = w;
-__arg3 = _35reg1325;
+__arg3 = _35reg2472;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1323 = __arg1;
+Obj _35val2470 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 17, _35clofun1979, 4, i, self, w, more);
+pushCont(co, 17, _35clofun3122, 4, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -7346,19 +7302,19 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1322 = __arg1;
+Obj _35val2469 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 18, _35clofun1979, 4, i, self, w, more);
+pushCont(co, 18, _35clofun3122, 4, i, self, w, more);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -7368,19 +7324,19 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1321 = __arg1;
+Obj _35val2468 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 19, _35clofun1979, 5, x, i, self, w, more);
+pushCont(co, 19, _35clofun3122, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -7388,7 +7344,7 @@ __arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3122) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7401,7 +7357,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1978(struct Cora* co){
+void _35clofun3121(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -7414,77 +7370,77 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1178 = __arg1;
+Obj _35val2325 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1179 = primCons(name, idx);
-Obj _35reg1180 = primCons(_35reg1179, fvs);
-Obj _35reg1181 = primCons(clo_45or_45cont, _35reg1180);
+Obj _35reg2326 = primCons(name, idx);
+Obj _35reg2327 = primCons(_35reg2326, fvs);
+Obj _35reg2328 = primCons(clo_45or_45cont, _35reg2327);
 __nargs = 2;
-__arg1 = _35reg1181;
+__arg1 = _35reg2328;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1978) { goto fail; }
+if (co->ctx.pc.func != _35clofun3121) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj _35val1191 = __arg1;
+Obj _35val2338 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1190= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2337= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1192 = primCons(_35val1191, fvs);
-Obj _35reg1193 = primCons(_35reg1190, _35reg1192);
-Obj _35reg1194 = primCons(clo_45or_45cont, _35reg1193);
+Obj _35reg2339 = primCons(_35val2338, fvs);
+Obj _35reg2340 = primCons(_35reg2337, _35reg2339);
+Obj _35reg2341 = primCons(clo_45or_45cont, _35reg2340);
 __nargs = 2;
-__arg1 = _35reg1194;
+__arg1 = _35reg2341;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1978) { goto fail; }
+if (co->ctx.pc.func != _35clofun3121) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val1189 = __arg1;
+Obj _35val2336 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1190 = primCons(name, idx);
-pushCont(co, 1, _35clofun1978, 3, fvs, _35reg1190, clo_45or_45cont);
+Obj _35reg2337 = primCons(name, idx);
+pushCont(co, 1, _35clofun3121, 3, fvs, _35reg2337, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val1199 = __arg1;
+Obj _35val2346 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1200 = primCons(name, idx);
-Obj _35reg1201 = primCons(_35reg1200, fvs);
-Obj _35reg1202 = primCons(clo_45or_45cont, _35reg1201);
+Obj _35reg2347 = primCons(name, idx);
+Obj _35reg2348 = primCons(_35reg2347, fvs);
+Obj _35reg2349 = primCons(clo_45or_45cont, _35reg2348);
 __nargs = 2;
-__arg1 = _35reg1202;
+__arg1 = _35reg2349;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1978) { goto fail; }
+if (co->ctx.pc.func != _35clofun3121) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label4:
 {
-Obj _35val1182 = __arg1;
+Obj _35val2329 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -7492,123 +7448,123 @@ Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 5];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 6];
-Obj _35reg1183 = primCar(_35val1182);
-Obj name = _35reg1183;
-Obj _35reg1184 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg1184) {
-Obj _35reg1185 = primCons(body1, Nil);
-Obj _35reg1186 = primCons(Nil, _35reg1185);
-Obj _35reg1187 = primCons(params, _35reg1186);
-Obj _35reg1188 = primCons(intern("lambda"), _35reg1187);
-pushCont(co, 2, _35clofun1978, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj _35reg2330 = primCar(_35val2329);
+Obj name = _35reg2330;
+Obj _35reg2331 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2331) {
+Obj _35reg2332 = primCons(body1, Nil);
+Obj _35reg2333 = primCons(Nil, _35reg2332);
+Obj _35reg2334 = primCons(params, _35reg2333);
+Obj _35reg2335 = primCons(intern("lambda"), _35reg2334);
+pushCont(co, 2, _35clofun3121, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg1188;
+co->args[5] = _35reg2335;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1195 = primCons(body1, Nil);
-Obj _35reg1196 = primCons(fvs, _35reg1195);
-Obj _35reg1197 = primCons(params, _35reg1196);
-Obj _35reg1198 = primCons(intern("lambda"), _35reg1197);
-pushCont(co, 3, _35clofun1978, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg2342 = primCons(body1, Nil);
+Obj _35reg2343 = primCons(fvs, _35reg2342);
+Obj _35reg2344 = primCons(params, _35reg2343);
+Obj _35reg2345 = primCons(intern("lambda"), _35reg2344);
+pushCont(co, 3, _35clofun3121, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg1198;
+co->args[5] = _35reg2345;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35val1160 = __arg1;
+Obj _35val2307 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj cur = _35val1160;
-Obj _35reg1161 = primEQ(idx, makeNumber(0));
-if (True == _35reg1161) {
-Obj _35reg1162 = primGenSym(intern("clofun"));
-Obj name = _35reg1162;
-Obj _35reg1163 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg1163) {
-Obj _35reg1164 = primCons(body1, Nil);
-Obj _35reg1165 = primCons(Nil, _35reg1164);
-Obj _35reg1166 = primCons(params, _35reg1165);
-Obj _35reg1167 = primCons(intern("lambda"), _35reg1166);
-pushCont(co, 20, _35clofun1977, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj cur = _35val2307;
+Obj _35reg2308 = primEQ(idx, makeNumber(0));
+if (True == _35reg2308) {
+Obj _35reg2309 = primGenSym(intern("clofun"));
+Obj name = _35reg2309;
+Obj _35reg2310 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2310) {
+Obj _35reg2311 = primCons(body1, Nil);
+Obj _35reg2312 = primCons(Nil, _35reg2311);
+Obj _35reg2313 = primCons(params, _35reg2312);
+Obj _35reg2314 = primCons(intern("lambda"), _35reg2313);
+pushCont(co, 20, _35clofun3120, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg1167;
+co->args[5] = _35reg2314;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1174 = primCons(body1, Nil);
-Obj _35reg1175 = primCons(fvs, _35reg1174);
-Obj _35reg1176 = primCons(params, _35reg1175);
-Obj _35reg1177 = primCons(intern("lambda"), _35reg1176);
-pushCont(co, 0, _35clofun1978, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg2321 = primCons(body1, Nil);
+Obj _35reg2322 = primCons(fvs, _35reg2321);
+Obj _35reg2323 = primCons(params, _35reg2322);
+Obj _35reg2324 = primCons(intern("lambda"), _35reg2323);
+pushCont(co, 0, _35clofun3121, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg1177;
+co->args[5] = _35reg2324;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 4, _35clofun1978, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
+pushCont(co, 4, _35clofun3121, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label6:
 {
-Obj _35val1159 = __arg1;
+Obj _35val2306 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val1159;
-pushCont(co, 5, _35clofun1978, 6, body1, params, v, idx, fvs, clo_45or_45cont);
+Obj idx = _35val2306;
+pushCont(co, 5, _35clofun3121, 6, body1, params, v, idx, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7616,19 +7572,19 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val1158 = __arg1;
+Obj _35val2305 = __arg1;
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj body1 = _35val1158;
-pushCont(co, 6, _35clofun1978, 5, body1, params, v, fvs, clo_45or_45cont);
+Obj body1 = _35val2305;
+pushCont(co, 6, _35clofun3121, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7636,119 +7592,119 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val1216 = __arg1;
+Obj _35val2363 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1215= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2362= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1217 = primCons(_35val1216, fvs);
-Obj _35reg1218 = primCons(_35reg1215, _35reg1217);
-Obj _35reg1219 = primCons(clo_45or_45cont, _35reg1218);
+Obj _35reg2364 = primCons(_35val2363, fvs);
+Obj _35reg2365 = primCons(_35reg2362, _35reg2364);
+Obj _35reg2366 = primCons(clo_45or_45cont, _35reg2365);
 __nargs = 2;
-__arg1 = _35reg1219;
+__arg1 = _35reg2366;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1978) { goto fail; }
+if (co->ctx.pc.func != _35clofun3121) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label9:
 {
-Obj _35val1214 = __arg1;
+Obj _35val2361 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1215 = primCons(name, idx);
-pushCont(co, 8, _35clofun1978, 3, fvs, _35reg1215, clo_45or_45cont);
+Obj _35reg2362 = primCons(name, idx);
+pushCont(co, 8, _35clofun3121, 3, fvs, _35reg2362, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val1224 = __arg1;
+Obj _35val2371 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1225 = primCons(name, idx);
-Obj _35reg1226 = primCons(_35reg1225, fvs);
-Obj _35reg1227 = primCons(clo_45or_45cont, _35reg1226);
+Obj _35reg2372 = primCons(name, idx);
+Obj _35reg2373 = primCons(_35reg2372, fvs);
+Obj _35reg2374 = primCons(clo_45or_45cont, _35reg2373);
 __nargs = 2;
-__arg1 = _35reg1227;
+__arg1 = _35reg2374;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1978) { goto fail; }
+if (co->ctx.pc.func != _35clofun3121) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label11:
 {
-Obj _35val1237 = __arg1;
+Obj _35val2384 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1236= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2383= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1238 = primCons(_35val1237, fvs);
-Obj _35reg1239 = primCons(_35reg1236, _35reg1238);
-Obj _35reg1240 = primCons(clo_45or_45cont, _35reg1239);
+Obj _35reg2385 = primCons(_35val2384, fvs);
+Obj _35reg2386 = primCons(_35reg2383, _35reg2385);
+Obj _35reg2387 = primCons(clo_45or_45cont, _35reg2386);
 __nargs = 2;
-__arg1 = _35reg1240;
+__arg1 = _35reg2387;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1978) { goto fail; }
+if (co->ctx.pc.func != _35clofun3121) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label12:
 {
-Obj _35val1235 = __arg1;
+Obj _35val2382 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1236 = primCons(name, idx);
-pushCont(co, 11, _35clofun1978, 3, fvs, _35reg1236, clo_45or_45cont);
+Obj _35reg2383 = primCons(name, idx);
+pushCont(co, 11, _35clofun3121, 3, fvs, _35reg2383, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35val1245 = __arg1;
+Obj _35val2392 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1246 = primCons(name, idx);
-Obj _35reg1247 = primCons(_35reg1246, fvs);
-Obj _35reg1248 = primCons(clo_45or_45cont, _35reg1247);
+Obj _35reg2393 = primCons(name, idx);
+Obj _35reg2394 = primCons(_35reg2393, fvs);
+Obj _35reg2395 = primCons(clo_45or_45cont, _35reg2394);
 __nargs = 2;
-__arg1 = _35reg1248;
+__arg1 = _35reg2395;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1978) { goto fail; }
+if (co->ctx.pc.func != _35clofun3121) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label14:
 {
-Obj _35val1228 = __arg1;
+Obj _35val2375 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -7756,123 +7712,123 @@ Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 5];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 6];
-Obj _35reg1229 = primCar(_35val1228);
-Obj name = _35reg1229;
-Obj _35reg1230 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg1230) {
-Obj _35reg1231 = primCons(body1, Nil);
-Obj _35reg1232 = primCons(Nil, _35reg1231);
-Obj _35reg1233 = primCons(params, _35reg1232);
-Obj _35reg1234 = primCons(intern("lambda"), _35reg1233);
-pushCont(co, 12, _35clofun1978, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj _35reg2376 = primCar(_35val2375);
+Obj name = _35reg2376;
+Obj _35reg2377 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2377) {
+Obj _35reg2378 = primCons(body1, Nil);
+Obj _35reg2379 = primCons(Nil, _35reg2378);
+Obj _35reg2380 = primCons(params, _35reg2379);
+Obj _35reg2381 = primCons(intern("lambda"), _35reg2380);
+pushCont(co, 12, _35clofun3121, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg1234;
+co->args[5] = _35reg2381;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1241 = primCons(body1, Nil);
-Obj _35reg1242 = primCons(fvs, _35reg1241);
-Obj _35reg1243 = primCons(params, _35reg1242);
-Obj _35reg1244 = primCons(intern("lambda"), _35reg1243);
-pushCont(co, 13, _35clofun1978, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg2388 = primCons(body1, Nil);
+Obj _35reg2389 = primCons(fvs, _35reg2388);
+Obj _35reg2390 = primCons(params, _35reg2389);
+Obj _35reg2391 = primCons(intern("lambda"), _35reg2390);
+pushCont(co, 13, _35clofun3121, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg1244;
+co->args[5] = _35reg2391;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label15:
 {
-Obj _35val1206 = __arg1;
+Obj _35val2353 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj cur = _35val1206;
-Obj _35reg1207 = primEQ(idx, makeNumber(0));
-if (True == _35reg1207) {
-Obj _35reg1208 = primGenSym(intern("clofun"));
-Obj name = _35reg1208;
-Obj _35reg1209 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg1209) {
-Obj _35reg1210 = primCons(body1, Nil);
-Obj _35reg1211 = primCons(Nil, _35reg1210);
-Obj _35reg1212 = primCons(params, _35reg1211);
-Obj _35reg1213 = primCons(intern("lambda"), _35reg1212);
-pushCont(co, 9, _35clofun1978, 5, name, idx, params, fvs, clo_45or_45cont);
+Obj cur = _35val2353;
+Obj _35reg2354 = primEQ(idx, makeNumber(0));
+if (True == _35reg2354) {
+Obj _35reg2355 = primGenSym(intern("clofun"));
+Obj name = _35reg2355;
+Obj _35reg2356 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2356) {
+Obj _35reg2357 = primCons(body1, Nil);
+Obj _35reg2358 = primCons(Nil, _35reg2357);
+Obj _35reg2359 = primCons(params, _35reg2358);
+Obj _35reg2360 = primCons(intern("lambda"), _35reg2359);
+pushCont(co, 9, _35clofun3121, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg1213;
+co->args[5] = _35reg2360;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1220 = primCons(body1, Nil);
-Obj _35reg1221 = primCons(fvs, _35reg1220);
-Obj _35reg1222 = primCons(params, _35reg1221);
-Obj _35reg1223 = primCons(intern("lambda"), _35reg1222);
-pushCont(co, 10, _35clofun1978, 4, name, idx, fvs, clo_45or_45cont);
+Obj _35reg2367 = primCons(body1, Nil);
+Obj _35reg2368 = primCons(fvs, _35reg2367);
+Obj _35reg2369 = primCons(params, _35reg2368);
+Obj _35reg2370 = primCons(intern("lambda"), _35reg2369);
+pushCont(co, 10, _35clofun3121, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
 __arg2 = idx;
 __arg3 = cur;
 co->args[4] = name;
-co->args[5] = _35reg1223;
+co->args[5] = _35reg2370;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 14, _35clofun1978, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
+pushCont(co, 14, _35clofun3121, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label16:
 {
-Obj _35val1205 = __arg1;
+Obj _35val2352 = __arg1;
 Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val1205;
-pushCont(co, 15, _35clofun1978, 6, body1, params, v, idx, fvs, clo_45or_45cont);
+Obj idx = _35val2352;
+pushCont(co, 15, _35clofun3121, 6, body1, params, v, idx, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7880,19 +7836,19 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val1204 = __arg1;
+Obj _35val2351 = __arg1;
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj body1 = _35val1204;
-pushCont(co, 16, _35clofun1978, 5, body1, params, v, fvs, clo_45or_45cont);
+Obj body1 = _35val2351;
+pushCont(co, 16, _35clofun3121, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7900,60 +7856,60 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35val1261 = __arg1;
+Obj _35val2408 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1260= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2407= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1262 = primCons(_35val1261, fvs);
-Obj _35reg1263 = primCons(_35reg1260, _35reg1262);
-Obj _35reg1264 = primCons(clo_45or_45cont, _35reg1263);
+Obj _35reg2409 = primCons(_35val2408, fvs);
+Obj _35reg2410 = primCons(_35reg2407, _35reg2409);
+Obj _35reg2411 = primCons(clo_45or_45cont, _35reg2410);
 __nargs = 2;
-__arg1 = _35reg1264;
+__arg1 = _35reg2411;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1978) { goto fail; }
+if (co->ctx.pc.func != _35clofun3121) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label19:
 {
-Obj _35val1259 = __arg1;
+Obj _35val2406 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1260 = primCons(name, idx);
-pushCont(co, 18, _35clofun1978, 3, fvs, _35reg1260, clo_45or_45cont);
+Obj _35reg2407 = primCons(name, idx);
+pushCont(co, 18, _35clofun3121, 3, fvs, _35reg2407, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3121) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1269 = __arg1;
+Obj _35val2416 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1270 = primCons(name, idx);
-Obj _35reg1271 = primCons(_35reg1270, fvs);
-Obj _35reg1272 = primCons(clo_45or_45cont, _35reg1271);
+Obj _35reg2417 = primCons(name, idx);
+Obj _35reg2418 = primCons(_35reg2417, fvs);
+Obj _35reg2419 = primCons(clo_45or_45cont, _35reg2418);
 __nargs = 2;
-__arg1 = _35reg1272;
+__arg1 = _35reg2419;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1978) { goto fail; }
+if (co->ctx.pc.func != _35clofun3121) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -7966,7 +7922,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1977(struct Cora* co){
+void _35clofun3120(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -7979,24 +7935,24 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1064 = __arg1;
-Obj _35val1063= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1065 = primCons(_35val1064, Nil);
-Obj _35reg1066 = primCons(_35val1063, _35reg1065);
-Obj _35reg1067 = primCons(intern("call"), _35reg1066);
+Obj _35val2211 = __arg1;
+Obj _35val2210= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2212 = primCons(_35val2211, Nil);
+Obj _35reg2213 = primCons(_35val2210, _35reg2212);
+Obj _35reg2214 = primCons(intern("call"), _35reg2213);
 __nargs = 2;
-__arg1 = _35reg1067;
+__arg1 = _35reg2214;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1977) { goto fail; }
+if (co->ctx.pc.func != _35clofun3120) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj _35val1063 = __arg1;
+Obj _35val2210 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun1977, 1, _35val1063);
+pushCont(co, 0, _35clofun3120, 1, _35val2210);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
@@ -8004,137 +7960,137 @@ __arg2 = cont;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1062 = __arg1;
+Obj _35val2209 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 1, _35clofun1977, 2, fvs, cont);
+pushCont(co, 1, _35clofun3120, 2, fvs, cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val1062;
+__arg1 = _35val2209;
 __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc102 = makeNative(20, _35clofun1976, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1249 = makeNative(20, _35clofun3119, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg1045 = primIsCons(closureRef(co, 1));
-if (True == _35reg1045) {
-Obj _35reg1046 = primCar(closureRef(co, 1));
-Obj _35reg1047 = primEQ(intern("call"), _35reg1046);
-if (True == _35reg1047) {
-Obj _35reg1048 = primCdr(closureRef(co, 1));
-Obj _35reg1049 = primIsCons(_35reg1048);
-if (True == _35reg1049) {
-Obj _35reg1050 = primCdr(closureRef(co, 1));
-Obj _35reg1051 = primCar(_35reg1050);
-Obj exp = _35reg1051;
-Obj _35reg1052 = primCdr(closureRef(co, 1));
-Obj _35reg1053 = primCdr(_35reg1052);
-Obj _35reg1054 = primIsCons(_35reg1053);
-if (True == _35reg1054) {
-Obj _35reg1055 = primCdr(closureRef(co, 1));
-Obj _35reg1056 = primCdr(_35reg1055);
-Obj _35reg1057 = primCar(_35reg1056);
-Obj cont = _35reg1057;
-Obj _35reg1058 = primCdr(closureRef(co, 1));
-Obj _35reg1059 = primCdr(_35reg1058);
-Obj _35reg1060 = primCdr(_35reg1059);
-Obj _35reg1061 = primEQ(Nil, _35reg1060);
-if (True == _35reg1061) {
-pushCont(co, 2, _35clofun1977, 3, exp, fvs, cont);
+Obj _35reg2192 = primIsCons(closureRef(co, 1));
+if (True == _35reg2192) {
+Obj _35reg2193 = primCar(closureRef(co, 1));
+Obj _35reg2194 = primEQ(intern("call"), _35reg2193);
+if (True == _35reg2194) {
+Obj _35reg2195 = primCdr(closureRef(co, 1));
+Obj _35reg2196 = primIsCons(_35reg2195);
+if (True == _35reg2196) {
+Obj _35reg2197 = primCdr(closureRef(co, 1));
+Obj _35reg2198 = primCar(_35reg2197);
+Obj exp = _35reg2198;
+Obj _35reg2199 = primCdr(closureRef(co, 1));
+Obj _35reg2200 = primCdr(_35reg2199);
+Obj _35reg2201 = primIsCons(_35reg2200);
+if (True == _35reg2201) {
+Obj _35reg2202 = primCdr(closureRef(co, 1));
+Obj _35reg2203 = primCdr(_35reg2202);
+Obj _35reg2204 = primCar(_35reg2203);
+Obj cont = _35reg2204;
+Obj _35reg2205 = primCdr(closureRef(co, 1));
+Obj _35reg2206 = primCdr(_35reg2205);
+Obj _35reg2207 = primCdr(_35reg2206);
+Obj _35reg2208 = primEQ(Nil, _35reg2207);
+if (True == _35reg2208) {
+pushCont(co, 2, _35clofun3120, 3, exp, fvs, cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc102;
+__arg0 = _35cc1249;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc102;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc102;
+__arg0 = _35cc1249;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc102;
+__arg0 = _35cc1249;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc102;
+__arg0 = _35cc1249;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1249;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35val1089 = __arg1;
+Obj _35val2236 = __arg1;
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fvs2= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1090 = primCons(_35val1089, Nil);
-Obj _35reg1091 = primCons(val, _35reg1090);
-Obj _35reg1092 = primCons(intern("lambda"), _35reg1091);
-Obj _35reg1093 = primCons(_35reg1092, fvs2);
-Obj _35reg1094 = primCons(intern("%continuation"), _35reg1093);
+Obj _35reg2237 = primCons(_35val2236, Nil);
+Obj _35reg2238 = primCons(val, _35reg2237);
+Obj _35reg2239 = primCons(intern("lambda"), _35reg2238);
+Obj _35reg2240 = primCons(_35reg2239, fvs2);
+Obj _35reg2241 = primCons(intern("%continuation"), _35reg2240);
 __nargs = 2;
-__arg1 = _35reg1094;
+__arg1 = _35reg2241;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1977) { goto fail; }
+if (co->ctx.pc.func != _35clofun3120) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label5:
 {
-Obj _35val1088 = __arg1;
+Obj _35val2235 = __arg1;
 Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs2 = _35val1088;
-pushCont(co, 4, _35clofun1977, 2, val, fvs2);
+Obj fvs2 = _35val2235;
+pushCont(co, 4, _35clofun3120, 2, val, fvs2);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs1;
@@ -8142,191 +8098,191 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val1087 = __arg1;
+Obj _35val2234 = __arg1;
 Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 5, _35clofun1977, 3, fvs1, body, val);
+pushCont(co, 5, _35clofun3120, 3, fvs1, body, val);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val1087;
+__arg1 = _35val2234;
 __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val1086 = __arg1;
+Obj _35val2233 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs1 = _35val1086;
-pushCont(co, 6, _35clofun1977, 3, fvs1, body, val);
+Obj fvs1 = _35val2233;
+pushCont(co, 6, _35clofun3120, 3, fvs1, body, val);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val1085 = __arg1;
+Obj _35val2232 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 7, _35clofun1977, 3, fvs, body, val);
+pushCont(co, 7, _35clofun3120, 3, fvs, body, val);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = _35val1085;
+__arg1 = _35val2232;
 __arg2 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35cc101 = makeNative(3, _35clofun1977, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1248 = makeNative(3, _35clofun3120, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg1068 = primIsCons(closureRef(co, 1));
-if (True == _35reg1068) {
-Obj _35reg1069 = primCar(closureRef(co, 1));
-Obj _35reg1070 = primEQ(intern("continuation"), _35reg1069);
-if (True == _35reg1070) {
-Obj _35reg1071 = primCdr(closureRef(co, 1));
-Obj _35reg1072 = primIsCons(_35reg1071);
-if (True == _35reg1072) {
-Obj _35reg1073 = primCdr(closureRef(co, 1));
-Obj _35reg1074 = primCar(_35reg1073);
-Obj val = _35reg1074;
-Obj _35reg1075 = primCdr(closureRef(co, 1));
-Obj _35reg1076 = primCdr(_35reg1075);
-Obj _35reg1077 = primIsCons(_35reg1076);
-if (True == _35reg1077) {
-Obj _35reg1078 = primCdr(closureRef(co, 1));
-Obj _35reg1079 = primCdr(_35reg1078);
-Obj _35reg1080 = primCar(_35reg1079);
-Obj body = _35reg1080;
-Obj _35reg1081 = primCdr(closureRef(co, 1));
-Obj _35reg1082 = primCdr(_35reg1081);
-Obj _35reg1083 = primCdr(_35reg1082);
-Obj _35reg1084 = primEQ(Nil, _35reg1083);
-if (True == _35reg1084) {
-pushCont(co, 8, _35clofun1977, 3, fvs, body, val);
+Obj _35reg2215 = primIsCons(closureRef(co, 1));
+if (True == _35reg2215) {
+Obj _35reg2216 = primCar(closureRef(co, 1));
+Obj _35reg2217 = primEQ(intern("continuation"), _35reg2216);
+if (True == _35reg2217) {
+Obj _35reg2218 = primCdr(closureRef(co, 1));
+Obj _35reg2219 = primIsCons(_35reg2218);
+if (True == _35reg2219) {
+Obj _35reg2220 = primCdr(closureRef(co, 1));
+Obj _35reg2221 = primCar(_35reg2220);
+Obj val = _35reg2221;
+Obj _35reg2222 = primCdr(closureRef(co, 1));
+Obj _35reg2223 = primCdr(_35reg2222);
+Obj _35reg2224 = primIsCons(_35reg2223);
+if (True == _35reg2224) {
+Obj _35reg2225 = primCdr(closureRef(co, 1));
+Obj _35reg2226 = primCdr(_35reg2225);
+Obj _35reg2227 = primCar(_35reg2226);
+Obj body = _35reg2227;
+Obj _35reg2228 = primCdr(closureRef(co, 1));
+Obj _35reg2229 = primCdr(_35reg2228);
+Obj _35reg2230 = primCdr(_35reg2229);
+Obj _35reg2231 = primEQ(Nil, _35reg2230);
+if (True == _35reg2231) {
+pushCont(co, 8, _35clofun3120, 3, fvs, body, val);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc101;
+__arg0 = _35cc1248;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc101;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc101;
+__arg0 = _35cc1248;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc101;
+__arg0 = _35cc1248;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc101;
+__arg0 = _35cc1248;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1248;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35val1112 = __arg1;
+Obj _35val2259 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1113 = primCons(_35val1112, Nil);
-Obj _35reg1114 = primCons(args, _35reg1113);
-Obj _35reg1115 = primCons(intern("lambda"), _35reg1114);
+Obj _35reg2260 = primCons(_35val2259, Nil);
+Obj _35reg2261 = primCons(args, _35reg2260);
+Obj _35reg2262 = primCons(intern("lambda"), _35reg2261);
 __nargs = 2;
-__arg1 = _35reg1115;
+__arg1 = _35reg2262;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1977) { goto fail; }
+if (co->ctx.pc.func != _35clofun3120) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label11:
 {
-Obj _35cc100 = makeNative(9, _35clofun1977, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1247 = makeNative(9, _35clofun3120, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg1095 = primIsCons(closureRef(co, 1));
-if (True == _35reg1095) {
-Obj _35reg1096 = primCar(closureRef(co, 1));
-Obj _35reg1097 = primEQ(intern("lambda"), _35reg1096);
-if (True == _35reg1097) {
-Obj _35reg1098 = primCdr(closureRef(co, 1));
-Obj _35reg1099 = primIsCons(_35reg1098);
-if (True == _35reg1099) {
-Obj _35reg1100 = primCdr(closureRef(co, 1));
-Obj _35reg1101 = primCar(_35reg1100);
-Obj args = _35reg1101;
-Obj _35reg1102 = primCdr(closureRef(co, 1));
-Obj _35reg1103 = primCdr(_35reg1102);
-Obj _35reg1104 = primIsCons(_35reg1103);
-if (True == _35reg1104) {
-Obj _35reg1105 = primCdr(closureRef(co, 1));
-Obj _35reg1106 = primCdr(_35reg1105);
-Obj _35reg1107 = primCar(_35reg1106);
-Obj body = _35reg1107;
-Obj _35reg1108 = primCdr(closureRef(co, 1));
-Obj _35reg1109 = primCdr(_35reg1108);
-Obj _35reg1110 = primCdr(_35reg1109);
-Obj _35reg1111 = primEQ(Nil, _35reg1110);
-if (True == _35reg1111) {
-pushCont(co, 10, _35clofun1977, 1, args);
+Obj _35reg2242 = primIsCons(closureRef(co, 1));
+if (True == _35reg2242) {
+Obj _35reg2243 = primCar(closureRef(co, 1));
+Obj _35reg2244 = primEQ(intern("lambda"), _35reg2243);
+if (True == _35reg2244) {
+Obj _35reg2245 = primCdr(closureRef(co, 1));
+Obj _35reg2246 = primIsCons(_35reg2245);
+if (True == _35reg2246) {
+Obj _35reg2247 = primCdr(closureRef(co, 1));
+Obj _35reg2248 = primCar(_35reg2247);
+Obj args = _35reg2248;
+Obj _35reg2249 = primCdr(closureRef(co, 1));
+Obj _35reg2250 = primCdr(_35reg2249);
+Obj _35reg2251 = primIsCons(_35reg2250);
+if (True == _35reg2251) {
+Obj _35reg2252 = primCdr(closureRef(co, 1));
+Obj _35reg2253 = primCdr(_35reg2252);
+Obj _35reg2254 = primCar(_35reg2253);
+Obj body = _35reg2254;
+Obj _35reg2255 = primCdr(closureRef(co, 1));
+Obj _35reg2256 = primCdr(_35reg2255);
+Obj _35reg2257 = primCdr(_35reg2256);
+Obj _35reg2258 = primEQ(Nil, _35reg2257);
+if (True == _35reg2258) {
+pushCont(co, 10, _35clofun3120, 1, args);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
@@ -8334,115 +8290,115 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc100;
+__arg0 = _35cc1247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc100;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc100;
+__arg0 = _35cc1247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc100;
+__arg0 = _35cc1247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc100;
+__arg0 = _35cc1247;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1247;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj _35cc99 = makeNative(11, _35clofun1977, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1246 = makeNative(11, _35clofun3120, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj _35reg1116 = primIsSymbol(var);
-if (True == _35reg1116) {
+Obj _35reg2263 = primIsSymbol(var);
+if (True == _35reg2263) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1977) { goto fail; }
+if (co->ctx.pc.func != _35clofun3120) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc99;
+__arg0 = _35cc1246;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label13:
 {
-Obj _35val1117 = __arg1;
+Obj _35val2264 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc98= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1117) {
+Obj _35cc1245= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val2264) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1977) { goto fail; }
+if (co->ctx.pc.func != _35clofun3120) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc98;
+__arg0 = _35cc1245;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label14:
 {
-Obj _35p96 = __arg1;
-Obj _35p97 = __arg2;
-Obj _35cc98 = makeNative(12, _35clofun1977, 0, 2, _35p96, _35p97);
-Obj __ = _35p96;
-Obj x = _35p97;
-pushCont(co, 13, _35clofun1977, 2, x, _35cc98);
+Obj _35p1243 = __arg1;
+Obj _35p1244 = __arg2;
+Obj _35cc1245 = makeNative(12, _35clofun3120, 0, 2, _35p1243, _35p1244);
+Obj __ = _35p1243;
+Obj x = _35p1244;
+pushCont(co, 13, _35clofun3120, 2, x, _35cc1245);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8454,19 +8410,19 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35cc108 = makeNative(15, _35clofun1977, 0, 0);
+Obj _35cc1255 = makeNative(15, _35clofun3120, 0, 0);
 Obj v = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1977) { goto fail; }
+if (co->ctx.pc.func != _35clofun3120) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -8480,70 +8436,70 @@ __arg2 = e;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35cc107 = makeNative(16, _35clofun1977, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1254 = makeNative(16, _35clofun3120, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj v = closureRef(co, 0);
 Obj f_45args = closureRef(co, 1);
-Obj _35reg1119 = primIsCons(f_45args);
-if (True == _35reg1119) {
+Obj _35reg2266 = primIsCons(f_45args);
+if (True == _35reg2266) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = makeNative(17, _35clofun1977, 1, 1, v);
+__arg1 = makeNative(17, _35clofun3120, 1, 1, v);
 __arg2 = f_45args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc107;
+__arg0 = _35cc1254;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label19:
 {
-Obj _35val1170 = __arg1;
+Obj _35val2317 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1169= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2316= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1171 = primCons(_35val1170, fvs);
-Obj _35reg1172 = primCons(_35reg1169, _35reg1171);
-Obj _35reg1173 = primCons(clo_45or_45cont, _35reg1172);
+Obj _35reg2318 = primCons(_35val2317, fvs);
+Obj _35reg2319 = primCons(_35reg2316, _35reg2318);
+Obj _35reg2320 = primCons(clo_45or_45cont, _35reg2319);
 __nargs = 2;
-__arg1 = _35reg1173;
+__arg1 = _35reg2320;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1977) { goto fail; }
+if (co->ctx.pc.func != _35clofun3120) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label20:
 {
-Obj _35val1168 = __arg1;
+Obj _35val2315 = __arg1;
 Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1169 = primCons(name, idx);
-pushCont(co, 19, _35clofun1977, 3, fvs, _35reg1169, clo_45or_45cont);
+Obj _35reg2316 = primCons(name, idx);
+pushCont(co, 19, _35clofun3120, 3, fvs, _35reg2316, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3120) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8556,7 +8512,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1976(struct Cora* co){
+void _35clofun3119(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -8569,25 +8525,25 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val984 = __arg1;
-Obj _35val983= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2131 = __arg1;
+Obj _35val2130= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg985 = primCons(_35val984, Nil);
-Obj _35reg986 = primCons(_35val983, _35reg985);
-Obj _35reg987 = primCons(ra, _35reg986);
-Obj _35reg988 = primCons(intern("if"), _35reg987);
+Obj _35reg2132 = primCons(_35val2131, Nil);
+Obj _35reg2133 = primCons(_35val2130, _35reg2132);
+Obj _35reg2134 = primCons(ra, _35reg2133);
+Obj _35reg2135 = primCons(intern("if"), _35reg2134);
 __nargs = 2;
-__arg1 = _35reg988;
+__arg1 = _35reg2135;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1976) { goto fail; }
+if (co->ctx.pc.func != _35clofun3119) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj _35val983 = __arg1;
+Obj _35val2130 = __arg1;
 Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun1976, 2, _35val983, ra);
+pushCont(co, 0, _35clofun3119, 2, _35val2130, ra);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 1);
@@ -8595,14 +8551,14 @@ __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
 Obj ra = __arg1;
-pushCont(co, 1, _35clofun1976, 1, ra);
+pushCont(co, 1, _35clofun3119, 1, ra);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 0);
@@ -8610,159 +8566,159 @@ __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc86 = makeNative(20, _35clofun1975, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg957 = primIsCons(closureRef(co, 0));
-if (True == _35reg957) {
-Obj _35reg958 = primCar(closureRef(co, 0));
-Obj _35reg959 = primEQ(intern("if"), _35reg958);
-if (True == _35reg959) {
-Obj _35reg960 = primCdr(closureRef(co, 0));
-Obj _35reg961 = primIsCons(_35reg960);
-if (True == _35reg961) {
-Obj _35reg962 = primCdr(closureRef(co, 0));
-Obj _35reg963 = primCar(_35reg962);
-Obj a = _35reg963;
-Obj _35reg964 = primCdr(closureRef(co, 0));
-Obj _35reg965 = primCdr(_35reg964);
-Obj _35reg966 = primIsCons(_35reg965);
-if (True == _35reg966) {
-Obj _35reg967 = primCdr(closureRef(co, 0));
-Obj _35reg968 = primCdr(_35reg967);
-Obj _35reg969 = primCar(_35reg968);
-Obj b = _35reg969;
-Obj _35reg970 = primCdr(closureRef(co, 0));
-Obj _35reg971 = primCdr(_35reg970);
-Obj _35reg972 = primCdr(_35reg971);
-Obj _35reg973 = primIsCons(_35reg972);
-if (True == _35reg973) {
-Obj _35reg974 = primCdr(closureRef(co, 0));
-Obj _35reg975 = primCdr(_35reg974);
-Obj _35reg976 = primCdr(_35reg975);
-Obj _35reg977 = primCar(_35reg976);
-Obj c = _35reg977;
-Obj _35reg978 = primCdr(closureRef(co, 0));
-Obj _35reg979 = primCdr(_35reg978);
-Obj _35reg980 = primCdr(_35reg979);
-Obj _35reg981 = primCdr(_35reg980);
-Obj _35reg982 = primEQ(Nil, _35reg981);
-if (True == _35reg982) {
+Obj _35cc1233 = makeNative(20, _35clofun3118, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2104 = primIsCons(closureRef(co, 0));
+if (True == _35reg2104) {
+Obj _35reg2105 = primCar(closureRef(co, 0));
+Obj _35reg2106 = primEQ(intern("if"), _35reg2105);
+if (True == _35reg2106) {
+Obj _35reg2107 = primCdr(closureRef(co, 0));
+Obj _35reg2108 = primIsCons(_35reg2107);
+if (True == _35reg2108) {
+Obj _35reg2109 = primCdr(closureRef(co, 0));
+Obj _35reg2110 = primCar(_35reg2109);
+Obj a = _35reg2110;
+Obj _35reg2111 = primCdr(closureRef(co, 0));
+Obj _35reg2112 = primCdr(_35reg2111);
+Obj _35reg2113 = primIsCons(_35reg2112);
+if (True == _35reg2113) {
+Obj _35reg2114 = primCdr(closureRef(co, 0));
+Obj _35reg2115 = primCdr(_35reg2114);
+Obj _35reg2116 = primCar(_35reg2115);
+Obj b = _35reg2116;
+Obj _35reg2117 = primCdr(closureRef(co, 0));
+Obj _35reg2118 = primCdr(_35reg2117);
+Obj _35reg2119 = primCdr(_35reg2118);
+Obj _35reg2120 = primIsCons(_35reg2119);
+if (True == _35reg2120) {
+Obj _35reg2121 = primCdr(closureRef(co, 0));
+Obj _35reg2122 = primCdr(_35reg2121);
+Obj _35reg2123 = primCdr(_35reg2122);
+Obj _35reg2124 = primCar(_35reg2123);
+Obj c = _35reg2124;
+Obj _35reg2125 = primCdr(closureRef(co, 0));
+Obj _35reg2126 = primCdr(_35reg2125);
+Obj _35reg2127 = primCdr(_35reg2126);
+Obj _35reg2128 = primCdr(_35reg2127);
+Obj _35reg2129 = primEQ(Nil, _35reg2128);
+if (True == _35reg2129) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = a;
-__arg2 = makeNative(2, _35clofun1976, 1, 3, b, c, next);
+__arg2 = makeNative(2, _35clofun3119, 1, 3, b, c, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc86;
+__arg0 = _35cc1233;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc86;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc86;
+__arg0 = _35cc1233;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc86;
+__arg0 = _35cc1233;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc86;
+__arg0 = _35cc1233;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc86;
+__arg0 = _35cc1233;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1233;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35val989 = __arg1;
+Obj _35val2136 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc85= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val989) {
+Obj _35cc1232= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val2136) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1976) { goto fail; }
+if (co->ctx.pc.func != _35clofun3119) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc85;
+__arg0 = _35cc1232;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35cc85 = makeNative(3, _35clofun1976, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1232 = makeNative(3, _35clofun3119, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj x = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
-pushCont(co, 4, _35clofun1976, 2, x, _35cc85);
+pushCont(co, 4, _35clofun3119, 2, x, _35cc1232);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35val991 = __arg1;
+Obj _35val2138 = __arg1;
 Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc84= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val991) {
+Obj _35cc1231= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val2138) {
 if (True == True) {
 __nargs = 2;
 __arg0 = next;
@@ -8770,15 +8726,15 @@ __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc84;
+__arg0 = _35cc1231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8789,15 +8745,15 @@ __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc84;
+__arg0 = _35cc1231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -8805,13 +8761,13 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35p82 = __arg1;
-Obj _35p83 = __arg2;
-Obj _35cc84 = makeNative(5, _35clofun1976, 0, 2, _35p82, _35p83);
-Obj x = _35p82;
-Obj next = _35p83;
-Obj _35reg990 = primIsSymbol(x);
-if (True == _35reg990) {
+Obj _35p1229 = __arg1;
+Obj _35p1230 = __arg2;
+Obj _35cc1231 = makeNative(5, _35clofun3119, 0, 2, _35p1229, _35p1230);
+Obj x = _35p1229;
+Obj next = _35p1230;
+Obj _35reg2137 = primIsSymbol(x);
+if (True == _35reg2137) {
 if (True == True) {
 __nargs = 2;
 __arg0 = next;
@@ -8819,26 +8775,26 @@ __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc84;
+__arg0 = _35cc1231;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 6, _35clofun1976, 3, next, x, _35cc84);
+pushCont(co, 6, _35clofun3119, 3, next, x, _35cc1231);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -8851,100 +8807,100 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
 Obj hd1 = __arg1;
-Obj _35reg996 = primCons(hd1, closureRef(co, 1));
+Obj _35reg2143 = primCons(hd1, closureRef(co, 1));
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#tailify-list"));
 __arg1 = closureRef(co, 0);
-__arg2 = _35reg996;
+__arg2 = _35reg2143;
 __arg3 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35cc95 = makeNative(8, _35clofun1976, 0, 0);
-Obj _35reg993 = primIsCons(closureRef(co, 0));
-if (True == _35reg993) {
-Obj _35reg994 = primCar(closureRef(co, 0));
-Obj hd = _35reg994;
-Obj _35reg995 = primCdr(closureRef(co, 0));
-Obj tl = _35reg995;
+Obj _35cc1242 = makeNative(8, _35clofun3119, 0, 0);
+Obj _35reg2140 = primIsCons(closureRef(co, 0));
+if (True == _35reg2140) {
+Obj _35reg2141 = primCar(closureRef(co, 0));
+Obj hd = _35reg2141;
+Obj _35reg2142 = primCdr(closureRef(co, 0));
+Obj tl = _35reg2142;
 Obj ls = closureRef(co, 1);
 Obj next = closureRef(co, 2);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = hd;
-__arg2 = makeNative(9, _35clofun1976, 1, 3, tl, ls, next);
+__arg2 = makeNative(9, _35clofun3119, 1, 3, tl, ls, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc95;
+__arg0 = _35cc1242;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35val1008 = __arg1;
-Obj _35reg1007= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2155 = __arg1;
+Obj _35reg2154= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1009 = primCons(_35val1008, Nil);
-Obj _35reg1010 = primCons(_35reg1007, _35reg1009);
-Obj _35reg1011 = primCons(intern("continuation"), _35reg1010);
-Obj _35reg1012 = primCons(_35reg1011, Nil);
-Obj _35reg1013 = primCons(exp, _35reg1012);
-Obj _35reg1014 = primCons(intern("call"), _35reg1013);
+Obj _35reg2156 = primCons(_35val2155, Nil);
+Obj _35reg2157 = primCons(_35reg2154, _35reg2156);
+Obj _35reg2158 = primCons(intern("continuation"), _35reg2157);
+Obj _35reg2159 = primCons(_35reg2158, Nil);
+Obj _35reg2160 = primCons(exp, _35reg2159);
+Obj _35reg2161 = primCons(intern("call"), _35reg2160);
 __nargs = 2;
-__arg1 = _35reg1014;
+__arg1 = _35reg2161;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1976) { goto fail; }
+if (co->ctx.pc.func != _35clofun3119) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label12:
 {
-Obj _35val1020 = __arg1;
-Obj _35reg1019= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2167 = __arg1;
+Obj _35reg2166= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1021 = primCons(_35val1020, Nil);
-Obj _35reg1022 = primCons(_35reg1019, _35reg1021);
-Obj _35reg1023 = primCons(intern("continuation"), _35reg1022);
-Obj _35reg1024 = primCons(_35reg1023, Nil);
-Obj _35reg1025 = primCons(exp, _35reg1024);
-Obj _35reg1026 = primCons(intern("call"), _35reg1025);
+Obj _35reg2168 = primCons(_35val2167, Nil);
+Obj _35reg2169 = primCons(_35reg2166, _35reg2168);
+Obj _35reg2170 = primCons(intern("continuation"), _35reg2169);
+Obj _35reg2171 = primCons(_35reg2170, Nil);
+Obj _35reg2172 = primCons(exp, _35reg2171);
+Obj _35reg2173 = primCons(intern("call"), _35reg2172);
 __nargs = 2;
-__arg1 = _35reg1026;
+__arg1 = _35reg2173;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1976) { goto fail; }
+if (co->ctx.pc.func != _35clofun3119) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label13:
 {
-Obj _35val1001 = __arg1;
+Obj _35val2148 = __arg1;
 Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1002 = primEQ(_35val1001, intern("%builtin"));
-if (True == _35reg1002) {
+Obj _35reg2149 = primEQ(_35val2148, intern("%builtin"));
+if (True == _35reg2149) {
 if (True == True) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#wrap-var"));
@@ -8953,30 +8909,30 @@ __arg2 = next;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1003 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
-if (True == _35reg1003) {
-Obj _35reg1004 = primCons(exp, Nil);
-Obj _35reg1005 = primCons(intern("tailcall"), _35reg1004);
+Obj _35reg2150 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
+if (True == _35reg2150) {
+Obj _35reg2151 = primCons(exp, Nil);
+Obj _35reg2152 = primCons(intern("tailcall"), _35reg2151);
 __nargs = 2;
-__arg1 = _35reg1005;
+__arg1 = _35reg2152;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1976) { goto fail; }
+if (co->ctx.pc.func != _35clofun3119) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg1006 = primGenSym(intern("val"));
-Obj val = _35reg1006;
-Obj _35reg1007 = primCons(val, Nil);
-pushCont(co, 11, _35clofun1976, 2, _35reg1007, exp);
+Obj _35reg2153 = primGenSym(intern("val"));
+Obj val = _35reg2153;
+Obj _35reg2154 = primCons(val, Nil);
+pushCont(co, 11, _35clofun3119, 2, _35reg2154, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -8989,30 +8945,30 @@ __arg2 = next;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1015 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
-if (True == _35reg1015) {
-Obj _35reg1016 = primCons(exp, Nil);
-Obj _35reg1017 = primCons(intern("tailcall"), _35reg1016);
+Obj _35reg2162 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
+if (True == _35reg2162) {
+Obj _35reg2163 = primCons(exp, Nil);
+Obj _35reg2164 = primCons(intern("tailcall"), _35reg2163);
 __nargs = 2;
-__arg1 = _35reg1017;
+__arg1 = _35reg2164;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1976) { goto fail; }
+if (co->ctx.pc.func != _35clofun3119) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg1018 = primGenSym(intern("val"));
-Obj val = _35reg1018;
-Obj _35reg1019 = primCons(val, Nil);
-pushCont(co, 12, _35clofun1976, 2, _35reg1019, exp);
+Obj _35reg2165 = primGenSym(intern("val"));
+Obj val = _35reg2165;
+Obj _35reg2166 = primCons(val, Nil);
+pushCont(co, 12, _35clofun3119, 2, _35reg2166, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9021,36 +8977,36 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj _35val1032 = __arg1;
-Obj _35reg1031= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2179 = __arg1;
+Obj _35reg2178= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1033 = primCons(_35val1032, Nil);
-Obj _35reg1034 = primCons(_35reg1031, _35reg1033);
-Obj _35reg1035 = primCons(intern("continuation"), _35reg1034);
-Obj _35reg1036 = primCons(_35reg1035, Nil);
-Obj _35reg1037 = primCons(exp, _35reg1036);
-Obj _35reg1038 = primCons(intern("call"), _35reg1037);
+Obj _35reg2180 = primCons(_35val2179, Nil);
+Obj _35reg2181 = primCons(_35reg2178, _35reg2180);
+Obj _35reg2182 = primCons(intern("continuation"), _35reg2181);
+Obj _35reg2183 = primCons(_35reg2182, Nil);
+Obj _35reg2184 = primCons(exp, _35reg2183);
+Obj _35reg2185 = primCons(intern("call"), _35reg2184);
 __nargs = 2;
-__arg1 = _35reg1038;
+__arg1 = _35reg2185;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1976) { goto fail; }
+if (co->ctx.pc.func != _35clofun3119) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label15:
 {
-Obj _35val1000 = __arg1;
+Obj _35val2147 = __arg1;
 Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1000) {
-pushCont(co, 13, _35clofun1976, 2, next, exp);
+if (True == _35val2147) {
+pushCont(co, 13, _35clofun3119, 2, next, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 if (True == False) {
@@ -9061,30 +9017,30 @@ __arg2 = next;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1027 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
-if (True == _35reg1027) {
-Obj _35reg1028 = primCons(exp, Nil);
-Obj _35reg1029 = primCons(intern("tailcall"), _35reg1028);
+Obj _35reg2174 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
+if (True == _35reg2174) {
+Obj _35reg2175 = primCons(exp, Nil);
+Obj _35reg2176 = primCons(intern("tailcall"), _35reg2175);
 __nargs = 2;
-__arg1 = _35reg1029;
+__arg1 = _35reg2176;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1976) { goto fail; }
+if (co->ctx.pc.func != _35clofun3119) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg1030 = primGenSym(intern("val"));
-Obj val = _35reg1030;
-Obj _35reg1031 = primCons(val, Nil);
-pushCont(co, 14, _35clofun1976, 2, _35reg1031, exp);
+Obj _35reg2177 = primGenSym(intern("val"));
+Obj val = _35reg2177;
+Obj _35reg2178 = primCons(val, Nil);
+pushCont(co, 14, _35clofun3119, 2, _35reg2178, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9093,47 +9049,47 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35val998 = __arg1;
+Obj _35val2145 = __arg1;
 Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp = _35val998;
-Obj _35reg999 = primCar(exp);
-pushCont(co, 15, _35clofun1976, 2, next, exp);
+Obj exp = _35val2145;
+Obj _35reg2146 = primCar(exp);
+pushCont(co, 15, _35clofun3119, 2, next, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#pair?"));
-__arg1 = _35reg999;
+__arg1 = _35reg2146;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35p91 = __arg1;
-Obj _35p92 = __arg2;
-Obj _35p93 = __arg3;
-Obj _35cc94 = makeNative(10, _35clofun1976, 0, 3, _35p91, _35p92, _35p93);
-Obj _35reg997 = primEQ(Nil, _35p91);
-if (True == _35reg997) {
-Obj ls = _35p92;
-Obj next = _35p93;
-pushCont(co, 16, _35clofun1976, 1, next);
+Obj _35p1238 = __arg1;
+Obj _35p1239 = __arg2;
+Obj _35p1240 = __arg3;
+Obj _35cc1241 = makeNative(10, _35clofun3119, 0, 3, _35p1238, _35p1239, _35p1240);
+Obj _35reg2144 = primEQ(Nil, _35p1238);
+if (True == _35reg2144) {
+Obj ls = _35p1239;
+Obj next = _35p1240;
+pushCont(co, 16, _35clofun3119, 1, next);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = ls;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc94;
+__arg0 = _35cc1241;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9146,53 +9102,53 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1043 = __arg1;
+Obj _35val2190 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1044 = primCons(f, args);
+Obj _35reg2191 = primCons(f, args);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val1043;
-__arg2 = _35reg1044;
+__arg1 = _35val2190;
+__arg2 = _35reg2191;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35cc103 = makeNative(18, _35clofun1976, 0, 0);
+Obj _35cc1250 = makeNative(18, _35clofun3119, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj _35reg1040 = primIsCons(closureRef(co, 1));
-if (True == _35reg1040) {
-Obj _35reg1041 = primCar(closureRef(co, 1));
-Obj f = _35reg1041;
-Obj _35reg1042 = primCdr(closureRef(co, 1));
-Obj args = _35reg1042;
-pushCont(co, 19, _35clofun1976, 2, f, args);
+Obj _35reg2187 = primIsCons(closureRef(co, 1));
+if (True == _35reg2187) {
+Obj _35reg2188 = primCar(closureRef(co, 1));
+Obj f = _35reg2188;
+Obj _35reg2189 = primCdr(closureRef(co, 1));
+Obj args = _35reg2189;
+pushCont(co, 19, _35clofun3119, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc103;
+__arg0 = _35cc1250;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3119) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9206,7 +9162,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1975(struct Cora* co){
+void _35clofun3118(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -9219,44 +9175,44 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc80 = makeNative(18, _35clofun1974, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1227 = makeNative(18, _35clofun3117, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg785 = primIsCons(closureRef(co, 1));
-if (True == _35reg785) {
-Obj _35reg786 = primCar(closureRef(co, 1));
-Obj _35reg787 = primEQ(intern("let"), _35reg786);
-if (True == _35reg787) {
-Obj _35reg788 = primCdr(closureRef(co, 1));
-Obj _35reg789 = primIsCons(_35reg788);
-if (True == _35reg789) {
-Obj _35reg790 = primCdr(closureRef(co, 1));
-Obj _35reg791 = primCar(_35reg790);
-Obj a = _35reg791;
-Obj _35reg792 = primCdr(closureRef(co, 1));
-Obj _35reg793 = primCdr(_35reg792);
-Obj _35reg794 = primIsCons(_35reg793);
-if (True == _35reg794) {
-Obj _35reg795 = primCdr(closureRef(co, 1));
-Obj _35reg796 = primCdr(_35reg795);
-Obj _35reg797 = primCar(_35reg796);
-Obj b = _35reg797;
-Obj _35reg798 = primCdr(closureRef(co, 1));
-Obj _35reg799 = primCdr(_35reg798);
-Obj _35reg800 = primCdr(_35reg799);
-Obj _35reg801 = primIsCons(_35reg800);
-if (True == _35reg801) {
-Obj _35reg802 = primCdr(closureRef(co, 1));
-Obj _35reg803 = primCdr(_35reg802);
-Obj _35reg804 = primCdr(_35reg803);
-Obj _35reg805 = primCar(_35reg804);
-Obj c = _35reg805;
-Obj _35reg806 = primCdr(closureRef(co, 1));
-Obj _35reg807 = primCdr(_35reg806);
-Obj _35reg808 = primCdr(_35reg807);
-Obj _35reg809 = primCdr(_35reg808);
-Obj _35reg810 = primEQ(Nil, _35reg809);
-if (True == _35reg810) {
-pushCont(co, 20, _35clofun1974, 3, fvs, c, a);
+Obj _35reg1932 = primIsCons(closureRef(co, 1));
+if (True == _35reg1932) {
+Obj _35reg1933 = primCar(closureRef(co, 1));
+Obj _35reg1934 = primEQ(intern("let"), _35reg1933);
+if (True == _35reg1934) {
+Obj _35reg1935 = primCdr(closureRef(co, 1));
+Obj _35reg1936 = primIsCons(_35reg1935);
+if (True == _35reg1936) {
+Obj _35reg1937 = primCdr(closureRef(co, 1));
+Obj _35reg1938 = primCar(_35reg1937);
+Obj a = _35reg1938;
+Obj _35reg1939 = primCdr(closureRef(co, 1));
+Obj _35reg1940 = primCdr(_35reg1939);
+Obj _35reg1941 = primIsCons(_35reg1940);
+if (True == _35reg1941) {
+Obj _35reg1942 = primCdr(closureRef(co, 1));
+Obj _35reg1943 = primCdr(_35reg1942);
+Obj _35reg1944 = primCar(_35reg1943);
+Obj b = _35reg1944;
+Obj _35reg1945 = primCdr(closureRef(co, 1));
+Obj _35reg1946 = primCdr(_35reg1945);
+Obj _35reg1947 = primCdr(_35reg1946);
+Obj _35reg1948 = primIsCons(_35reg1947);
+if (True == _35reg1948) {
+Obj _35reg1949 = primCdr(closureRef(co, 1));
+Obj _35reg1950 = primCdr(_35reg1949);
+Obj _35reg1951 = primCdr(_35reg1950);
+Obj _35reg1952 = primCar(_35reg1951);
+Obj c = _35reg1952;
+Obj _35reg1953 = primCdr(closureRef(co, 1));
+Obj _35reg1954 = primCdr(_35reg1953);
+Obj _35reg1955 = primCdr(_35reg1954);
+Obj _35reg1956 = primCdr(_35reg1955);
+Obj _35reg1957 = primEQ(Nil, _35reg1956);
+if (True == _35reg1957) {
+pushCont(co, 20, _35clofun3117, 3, fvs, c, a);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs;
@@ -9264,122 +9220,122 @@ __arg2 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc80;
+__arg0 = _35cc1227;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc80;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc80;
+__arg0 = _35cc1227;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc80;
+__arg0 = _35cc1227;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc80;
+__arg0 = _35cc1227;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc80;
+__arg0 = _35cc1227;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1227;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35val843 = __arg1;
-Obj _35reg841= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg844 = primCons(_35reg841, _35val843);
-Obj _35reg845 = primCons(intern("%closure"), _35reg844);
+Obj _35val1990 = __arg1;
+Obj _35reg1988= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1991 = primCons(_35reg1988, _35val1990);
+Obj _35reg1992 = primCons(intern("%closure"), _35reg1991);
 __nargs = 2;
-__arg1 = _35reg845;
+__arg1 = _35reg1992;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1975) { goto fail; }
+if (co->ctx.pc.func != _35clofun3118) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val842 = __arg1;
+Obj _35val1989 = __arg1;
 Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg841= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun1975, 1, _35reg841);
+Obj _35reg1988= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 1, _35clofun3118, 1, _35reg1988);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val842;
+__arg1 = _35val1989;
 __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val838 = __arg1;
+Obj _35val1985 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg839 = primCons(_35val838, Nil);
-Obj _35reg840 = primCons(args, _35reg839);
-Obj _35reg841 = primCons(intern("lambda"), _35reg840);
-pushCont(co, 2, _35clofun1975, 2, fvs1, _35reg841);
+Obj _35reg1986 = primCons(_35val1985, Nil);
+Obj _35reg1987 = primCons(args, _35reg1986);
+Obj _35reg1988 = primCons(intern("lambda"), _35reg1987);
+pushCont(co, 2, _35clofun3118, 2, fvs1, _35reg1988);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val837 = __arg1;
+Obj _35val1984 = __arg1;
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs1 = _35val837;
-pushCont(co, 3, _35clofun1975, 3, args, fvs, fvs1);
+Obj fvs1 = _35val1984;
+pushCont(co, 3, _35clofun3118, 3, args, fvs, fvs1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs1;
@@ -9387,128 +9343,128 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35cc79 = makeNative(0, _35clofun1975, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1226 = makeNative(0, _35clofun3118, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg817 = primIsCons(closureRef(co, 1));
-if (True == _35reg817) {
-Obj _35reg818 = primCar(closureRef(co, 1));
-Obj _35reg819 = primEQ(intern("lambda"), _35reg818);
-if (True == _35reg819) {
-Obj _35reg820 = primCdr(closureRef(co, 1));
-Obj _35reg821 = primIsCons(_35reg820);
-if (True == _35reg821) {
-Obj _35reg822 = primCdr(closureRef(co, 1));
-Obj _35reg823 = primCar(_35reg822);
-Obj args = _35reg823;
-Obj _35reg824 = primCdr(closureRef(co, 1));
-Obj _35reg825 = primCdr(_35reg824);
-Obj _35reg826 = primIsCons(_35reg825);
-if (True == _35reg826) {
-Obj _35reg827 = primCdr(closureRef(co, 1));
-Obj _35reg828 = primCdr(_35reg827);
-Obj _35reg829 = primCar(_35reg828);
-Obj body = _35reg829;
-Obj _35reg830 = primCdr(closureRef(co, 1));
-Obj _35reg831 = primCdr(_35reg830);
-Obj _35reg832 = primCdr(_35reg831);
-Obj _35reg833 = primEQ(Nil, _35reg832);
-if (True == _35reg833) {
-Obj _35reg834 = primCons(body, Nil);
-Obj _35reg835 = primCons(args, _35reg834);
-Obj _35reg836 = primCons(intern("lambda"), _35reg835);
-pushCont(co, 4, _35clofun1975, 3, body, args, fvs);
+Obj _35reg1964 = primIsCons(closureRef(co, 1));
+if (True == _35reg1964) {
+Obj _35reg1965 = primCar(closureRef(co, 1));
+Obj _35reg1966 = primEQ(intern("lambda"), _35reg1965);
+if (True == _35reg1966) {
+Obj _35reg1967 = primCdr(closureRef(co, 1));
+Obj _35reg1968 = primIsCons(_35reg1967);
+if (True == _35reg1968) {
+Obj _35reg1969 = primCdr(closureRef(co, 1));
+Obj _35reg1970 = primCar(_35reg1969);
+Obj args = _35reg1970;
+Obj _35reg1971 = primCdr(closureRef(co, 1));
+Obj _35reg1972 = primCdr(_35reg1971);
+Obj _35reg1973 = primIsCons(_35reg1972);
+if (True == _35reg1973) {
+Obj _35reg1974 = primCdr(closureRef(co, 1));
+Obj _35reg1975 = primCdr(_35reg1974);
+Obj _35reg1976 = primCar(_35reg1975);
+Obj body = _35reg1976;
+Obj _35reg1977 = primCdr(closureRef(co, 1));
+Obj _35reg1978 = primCdr(_35reg1977);
+Obj _35reg1979 = primCdr(_35reg1978);
+Obj _35reg1980 = primEQ(Nil, _35reg1979);
+if (True == _35reg1980) {
+Obj _35reg1981 = primCons(body, Nil);
+Obj _35reg1982 = primCons(args, _35reg1981);
+Obj _35reg1983 = primCons(intern("lambda"), _35reg1982);
+pushCont(co, 4, _35clofun3118, 3, body, args, fvs);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = _35reg836;
+__arg1 = _35reg1983;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc79;
+__arg0 = _35cc1226;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc79;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc79;
+__arg0 = _35cc1226;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc79;
+__arg0 = _35cc1226;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc79;
+__arg0 = _35cc1226;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1226;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label6:
 {
-Obj _35val847 = __arg1;
+Obj _35val1994 = __arg1;
 Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj pos = _35val847;
-Obj _35reg848 = primEQ(makeNumber(-1), pos);
-if (True == _35reg848) {
+Obj pos = _35val1994;
+Obj _35reg1995 = primEQ(makeNumber(-1), pos);
+if (True == _35reg1995) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1975) { goto fail; }
+if (co->ctx.pc.func != _35clofun3118) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg849 = primCons(pos, Nil);
-Obj _35reg850 = primCons(intern("%closure-ref"), _35reg849);
+Obj _35reg1996 = primCons(pos, Nil);
+Obj _35reg1997 = primCons(intern("%closure-ref"), _35reg1996);
 __nargs = 2;
-__arg1 = _35reg850;
+__arg1 = _35reg1997;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1975) { goto fail; }
+if (co->ctx.pc.func != _35clofun3118) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
 
 label7:
 {
-Obj _35cc78 = makeNative(5, _35clofun1975, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1225 = makeNative(5, _35clofun3118, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj _35reg846 = primIsSymbol(var);
-if (True == _35reg846) {
-pushCont(co, 6, _35clofun1975, 1, var);
+Obj _35reg1993 = primIsSymbol(var);
+if (True == _35reg1993) {
+pushCont(co, 6, _35clofun3118, 1, var);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#index"));
 __arg1 = var;
@@ -9516,68 +9472,68 @@ __arg2 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc78;
+__arg0 = _35cc1225;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35val851 = __arg1;
+Obj _35val1998 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc77= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val851) {
+Obj _35cc1224= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1998) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1975) { goto fail; }
+if (co->ctx.pc.func != _35clofun3118) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc77;
+__arg0 = _35cc1224;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label9:
 {
-Obj _35p75 = __arg1;
-Obj _35p76 = __arg2;
-Obj _35cc77 = makeNative(7, _35clofun1975, 0, 2, _35p75, _35p76);
-Obj __ = _35p75;
-Obj x = _35p76;
-pushCont(co, 8, _35clofun1975, 2, x, _35cc77);
+Obj _35p1222 = __arg1;
+Obj _35p1223 = __arg2;
+Obj _35cc1224 = makeNative(7, _35clofun3118, 0, 2, _35p1222, _35p1223);
+Obj __ = _35p1222;
+Obj x = _35p1223;
+pushCont(co, 8, _35clofun3118, 2, x, _35cc1224);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
 Obj x = __arg1;
-Obj _35reg853 = primCons(x, Nil);
-Obj _35reg854 = primCons(intern("return"), _35reg853);
+Obj _35reg2000 = primCons(x, Nil);
+Obj _35reg2001 = primCons(intern("return"), _35reg2000);
 __nargs = 2;
-__arg1 = _35reg854;
+__arg1 = _35reg2001;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1975) { goto fail; }
+if (co->ctx.pc.func != _35clofun3118) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -9589,117 +9545,117 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35cc90 = makeNative(11, _35clofun1975, 0, 0);
-Obj _35reg856 = primIsCons(closureRef(co, 0));
-if (True == _35reg856) {
-Obj _35reg857 = primCar(closureRef(co, 0));
-Obj f = _35reg857;
-Obj _35reg858 = primCdr(closureRef(co, 0));
-Obj args = _35reg858;
+Obj _35cc1237 = makeNative(11, _35clofun3118, 0, 0);
+Obj _35reg2003 = primIsCons(closureRef(co, 0));
+if (True == _35reg2003) {
+Obj _35reg2004 = primCar(closureRef(co, 0));
+Obj f = _35reg2004;
+Obj _35reg2005 = primCdr(closureRef(co, 0));
+Obj args = _35reg2005;
 Obj next = closureRef(co, 1);
-Obj _35reg859 = primCons(f, args);
+Obj _35reg2006 = primCons(f, args);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#tailify-list"));
-__arg1 = _35reg859;
+__arg1 = _35reg2006;
 __arg2 = Nil;
 __arg3 = next;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc90;
+__arg0 = _35cc1237;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label13:
 {
-Obj _35val898 = __arg1;
+Obj _35val2045 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj next= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg899 = primCons(_35val898, Nil);
-Obj _35reg900 = primCons(args, _35reg899);
-Obj _35reg901 = primCons(intern("lambda"), _35reg900);
-Obj _35reg902 = primCons(_35reg901, frees);
-Obj _35reg903 = primCons(intern("%closure"), _35reg902);
+Obj _35reg2046 = primCons(_35val2045, Nil);
+Obj _35reg2047 = primCons(args, _35reg2046);
+Obj _35reg2048 = primCons(intern("lambda"), _35reg2047);
+Obj _35reg2049 = primCons(_35reg2048, frees);
+Obj _35reg2050 = primCons(intern("%closure"), _35reg2049);
 __nargs = 2;
 __arg0 = next;
-__arg1 = _35reg903;
+__arg1 = _35reg2050;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35cc89 = makeNative(12, _35clofun1975, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg860 = primIsCons(closureRef(co, 0));
-if (True == _35reg860) {
-Obj _35reg861 = primCar(closureRef(co, 0));
-Obj _35reg862 = primEQ(intern("%closure"), _35reg861);
-if (True == _35reg862) {
-Obj _35reg863 = primCdr(closureRef(co, 0));
-Obj _35reg864 = primIsCons(_35reg863);
-if (True == _35reg864) {
-Obj _35reg865 = primCdr(closureRef(co, 0));
-Obj _35reg866 = primCar(_35reg865);
-Obj _35reg867 = primIsCons(_35reg866);
-if (True == _35reg867) {
-Obj _35reg868 = primCdr(closureRef(co, 0));
-Obj _35reg869 = primCar(_35reg868);
-Obj _35reg870 = primCar(_35reg869);
-Obj _35reg871 = primEQ(intern("lambda"), _35reg870);
-if (True == _35reg871) {
-Obj _35reg872 = primCdr(closureRef(co, 0));
-Obj _35reg873 = primCar(_35reg872);
-Obj _35reg874 = primCdr(_35reg873);
-Obj _35reg875 = primIsCons(_35reg874);
-if (True == _35reg875) {
-Obj _35reg876 = primCdr(closureRef(co, 0));
-Obj _35reg877 = primCar(_35reg876);
-Obj _35reg878 = primCdr(_35reg877);
-Obj _35reg879 = primCar(_35reg878);
-Obj args = _35reg879;
-Obj _35reg880 = primCdr(closureRef(co, 0));
-Obj _35reg881 = primCar(_35reg880);
-Obj _35reg882 = primCdr(_35reg881);
-Obj _35reg883 = primCdr(_35reg882);
-Obj _35reg884 = primIsCons(_35reg883);
-if (True == _35reg884) {
-Obj _35reg885 = primCdr(closureRef(co, 0));
-Obj _35reg886 = primCar(_35reg885);
-Obj _35reg887 = primCdr(_35reg886);
-Obj _35reg888 = primCdr(_35reg887);
-Obj _35reg889 = primCar(_35reg888);
-Obj body = _35reg889;
-Obj _35reg890 = primCdr(closureRef(co, 0));
-Obj _35reg891 = primCar(_35reg890);
-Obj _35reg892 = primCdr(_35reg891);
-Obj _35reg893 = primCdr(_35reg892);
-Obj _35reg894 = primCdr(_35reg893);
-Obj _35reg895 = primEQ(Nil, _35reg894);
-if (True == _35reg895) {
-Obj _35reg896 = primCdr(closureRef(co, 0));
-Obj _35reg897 = primCdr(_35reg896);
-Obj frees = _35reg897;
+Obj _35cc1236 = makeNative(12, _35clofun3118, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2007 = primIsCons(closureRef(co, 0));
+if (True == _35reg2007) {
+Obj _35reg2008 = primCar(closureRef(co, 0));
+Obj _35reg2009 = primEQ(intern("%closure"), _35reg2008);
+if (True == _35reg2009) {
+Obj _35reg2010 = primCdr(closureRef(co, 0));
+Obj _35reg2011 = primIsCons(_35reg2010);
+if (True == _35reg2011) {
+Obj _35reg2012 = primCdr(closureRef(co, 0));
+Obj _35reg2013 = primCar(_35reg2012);
+Obj _35reg2014 = primIsCons(_35reg2013);
+if (True == _35reg2014) {
+Obj _35reg2015 = primCdr(closureRef(co, 0));
+Obj _35reg2016 = primCar(_35reg2015);
+Obj _35reg2017 = primCar(_35reg2016);
+Obj _35reg2018 = primEQ(intern("lambda"), _35reg2017);
+if (True == _35reg2018) {
+Obj _35reg2019 = primCdr(closureRef(co, 0));
+Obj _35reg2020 = primCar(_35reg2019);
+Obj _35reg2021 = primCdr(_35reg2020);
+Obj _35reg2022 = primIsCons(_35reg2021);
+if (True == _35reg2022) {
+Obj _35reg2023 = primCdr(closureRef(co, 0));
+Obj _35reg2024 = primCar(_35reg2023);
+Obj _35reg2025 = primCdr(_35reg2024);
+Obj _35reg2026 = primCar(_35reg2025);
+Obj args = _35reg2026;
+Obj _35reg2027 = primCdr(closureRef(co, 0));
+Obj _35reg2028 = primCar(_35reg2027);
+Obj _35reg2029 = primCdr(_35reg2028);
+Obj _35reg2030 = primCdr(_35reg2029);
+Obj _35reg2031 = primIsCons(_35reg2030);
+if (True == _35reg2031) {
+Obj _35reg2032 = primCdr(closureRef(co, 0));
+Obj _35reg2033 = primCar(_35reg2032);
+Obj _35reg2034 = primCdr(_35reg2033);
+Obj _35reg2035 = primCdr(_35reg2034);
+Obj _35reg2036 = primCar(_35reg2035);
+Obj body = _35reg2036;
+Obj _35reg2037 = primCdr(closureRef(co, 0));
+Obj _35reg2038 = primCar(_35reg2037);
+Obj _35reg2039 = primCdr(_35reg2038);
+Obj _35reg2040 = primCdr(_35reg2039);
+Obj _35reg2041 = primCdr(_35reg2040);
+Obj _35reg2042 = primEQ(Nil, _35reg2041);
+if (True == _35reg2042) {
+Obj _35reg2043 = primCdr(closureRef(co, 0));
+Obj _35reg2044 = primCdr(_35reg2043);
+Obj frees = _35reg2044;
 Obj next = closureRef(co, 1);
-pushCont(co, 13, _35clofun1975, 3, args, frees, next);
+pushCont(co, 13, _35clofun3118, 3, args, frees, next);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = body;
@@ -9707,101 +9663,101 @@ __arg2 = globalRef(intern("cora/lib/toc#id"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc89;
+__arg0 = _35cc1236;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc89;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc89;
+__arg0 = _35cc1236;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc89;
+__arg0 = _35cc1236;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc89;
+__arg0 = _35cc1236;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc89;
+__arg0 = _35cc1236;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc89;
+__arg0 = _35cc1236;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc89;
+__arg0 = _35cc1236;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1236;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label15:
 {
-Obj _35val930 = __arg1;
+Obj _35val2077 = __arg1;
 Obj rb= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg931 = primCons(_35val930, Nil);
-Obj _35reg932 = primCons(rb, _35reg931);
-Obj _35reg933 = primCons(closureRef(co, 0), _35reg932);
-Obj _35reg934 = primCons(intern("let"), _35reg933);
+Obj _35reg2078 = primCons(_35val2077, Nil);
+Obj _35reg2079 = primCons(rb, _35reg2078);
+Obj _35reg2080 = primCons(closureRef(co, 0), _35reg2079);
+Obj _35reg2081 = primCons(intern("let"), _35reg2080);
 __nargs = 2;
-__arg1 = _35reg934;
+__arg1 = _35reg2081;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1975) { goto fail; }
+if (co->ctx.pc.func != _35clofun3118) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label16:
 {
 Obj rb = __arg1;
-pushCont(co, 15, _35clofun1975, 1, rb);
+pushCont(co, 15, _35clofun3118, 1, rb);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 1);
@@ -9809,133 +9765,133 @@ __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35cc88 = makeNative(14, _35clofun1975, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg904 = primIsCons(closureRef(co, 0));
-if (True == _35reg904) {
-Obj _35reg905 = primCar(closureRef(co, 0));
-Obj _35reg906 = primEQ(intern("let"), _35reg905);
-if (True == _35reg906) {
-Obj _35reg907 = primCdr(closureRef(co, 0));
-Obj _35reg908 = primIsCons(_35reg907);
-if (True == _35reg908) {
-Obj _35reg909 = primCdr(closureRef(co, 0));
-Obj _35reg910 = primCar(_35reg909);
-Obj a = _35reg910;
-Obj _35reg911 = primCdr(closureRef(co, 0));
-Obj _35reg912 = primCdr(_35reg911);
-Obj _35reg913 = primIsCons(_35reg912);
-if (True == _35reg913) {
-Obj _35reg914 = primCdr(closureRef(co, 0));
-Obj _35reg915 = primCdr(_35reg914);
-Obj _35reg916 = primCar(_35reg915);
-Obj b = _35reg916;
-Obj _35reg917 = primCdr(closureRef(co, 0));
-Obj _35reg918 = primCdr(_35reg917);
-Obj _35reg919 = primCdr(_35reg918);
-Obj _35reg920 = primIsCons(_35reg919);
-if (True == _35reg920) {
-Obj _35reg921 = primCdr(closureRef(co, 0));
-Obj _35reg922 = primCdr(_35reg921);
-Obj _35reg923 = primCdr(_35reg922);
-Obj _35reg924 = primCar(_35reg923);
-Obj c = _35reg924;
-Obj _35reg925 = primCdr(closureRef(co, 0));
-Obj _35reg926 = primCdr(_35reg925);
-Obj _35reg927 = primCdr(_35reg926);
-Obj _35reg928 = primCdr(_35reg927);
-Obj _35reg929 = primEQ(Nil, _35reg928);
-if (True == _35reg929) {
+Obj _35cc1235 = makeNative(14, _35clofun3118, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2051 = primIsCons(closureRef(co, 0));
+if (True == _35reg2051) {
+Obj _35reg2052 = primCar(closureRef(co, 0));
+Obj _35reg2053 = primEQ(intern("let"), _35reg2052);
+if (True == _35reg2053) {
+Obj _35reg2054 = primCdr(closureRef(co, 0));
+Obj _35reg2055 = primIsCons(_35reg2054);
+if (True == _35reg2055) {
+Obj _35reg2056 = primCdr(closureRef(co, 0));
+Obj _35reg2057 = primCar(_35reg2056);
+Obj a = _35reg2057;
+Obj _35reg2058 = primCdr(closureRef(co, 0));
+Obj _35reg2059 = primCdr(_35reg2058);
+Obj _35reg2060 = primIsCons(_35reg2059);
+if (True == _35reg2060) {
+Obj _35reg2061 = primCdr(closureRef(co, 0));
+Obj _35reg2062 = primCdr(_35reg2061);
+Obj _35reg2063 = primCar(_35reg2062);
+Obj b = _35reg2063;
+Obj _35reg2064 = primCdr(closureRef(co, 0));
+Obj _35reg2065 = primCdr(_35reg2064);
+Obj _35reg2066 = primCdr(_35reg2065);
+Obj _35reg2067 = primIsCons(_35reg2066);
+if (True == _35reg2067) {
+Obj _35reg2068 = primCdr(closureRef(co, 0));
+Obj _35reg2069 = primCdr(_35reg2068);
+Obj _35reg2070 = primCdr(_35reg2069);
+Obj _35reg2071 = primCar(_35reg2070);
+Obj c = _35reg2071;
+Obj _35reg2072 = primCdr(closureRef(co, 0));
+Obj _35reg2073 = primCdr(_35reg2072);
+Obj _35reg2074 = primCdr(_35reg2073);
+Obj _35reg2075 = primCdr(_35reg2074);
+Obj _35reg2076 = primEQ(Nil, _35reg2075);
+if (True == _35reg2076) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = b;
-__arg2 = makeNative(16, _35clofun1975, 1, 3, a, c, next);
+__arg2 = makeNative(16, _35clofun3118, 1, 3, a, c, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc88;
+__arg0 = _35cc1235;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc88;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc88;
+__arg0 = _35cc1235;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc88;
+__arg0 = _35cc1235;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc88;
+__arg0 = _35cc1235;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc88;
+__arg0 = _35cc1235;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1235;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label18:
 {
-Obj _35val953 = __arg1;
+Obj _35val2100 = __arg1;
 Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg954 = primCons(_35val953, Nil);
-Obj _35reg955 = primCons(ra, _35reg954);
-Obj _35reg956 = primCons(intern("do"), _35reg955);
+Obj _35reg2101 = primCons(_35val2100, Nil);
+Obj _35reg2102 = primCons(ra, _35reg2101);
+Obj _35reg2103 = primCons(intern("do"), _35reg2102);
 __nargs = 2;
-__arg1 = _35reg956;
+__arg1 = _35reg2103;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1975) { goto fail; }
+if (co->ctx.pc.func != _35clofun3118) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label19:
 {
 Obj ra = __arg1;
-Obj _35reg952 = primIsSymbol(ra);
-if (True == _35reg952) {
+Obj _35reg2099 = primIsSymbol(ra);
+if (True == _35reg2099) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 0);
@@ -9943,10 +9899,10 @@ __arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 18, _35clofun1975, 1, ra);
+pushCont(co, 18, _35clofun3118, 1, ra);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 0);
@@ -9954,91 +9910,91 @@ __arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label20:
 {
-Obj _35cc87 = makeNative(17, _35clofun1975, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg935 = primIsCons(closureRef(co, 0));
-if (True == _35reg935) {
-Obj _35reg936 = primCar(closureRef(co, 0));
-Obj _35reg937 = primEQ(intern("do"), _35reg936);
-if (True == _35reg937) {
-Obj _35reg938 = primCdr(closureRef(co, 0));
-Obj _35reg939 = primIsCons(_35reg938);
-if (True == _35reg939) {
-Obj _35reg940 = primCdr(closureRef(co, 0));
-Obj _35reg941 = primCar(_35reg940);
-Obj a = _35reg941;
-Obj _35reg942 = primCdr(closureRef(co, 0));
-Obj _35reg943 = primCdr(_35reg942);
-Obj _35reg944 = primIsCons(_35reg943);
-if (True == _35reg944) {
-Obj _35reg945 = primCdr(closureRef(co, 0));
-Obj _35reg946 = primCdr(_35reg945);
-Obj _35reg947 = primCar(_35reg946);
-Obj b = _35reg947;
-Obj _35reg948 = primCdr(closureRef(co, 0));
-Obj _35reg949 = primCdr(_35reg948);
-Obj _35reg950 = primCdr(_35reg949);
-Obj _35reg951 = primEQ(Nil, _35reg950);
-if (True == _35reg951) {
+Obj _35cc1234 = makeNative(17, _35clofun3118, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2082 = primIsCons(closureRef(co, 0));
+if (True == _35reg2082) {
+Obj _35reg2083 = primCar(closureRef(co, 0));
+Obj _35reg2084 = primEQ(intern("do"), _35reg2083);
+if (True == _35reg2084) {
+Obj _35reg2085 = primCdr(closureRef(co, 0));
+Obj _35reg2086 = primIsCons(_35reg2085);
+if (True == _35reg2086) {
+Obj _35reg2087 = primCdr(closureRef(co, 0));
+Obj _35reg2088 = primCar(_35reg2087);
+Obj a = _35reg2088;
+Obj _35reg2089 = primCdr(closureRef(co, 0));
+Obj _35reg2090 = primCdr(_35reg2089);
+Obj _35reg2091 = primIsCons(_35reg2090);
+if (True == _35reg2091) {
+Obj _35reg2092 = primCdr(closureRef(co, 0));
+Obj _35reg2093 = primCdr(_35reg2092);
+Obj _35reg2094 = primCar(_35reg2093);
+Obj b = _35reg2094;
+Obj _35reg2095 = primCdr(closureRef(co, 0));
+Obj _35reg2096 = primCdr(_35reg2095);
+Obj _35reg2097 = primCdr(_35reg2096);
+Obj _35reg2098 = primEQ(Nil, _35reg2097);
+if (True == _35reg2098) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = a;
-__arg2 = makeNative(19, _35clofun1975, 1, 2, b, next);
+__arg2 = makeNative(19, _35clofun3118, 1, 2, b, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc87;
+__arg0 = _35cc1234;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc87;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc87;
+__arg0 = _35cc1234;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc87;
+__arg0 = _35cc1234;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc87;
+__arg0 = _35cc1234;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1234;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3118) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -10052,7 +10008,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1974(struct Cora* co){
+void _35clofun3117(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -10065,739 +10021,739 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc71 = makeNative(19, _35clofun1973, 0, 1, closureRef(co, 0));
-Obj _35reg638 = primIsCons(closureRef(co, 0));
-if (True == _35reg638) {
-Obj _35reg639 = primCar(closureRef(co, 0));
-Obj _35reg640 = primEQ(intern("call"), _35reg639);
-if (True == _35reg640) {
-Obj _35reg641 = primCdr(closureRef(co, 0));
-Obj _35reg642 = primIsCons(_35reg641);
-if (True == _35reg642) {
-Obj _35reg643 = primCdr(closureRef(co, 0));
-Obj _35reg644 = primCar(_35reg643);
-Obj exp = _35reg644;
-Obj _35reg645 = primCdr(closureRef(co, 0));
-Obj _35reg646 = primCdr(_35reg645);
-Obj _35reg647 = primIsCons(_35reg646);
-if (True == _35reg647) {
-Obj _35reg648 = primCdr(closureRef(co, 0));
-Obj _35reg649 = primCdr(_35reg648);
-Obj _35reg650 = primCar(_35reg649);
-Obj cont = _35reg650;
-Obj _35reg651 = primCdr(closureRef(co, 0));
-Obj _35reg652 = primCdr(_35reg651);
-Obj _35reg653 = primCdr(_35reg652);
-Obj _35reg654 = primEQ(Nil, _35reg653);
-if (True == _35reg654) {
-Obj _35reg655 = primCons(cont, Nil);
-Obj _35reg656 = primCons(exp, _35reg655);
-pushCont(co, 20, _35clofun1973, 0);
+Obj _35cc1218 = makeNative(19, _35clofun3116, 0, 1, closureRef(co, 0));
+Obj _35reg1785 = primIsCons(closureRef(co, 0));
+if (True == _35reg1785) {
+Obj _35reg1786 = primCar(closureRef(co, 0));
+Obj _35reg1787 = primEQ(intern("call"), _35reg1786);
+if (True == _35reg1787) {
+Obj _35reg1788 = primCdr(closureRef(co, 0));
+Obj _35reg1789 = primIsCons(_35reg1788);
+if (True == _35reg1789) {
+Obj _35reg1790 = primCdr(closureRef(co, 0));
+Obj _35reg1791 = primCar(_35reg1790);
+Obj exp = _35reg1791;
+Obj _35reg1792 = primCdr(closureRef(co, 0));
+Obj _35reg1793 = primCdr(_35reg1792);
+Obj _35reg1794 = primIsCons(_35reg1793);
+if (True == _35reg1794) {
+Obj _35reg1795 = primCdr(closureRef(co, 0));
+Obj _35reg1796 = primCdr(_35reg1795);
+Obj _35reg1797 = primCar(_35reg1796);
+Obj cont = _35reg1797;
+Obj _35reg1798 = primCdr(closureRef(co, 0));
+Obj _35reg1799 = primCdr(_35reg1798);
+Obj _35reg1800 = primCdr(_35reg1799);
+Obj _35reg1801 = primEQ(Nil, _35reg1800);
+if (True == _35reg1801) {
+Obj _35reg1802 = primCons(cont, Nil);
+Obj _35reg1803 = primCons(exp, _35reg1802);
+pushCont(co, 20, _35clofun3116, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg2 = _35reg656;
+__arg2 = _35reg1803;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc71;
+__arg0 = _35cc1218;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc71;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc71;
+__arg0 = _35cc1218;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc71;
+__arg0 = _35cc1218;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc71;
+__arg0 = _35cc1218;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1218;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35cc70 = makeNative(0, _35clofun1974, 0, 1, closureRef(co, 0));
-Obj _35reg658 = primIsCons(closureRef(co, 0));
-if (True == _35reg658) {
-Obj _35reg659 = primCar(closureRef(co, 0));
-Obj _35reg660 = primEQ(intern("return"), _35reg659);
-if (True == _35reg660) {
-Obj _35reg661 = primCdr(closureRef(co, 0));
-Obj _35reg662 = primIsCons(_35reg661);
-if (True == _35reg662) {
-Obj _35reg663 = primCdr(closureRef(co, 0));
-Obj _35reg664 = primCar(_35reg663);
-Obj x = _35reg664;
-Obj _35reg665 = primCdr(closureRef(co, 0));
-Obj _35reg666 = primCdr(_35reg665);
-Obj _35reg667 = primEQ(Nil, _35reg666);
-if (True == _35reg667) {
+Obj _35cc1217 = makeNative(0, _35clofun3117, 0, 1, closureRef(co, 0));
+Obj _35reg1805 = primIsCons(closureRef(co, 0));
+if (True == _35reg1805) {
+Obj _35reg1806 = primCar(closureRef(co, 0));
+Obj _35reg1807 = primEQ(intern("return"), _35reg1806);
+if (True == _35reg1807) {
+Obj _35reg1808 = primCdr(closureRef(co, 0));
+Obj _35reg1809 = primIsCons(_35reg1808);
+if (True == _35reg1809) {
+Obj _35reg1810 = primCdr(closureRef(co, 0));
+Obj _35reg1811 = primCar(_35reg1810);
+Obj x = _35reg1811;
+Obj _35reg1812 = primCdr(closureRef(co, 0));
+Obj _35reg1813 = primCdr(_35reg1812);
+Obj _35reg1814 = primEQ(Nil, _35reg1813);
+if (True == _35reg1814) {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc70;
+__arg0 = _35cc1217;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc70;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc70;
+__arg0 = _35cc1217;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc70;
+__arg0 = _35cc1217;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1217;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label2:
 {
-Obj _35cc69 = makeNative(1, _35clofun1974, 0, 1, closureRef(co, 0));
-Obj _35reg668 = primIsCons(closureRef(co, 0));
-if (True == _35reg668) {
-Obj _35reg669 = primCar(closureRef(co, 0));
-Obj _35reg670 = primEQ(intern("%closure"), _35reg669);
-if (True == _35reg670) {
-Obj _35reg671 = primCdr(closureRef(co, 0));
-Obj _35reg672 = primIsCons(_35reg671);
-if (True == _35reg672) {
-Obj _35reg673 = primCdr(closureRef(co, 0));
-Obj _35reg674 = primCar(_35reg673);
-Obj lam = _35reg674;
-Obj _35reg675 = primCdr(closureRef(co, 0));
-Obj _35reg676 = primCdr(_35reg675);
-Obj more = _35reg676;
-Obj _35reg677 = primCons(lam, more);
+Obj _35cc1216 = makeNative(1, _35clofun3117, 0, 1, closureRef(co, 0));
+Obj _35reg1815 = primIsCons(closureRef(co, 0));
+if (True == _35reg1815) {
+Obj _35reg1816 = primCar(closureRef(co, 0));
+Obj _35reg1817 = primEQ(intern("%closure"), _35reg1816);
+if (True == _35reg1817) {
+Obj _35reg1818 = primCdr(closureRef(co, 0));
+Obj _35reg1819 = primIsCons(_35reg1818);
+if (True == _35reg1819) {
+Obj _35reg1820 = primCdr(closureRef(co, 0));
+Obj _35reg1821 = primCar(_35reg1820);
+Obj lam = _35reg1821;
+Obj _35reg1822 = primCdr(closureRef(co, 0));
+Obj _35reg1823 = primCdr(_35reg1822);
+Obj more = _35reg1823;
+Obj _35reg1824 = primCons(lam, more);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = _35reg677;
+__arg1 = _35reg1824;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc69;
+__arg0 = _35cc1216;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc69;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc69;
+__arg0 = _35cc1216;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1216;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35val707 = __arg1;
-Obj _35val704= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val1854 = __arg1;
+Obj _35val1851= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#union"));
-__arg1 = _35val704;
-__arg2 = _35val707;
+__arg1 = _35val1851;
+__arg2 = _35val1854;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val705 = __arg1;
+Obj _35val1852 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val704= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg706 = primCons(a, Nil);
-pushCont(co, 3, _35clofun1974, 1, _35val704);
+Obj _35val1851= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1853 = primCons(a, Nil);
+pushCont(co, 3, _35clofun3117, 1, _35val1851);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = _35val705;
-__arg2 = _35reg706;
+__arg1 = _35val1852;
+__arg2 = _35reg1853;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val704 = __arg1;
+Obj _35val1851 = __arg1;
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun1974, 2, a, _35val704);
+pushCont(co, 4, _35clofun3117, 2, a, _35val1851);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc68 = makeNative(2, _35clofun1974, 0, 1, closureRef(co, 0));
-Obj _35reg678 = primIsCons(closureRef(co, 0));
-if (True == _35reg678) {
-Obj _35reg679 = primCar(closureRef(co, 0));
-Obj _35reg680 = primEQ(intern("let"), _35reg679);
-if (True == _35reg680) {
-Obj _35reg681 = primCdr(closureRef(co, 0));
-Obj _35reg682 = primIsCons(_35reg681);
-if (True == _35reg682) {
-Obj _35reg683 = primCdr(closureRef(co, 0));
-Obj _35reg684 = primCar(_35reg683);
-Obj a = _35reg684;
-Obj _35reg685 = primCdr(closureRef(co, 0));
-Obj _35reg686 = primCdr(_35reg685);
-Obj _35reg687 = primIsCons(_35reg686);
-if (True == _35reg687) {
-Obj _35reg688 = primCdr(closureRef(co, 0));
-Obj _35reg689 = primCdr(_35reg688);
-Obj _35reg690 = primCar(_35reg689);
-Obj b = _35reg690;
-Obj _35reg691 = primCdr(closureRef(co, 0));
-Obj _35reg692 = primCdr(_35reg691);
-Obj _35reg693 = primCdr(_35reg692);
-Obj _35reg694 = primIsCons(_35reg693);
-if (True == _35reg694) {
-Obj _35reg695 = primCdr(closureRef(co, 0));
-Obj _35reg696 = primCdr(_35reg695);
-Obj _35reg697 = primCdr(_35reg696);
-Obj _35reg698 = primCar(_35reg697);
-Obj c = _35reg698;
-Obj _35reg699 = primCdr(closureRef(co, 0));
-Obj _35reg700 = primCdr(_35reg699);
-Obj _35reg701 = primCdr(_35reg700);
-Obj _35reg702 = primCdr(_35reg701);
-Obj _35reg703 = primEQ(Nil, _35reg702);
-if (True == _35reg703) {
-pushCont(co, 5, _35clofun1974, 2, c, a);
+Obj _35cc1215 = makeNative(2, _35clofun3117, 0, 1, closureRef(co, 0));
+Obj _35reg1825 = primIsCons(closureRef(co, 0));
+if (True == _35reg1825) {
+Obj _35reg1826 = primCar(closureRef(co, 0));
+Obj _35reg1827 = primEQ(intern("let"), _35reg1826);
+if (True == _35reg1827) {
+Obj _35reg1828 = primCdr(closureRef(co, 0));
+Obj _35reg1829 = primIsCons(_35reg1828);
+if (True == _35reg1829) {
+Obj _35reg1830 = primCdr(closureRef(co, 0));
+Obj _35reg1831 = primCar(_35reg1830);
+Obj a = _35reg1831;
+Obj _35reg1832 = primCdr(closureRef(co, 0));
+Obj _35reg1833 = primCdr(_35reg1832);
+Obj _35reg1834 = primIsCons(_35reg1833);
+if (True == _35reg1834) {
+Obj _35reg1835 = primCdr(closureRef(co, 0));
+Obj _35reg1836 = primCdr(_35reg1835);
+Obj _35reg1837 = primCar(_35reg1836);
+Obj b = _35reg1837;
+Obj _35reg1838 = primCdr(closureRef(co, 0));
+Obj _35reg1839 = primCdr(_35reg1838);
+Obj _35reg1840 = primCdr(_35reg1839);
+Obj _35reg1841 = primIsCons(_35reg1840);
+if (True == _35reg1841) {
+Obj _35reg1842 = primCdr(closureRef(co, 0));
+Obj _35reg1843 = primCdr(_35reg1842);
+Obj _35reg1844 = primCdr(_35reg1843);
+Obj _35reg1845 = primCar(_35reg1844);
+Obj c = _35reg1845;
+Obj _35reg1846 = primCdr(closureRef(co, 0));
+Obj _35reg1847 = primCdr(_35reg1846);
+Obj _35reg1848 = primCdr(_35reg1847);
+Obj _35reg1849 = primCdr(_35reg1848);
+Obj _35reg1850 = primEQ(Nil, _35reg1849);
+if (True == _35reg1850) {
+pushCont(co, 5, _35clofun3117, 2, c, a);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc68;
+__arg0 = _35cc1215;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc68;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc68;
+__arg0 = _35cc1215;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc68;
+__arg0 = _35cc1215;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc68;
+__arg0 = _35cc1215;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc68;
+__arg0 = _35cc1215;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1215;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35val727 = __arg1;
+Obj _35val1874 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#foldl"));
 __arg1 = globalRef(intern("cora/lib/toc#union"));
 __arg2 = Nil;
-__arg3 = _35val727;
+__arg3 = _35val1874;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35cc67 = makeNative(6, _35clofun1974, 0, 1, closureRef(co, 0));
-Obj _35reg708 = primIsCons(closureRef(co, 0));
-if (True == _35reg708) {
-Obj _35reg709 = primCar(closureRef(co, 0));
-Obj _35reg710 = primEQ(intern("do"), _35reg709);
-if (True == _35reg710) {
-Obj _35reg711 = primCdr(closureRef(co, 0));
-Obj _35reg712 = primIsCons(_35reg711);
-if (True == _35reg712) {
-Obj _35reg713 = primCdr(closureRef(co, 0));
-Obj _35reg714 = primCar(_35reg713);
-Obj x = _35reg714;
-Obj _35reg715 = primCdr(closureRef(co, 0));
-Obj _35reg716 = primCdr(_35reg715);
-Obj _35reg717 = primIsCons(_35reg716);
-if (True == _35reg717) {
-Obj _35reg718 = primCdr(closureRef(co, 0));
-Obj _35reg719 = primCdr(_35reg718);
-Obj _35reg720 = primCar(_35reg719);
-Obj y = _35reg720;
-Obj _35reg721 = primCdr(closureRef(co, 0));
-Obj _35reg722 = primCdr(_35reg721);
-Obj _35reg723 = primCdr(_35reg722);
-Obj _35reg724 = primEQ(Nil, _35reg723);
-if (True == _35reg724) {
-Obj _35reg725 = primCons(y, Nil);
-Obj _35reg726 = primCons(x, _35reg725);
-pushCont(co, 7, _35clofun1974, 0);
+Obj _35cc1214 = makeNative(6, _35clofun3117, 0, 1, closureRef(co, 0));
+Obj _35reg1855 = primIsCons(closureRef(co, 0));
+if (True == _35reg1855) {
+Obj _35reg1856 = primCar(closureRef(co, 0));
+Obj _35reg1857 = primEQ(intern("do"), _35reg1856);
+if (True == _35reg1857) {
+Obj _35reg1858 = primCdr(closureRef(co, 0));
+Obj _35reg1859 = primIsCons(_35reg1858);
+if (True == _35reg1859) {
+Obj _35reg1860 = primCdr(closureRef(co, 0));
+Obj _35reg1861 = primCar(_35reg1860);
+Obj x = _35reg1861;
+Obj _35reg1862 = primCdr(closureRef(co, 0));
+Obj _35reg1863 = primCdr(_35reg1862);
+Obj _35reg1864 = primIsCons(_35reg1863);
+if (True == _35reg1864) {
+Obj _35reg1865 = primCdr(closureRef(co, 0));
+Obj _35reg1866 = primCdr(_35reg1865);
+Obj _35reg1867 = primCar(_35reg1866);
+Obj y = _35reg1867;
+Obj _35reg1868 = primCdr(closureRef(co, 0));
+Obj _35reg1869 = primCdr(_35reg1868);
+Obj _35reg1870 = primCdr(_35reg1869);
+Obj _35reg1871 = primEQ(Nil, _35reg1870);
+if (True == _35reg1871) {
+Obj _35reg1872 = primCons(y, Nil);
+Obj _35reg1873 = primCons(x, _35reg1872);
+pushCont(co, 7, _35clofun3117, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg2 = _35reg726;
+__arg2 = _35reg1873;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc67;
+__arg0 = _35cc1214;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc67;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc67;
+__arg0 = _35cc1214;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc67;
+__arg0 = _35cc1214;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc67;
+__arg0 = _35cc1214;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1214;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label9:
 {
-Obj _35val757 = __arg1;
+Obj _35val1904 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#foldl"));
 __arg1 = globalRef(intern("cora/lib/toc#union"));
 __arg2 = Nil;
-__arg3 = _35val757;
+__arg3 = _35val1904;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35cc66 = makeNative(8, _35clofun1974, 0, 1, closureRef(co, 0));
-Obj _35reg728 = primIsCons(closureRef(co, 0));
-if (True == _35reg728) {
-Obj _35reg729 = primCar(closureRef(co, 0));
-Obj _35reg730 = primEQ(intern("if"), _35reg729);
-if (True == _35reg730) {
-Obj _35reg731 = primCdr(closureRef(co, 0));
-Obj _35reg732 = primIsCons(_35reg731);
-if (True == _35reg732) {
-Obj _35reg733 = primCdr(closureRef(co, 0));
-Obj _35reg734 = primCar(_35reg733);
-Obj x = _35reg734;
-Obj _35reg735 = primCdr(closureRef(co, 0));
-Obj _35reg736 = primCdr(_35reg735);
-Obj _35reg737 = primIsCons(_35reg736);
-if (True == _35reg737) {
-Obj _35reg738 = primCdr(closureRef(co, 0));
-Obj _35reg739 = primCdr(_35reg738);
-Obj _35reg740 = primCar(_35reg739);
-Obj y = _35reg740;
-Obj _35reg741 = primCdr(closureRef(co, 0));
-Obj _35reg742 = primCdr(_35reg741);
-Obj _35reg743 = primCdr(_35reg742);
-Obj _35reg744 = primIsCons(_35reg743);
-if (True == _35reg744) {
-Obj _35reg745 = primCdr(closureRef(co, 0));
-Obj _35reg746 = primCdr(_35reg745);
-Obj _35reg747 = primCdr(_35reg746);
-Obj _35reg748 = primCar(_35reg747);
-Obj z = _35reg748;
-Obj _35reg749 = primCdr(closureRef(co, 0));
-Obj _35reg750 = primCdr(_35reg749);
-Obj _35reg751 = primCdr(_35reg750);
-Obj _35reg752 = primCdr(_35reg751);
-Obj _35reg753 = primEQ(Nil, _35reg752);
-if (True == _35reg753) {
-Obj _35reg754 = primCons(z, Nil);
-Obj _35reg755 = primCons(y, _35reg754);
-Obj _35reg756 = primCons(x, _35reg755);
-pushCont(co, 9, _35clofun1974, 0);
+Obj _35cc1213 = makeNative(8, _35clofun3117, 0, 1, closureRef(co, 0));
+Obj _35reg1875 = primIsCons(closureRef(co, 0));
+if (True == _35reg1875) {
+Obj _35reg1876 = primCar(closureRef(co, 0));
+Obj _35reg1877 = primEQ(intern("if"), _35reg1876);
+if (True == _35reg1877) {
+Obj _35reg1878 = primCdr(closureRef(co, 0));
+Obj _35reg1879 = primIsCons(_35reg1878);
+if (True == _35reg1879) {
+Obj _35reg1880 = primCdr(closureRef(co, 0));
+Obj _35reg1881 = primCar(_35reg1880);
+Obj x = _35reg1881;
+Obj _35reg1882 = primCdr(closureRef(co, 0));
+Obj _35reg1883 = primCdr(_35reg1882);
+Obj _35reg1884 = primIsCons(_35reg1883);
+if (True == _35reg1884) {
+Obj _35reg1885 = primCdr(closureRef(co, 0));
+Obj _35reg1886 = primCdr(_35reg1885);
+Obj _35reg1887 = primCar(_35reg1886);
+Obj y = _35reg1887;
+Obj _35reg1888 = primCdr(closureRef(co, 0));
+Obj _35reg1889 = primCdr(_35reg1888);
+Obj _35reg1890 = primCdr(_35reg1889);
+Obj _35reg1891 = primIsCons(_35reg1890);
+if (True == _35reg1891) {
+Obj _35reg1892 = primCdr(closureRef(co, 0));
+Obj _35reg1893 = primCdr(_35reg1892);
+Obj _35reg1894 = primCdr(_35reg1893);
+Obj _35reg1895 = primCar(_35reg1894);
+Obj z = _35reg1895;
+Obj _35reg1896 = primCdr(closureRef(co, 0));
+Obj _35reg1897 = primCdr(_35reg1896);
+Obj _35reg1898 = primCdr(_35reg1897);
+Obj _35reg1899 = primCdr(_35reg1898);
+Obj _35reg1900 = primEQ(Nil, _35reg1899);
+if (True == _35reg1900) {
+Obj _35reg1901 = primCons(z, Nil);
+Obj _35reg1902 = primCons(y, _35reg1901);
+Obj _35reg1903 = primCons(x, _35reg1902);
+pushCont(co, 9, _35clofun3117, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg2 = _35reg756;
+__arg2 = _35reg1903;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc66;
+__arg0 = _35cc1213;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc66;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc66;
+__arg0 = _35cc1213;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc66;
+__arg0 = _35cc1213;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc66;
+__arg0 = _35cc1213;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc66;
+__arg0 = _35cc1213;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1213;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35val775 = __arg1;
+Obj _35val1922 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = _35val775;
+__arg1 = _35val1922;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35cc65 = makeNative(10, _35clofun1974, 0, 1, closureRef(co, 0));
-Obj _35reg758 = primIsCons(closureRef(co, 0));
-if (True == _35reg758) {
-Obj _35reg759 = primCar(closureRef(co, 0));
-Obj _35reg760 = primEQ(intern("lambda"), _35reg759);
-if (True == _35reg760) {
-Obj _35reg761 = primCdr(closureRef(co, 0));
-Obj _35reg762 = primIsCons(_35reg761);
-if (True == _35reg762) {
-Obj _35reg763 = primCdr(closureRef(co, 0));
-Obj _35reg764 = primCar(_35reg763);
-Obj args = _35reg764;
-Obj _35reg765 = primCdr(closureRef(co, 0));
-Obj _35reg766 = primCdr(_35reg765);
-Obj _35reg767 = primIsCons(_35reg766);
-if (True == _35reg767) {
-Obj _35reg768 = primCdr(closureRef(co, 0));
-Obj _35reg769 = primCdr(_35reg768);
-Obj _35reg770 = primCar(_35reg769);
-Obj body = _35reg770;
-Obj _35reg771 = primCdr(closureRef(co, 0));
-Obj _35reg772 = primCdr(_35reg771);
-Obj _35reg773 = primCdr(_35reg772);
-Obj _35reg774 = primEQ(Nil, _35reg773);
-if (True == _35reg774) {
-pushCont(co, 11, _35clofun1974, 1, args);
+Obj _35cc1212 = makeNative(10, _35clofun3117, 0, 1, closureRef(co, 0));
+Obj _35reg1905 = primIsCons(closureRef(co, 0));
+if (True == _35reg1905) {
+Obj _35reg1906 = primCar(closureRef(co, 0));
+Obj _35reg1907 = primEQ(intern("lambda"), _35reg1906);
+if (True == _35reg1907) {
+Obj _35reg1908 = primCdr(closureRef(co, 0));
+Obj _35reg1909 = primIsCons(_35reg1908);
+if (True == _35reg1909) {
+Obj _35reg1910 = primCdr(closureRef(co, 0));
+Obj _35reg1911 = primCar(_35reg1910);
+Obj args = _35reg1911;
+Obj _35reg1912 = primCdr(closureRef(co, 0));
+Obj _35reg1913 = primCdr(_35reg1912);
+Obj _35reg1914 = primIsCons(_35reg1913);
+if (True == _35reg1914) {
+Obj _35reg1915 = primCdr(closureRef(co, 0));
+Obj _35reg1916 = primCdr(_35reg1915);
+Obj _35reg1917 = primCar(_35reg1916);
+Obj body = _35reg1917;
+Obj _35reg1918 = primCdr(closureRef(co, 0));
+Obj _35reg1919 = primCdr(_35reg1918);
+Obj _35reg1920 = primCdr(_35reg1919);
+Obj _35reg1921 = primEQ(Nil, _35reg1920);
+if (True == _35reg1921) {
+pushCont(co, 11, _35clofun3117, 1, args);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc65;
+__arg0 = _35cc1212;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc65;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc65;
+__arg0 = _35cc1212;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc65;
+__arg0 = _35cc1212;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc65;
+__arg0 = _35cc1212;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1212;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label13:
 {
-Obj _35cc64 = makeNative(12, _35clofun1974, 0, 1, closureRef(co, 0));
+Obj _35cc1211 = makeNative(12, _35clofun3117, 0, 1, closureRef(co, 0));
 Obj x = closureRef(co, 0);
-Obj _35reg776 = primIsSymbol(x);
-if (True == _35reg776) {
-Obj _35reg777 = primCons(x, Nil);
+Obj _35reg1923 = primIsSymbol(x);
+if (True == _35reg1923) {
+Obj _35reg1924 = primCons(x, Nil);
 __nargs = 2;
-__arg1 = _35reg777;
+__arg1 = _35reg1924;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1974) { goto fail; }
+if (co->ctx.pc.func != _35clofun3117) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc64;
+__arg0 = _35cc1211;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label14:
 {
-Obj _35val778 = __arg1;
-Obj _35cc63= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val778) {
+Obj _35val1925 = __arg1;
+Obj _35cc1210= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1925) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1974) { goto fail; }
+if (co->ctx.pc.func != _35clofun3117) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc63;
+__arg0 = _35cc1210;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label15:
 {
-Obj _35p62 = __arg1;
-Obj _35cc63 = makeNative(13, _35clofun1974, 0, 1, _35p62);
-Obj x = _35p62;
-pushCont(co, 14, _35clofun1974, 1, _35cc63);
+Obj _35p1209 = __arg1;
+Obj _35cc1210 = makeNative(13, _35clofun3117, 0, 1, _35p1209);
+Obj x = _35p1209;
+pushCont(co, 14, _35clofun3117, 1, _35cc1210);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -10809,80 +10765,80 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val783 = __arg1;
+Obj _35val1930 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg784 = primCons(f, args);
+Obj _35reg1931 = primCons(f, args);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val783;
-__arg2 = _35reg784;
+__arg1 = _35val1930;
+__arg2 = _35reg1931;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35cc81 = makeNative(16, _35clofun1974, 0, 0);
+Obj _35cc1228 = makeNative(16, _35clofun3117, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj _35reg780 = primIsCons(closureRef(co, 1));
-if (True == _35reg780) {
-Obj _35reg781 = primCar(closureRef(co, 1));
-Obj f = _35reg781;
-Obj _35reg782 = primCdr(closureRef(co, 1));
-Obj args = _35reg782;
-pushCont(co, 17, _35clofun1974, 2, f, args);
+Obj _35reg1927 = primIsCons(closureRef(co, 1));
+if (True == _35reg1927) {
+Obj _35reg1928 = primCar(closureRef(co, 1));
+Obj f = _35reg1928;
+Obj _35reg1929 = primCdr(closureRef(co, 1));
+Obj args = _35reg1929;
+pushCont(co, 17, _35clofun3117, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc81;
+__arg0 = _35cc1228;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label19:
 {
-Obj _35val812 = __arg1;
-Obj _35val811= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val1959 = __arg1;
+Obj _35val1958= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg813 = primCons(_35val812, Nil);
-Obj _35reg814 = primCons(_35val811, _35reg813);
-Obj _35reg815 = primCons(a, _35reg814);
-Obj _35reg816 = primCons(intern("let"), _35reg815);
+Obj _35reg1960 = primCons(_35val1959, Nil);
+Obj _35reg1961 = primCons(_35val1958, _35reg1960);
+Obj _35reg1962 = primCons(a, _35reg1961);
+Obj _35reg1963 = primCons(intern("let"), _35reg1962);
 __nargs = 2;
-__arg1 = _35reg816;
+__arg1 = _35reg1963;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1974) { goto fail; }
+if (co->ctx.pc.func != _35clofun3117) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label20:
 {
-Obj _35val811 = __arg1;
+Obj _35val1958 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 19, _35clofun1974, 2, _35val811, a);
+pushCont(co, 19, _35clofun3117, 2, _35val1958, a);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs;
@@ -10890,7 +10846,7 @@ __arg2 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3117) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -10903,7 +10859,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1973(struct Cora* co){
+void _35clofun3116(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -10916,24 +10872,24 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35p45 = __arg1;
-Obj _35p46 = __arg2;
-Obj _35cc47 = makeNative(20, _35clofun1972, 0, 2, _35p45, _35p46);
-Obj _35reg541 = primEQ(Nil, _35p45);
-if (True == _35reg541) {
-Obj s2 = _35p46;
+Obj _35p1192 = __arg1;
+Obj _35p1193 = __arg2;
+Obj _35cc1194 = makeNative(20, _35clofun3115, 0, 2, _35p1192, _35p1193);
+Obj _35reg1688 = primEQ(Nil, _35p1192);
+if (True == _35reg1688) {
+Obj s2 = _35p1193;
 __nargs = 2;
 __arg1 = s2;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1973) { goto fail; }
+if (co->ctx.pc.func != _35clofun3116) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc47;
+__arg0 = _35cc1194;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -10946,33 +10902,33 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val546 = __arg1;
+Obj _35val1693 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg547 = primCons(x, _35val546);
+Obj _35reg1694 = primCons(x, _35val1693);
 __nargs = 2;
-__arg1 = _35reg547;
+__arg1 = _35reg1694;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1973) { goto fail; }
+if (co->ctx.pc.func != _35clofun3116) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label3:
 {
-Obj _35cc54 = makeNative(1, _35clofun1973, 0, 0);
-Obj _35reg543 = primIsCons(closureRef(co, 0));
-if (True == _35reg543) {
-Obj _35reg544 = primCar(closureRef(co, 0));
-Obj x = _35reg544;
-Obj _35reg545 = primCdr(closureRef(co, 0));
-Obj y = _35reg545;
+Obj _35cc1201 = makeNative(1, _35clofun3116, 0, 0);
+Obj _35reg1690 = primIsCons(closureRef(co, 0));
+if (True == _35reg1690) {
+Obj _35reg1691 = primCar(closureRef(co, 0));
+Obj x = _35reg1691;
+Obj _35reg1692 = primCdr(closureRef(co, 0));
+Obj y = _35reg1692;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 2, _35clofun1973, 1, x);
+pushCont(co, 2, _35clofun3116, 1, x);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#diff"));
 __arg1 = y;
@@ -10980,26 +10936,26 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc54;
+__arg0 = _35cc1201;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35val551 = __arg1;
+Obj _35val1698 = __arg1;
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc53= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val551) {
+Obj _35cc1200= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val1698) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#diff"));
 __arg1 = y;
@@ -11007,30 +10963,30 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc53;
+__arg0 = _35cc1200;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35cc53 = makeNative(3, _35clofun1973, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg548 = primIsCons(closureRef(co, 0));
-if (True == _35reg548) {
-Obj _35reg549 = primCar(closureRef(co, 0));
-Obj x = _35reg549;
-Obj _35reg550 = primCdr(closureRef(co, 0));
-Obj y = _35reg550;
+Obj _35cc1200 = makeNative(3, _35clofun3116, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1695 = primIsCons(closureRef(co, 0));
+if (True == _35reg1695) {
+Obj _35reg1696 = primCar(closureRef(co, 0));
+Obj x = _35reg1696;
+Obj _35reg1697 = primCdr(closureRef(co, 0));
+Obj y = _35reg1697;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 4, _35clofun1973, 3, y, s2, _35cc53);
+pushCont(co, 4, _35clofun3116, 3, y, s2, _35cc1200);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#elem?"));
 __arg1 = x;
@@ -11038,39 +10994,39 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc53;
+__arg0 = _35cc1200;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label6:
 {
-Obj _35p50 = __arg1;
-Obj _35p51 = __arg2;
-Obj _35cc52 = makeNative(5, _35clofun1973, 0, 2, _35p50, _35p51);
-Obj _35reg552 = primEQ(Nil, _35p50);
-if (True == _35reg552) {
-Obj __ = _35p51;
+Obj _35p1197 = __arg1;
+Obj _35p1198 = __arg2;
+Obj _35cc1199 = makeNative(5, _35clofun3116, 0, 2, _35p1197, _35p1198);
+Obj _35reg1699 = primEQ(Nil, _35p1197);
+if (True == _35reg1699) {
+Obj __ = _35p1198;
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1973) { goto fail; }
+if (co->ctx.pc.func != _35clofun3116) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc52;
+__arg0 = _35cc1199;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11083,323 +11039,323 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35cc61 = makeNative(7, _35clofun1973, 0, 0);
+Obj _35cc1208 = makeNative(7, _35clofun3116, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1973) { goto fail; }
+if (co->ctx.pc.func != _35clofun3116) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label9:
 {
-Obj _35cc60 = makeNative(8, _35clofun1973, 0, 1, closureRef(co, 0));
-Obj _35reg554 = primIsCons(closureRef(co, 0));
-if (True == _35reg554) {
-Obj _35reg555 = primCar(closureRef(co, 0));
-Obj _35reg556 = primEQ(intern("%closure-ref"), _35reg555);
-if (True == _35reg556) {
-Obj _35reg557 = primCdr(closureRef(co, 0));
-Obj _35reg558 = primIsCons(_35reg557);
-if (True == _35reg558) {
-Obj _35reg559 = primCdr(closureRef(co, 0));
-Obj _35reg560 = primCar(_35reg559);
-Obj __ = _35reg560;
-Obj _35reg561 = primCdr(closureRef(co, 0));
-Obj _35reg562 = primCdr(_35reg561);
-Obj _35reg563 = primEQ(Nil, _35reg562);
-if (True == _35reg563) {
+Obj _35cc1207 = makeNative(8, _35clofun3116, 0, 1, closureRef(co, 0));
+Obj _35reg1701 = primIsCons(closureRef(co, 0));
+if (True == _35reg1701) {
+Obj _35reg1702 = primCar(closureRef(co, 0));
+Obj _35reg1703 = primEQ(intern("%closure-ref"), _35reg1702);
+if (True == _35reg1703) {
+Obj _35reg1704 = primCdr(closureRef(co, 0));
+Obj _35reg1705 = primIsCons(_35reg1704);
+if (True == _35reg1705) {
+Obj _35reg1706 = primCdr(closureRef(co, 0));
+Obj _35reg1707 = primCar(_35reg1706);
+Obj __ = _35reg1707;
+Obj _35reg1708 = primCdr(closureRef(co, 0));
+Obj _35reg1709 = primCdr(_35reg1708);
+Obj _35reg1710 = primEQ(Nil, _35reg1709);
+if (True == _35reg1710) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1973) { goto fail; }
+if (co->ctx.pc.func != _35clofun3116) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc60;
+__arg0 = _35cc1207;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc60;
+__arg0 = _35cc1207;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc60;
+__arg0 = _35cc1207;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc60;
+__arg0 = _35cc1207;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35cc59 = makeNative(9, _35clofun1973, 0, 1, closureRef(co, 0));
-Obj _35reg564 = primIsCons(closureRef(co, 0));
-if (True == _35reg564) {
-Obj _35reg565 = primCar(closureRef(co, 0));
-Obj _35reg566 = primEQ(intern("quote"), _35reg565);
-if (True == _35reg566) {
-Obj _35reg567 = primCdr(closureRef(co, 0));
-Obj _35reg568 = primIsCons(_35reg567);
-if (True == _35reg568) {
-Obj _35reg569 = primCdr(closureRef(co, 0));
-Obj _35reg570 = primCar(_35reg569);
-Obj x = _35reg570;
-Obj _35reg571 = primCdr(closureRef(co, 0));
-Obj _35reg572 = primCdr(_35reg571);
-Obj _35reg573 = primEQ(Nil, _35reg572);
-if (True == _35reg573) {
+Obj _35cc1206 = makeNative(9, _35clofun3116, 0, 1, closureRef(co, 0));
+Obj _35reg1711 = primIsCons(closureRef(co, 0));
+if (True == _35reg1711) {
+Obj _35reg1712 = primCar(closureRef(co, 0));
+Obj _35reg1713 = primEQ(intern("quote"), _35reg1712);
+if (True == _35reg1713) {
+Obj _35reg1714 = primCdr(closureRef(co, 0));
+Obj _35reg1715 = primIsCons(_35reg1714);
+if (True == _35reg1715) {
+Obj _35reg1716 = primCdr(closureRef(co, 0));
+Obj _35reg1717 = primCar(_35reg1716);
+Obj x = _35reg1717;
+Obj _35reg1718 = primCdr(closureRef(co, 0));
+Obj _35reg1719 = primCdr(_35reg1718);
+Obj _35reg1720 = primEQ(Nil, _35reg1719);
+if (True == _35reg1720) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1973) { goto fail; }
+if (co->ctx.pc.func != _35clofun3116) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc59;
+__arg0 = _35cc1206;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc59;
+__arg0 = _35cc1206;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc59;
+__arg0 = _35cc1206;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc59;
+__arg0 = _35cc1206;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35cc58 = makeNative(10, _35clofun1973, 0, 1, closureRef(co, 0));
-Obj _35reg574 = primIsCons(closureRef(co, 0));
-if (True == _35reg574) {
-Obj _35reg575 = primCar(closureRef(co, 0));
-Obj _35reg576 = primEQ(intern("%builtin"), _35reg575);
-if (True == _35reg576) {
-Obj _35reg577 = primCdr(closureRef(co, 0));
-Obj _35reg578 = primIsCons(_35reg577);
-if (True == _35reg578) {
-Obj _35reg579 = primCdr(closureRef(co, 0));
-Obj _35reg580 = primCar(_35reg579);
-Obj op = _35reg580;
-Obj _35reg581 = primCdr(closureRef(co, 0));
-Obj _35reg582 = primCdr(_35reg581);
-Obj _35reg583 = primEQ(Nil, _35reg582);
-if (True == _35reg583) {
+Obj _35cc1205 = makeNative(10, _35clofun3116, 0, 1, closureRef(co, 0));
+Obj _35reg1721 = primIsCons(closureRef(co, 0));
+if (True == _35reg1721) {
+Obj _35reg1722 = primCar(closureRef(co, 0));
+Obj _35reg1723 = primEQ(intern("%builtin"), _35reg1722);
+if (True == _35reg1723) {
+Obj _35reg1724 = primCdr(closureRef(co, 0));
+Obj _35reg1725 = primIsCons(_35reg1724);
+if (True == _35reg1725) {
+Obj _35reg1726 = primCdr(closureRef(co, 0));
+Obj _35reg1727 = primCar(_35reg1726);
+Obj op = _35reg1727;
+Obj _35reg1728 = primCdr(closureRef(co, 0));
+Obj _35reg1729 = primCdr(_35reg1728);
+Obj _35reg1730 = primEQ(Nil, _35reg1729);
+if (True == _35reg1730) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1973) { goto fail; }
+if (co->ctx.pc.func != _35clofun3116) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc58;
+__arg0 = _35cc1205;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc58;
+__arg0 = _35cc1205;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc58;
+__arg0 = _35cc1205;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc58;
+__arg0 = _35cc1205;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj _35cc57 = makeNative(11, _35clofun1973, 0, 1, closureRef(co, 0));
-Obj _35reg584 = primIsCons(closureRef(co, 0));
-if (True == _35reg584) {
-Obj _35reg585 = primCar(closureRef(co, 0));
-Obj _35reg586 = primEQ(intern("%global"), _35reg585);
-if (True == _35reg586) {
-Obj _35reg587 = primCdr(closureRef(co, 0));
-Obj _35reg588 = primIsCons(_35reg587);
-if (True == _35reg588) {
-Obj _35reg589 = primCdr(closureRef(co, 0));
-Obj _35reg590 = primCar(_35reg589);
-Obj x = _35reg590;
-Obj _35reg591 = primCdr(closureRef(co, 0));
-Obj _35reg592 = primCdr(_35reg591);
-Obj _35reg593 = primEQ(Nil, _35reg592);
-if (True == _35reg593) {
+Obj _35cc1204 = makeNative(11, _35clofun3116, 0, 1, closureRef(co, 0));
+Obj _35reg1731 = primIsCons(closureRef(co, 0));
+if (True == _35reg1731) {
+Obj _35reg1732 = primCar(closureRef(co, 0));
+Obj _35reg1733 = primEQ(intern("%global"), _35reg1732);
+if (True == _35reg1733) {
+Obj _35reg1734 = primCdr(closureRef(co, 0));
+Obj _35reg1735 = primIsCons(_35reg1734);
+if (True == _35reg1735) {
+Obj _35reg1736 = primCdr(closureRef(co, 0));
+Obj _35reg1737 = primCar(_35reg1736);
+Obj x = _35reg1737;
+Obj _35reg1738 = primCdr(closureRef(co, 0));
+Obj _35reg1739 = primCdr(_35reg1738);
+Obj _35reg1740 = primEQ(Nil, _35reg1739);
+if (True == _35reg1740) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1973) { goto fail; }
+if (co->ctx.pc.func != _35clofun3116) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc57;
+__arg0 = _35cc1204;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc57;
+__arg0 = _35cc1204;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc57;
+__arg0 = _35cc1204;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc57;
+__arg0 = _35cc1204;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label13:
 {
-Obj _35p55 = __arg1;
-Obj _35cc56 = makeNative(12, _35clofun1973, 0, 1, _35p55);
-Obj _35reg594 = primIsCons(_35p55);
-if (True == _35reg594) {
-Obj _35reg595 = primCar(_35p55);
-Obj _35reg596 = primEQ(intern("%const"), _35reg595);
-if (True == _35reg596) {
-Obj _35reg597 = primCdr(_35p55);
-Obj _35reg598 = primIsCons(_35reg597);
-if (True == _35reg598) {
-Obj _35reg599 = primCdr(_35p55);
-Obj _35reg600 = primCar(_35reg599);
-Obj x = _35reg600;
-Obj _35reg601 = primCdr(_35p55);
-Obj _35reg602 = primCdr(_35reg601);
-Obj _35reg603 = primEQ(Nil, _35reg602);
-if (True == _35reg603) {
+Obj _35p1202 = __arg1;
+Obj _35cc1203 = makeNative(12, _35clofun3116, 0, 1, _35p1202);
+Obj _35reg1741 = primIsCons(_35p1202);
+if (True == _35reg1741) {
+Obj _35reg1742 = primCar(_35p1202);
+Obj _35reg1743 = primEQ(intern("%const"), _35reg1742);
+if (True == _35reg1743) {
+Obj _35reg1744 = primCdr(_35p1202);
+Obj _35reg1745 = primIsCons(_35reg1744);
+if (True == _35reg1745) {
+Obj _35reg1746 = primCdr(_35p1202);
+Obj _35reg1747 = primCar(_35reg1746);
+Obj x = _35reg1747;
+Obj _35reg1748 = primCdr(_35p1202);
+Obj _35reg1749 = primCdr(_35reg1748);
+Obj _35reg1750 = primEQ(Nil, _35reg1749);
+if (True == _35reg1750) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1973) { goto fail; }
+if (co->ctx.pc.func != _35clofun3116) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc56;
+__arg0 = _35cc1203;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc56;
+__arg0 = _35cc1203;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc56;
+__arg0 = _35cc1203;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc56;
+__arg0 = _35cc1203;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11412,230 +11368,230 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val609 = __arg1;
+Obj _35val1756 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#foldl"));
 __arg1 = globalRef(intern("cora/lib/toc#union"));
 __arg2 = Nil;
-__arg3 = _35val609;
+__arg3 = _35val1756;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35cc74 = makeNative(14, _35clofun1973, 0, 0);
-Obj _35reg605 = primIsCons(closureRef(co, 0));
-if (True == _35reg605) {
-Obj _35reg606 = primCar(closureRef(co, 0));
-Obj f = _35reg606;
-Obj _35reg607 = primCdr(closureRef(co, 0));
-Obj args = _35reg607;
-Obj _35reg608 = primCons(f, args);
-pushCont(co, 15, _35clofun1973, 0);
+Obj _35cc1221 = makeNative(14, _35clofun3116, 0, 0);
+Obj _35reg1752 = primIsCons(closureRef(co, 0));
+if (True == _35reg1752) {
+Obj _35reg1753 = primCar(closureRef(co, 0));
+Obj f = _35reg1753;
+Obj _35reg1754 = primCdr(closureRef(co, 0));
+Obj args = _35reg1754;
+Obj _35reg1755 = primCons(f, args);
+pushCont(co, 15, _35clofun3116, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg2 = _35reg608;
+__arg2 = _35reg1755;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc74;
+__arg0 = _35cc1221;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label17:
 {
-Obj _35val627 = __arg1;
+Obj _35val1774 = __arg1;
 Obj arg= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = _35val627;
+__arg1 = _35val1774;
 __arg2 = arg;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35cc73 = makeNative(16, _35clofun1973, 0, 1, closureRef(co, 0));
-Obj _35reg610 = primIsCons(closureRef(co, 0));
-if (True == _35reg610) {
-Obj _35reg611 = primCar(closureRef(co, 0));
-Obj _35reg612 = primEQ(intern("continuation"), _35reg611);
-if (True == _35reg612) {
-Obj _35reg613 = primCdr(closureRef(co, 0));
-Obj _35reg614 = primIsCons(_35reg613);
-if (True == _35reg614) {
-Obj _35reg615 = primCdr(closureRef(co, 0));
-Obj _35reg616 = primCar(_35reg615);
-Obj arg = _35reg616;
-Obj _35reg617 = primCdr(closureRef(co, 0));
-Obj _35reg618 = primCdr(_35reg617);
-Obj _35reg619 = primIsCons(_35reg618);
-if (True == _35reg619) {
-Obj _35reg620 = primCdr(closureRef(co, 0));
-Obj _35reg621 = primCdr(_35reg620);
-Obj _35reg622 = primCar(_35reg621);
-Obj body = _35reg622;
-Obj _35reg623 = primCdr(closureRef(co, 0));
-Obj _35reg624 = primCdr(_35reg623);
-Obj _35reg625 = primCdr(_35reg624);
-Obj _35reg626 = primEQ(Nil, _35reg625);
-if (True == _35reg626) {
-pushCont(co, 17, _35clofun1973, 1, arg);
+Obj _35cc1220 = makeNative(16, _35clofun3116, 0, 1, closureRef(co, 0));
+Obj _35reg1757 = primIsCons(closureRef(co, 0));
+if (True == _35reg1757) {
+Obj _35reg1758 = primCar(closureRef(co, 0));
+Obj _35reg1759 = primEQ(intern("continuation"), _35reg1758);
+if (True == _35reg1759) {
+Obj _35reg1760 = primCdr(closureRef(co, 0));
+Obj _35reg1761 = primIsCons(_35reg1760);
+if (True == _35reg1761) {
+Obj _35reg1762 = primCdr(closureRef(co, 0));
+Obj _35reg1763 = primCar(_35reg1762);
+Obj arg = _35reg1763;
+Obj _35reg1764 = primCdr(closureRef(co, 0));
+Obj _35reg1765 = primCdr(_35reg1764);
+Obj _35reg1766 = primIsCons(_35reg1765);
+if (True == _35reg1766) {
+Obj _35reg1767 = primCdr(closureRef(co, 0));
+Obj _35reg1768 = primCdr(_35reg1767);
+Obj _35reg1769 = primCar(_35reg1768);
+Obj body = _35reg1769;
+Obj _35reg1770 = primCdr(closureRef(co, 0));
+Obj _35reg1771 = primCdr(_35reg1770);
+Obj _35reg1772 = primCdr(_35reg1771);
+Obj _35reg1773 = primEQ(Nil, _35reg1772);
+if (True == _35reg1773) {
+pushCont(co, 17, _35clofun3116, 1, arg);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc73;
+__arg0 = _35cc1220;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc73;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc73;
+__arg0 = _35cc1220;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc73;
+__arg0 = _35cc1220;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc73;
+__arg0 = _35cc1220;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1220;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label19:
 {
-Obj _35cc72 = makeNative(18, _35clofun1973, 0, 1, closureRef(co, 0));
-Obj _35reg628 = primIsCons(closureRef(co, 0));
-if (True == _35reg628) {
-Obj _35reg629 = primCar(closureRef(co, 0));
-Obj _35reg630 = primEQ(intern("tailcall"), _35reg629);
-if (True == _35reg630) {
-Obj _35reg631 = primCdr(closureRef(co, 0));
-Obj _35reg632 = primIsCons(_35reg631);
-if (True == _35reg632) {
-Obj _35reg633 = primCdr(closureRef(co, 0));
-Obj _35reg634 = primCar(_35reg633);
-Obj exp = _35reg634;
-Obj _35reg635 = primCdr(closureRef(co, 0));
-Obj _35reg636 = primCdr(_35reg635);
-Obj _35reg637 = primEQ(Nil, _35reg636);
-if (True == _35reg637) {
+Obj _35cc1219 = makeNative(18, _35clofun3116, 0, 1, closureRef(co, 0));
+Obj _35reg1775 = primIsCons(closureRef(co, 0));
+if (True == _35reg1775) {
+Obj _35reg1776 = primCar(closureRef(co, 0));
+Obj _35reg1777 = primEQ(intern("tailcall"), _35reg1776);
+if (True == _35reg1777) {
+Obj _35reg1778 = primCdr(closureRef(co, 0));
+Obj _35reg1779 = primIsCons(_35reg1778);
+if (True == _35reg1779) {
+Obj _35reg1780 = primCdr(closureRef(co, 0));
+Obj _35reg1781 = primCar(_35reg1780);
+Obj exp = _35reg1781;
+Obj _35reg1782 = primCdr(closureRef(co, 0));
+Obj _35reg1783 = primCdr(_35reg1782);
+Obj _35reg1784 = primEQ(Nil, _35reg1783);
+if (True == _35reg1784) {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc72;
+__arg0 = _35cc1219;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc72;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc72;
+__arg0 = _35cc1219;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc72;
+__arg0 = _35cc1219;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1219;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label20:
 {
-Obj _35val657 = __arg1;
+Obj _35val1804 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#foldl"));
 __arg1 = globalRef(intern("cora/lib/toc#union"));
 __arg2 = Nil;
-__arg3 = _35val657;
+__arg3 = _35val1804;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3116) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -11648,7 +11604,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1972(struct Cora* co){
+void _35clofun3115(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -11661,12 +11617,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val466 = __arg1;
+Obj _35val1613 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 20, _35clofun1971, 1, _35val466);
+pushCont(co, 20, _35clofun3114, 1, _35val1613);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -11676,41 +11632,41 @@ co->args[4] = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35cc39 = makeNative(19, _35clofun1971, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1186 = makeNative(19, _35clofun3114, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj _35reg449 = primIsCons(closureRef(co, 3));
-if (True == _35reg449) {
-Obj _35reg450 = primCar(closureRef(co, 3));
-Obj _35reg451 = primEQ(intern("do"), _35reg450);
-if (True == _35reg451) {
-Obj _35reg452 = primCdr(closureRef(co, 3));
-Obj _35reg453 = primIsCons(_35reg452);
-if (True == _35reg453) {
-Obj _35reg454 = primCdr(closureRef(co, 3));
-Obj _35reg455 = primCar(_35reg454);
-Obj x = _35reg455;
-Obj _35reg456 = primCdr(closureRef(co, 3));
-Obj _35reg457 = primCdr(_35reg456);
-Obj _35reg458 = primIsCons(_35reg457);
-if (True == _35reg458) {
-Obj _35reg459 = primCdr(closureRef(co, 3));
-Obj _35reg460 = primCdr(_35reg459);
-Obj _35reg461 = primCar(_35reg460);
-Obj y = _35reg461;
-Obj _35reg462 = primCdr(closureRef(co, 3));
-Obj _35reg463 = primCdr(_35reg462);
-Obj _35reg464 = primCdr(_35reg463);
-Obj _35reg465 = primEQ(Nil, _35reg464);
-if (True == _35reg465) {
-pushCont(co, 0, _35clofun1972, 4, env, ns, import, y);
+Obj _35reg1596 = primIsCons(closureRef(co, 3));
+if (True == _35reg1596) {
+Obj _35reg1597 = primCar(closureRef(co, 3));
+Obj _35reg1598 = primEQ(intern("do"), _35reg1597);
+if (True == _35reg1598) {
+Obj _35reg1599 = primCdr(closureRef(co, 3));
+Obj _35reg1600 = primIsCons(_35reg1599);
+if (True == _35reg1600) {
+Obj _35reg1601 = primCdr(closureRef(co, 3));
+Obj _35reg1602 = primCar(_35reg1601);
+Obj x = _35reg1602;
+Obj _35reg1603 = primCdr(closureRef(co, 3));
+Obj _35reg1604 = primCdr(_35reg1603);
+Obj _35reg1605 = primIsCons(_35reg1604);
+if (True == _35reg1605) {
+Obj _35reg1606 = primCdr(closureRef(co, 3));
+Obj _35reg1607 = primCdr(_35reg1606);
+Obj _35reg1608 = primCar(_35reg1607);
+Obj y = _35reg1608;
+Obj _35reg1609 = primCdr(closureRef(co, 3));
+Obj _35reg1610 = primCdr(_35reg1609);
+Obj _35reg1611 = primCdr(_35reg1610);
+Obj _35reg1612 = primEQ(Nil, _35reg1611);
+if (True == _35reg1612) {
+pushCont(co, 0, _35clofun3115, 4, env, ns, import, y);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -11720,96 +11676,96 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc39;
+__arg0 = _35cc1186;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc39;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc39;
+__arg0 = _35cc1186;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc39;
+__arg0 = _35cc1186;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc39;
+__arg0 = _35cc1186;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1186;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label2:
 {
-Obj _35val476 = __arg1;
-Obj _35reg477 = primCons(intern("if"), _35val476);
+Obj _35val1623 = __arg1;
+Obj _35reg1624 = primCons(intern("if"), _35val1623);
 __nargs = 2;
-__arg1 = _35reg477;
+__arg1 = _35reg1624;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1972) { goto fail; }
+if (co->ctx.pc.func != _35clofun3115) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label3:
 {
-Obj _35val475 = __arg1;
+Obj _35val1622 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 2, _35clofun1972, 0);
+pushCont(co, 2, _35clofun3115, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val475;
+__arg1 = _35val1622;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35cc38 = makeNative(1, _35clofun1972, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1185 = makeNative(1, _35clofun3115, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj _35reg471 = primIsCons(closureRef(co, 3));
-if (True == _35reg471) {
-Obj _35reg472 = primCar(closureRef(co, 3));
-Obj _35reg473 = primEQ(intern("if"), _35reg472);
-if (True == _35reg473) {
-Obj _35reg474 = primCdr(closureRef(co, 3));
-Obj args = _35reg474;
-pushCont(co, 3, _35clofun1972, 1, args);
+Obj _35reg1618 = primIsCons(closureRef(co, 3));
+if (True == _35reg1618) {
+Obj _35reg1619 = primCar(closureRef(co, 3));
+Obj _35reg1620 = primEQ(intern("if"), _35reg1619);
+if (True == _35reg1620) {
+Obj _35reg1621 = primCdr(closureRef(co, 3));
+Obj args = _35reg1621;
+pushCont(co, 3, _35clofun3115, 1, args);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -11818,94 +11774,94 @@ __arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc38;
+__arg0 = _35cc1185;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc38;
+__arg0 = _35cc1185;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35val496 = __arg1;
+Obj _35val1643 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg497 = primCons(_35val496, Nil);
-Obj _35reg498 = primCons(args, _35reg497);
-Obj _35reg499 = primCons(intern("lambda"), _35reg498);
+Obj _35reg1644 = primCons(_35val1643, Nil);
+Obj _35reg1645 = primCons(args, _35reg1644);
+Obj _35reg1646 = primCons(intern("lambda"), _35reg1645);
 __nargs = 2;
-__arg1 = _35reg499;
+__arg1 = _35reg1646;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1972) { goto fail; }
+if (co->ctx.pc.func != _35clofun3115) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label6:
 {
-Obj _35val495 = __arg1;
+Obj _35val1642 = __arg1;
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 5, _35clofun1972, 1, args);
+pushCont(co, 5, _35clofun3115, 1, args);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = _35val495;
+__arg1 = _35val1642;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35cc37 = makeNative(4, _35clofun1972, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1184 = makeNative(4, _35clofun3115, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj _35reg478 = primIsCons(closureRef(co, 3));
-if (True == _35reg478) {
-Obj _35reg479 = primCar(closureRef(co, 3));
-Obj _35reg480 = primEQ(intern("lambda"), _35reg479);
-if (True == _35reg480) {
-Obj _35reg481 = primCdr(closureRef(co, 3));
-Obj _35reg482 = primIsCons(_35reg481);
-if (True == _35reg482) {
-Obj _35reg483 = primCdr(closureRef(co, 3));
-Obj _35reg484 = primCar(_35reg483);
-Obj args = _35reg484;
-Obj _35reg485 = primCdr(closureRef(co, 3));
-Obj _35reg486 = primCdr(_35reg485);
-Obj _35reg487 = primIsCons(_35reg486);
-if (True == _35reg487) {
-Obj _35reg488 = primCdr(closureRef(co, 3));
-Obj _35reg489 = primCdr(_35reg488);
-Obj _35reg490 = primCar(_35reg489);
-Obj body = _35reg490;
-Obj _35reg491 = primCdr(closureRef(co, 3));
-Obj _35reg492 = primCdr(_35reg491);
-Obj _35reg493 = primCdr(_35reg492);
-Obj _35reg494 = primEQ(Nil, _35reg493);
-if (True == _35reg494) {
-pushCont(co, 6, _35clofun1972, 4, ns, import, body, args);
+Obj _35reg1625 = primIsCons(closureRef(co, 3));
+if (True == _35reg1625) {
+Obj _35reg1626 = primCar(closureRef(co, 3));
+Obj _35reg1627 = primEQ(intern("lambda"), _35reg1626);
+if (True == _35reg1627) {
+Obj _35reg1628 = primCdr(closureRef(co, 3));
+Obj _35reg1629 = primIsCons(_35reg1628);
+if (True == _35reg1629) {
+Obj _35reg1630 = primCdr(closureRef(co, 3));
+Obj _35reg1631 = primCar(_35reg1630);
+Obj args = _35reg1631;
+Obj _35reg1632 = primCdr(closureRef(co, 3));
+Obj _35reg1633 = primCdr(_35reg1632);
+Obj _35reg1634 = primIsCons(_35reg1633);
+if (True == _35reg1634) {
+Obj _35reg1635 = primCdr(closureRef(co, 3));
+Obj _35reg1636 = primCdr(_35reg1635);
+Obj _35reg1637 = primCar(_35reg1636);
+Obj body = _35reg1637;
+Obj _35reg1638 = primCdr(closureRef(co, 3));
+Obj _35reg1639 = primCdr(_35reg1638);
+Obj _35reg1640 = primCdr(_35reg1639);
+Obj _35reg1641 = primEQ(Nil, _35reg1640);
+if (True == _35reg1641) {
+pushCont(co, 6, _35clofun3115, 4, ns, import, body, args);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#append"));
 __arg1 = args;
@@ -11913,81 +11869,81 @@ __arg2 = env;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc37;
+__arg0 = _35cc1184;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc37;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc37;
+__arg0 = _35cc1184;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc37;
+__arg0 = _35cc1184;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc37;
+__arg0 = _35cc1184;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1184;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35val502 = __arg1;
-Obj _35reg503 = primCons(_35val502, Nil);
-Obj _35reg504 = primCons(intern("%global"), _35reg503);
+Obj _35val1649 = __arg1;
+Obj _35reg1650 = primCons(_35val1649, Nil);
+Obj _35reg1651 = primCons(intern("%global"), _35reg1650);
 __nargs = 2;
-__arg1 = _35reg504;
+__arg1 = _35reg1651;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1972) { goto fail; }
+if (co->ctx.pc.func != _35clofun3115) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label9:
 {
-Obj _35val501 = __arg1;
+Obj _35val1648 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val501) {
+if (True == _35val1648) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1972) { goto fail; }
+if (co->ctx.pc.func != _35clofun3115) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 8, _35clofun1972, 0);
+pushCont(co, 8, _35clofun3115, 0);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#lookup-var"));
 __arg1 = x;
@@ -11996,21 +11952,21 @@ __arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35cc36 = makeNative(7, _35clofun1972, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1183 = makeNative(7, _35clofun3115, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj x = closureRef(co, 3);
-Obj _35reg500 = primIsSymbol(x);
-if (True == _35reg500) {
-pushCont(co, 9, _35clofun1972, 3, x, ns, import);
+Obj _35reg1647 = primIsSymbol(x);
+if (True == _35reg1647) {
+pushCont(co, 9, _35clofun3115, 3, x, ns, import);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#elem?"));
 __arg1 = x;
@@ -12018,124 +11974,124 @@ __arg2 = env;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc36;
+__arg0 = _35cc1183;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35cc35 = makeNative(10, _35clofun1972, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1182 = makeNative(10, _35clofun3115, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj __ = closureRef(co, 0);
 __ = closureRef(co, 1);
 __ = closureRef(co, 2);
-Obj _35reg505 = primIsCons(closureRef(co, 3));
-if (True == _35reg505) {
-Obj _35reg506 = primCar(closureRef(co, 3));
-Obj _35reg507 = primEQ(intern("quote"), _35reg506);
-if (True == _35reg507) {
-Obj _35reg508 = primCdr(closureRef(co, 3));
-Obj _35reg509 = primIsCons(_35reg508);
-if (True == _35reg509) {
-Obj _35reg510 = primCdr(closureRef(co, 3));
-Obj _35reg511 = primCar(_35reg510);
-Obj x = _35reg511;
-Obj _35reg512 = primCdr(closureRef(co, 3));
-Obj _35reg513 = primCdr(_35reg512);
-Obj _35reg514 = primEQ(Nil, _35reg513);
-if (True == _35reg514) {
-Obj _35reg515 = primCons(x, Nil);
-Obj _35reg516 = primCons(intern("%const"), _35reg515);
+Obj _35reg1652 = primIsCons(closureRef(co, 3));
+if (True == _35reg1652) {
+Obj _35reg1653 = primCar(closureRef(co, 3));
+Obj _35reg1654 = primEQ(intern("quote"), _35reg1653);
+if (True == _35reg1654) {
+Obj _35reg1655 = primCdr(closureRef(co, 3));
+Obj _35reg1656 = primIsCons(_35reg1655);
+if (True == _35reg1656) {
+Obj _35reg1657 = primCdr(closureRef(co, 3));
+Obj _35reg1658 = primCar(_35reg1657);
+Obj x = _35reg1658;
+Obj _35reg1659 = primCdr(closureRef(co, 3));
+Obj _35reg1660 = primCdr(_35reg1659);
+Obj _35reg1661 = primEQ(Nil, _35reg1660);
+if (True == _35reg1661) {
+Obj _35reg1662 = primCons(x, Nil);
+Obj _35reg1663 = primCons(intern("%const"), _35reg1662);
 __nargs = 2;
-__arg1 = _35reg516;
+__arg1 = _35reg1663;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1972) { goto fail; }
+if (co->ctx.pc.func != _35clofun3115) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc35;
+__arg0 = _35cc1182;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc35;
+__arg0 = _35cc1182;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc35;
+__arg0 = _35cc1182;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc35;
+__arg0 = _35cc1182;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj _35val526 = __arg1;
+Obj _35val1673 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc34= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val526) {
+Obj _35cc1181= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1673) {
 if (True == True) {
-Obj _35reg527 = primCons(x, Nil);
-Obj _35reg528 = primCons(intern("%const"), _35reg527);
+Obj _35reg1674 = primCons(x, Nil);
+Obj _35reg1675 = primCons(intern("%const"), _35reg1674);
 __nargs = 2;
-__arg1 = _35reg528;
+__arg1 = _35reg1675;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1972) { goto fail; }
+if (co->ctx.pc.func != _35clofun3115) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc34;
+__arg0 = _35cc1181;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj _35reg529 = primCons(x, Nil);
-Obj _35reg530 = primCons(intern("%const"), _35reg529);
+Obj _35reg1676 = primCons(x, Nil);
+Obj _35reg1677 = primCons(intern("%const"), _35reg1676);
 __nargs = 2;
-__arg1 = _35reg530;
+__arg1 = _35reg1677;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1972) { goto fail; }
+if (co->ctx.pc.func != _35clofun3115) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc34;
+__arg0 = _35cc1181;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12143,92 +12099,92 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35val523 = __arg1;
+Obj _35val1670 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc34= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val523) {
+Obj _35cc1181= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1670) {
 if (True == True) {
-Obj _35reg524 = primCons(x, Nil);
-Obj _35reg525 = primCons(intern("%const"), _35reg524);
+Obj _35reg1671 = primCons(x, Nil);
+Obj _35reg1672 = primCons(intern("%const"), _35reg1671);
 __nargs = 2;
-__arg1 = _35reg525;
+__arg1 = _35reg1672;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1972) { goto fail; }
+if (co->ctx.pc.func != _35clofun3115) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc34;
+__arg0 = _35cc1181;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 12, _35clofun1972, 2, x, _35cc34);
+pushCont(co, 12, _35clofun3115, 2, x, _35cc1181);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label14:
 {
-Obj _35val517 = __arg1;
+Obj _35val1664 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc34= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val517) {
+Obj _35cc1181= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1664) {
 if (True == True) {
-Obj _35reg518 = primCons(x, Nil);
-Obj _35reg519 = primCons(intern("%const"), _35reg518);
+Obj _35reg1665 = primCons(x, Nil);
+Obj _35reg1666 = primCons(intern("%const"), _35reg1665);
 __nargs = 2;
-__arg1 = _35reg519;
+__arg1 = _35reg1666;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1972) { goto fail; }
+if (co->ctx.pc.func != _35clofun3115) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc34;
+__arg0 = _35cc1181;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj _35reg520 = primIsString(x);
-if (True == _35reg520) {
+Obj _35reg1667 = primIsString(x);
+if (True == _35reg1667) {
 if (True == True) {
-Obj _35reg521 = primCons(x, Nil);
-Obj _35reg522 = primCons(intern("%const"), _35reg521);
+Obj _35reg1668 = primCons(x, Nil);
+Obj _35reg1669 = primCons(intern("%const"), _35reg1668);
 __nargs = 2;
-__arg1 = _35reg522;
+__arg1 = _35reg1669;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1972) { goto fail; }
+if (co->ctx.pc.func != _35clofun3115) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc34;
+__arg0 = _35cc1181;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 13, _35clofun1972, 2, x, _35cc34);
+pushCont(co, 13, _35clofun3115, 2, x, _35cc1181);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#boolean?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12236,23 +12192,23 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj _35p30 = __arg1;
-Obj _35p31 = __arg2;
-Obj _35p32 = __arg3;
-Obj _35p33 = co->args[4];
-Obj _35cc34 = makeNative(11, _35clofun1972, 0, 4, _35p30, _35p31, _35p32, _35p33);
-Obj __ = _35p30;
-__ = _35p31;
-__ = _35p32;
-Obj x = _35p33;
-pushCont(co, 14, _35clofun1972, 2, x, _35cc34);
+Obj _35p1177 = __arg1;
+Obj _35p1178 = __arg2;
+Obj _35p1179 = __arg3;
+Obj _35p1180 = co->args[4];
+Obj _35cc1181 = makeNative(11, _35clofun3115, 0, 4, _35p1177, _35p1178, _35p1179, _35p1180);
+Obj __ = _35p1177;
+__ = _35p1178;
+__ = _35p1179;
+Obj x = _35p1180;
+pushCont(co, 14, _35clofun3115, 2, x, _35cc1181);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#number?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12264,33 +12220,33 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val535 = __arg1;
+Obj _35val1682 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg536 = primCons(x, _35val535);
+Obj _35reg1683 = primCons(x, _35val1682);
 __nargs = 2;
-__arg1 = _35reg536;
+__arg1 = _35reg1683;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1972) { goto fail; }
+if (co->ctx.pc.func != _35clofun3115) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label18:
 {
-Obj _35cc49 = makeNative(16, _35clofun1972, 0, 0);
-Obj _35reg532 = primIsCons(closureRef(co, 0));
-if (True == _35reg532) {
-Obj _35reg533 = primCar(closureRef(co, 0));
-Obj x = _35reg533;
-Obj _35reg534 = primCdr(closureRef(co, 0));
-Obj y = _35reg534;
+Obj _35cc1196 = makeNative(16, _35clofun3115, 0, 0);
+Obj _35reg1679 = primIsCons(closureRef(co, 0));
+if (True == _35reg1679) {
+Obj _35reg1680 = primCar(closureRef(co, 0));
+Obj x = _35reg1680;
+Obj _35reg1681 = primCdr(closureRef(co, 0));
+Obj y = _35reg1681;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 17, _35clofun1972, 1, x);
+pushCont(co, 17, _35clofun3115, 1, x);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#union"));
 __arg1 = y;
@@ -12298,26 +12254,26 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc49;
+__arg0 = _35cc1196;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label19:
 {
-Obj _35val540 = __arg1;
+Obj _35val1687 = __arg1;
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc48= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val540) {
+Obj _35cc1195= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val1687) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#union"));
 __arg1 = y;
@@ -12325,30 +12281,30 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc48;
+__arg0 = _35cc1195;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label20:
 {
-Obj _35cc48 = makeNative(18, _35clofun1972, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg537 = primIsCons(closureRef(co, 0));
-if (True == _35reg537) {
-Obj _35reg538 = primCar(closureRef(co, 0));
-Obj x = _35reg538;
-Obj _35reg539 = primCdr(closureRef(co, 0));
-Obj y = _35reg539;
+Obj _35cc1195 = makeNative(18, _35clofun3115, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1684 = primIsCons(closureRef(co, 0));
+if (True == _35reg1684) {
+Obj _35reg1685 = primCar(closureRef(co, 0));
+Obj x = _35reg1685;
+Obj _35reg1686 = primCdr(closureRef(co, 0));
+Obj y = _35reg1686;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 19, _35clofun1972, 3, y, s2, _35cc48);
+pushCont(co, 19, _35clofun3115, 3, y, s2, _35cc1195);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#elem?"));
 __arg1 = x;
@@ -12356,15 +12312,15 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc48;
+__arg0 = _35cc1195;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3115) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12378,7 +12334,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1971(struct Cora* co){
+void _35clofun3114(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -12391,16 +12347,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc29 = makeNative(13, _35clofun1970, 0, 0);
+Obj _35cc1176 = makeNative(13, _35clofun3113, 0, 0);
 Obj s = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
-Obj _35reg331 = primIsCons(closureRef(co, 2));
-if (True == _35reg331) {
-Obj _35reg332 = primCar(closureRef(co, 2));
-Obj import = _35reg332;
-Obj _35reg333 = primCdr(closureRef(co, 2));
-Obj more = _35reg333;
-pushCont(co, 20, _35clofun1970, 4, import, s, ns, more);
+Obj _35reg1478 = primIsCons(closureRef(co, 2));
+if (True == _35reg1478) {
+Obj _35reg1479 = primCar(closureRef(co, 2));
+Obj import = _35reg1479;
+Obj _35reg1480 = primCdr(closureRef(co, 2));
+Obj more = _35reg1480;
+pushCont(co, 20, _35clofun3113, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = import;
@@ -12408,29 +12364,29 @@ __arg2 = makeCString("#*ns-export*");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc29;
+__arg0 = _35cc1176;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35p25 = __arg1;
-Obj _35p26 = __arg2;
-Obj _35p27 = __arg3;
-Obj _35cc28 = makeNative(0, _35clofun1971, 0, 3, _35p25, _35p26, _35p27);
-Obj s = _35p25;
-Obj ns = _35p26;
-Obj _35reg341 = primEQ(Nil, _35p27);
-if (True == _35reg341) {
+Obj _35p1172 = __arg1;
+Obj _35p1173 = __arg2;
+Obj _35p1174 = __arg3;
+Obj _35cc1175 = makeNative(0, _35clofun3114, 0, 3, _35p1172, _35p1173, _35p1174);
+Obj s = _35p1172;
+Obj ns = _35p1173;
+Obj _35reg1488 = primEQ(Nil, _35p1174);
+if (True == _35reg1488) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#var-with-ns"));
 __arg1 = s;
@@ -12438,15 +12394,15 @@ __arg2 = ns;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc28;
+__arg0 = _35cc1175;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12459,33 +12415,33 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val343 = __arg1;
+Obj _35val1490 = __arg1;
 Obj ls= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val343;
+__arg1 = _35val1490;
 __arg2 = ls;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35cc44 = makeNative(2, _35clofun1971, 0, 0);
+Obj _35cc1191 = makeNative(2, _35clofun3114, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj ls = closureRef(co, 3);
-pushCont(co, 3, _35clofun1971, 1, ls);
+pushCont(co, 3, _35clofun3114, 1, ls);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -12494,99 +12450,99 @@ __arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val354 = __arg1;
-Obj _35reg352= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg355 = primCons(_35reg352, _35val354);
+Obj _35val1501 = __arg1;
+Obj _35reg1499= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1502 = primCons(_35reg1499, _35val1501);
 __nargs = 2;
-__arg1 = _35reg355;
+__arg1 = _35reg1502;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1971) { goto fail; }
+if (co->ctx.pc.func != _35clofun3114) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label6:
 {
-Obj _35val353 = __arg1;
+Obj _35val1500 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg352= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun1971, 1, _35reg352);
+Obj _35reg1499= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 5, _35clofun3114, 1, _35reg1499);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val353;
+__arg1 = _35val1500;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35val360 = __arg1;
+Obj _35val1507 = __arg1;
 Obj tmp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg361 = primCons(_35val360, Nil);
-Obj _35reg362 = primCons(tmp, _35reg361);
-Obj _35reg363 = primCons(intern("lambda"), _35reg362);
+Obj _35reg1508 = primCons(_35val1507, Nil);
+Obj _35reg1509 = primCons(tmp, _35reg1508);
+Obj _35reg1510 = primCons(intern("lambda"), _35reg1509);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
 __arg2 = ns;
 __arg3 = import;
-co->args[4] = _35reg363;
+co->args[4] = _35reg1510;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35val358 = __arg1;
+Obj _35val1505 = __arg1;
 Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj tmp = _35val358;
-Obj _35reg359 = primCons(op, args);
-pushCont(co, 7, _35clofun1971, 4, tmp, env, ns, import);
+Obj tmp = _35val1505;
+Obj _35reg1506 = primCons(op, args);
+pushCont(co, 7, _35clofun3114, 4, tmp, env, ns, import);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#append"));
-__arg1 = _35reg359;
+__arg1 = _35reg1506;
 __arg2 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val349 = __arg1;
+Obj _35val1496 = __arg1;
 Obj required= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj op= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj provided = _35val349;
-Obj _35reg350 = primEQ(required, provided);
-if (True == _35reg350) {
-Obj _35reg351 = primCons(op, Nil);
-Obj _35reg352 = primCons(intern("%builtin"), _35reg351);
-pushCont(co, 6, _35clofun1971, 2, args, _35reg352);
+Obj provided = _35val1496;
+Obj _35reg1497 = primEQ(required, provided);
+if (True == _35reg1497) {
+Obj _35reg1498 = primCons(op, Nil);
+Obj _35reg1499 = primCons(intern("%builtin"), _35reg1498);
+pushCont(co, 6, _35clofun3114, 2, args, _35reg1499);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -12595,21 +12551,21 @@ __arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg356 = primGT(required, provided);
-if (True == _35reg356) {
-Obj _35reg357 = primSub(required, provided);
-pushCont(co, 8, _35clofun1971, 5, op, args, env, ns, import);
+Obj _35reg1503 = primGT(required, provided);
+if (True == _35reg1503) {
+Obj _35reg1504 = primSub(required, provided);
+pushCont(co, 8, _35clofun3114, 5, op, args, env, ns, import);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#temp-list"));
-__arg1 = _35reg357;
+__arg1 = _35reg1504;
 __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -12618,7 +12574,7 @@ __arg1 = makeCString("primitive call mismatch");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12626,114 +12582,114 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj _35val348 = __arg1;
+Obj _35val1495 = __arg1;
 Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj required = _35val348;
-pushCont(co, 9, _35clofun1971, 6, required, op, args, env, ns, import);
+Obj required = _35val1495;
+pushCont(co, 9, _35clofun3114, 6, required, op, args, env, ns, import);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val347 = __arg1;
+Obj _35val1494 = __arg1;
 Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35cc43= co->ctx.stk.stack[co->ctx.stk.base + 5];
-if (True == _35val347) {
-pushCont(co, 10, _35clofun1971, 5, op, args, env, ns, import);
+Obj _35cc1190= co->ctx.stk.stack[co->ctx.stk.base + 5];
+if (True == _35val1494) {
+pushCont(co, 10, _35clofun3114, 5, op, args, env, ns, import);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#builtin->args"));
 __arg1 = op;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc43;
+__arg0 = _35cc1190;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj _35cc43 = makeNative(4, _35clofun1971, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1190 = makeNative(4, _35clofun3114, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj _35reg344 = primIsCons(closureRef(co, 3));
-if (True == _35reg344) {
-Obj _35reg345 = primCar(closureRef(co, 3));
-Obj op = _35reg345;
-Obj _35reg346 = primCdr(closureRef(co, 3));
-Obj args = _35reg346;
-pushCont(co, 11, _35clofun1971, 6, op, args, env, ns, import, _35cc43);
+Obj _35reg1491 = primIsCons(closureRef(co, 3));
+if (True == _35reg1491) {
+Obj _35reg1492 = primCar(closureRef(co, 3));
+Obj op = _35reg1492;
+Obj _35reg1493 = primCdr(closureRef(co, 3));
+Obj args = _35reg1493;
+pushCont(co, 11, _35clofun3114, 6, op, args, env, ns, import, _35cc1190);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#builtin?"));
 __arg1 = op;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc43;
+__arg0 = _35cc1190;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label13:
 {
-Obj _35val386 = __arg1;
-Obj _35reg385= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg383= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg387 = primCons(_35val386, Nil);
-Obj _35reg388 = primCons(_35reg385, _35reg387);
-Obj _35reg389 = primCons(_35reg383, _35reg388);
+Obj _35val1533 = __arg1;
+Obj _35reg1532= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1530= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1534 = primCons(_35val1533, Nil);
+Obj _35reg1535 = primCons(_35reg1532, _35reg1534);
+Obj _35reg1536 = primCons(_35reg1530, _35reg1535);
 __nargs = 2;
-__arg1 = _35reg389;
+__arg1 = _35reg1536;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1971) { goto fail; }
+if (co->ctx.pc.func != _35clofun3114) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label14:
 {
-Obj _35val381 = __arg1;
+Obj _35val1528 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj var1 = _35val381;
-Obj _35reg382 = primCons(intern("set"), Nil);
-Obj _35reg383 = primCons(intern("%builtin"), _35reg382);
-Obj _35reg384 = primCons(var1, Nil);
-Obj _35reg385 = primCons(intern("%const"), _35reg384);
-pushCont(co, 13, _35clofun1971, 2, _35reg385, _35reg383);
+Obj var1 = _35val1528;
+Obj _35reg1529 = primCons(intern("set"), Nil);
+Obj _35reg1530 = primCons(intern("%builtin"), _35reg1529);
+Obj _35reg1531 = primCons(var1, Nil);
+Obj _35reg1532 = primCons(intern("%const"), _35reg1531);
+pushCont(co, 13, _35clofun3114, 2, _35reg1532, _35reg1530);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -12743,41 +12699,41 @@ co->args[4] = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35cc42 = makeNative(12, _35clofun1971, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1189 = makeNative(12, _35clofun3114, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj _35reg364 = primIsCons(closureRef(co, 3));
-if (True == _35reg364) {
-Obj _35reg365 = primCar(closureRef(co, 3));
-Obj _35reg366 = primEQ(intern("def"), _35reg365);
-if (True == _35reg366) {
-Obj _35reg367 = primCdr(closureRef(co, 3));
-Obj _35reg368 = primIsCons(_35reg367);
-if (True == _35reg368) {
-Obj _35reg369 = primCdr(closureRef(co, 3));
-Obj _35reg370 = primCar(_35reg369);
-Obj var = _35reg370;
-Obj _35reg371 = primCdr(closureRef(co, 3));
-Obj _35reg372 = primCdr(_35reg371);
-Obj _35reg373 = primIsCons(_35reg372);
-if (True == _35reg373) {
-Obj _35reg374 = primCdr(closureRef(co, 3));
-Obj _35reg375 = primCdr(_35reg374);
-Obj _35reg376 = primCar(_35reg375);
-Obj val = _35reg376;
-Obj _35reg377 = primCdr(closureRef(co, 3));
-Obj _35reg378 = primCdr(_35reg377);
-Obj _35reg379 = primCdr(_35reg378);
-Obj _35reg380 = primEQ(Nil, _35reg379);
-if (True == _35reg380) {
-pushCont(co, 14, _35clofun1971, 4, env, ns, import, val);
+Obj _35reg1511 = primIsCons(closureRef(co, 3));
+if (True == _35reg1511) {
+Obj _35reg1512 = primCar(closureRef(co, 3));
+Obj _35reg1513 = primEQ(intern("def"), _35reg1512);
+if (True == _35reg1513) {
+Obj _35reg1514 = primCdr(closureRef(co, 3));
+Obj _35reg1515 = primIsCons(_35reg1514);
+if (True == _35reg1515) {
+Obj _35reg1516 = primCdr(closureRef(co, 3));
+Obj _35reg1517 = primCar(_35reg1516);
+Obj var = _35reg1517;
+Obj _35reg1518 = primCdr(closureRef(co, 3));
+Obj _35reg1519 = primCdr(_35reg1518);
+Obj _35reg1520 = primIsCons(_35reg1519);
+if (True == _35reg1520) {
+Obj _35reg1521 = primCdr(closureRef(co, 3));
+Obj _35reg1522 = primCdr(_35reg1521);
+Obj _35reg1523 = primCar(_35reg1522);
+Obj val = _35reg1523;
+Obj _35reg1524 = primCdr(closureRef(co, 3));
+Obj _35reg1525 = primCdr(_35reg1524);
+Obj _35reg1526 = primCdr(_35reg1525);
+Obj _35reg1527 = primEQ(Nil, _35reg1526);
+if (True == _35reg1527) {
+pushCont(co, 14, _35clofun3114, 4, env, ns, import, val);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#var-with-ns"));
 __arg1 = var;
@@ -12785,96 +12741,96 @@ __arg2 = ns;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc42;
+__arg0 = _35cc1189;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc42;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc42;
+__arg0 = _35cc1189;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc42;
+__arg0 = _35cc1189;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc42;
+__arg0 = _35cc1189;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1189;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label16:
 {
-Obj _35cc41 = makeNative(15, _35clofun1971, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1188 = makeNative(15, _35clofun3114, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
 __ = closureRef(co, 2);
-Obj _35reg390 = primIsCons(closureRef(co, 3));
-if (True == _35reg390) {
-Obj _35reg391 = primCar(closureRef(co, 3));
-Obj _35reg392 = primEQ(intern("ns"), _35reg391);
-if (True == _35reg392) {
-Obj _35reg393 = primCdr(closureRef(co, 3));
-Obj _35reg394 = primIsCons(_35reg393);
-if (True == _35reg394) {
-Obj _35reg395 = primCdr(closureRef(co, 3));
-Obj _35reg396 = primCar(_35reg395);
-Obj path = _35reg396;
-Obj _35reg397 = primCdr(closureRef(co, 3));
-Obj _35reg398 = primCdr(_35reg397);
-Obj _35reg399 = primIsCons(_35reg398);
-if (True == _35reg399) {
-Obj _35reg400 = primCdr(closureRef(co, 3));
-Obj _35reg401 = primCdr(_35reg400);
-Obj _35reg402 = primCar(_35reg401);
-Obj import = _35reg402;
-Obj _35reg403 = primCdr(closureRef(co, 3));
-Obj _35reg404 = primCdr(_35reg403);
-Obj _35reg405 = primCdr(_35reg404);
-Obj _35reg406 = primIsCons(_35reg405);
-if (True == _35reg406) {
-Obj _35reg407 = primCdr(closureRef(co, 3));
-Obj _35reg408 = primCdr(_35reg407);
-Obj _35reg409 = primCdr(_35reg408);
-Obj _35reg410 = primCar(_35reg409);
-Obj body = _35reg410;
-Obj _35reg411 = primCdr(closureRef(co, 3));
-Obj _35reg412 = primCdr(_35reg411);
-Obj _35reg413 = primCdr(_35reg412);
-Obj _35reg414 = primCdr(_35reg413);
-Obj _35reg415 = primEQ(Nil, _35reg414);
-if (True == _35reg415) {
+Obj _35reg1537 = primIsCons(closureRef(co, 3));
+if (True == _35reg1537) {
+Obj _35reg1538 = primCar(closureRef(co, 3));
+Obj _35reg1539 = primEQ(intern("ns"), _35reg1538);
+if (True == _35reg1539) {
+Obj _35reg1540 = primCdr(closureRef(co, 3));
+Obj _35reg1541 = primIsCons(_35reg1540);
+if (True == _35reg1541) {
+Obj _35reg1542 = primCdr(closureRef(co, 3));
+Obj _35reg1543 = primCar(_35reg1542);
+Obj path = _35reg1543;
+Obj _35reg1544 = primCdr(closureRef(co, 3));
+Obj _35reg1545 = primCdr(_35reg1544);
+Obj _35reg1546 = primIsCons(_35reg1545);
+if (True == _35reg1546) {
+Obj _35reg1547 = primCdr(closureRef(co, 3));
+Obj _35reg1548 = primCdr(_35reg1547);
+Obj _35reg1549 = primCar(_35reg1548);
+Obj import = _35reg1549;
+Obj _35reg1550 = primCdr(closureRef(co, 3));
+Obj _35reg1551 = primCdr(_35reg1550);
+Obj _35reg1552 = primCdr(_35reg1551);
+Obj _35reg1553 = primIsCons(_35reg1552);
+if (True == _35reg1553) {
+Obj _35reg1554 = primCdr(closureRef(co, 3));
+Obj _35reg1555 = primCdr(_35reg1554);
+Obj _35reg1556 = primCdr(_35reg1555);
+Obj _35reg1557 = primCar(_35reg1556);
+Obj body = _35reg1557;
+Obj _35reg1558 = primCdr(closureRef(co, 3));
+Obj _35reg1559 = primCdr(_35reg1558);
+Obj _35reg1560 = primCdr(_35reg1559);
+Obj _35reg1561 = primCdr(_35reg1560);
+Obj _35reg1562 = primEQ(Nil, _35reg1561);
+if (True == _35reg1562) {
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -12884,145 +12840,145 @@ co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc41;
+__arg0 = _35cc1188;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc41;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc41;
+__arg0 = _35cc1188;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc41;
+__arg0 = _35cc1188;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc41;
+__arg0 = _35cc1188;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc41;
+__arg0 = _35cc1188;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1188;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label17:
 {
-Obj _35val444 = __arg1;
-Obj _35val442= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val1591 = __arg1;
+Obj _35val1589= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg445 = primCons(_35val444, Nil);
-Obj _35reg446 = primCons(_35val442, _35reg445);
-Obj _35reg447 = primCons(a, _35reg446);
-Obj _35reg448 = primCons(intern("let"), _35reg447);
+Obj _35reg1592 = primCons(_35val1591, Nil);
+Obj _35reg1593 = primCons(_35val1589, _35reg1592);
+Obj _35reg1594 = primCons(a, _35reg1593);
+Obj _35reg1595 = primCons(intern("let"), _35reg1594);
 __nargs = 2;
-__arg1 = _35reg448;
+__arg1 = _35reg1595;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1971) { goto fail; }
+if (co->ctx.pc.func != _35clofun3114) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label18:
 {
-Obj _35val442 = __arg1;
+Obj _35val1589 = __arg1;
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg443 = primCons(a, env);
-pushCont(co, 17, _35clofun1971, 2, _35val442, a);
+Obj _35reg1590 = primCons(a, env);
+pushCont(co, 17, _35clofun3114, 2, _35val1589, a);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = _35reg443;
+__arg1 = _35reg1590;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35cc40 = makeNative(16, _35clofun1971, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1187 = makeNative(16, _35clofun3114, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj _35reg416 = primIsCons(closureRef(co, 3));
-if (True == _35reg416) {
-Obj _35reg417 = primCar(closureRef(co, 3));
-Obj _35reg418 = primEQ(intern("let"), _35reg417);
-if (True == _35reg418) {
-Obj _35reg419 = primCdr(closureRef(co, 3));
-Obj _35reg420 = primIsCons(_35reg419);
-if (True == _35reg420) {
-Obj _35reg421 = primCdr(closureRef(co, 3));
-Obj _35reg422 = primCar(_35reg421);
-Obj a = _35reg422;
-Obj _35reg423 = primCdr(closureRef(co, 3));
-Obj _35reg424 = primCdr(_35reg423);
-Obj _35reg425 = primIsCons(_35reg424);
-if (True == _35reg425) {
-Obj _35reg426 = primCdr(closureRef(co, 3));
-Obj _35reg427 = primCdr(_35reg426);
-Obj _35reg428 = primCar(_35reg427);
-Obj b = _35reg428;
-Obj _35reg429 = primCdr(closureRef(co, 3));
-Obj _35reg430 = primCdr(_35reg429);
-Obj _35reg431 = primCdr(_35reg430);
-Obj _35reg432 = primIsCons(_35reg431);
-if (True == _35reg432) {
-Obj _35reg433 = primCdr(closureRef(co, 3));
-Obj _35reg434 = primCdr(_35reg433);
-Obj _35reg435 = primCdr(_35reg434);
-Obj _35reg436 = primCar(_35reg435);
-Obj c = _35reg436;
-Obj _35reg437 = primCdr(closureRef(co, 3));
-Obj _35reg438 = primCdr(_35reg437);
-Obj _35reg439 = primCdr(_35reg438);
-Obj _35reg440 = primCdr(_35reg439);
-Obj _35reg441 = primEQ(Nil, _35reg440);
-if (True == _35reg441) {
-pushCont(co, 18, _35clofun1971, 5, env, ns, import, c, a);
+Obj _35reg1563 = primIsCons(closureRef(co, 3));
+if (True == _35reg1563) {
+Obj _35reg1564 = primCar(closureRef(co, 3));
+Obj _35reg1565 = primEQ(intern("let"), _35reg1564);
+if (True == _35reg1565) {
+Obj _35reg1566 = primCdr(closureRef(co, 3));
+Obj _35reg1567 = primIsCons(_35reg1566);
+if (True == _35reg1567) {
+Obj _35reg1568 = primCdr(closureRef(co, 3));
+Obj _35reg1569 = primCar(_35reg1568);
+Obj a = _35reg1569;
+Obj _35reg1570 = primCdr(closureRef(co, 3));
+Obj _35reg1571 = primCdr(_35reg1570);
+Obj _35reg1572 = primIsCons(_35reg1571);
+if (True == _35reg1572) {
+Obj _35reg1573 = primCdr(closureRef(co, 3));
+Obj _35reg1574 = primCdr(_35reg1573);
+Obj _35reg1575 = primCar(_35reg1574);
+Obj b = _35reg1575;
+Obj _35reg1576 = primCdr(closureRef(co, 3));
+Obj _35reg1577 = primCdr(_35reg1576);
+Obj _35reg1578 = primCdr(_35reg1577);
+Obj _35reg1579 = primIsCons(_35reg1578);
+if (True == _35reg1579) {
+Obj _35reg1580 = primCdr(closureRef(co, 3));
+Obj _35reg1581 = primCdr(_35reg1580);
+Obj _35reg1582 = primCdr(_35reg1581);
+Obj _35reg1583 = primCar(_35reg1582);
+Obj c = _35reg1583;
+Obj _35reg1584 = primCdr(closureRef(co, 3));
+Obj _35reg1585 = primCdr(_35reg1584);
+Obj _35reg1586 = primCdr(_35reg1585);
+Obj _35reg1587 = primCdr(_35reg1586);
+Obj _35reg1588 = primEQ(Nil, _35reg1587);
+if (True == _35reg1588) {
+pushCont(co, 18, _35clofun3114, 5, env, ns, import, c, a);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -13032,75 +12988,75 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc40;
+__arg0 = _35cc1187;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc40;
+__arg0 = _35cc1187;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc40;
+__arg0 = _35cc1187;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc40;
+__arg0 = _35cc1187;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc40;
+__arg0 = _35cc1187;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1187;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun3114) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label20:
 {
-Obj _35val467 = __arg1;
-Obj _35val466= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg468 = primCons(_35val467, Nil);
-Obj _35reg469 = primCons(_35val466, _35reg468);
-Obj _35reg470 = primCons(intern("do"), _35reg469);
+Obj _35val1614 = __arg1;
+Obj _35val1613= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1615 = primCons(_35val1614, Nil);
+Obj _35reg1616 = primCons(_35val1613, _35reg1615);
+Obj _35reg1617 = primCons(intern("do"), _35reg1616);
 __nargs = 2;
-__arg1 = _35reg470;
+__arg1 = _35reg1617;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1971) { goto fail; }
+if (co->ctx.pc.func != _35clofun3114) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -13113,7 +13069,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1970(struct Cora* co){
+void _35clofun3113(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -13126,23 +13082,23 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val314 = __arg1;
-Obj find = _35val314;
-pushCont(co, 20, _35clofun1969, 1, find);
+Obj _35val1461 = __arg1;
+Obj find = _35val1461;
+pushCont(co, 20, _35clofun3112, 1, find);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
 Obj x = __arg1;
-pushCont(co, 0, _35clofun1970, 0);
+pushCont(co, 0, _35clofun3113, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#assq"));
 __arg1 = x;
@@ -13150,19 +13106,19 @@ __arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val318 = __arg1;
+Obj _35val1465 = __arg1;
 Obj find= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val318) {
+if (True == _35val1465) {
 __nargs = 2;
 __arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1970) { goto fail; }
+if (co->ctx.pc.func != _35clofun3113) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
@@ -13171,30 +13127,30 @@ __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35val317 = __arg1;
-Obj find = _35val317;
-pushCont(co, 2, _35clofun1970, 1, find);
+Obj _35val1464 = __arg1;
+Obj find = _35val1464;
+pushCont(co, 2, _35clofun3113, 1, find);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
 Obj x = __arg1;
-pushCont(co, 3, _35clofun1970, 0);
+pushCont(co, 3, _35clofun3113, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#assq"));
 __arg1 = x;
@@ -13202,7 +13158,7 @@ __arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13214,118 +13170,118 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc24 = makeNative(5, _35clofun1970, 0, 0);
+Obj _35cc1171 = makeNative(5, _35clofun3113, 0, 0);
 Obj n = closureRef(co, 0);
 Obj res = closureRef(co, 1);
-Obj _35reg320 = primSub(n, makeNumber(1));
-Obj _35reg321 = primGenSym(intern("tmp"));
-Obj _35reg322 = primCons(_35reg321, res);
+Obj _35reg1467 = primSub(n, makeNumber(1));
+Obj _35reg1468 = primGenSym(intern("tmp"));
+Obj _35reg1469 = primCons(_35reg1468, res);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#temp-list"));
-__arg1 = _35reg320;
-__arg2 = _35reg322;
+__arg1 = _35reg1467;
+__arg2 = _35reg1469;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35p21 = __arg1;
-Obj _35p22 = __arg2;
-Obj _35cc23 = makeNative(6, _35clofun1970, 0, 2, _35p21, _35p22);
-Obj _35reg323 = primEQ(makeNumber(0), _35p21);
-if (True == _35reg323) {
-Obj res = _35p22;
+Obj _35p1168 = __arg1;
+Obj _35p1169 = __arg2;
+Obj _35cc1170 = makeNative(6, _35clofun3113, 0, 2, _35p1168, _35p1169);
+Obj _35reg1470 = primEQ(makeNumber(0), _35p1168);
+if (True == _35reg1470) {
+Obj res = _35p1169;
 __nargs = 2;
 __arg1 = res;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1970) { goto fail; }
+if (co->ctx.pc.func != _35clofun3113) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc23;
+__arg0 = _35cc1170;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label8:
 {
-Obj _35val329 = __arg1;
+Obj _35val1476 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#intern"));
-__arg1 = _35val329;
+__arg1 = _35val1476;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35val328 = __arg1;
+Obj _35val1475 = __arg1;
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 8, _35clofun1970, 0);
+pushCont(co, 8, _35clofun3113, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = ns;
-__arg2 = _35val328;
+__arg2 = _35val1475;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35val327 = __arg1;
+Obj _35val1474 = __arg1;
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 9, _35clofun1970, 1, ns);
+pushCont(co, 9, _35clofun3113, 1, ns);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = makeCString("#");
-__arg2 = _35val327;
+__arg2 = _35val1474;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label11:
 {
-Obj _35val326 = __arg1;
+Obj _35val1473 = __arg1;
 Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val326) {
+if (True == _35val1473) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1970) { goto fail; }
+if (co->ctx.pc.func != _35clofun3113) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 10, _35clofun1970, 1, ns);
+pushCont(co, 10, _35clofun3113, 1, ns);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13334,22 +13290,22 @@ label12:
 {
 Obj var = __arg1;
 Obj ns = __arg2;
-Obj _35reg325 = primEQ(ns, makeCString(""));
-if (True == _35reg325) {
+Obj _35reg1472 = primEQ(ns, makeCString(""));
+if (True == _35reg1472) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1970) { goto fail; }
+if (co->ctx.pc.func != _35clofun3113) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 11, _35clofun1970, 2, var, ns);
+pushCont(co, 11, _35clofun3113, 2, var, ns);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol-cooked?"));
 __arg1 = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13362,71 +13318,71 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val340 = __arg1;
+Obj _35val1487 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#intern"));
-__arg1 = _35val340;
+__arg1 = _35val1487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35val339 = __arg1;
+Obj _35val1486 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 14, _35clofun1970, 0);
+pushCont(co, 14, _35clofun3113, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = import;
-__arg2 = _35val339;
+__arg2 = _35val1486;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35val338 = __arg1;
+Obj _35val1485 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 15, _35clofun1970, 1, import);
+pushCont(co, 15, _35clofun3113, 1, import);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = makeCString("#");
-__arg2 = _35val338;
+__arg2 = _35val1485;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35val337 = __arg1;
+Obj _35val1484 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-if (True == _35val337) {
-pushCont(co, 16, _35clofun1970, 1, import);
+if (True == _35val1484) {
+pushCont(co, 16, _35clofun3113, 1, import);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = s;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 4;
@@ -13437,20 +13393,20 @@ __arg3 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label18:
 {
-Obj _35val336 = __arg1;
+Obj _35val1483 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj export = _35val336;
-pushCont(co, 17, _35clofun1970, 4, import, s, ns, more);
+Obj export = _35val1483;
+pushCont(co, 17, _35clofun3113, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#elem?"));
 __arg1 = s;
@@ -13458,44 +13414,44 @@ __arg2 = export;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val335 = __arg1;
+Obj _35val1482 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun1970, 4, import, s, ns, more);
+pushCont(co, 18, _35clofun3113, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#value-or"));
-__arg1 = _35val335;
+__arg1 = _35val1482;
 __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val334 = __arg1;
+Obj _35val1481 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun1970, 4, import, s, ns, more);
+pushCont(co, 19, _35clofun3113, 4, import, s, ns, more);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#intern"));
-__arg1 = _35val334;
+__arg1 = _35val1481;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3113) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13508,7 +13464,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1969(struct Cora* co){
+void _35clofun3112(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -13527,20 +13483,20 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35cc5 = makeNative(0, _35clofun1969, 0, 0);
+Obj _35cc1152 = makeNative(0, _35clofun3112, 0, 0);
 Obj var = closureRef(co, 0);
-Obj _35reg202 = primIsCons(closureRef(co, 1));
-if (True == _35reg202) {
-Obj _35reg203 = primCar(closureRef(co, 1));
-Obj __ = _35reg203;
-Obj _35reg204 = primCdr(closureRef(co, 1));
-Obj y = _35reg204;
+Obj _35reg1349 = primIsCons(closureRef(co, 1));
+if (True == _35reg1349) {
+Obj _35reg1350 = primCar(closureRef(co, 1));
+Obj __ = _35reg1350;
+Obj _35reg1351 = primCdr(closureRef(co, 1));
+Obj y = _35reg1351;
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#assq"));
 __arg1 = var;
@@ -13548,93 +13504,93 @@ __arg2 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc5;
+__arg0 = _35cc1152;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label2:
 {
-Obj _35cc4 = makeNative(1, _35clofun1969, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc1151 = makeNative(1, _35clofun3112, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
-Obj _35reg205 = primIsCons(closureRef(co, 1));
-if (True == _35reg205) {
-Obj _35reg206 = primCar(closureRef(co, 1));
-Obj _35reg207 = primIsCons(_35reg206);
-if (True == _35reg207) {
-Obj _35reg208 = primCar(closureRef(co, 1));
-Obj _35reg209 = primCar(_35reg208);
-Obj x = _35reg209;
-Obj _35reg210 = primCar(closureRef(co, 1));
-Obj _35reg211 = primCdr(_35reg210);
-Obj y = _35reg211;
-Obj _35reg212 = primCdr(closureRef(co, 1));
-Obj __ = _35reg212;
-Obj _35reg213 = primEQ(var, x);
-if (True == _35reg213) {
-Obj _35reg214 = primCons(x, y);
+Obj _35reg1352 = primIsCons(closureRef(co, 1));
+if (True == _35reg1352) {
+Obj _35reg1353 = primCar(closureRef(co, 1));
+Obj _35reg1354 = primIsCons(_35reg1353);
+if (True == _35reg1354) {
+Obj _35reg1355 = primCar(closureRef(co, 1));
+Obj _35reg1356 = primCar(_35reg1355);
+Obj x = _35reg1356;
+Obj _35reg1357 = primCar(closureRef(co, 1));
+Obj _35reg1358 = primCdr(_35reg1357);
+Obj y = _35reg1358;
+Obj _35reg1359 = primCdr(closureRef(co, 1));
+Obj __ = _35reg1359;
+Obj _35reg1360 = primEQ(var, x);
+if (True == _35reg1360) {
+Obj _35reg1361 = primCons(x, y);
 __nargs = 2;
-__arg1 = _35reg214;
+__arg1 = _35reg1361;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1969) { goto fail; }
+if (co->ctx.pc.func != _35clofun3112) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc4;
+__arg0 = _35cc1151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc4;
+__arg0 = _35cc1151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc4;
+__arg0 = _35cc1151;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35p1 = __arg1;
-Obj _35p2 = __arg2;
-Obj _35cc3 = makeNative(2, _35clofun1969, 0, 2, _35p1, _35p2);
-Obj var = _35p1;
-Obj _35reg215 = primEQ(Nil, _35p2);
-if (True == _35reg215) {
+Obj _35p1148 = __arg1;
+Obj _35p1149 = __arg2;
+Obj _35cc1150 = makeNative(2, _35clofun3112, 0, 2, _35p1148, _35p1149);
+Obj var = _35p1148;
+Obj _35reg1362 = primEQ(Nil, _35p1149);
+if (True == _35reg1362) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1969) { goto fail; }
+if (co->ctx.pc.func != _35clofun3112) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc3;
+__arg0 = _35cc1150;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13647,39 +13603,39 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val220 = __arg1;
+Obj _35val1367 = __arg1;
 Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#foldl"));
 __arg1 = f;
-__arg2 = _35val220;
+__arg2 = _35val1367;
 __arg3 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc10 = makeNative(4, _35clofun1969, 0, 0);
+Obj _35cc1157 = makeNative(4, _35clofun3112, 0, 0);
 Obj f = closureRef(co, 0);
 Obj acc = closureRef(co, 1);
-Obj _35reg217 = primIsCons(closureRef(co, 2));
-if (True == _35reg217) {
-Obj _35reg218 = primCar(closureRef(co, 2));
-Obj x = _35reg218;
-Obj _35reg219 = primCdr(closureRef(co, 2));
-Obj y = _35reg219;
-pushCont(co, 5, _35clofun1969, 2, f, y);
+Obj _35reg1364 = primIsCons(closureRef(co, 2));
+if (True == _35reg1364) {
+Obj _35reg1365 = primCar(closureRef(co, 2));
+Obj x = _35reg1365;
+Obj _35reg1366 = primCdr(closureRef(co, 2));
+Obj y = _35reg1366;
+pushCont(co, 5, _35clofun3112, 2, f, y);
 __nargs = 3;
 __arg0 = f;
 __arg1 = acc;
@@ -13687,41 +13643,41 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc10;
+__arg0 = _35cc1157;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label7:
 {
-Obj _35p6 = __arg1;
-Obj _35p7 = __arg2;
-Obj _35p8 = __arg3;
-Obj _35cc9 = makeNative(6, _35clofun1969, 0, 3, _35p6, _35p7, _35p8);
-Obj f = _35p6;
-Obj acc = _35p7;
-Obj _35reg221 = primEQ(Nil, _35p8);
-if (True == _35reg221) {
+Obj _35p1153 = __arg1;
+Obj _35p1154 = __arg2;
+Obj _35p1155 = __arg3;
+Obj _35cc1156 = makeNative(6, _35clofun3112, 0, 3, _35p1153, _35p1154, _35p1155);
+Obj f = _35p1153;
+Obj acc = _35p1154;
+Obj _35reg1368 = primEQ(Nil, _35p1155);
+if (True == _35reg1368) {
 __nargs = 2;
 __arg1 = acc;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1969) { goto fail; }
+if (co->ctx.pc.func != _35clofun3112) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc9;
+__arg0 = _35cc1156;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13734,103 +13690,103 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35cc16 = makeNative(8, _35clofun1969, 0, 0);
+Obj _35cc1163 = makeNative(8, _35clofun3112, 0, 0);
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg223 = primIsCons(closureRef(co, 2));
-if (True == _35reg223) {
-Obj _35reg224 = primCar(closureRef(co, 2));
-Obj a = _35reg224;
-Obj _35reg225 = primCdr(closureRef(co, 2));
-Obj b = _35reg225;
-Obj _35reg226 = primAdd(pos, makeNumber(1));
+Obj _35reg1370 = primIsCons(closureRef(co, 2));
+if (True == _35reg1370) {
+Obj _35reg1371 = primCar(closureRef(co, 2));
+Obj a = _35reg1371;
+Obj _35reg1372 = primCdr(closureRef(co, 2));
+Obj b = _35reg1372;
+Obj _35reg1373 = primAdd(pos, makeNumber(1));
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#pos-in-list0"));
-__arg1 = _35reg226;
+__arg1 = _35reg1373;
 __arg2 = x;
 __arg3 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc16;
+__arg0 = _35cc1163;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35cc15 = makeNative(9, _35clofun1969, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc1162 = makeNative(9, _35clofun3112, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg227 = primIsCons(closureRef(co, 2));
-if (True == _35reg227) {
-Obj _35reg228 = primCar(closureRef(co, 2));
-Obj a = _35reg228;
-Obj _35reg229 = primCdr(closureRef(co, 2));
-Obj b = _35reg229;
-Obj _35reg230 = primEQ(x, a);
-if (True == _35reg230) {
+Obj _35reg1374 = primIsCons(closureRef(co, 2));
+if (True == _35reg1374) {
+Obj _35reg1375 = primCar(closureRef(co, 2));
+Obj a = _35reg1375;
+Obj _35reg1376 = primCdr(closureRef(co, 2));
+Obj b = _35reg1376;
+Obj _35reg1377 = primEQ(x, a);
+if (True == _35reg1377) {
 __nargs = 2;
 __arg1 = pos;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1969) { goto fail; }
+if (co->ctx.pc.func != _35clofun3112) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc15;
+__arg0 = _35cc1162;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc15;
+__arg0 = _35cc1162;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35p11 = __arg1;
-Obj _35p12 = __arg2;
-Obj _35p13 = __arg3;
-Obj _35cc14 = makeNative(10, _35clofun1969, 0, 3, _35p11, _35p12, _35p13);
-Obj __ = _35p11;
-Obj x = _35p12;
-Obj _35reg231 = primEQ(Nil, _35p13);
-if (True == _35reg231) {
+Obj _35p1158 = __arg1;
+Obj _35p1159 = __arg2;
+Obj _35p1160 = __arg3;
+Obj _35cc1161 = makeNative(10, _35clofun3112, 0, 3, _35p1158, _35p1159, _35p1160);
+Obj __ = _35p1158;
+Obj x = _35p1159;
+Obj _35reg1378 = primEQ(Nil, _35p1160);
+if (True == _35reg1378) {
 __nargs = 2;
 __arg1 = makeNumber(-1);
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1969) { goto fail; }
+if (co->ctx.pc.func != _35clofun3112) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc14;
+__arg0 = _35cc1161;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13847,7 +13803,7 @@ __arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13859,17 +13815,17 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35val237 = __arg1;
+Obj _35val1384 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj tl= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg238 = primLT(_35val237, makeNumber(0));
-if (True == _35reg238) {
+Obj _35reg1385 = primLT(_35val1384, makeNumber(0));
+if (True == _35reg1385) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#exist-in-env"));
 __arg1 = x;
@@ -13877,28 +13833,28 @@ __arg2 = tl;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1969) { goto fail; }
+if (co->ctx.pc.func != _35clofun3112) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
 
 label15:
 {
-Obj _35cc20 = makeNative(13, _35clofun1969, 0, 0);
+Obj _35cc1167 = makeNative(13, _35clofun3112, 0, 0);
 Obj x = closureRef(co, 0);
-Obj _35reg234 = primIsCons(closureRef(co, 1));
-if (True == _35reg234) {
-Obj _35reg235 = primCar(closureRef(co, 1));
-Obj hd = _35reg235;
-Obj _35reg236 = primCdr(closureRef(co, 1));
-Obj tl = _35reg236;
-pushCont(co, 14, _35clofun1969, 2, x, tl);
+Obj _35reg1381 = primIsCons(closureRef(co, 1));
+if (True == _35reg1381) {
+Obj _35reg1382 = primCar(closureRef(co, 1));
+Obj hd = _35reg1382;
+Obj _35reg1383 = primCdr(closureRef(co, 1));
+Obj tl = _35reg1383;
+pushCont(co, 14, _35clofun3112, 2, x, tl);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#index"));
 __arg1 = x;
@@ -13906,72 +13862,72 @@ __arg2 = hd;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc20;
+__arg0 = _35cc1167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label16:
 {
-Obj _35p17 = __arg1;
-Obj _35p18 = __arg2;
-Obj _35cc19 = makeNative(15, _35clofun1969, 0, 2, _35p17, _35p18);
-Obj x = _35p17;
-Obj _35reg239 = primEQ(Nil, _35p18);
-if (True == _35reg239) {
+Obj _35p1164 = __arg1;
+Obj _35p1165 = __arg2;
+Obj _35cc1166 = makeNative(15, _35clofun3112, 0, 2, _35p1164, _35p1165);
+Obj x = _35p1164;
+Obj _35reg1386 = primEQ(Nil, _35p1165);
+if (True == _35reg1386) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1969) { goto fail; }
+if (co->ctx.pc.func != _35clofun3112) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc19;
+__arg0 = _35cc1166;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label17:
 {
-Obj _35val311 = __arg1;
-Obj _35reg312 = primNot(_35val311);
+Obj _35val1458 = __arg1;
+Obj _35reg1459 = primNot(_35val1458);
 __nargs = 2;
-__arg1 = _35reg312;
+__arg1 = _35reg1459;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1969) { goto fail; }
+if (co->ctx.pc.func != _35clofun3112) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label18:
 {
-Obj _35val310 = __arg1;
-pushCont(co, 17, _35clofun1969, 0);
+Obj _35val1457 = __arg1;
+pushCont(co, 17, _35clofun3112, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
-__arg1 = _35val310;
+__arg1 = _35val1457;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
 Obj x = __arg1;
-pushCont(co, 18, _35clofun1969, 0);
+pushCont(co, 18, _35clofun3112, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#assq"));
 __arg1 = x;
@@ -13979,19 +13935,19 @@ __arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val315 = __arg1;
+Obj _35val1462 = __arg1;
 Obj find= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val315) {
+if (True == _35val1462) {
 __nargs = 2;
 __arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1969) { goto fail; }
+if (co->ctx.pc.func != _35clofun3112) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
@@ -14000,7 +13956,7 @@ __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun3112) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }

--- a/lib/toc.c
+++ b/lib/toc.c
@@ -2,31 +2,30 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun2020(struct Cora* co);
-void _35clofun2019(struct Cora* co);
-void _35clofun2018(struct Cora* co);
-void _35clofun2017(struct Cora* co);
-void _35clofun2016(struct Cora* co);
-void _35clofun2015(struct Cora* co);
-void _35clofun2014(struct Cora* co);
-void _35clofun2013(struct Cora* co);
-void _35clofun2012(struct Cora* co);
-void _35clofun2011(struct Cora* co);
-void _35clofun2010(struct Cora* co);
-void _35clofun2009(struct Cora* co);
-void _35clofun2008(struct Cora* co);
-void _35clofun2007(struct Cora* co);
-void _35clofun2006(struct Cora* co);
-void _35clofun2005(struct Cora* co);
-void _35clofun2004(struct Cora* co);
-void _35clofun2003(struct Cora* co);
-void _35clofun2002(struct Cora* co);
-void _35clofun2001(struct Cora* co);
-void _35clofun2000(struct Cora* co);
-void _35clofun1999(struct Cora* co);
-void _35clofun1998(struct Cora* co);
-void _35clofun1997(struct Cora* co);
-void _35clofun1996(struct Cora* co);
+void _35clofun1992(struct Cora* co);
+void _35clofun1991(struct Cora* co);
+void _35clofun1990(struct Cora* co);
+void _35clofun1989(struct Cora* co);
+void _35clofun1988(struct Cora* co);
+void _35clofun1987(struct Cora* co);
+void _35clofun1986(struct Cora* co);
+void _35clofun1985(struct Cora* co);
+void _35clofun1984(struct Cora* co);
+void _35clofun1983(struct Cora* co);
+void _35clofun1982(struct Cora* co);
+void _35clofun1981(struct Cora* co);
+void _35clofun1980(struct Cora* co);
+void _35clofun1979(struct Cora* co);
+void _35clofun1978(struct Cora* co);
+void _35clofun1977(struct Cora* co);
+void _35clofun1976(struct Cora* co);
+void _35clofun1975(struct Cora* co);
+void _35clofun1974(struct Cora* co);
+void _35clofun1973(struct Cora* co);
+void _35clofun1972(struct Cora* co);
+void _35clofun1971(struct Cora* co);
+void _35clofun1970(struct Cora* co);
+void _35clofun1969(struct Cora* co);
 
 
 void entry(struct Cora* co){
@@ -42,7 +41,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-pushCont(co, 3, _35clofun2020, 0);
+pushCont(co, 13, _35clofun1992, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#import"));
 __arg1 = makeCString("cora/lib/toc/internal");
@@ -62,92 +61,465 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2020(struct Cora* co){
+void _35clofun1992(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj exp = __arg1;
-Obj _35reg1929 = primIsSymbol(exp);
-if (True == _35reg1929) {
-pushCont(co, 18, _35clofun2018, 0);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#lookup-var"));
-__arg1 = exp;
-__arg2 = makeCString("");
-__arg3 = globalRef(intern("cora/lib/toc#*repl-ns*"));
+Obj _35val1942 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1943 = primCdr(exp);
+pushCont(co, 20, _35clofun1991, 1, _35val1942);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg1943;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2020) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val1952 = __arg1;
+Obj _35val1950= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val1950;
+__arg2 = _35val1952;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val1950 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1951 = primCdr(exp);
+pushCont(co, 1, _35clofun1992, 1, _35val1950);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg1951;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val1960 = __arg1;
+Obj _35val1958= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val1958;
+__arg2 = _35val1960;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val1958 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1959 = primCdr(exp);
+pushCont(co, 3, _35clofun1992, 1, _35val1958);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg1959;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val1967 = __arg1;
+Obj _35val1965= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val1965;
+__arg2 = _35val1967;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label6:
+{
+Obj _35val1965 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1966 = primCdr(exp);
+pushCont(co, 5, _35clofun1992, 1, _35val1965);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg1966;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label7:
+{
+Obj _35val1953 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1953) {
+if (True == True) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun1992) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg1954 = primIsCons(exp);
+if (True == _35reg1954) {
+Obj _35reg1955 = primCar(exp);
+Obj _35reg1956 = primEQ(_35reg1955, intern("quote"));
+if (True == _35reg1956) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 20, _35clofun2019, 1, exp);
+Obj _35reg1957 = primCar(exp);
+pushCont(co, 4, _35clofun1992, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#eval0"));
+__arg1 = _35reg1957;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+if (True == False) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun1992) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg1961 = primIsCons(exp);
+if (True == _35reg1961) {
+Obj _35reg1962 = primCar(exp);
+Obj _35reg1963 = primEQ(_35reg1962, intern("quote"));
+if (True == _35reg1963) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1964 = primCar(exp);
+pushCont(co, 6, _35clofun1992, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#eval0"));
+__arg1 = _35reg1964;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+}
+
+label8:
+{
+Obj _35val1945 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1945) {
+if (True == True) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun1992) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg1946 = primIsCons(exp);
+if (True == _35reg1946) {
+Obj _35reg1947 = primCar(exp);
+Obj _35reg1948 = primEQ(_35reg1947, intern("quote"));
+if (True == _35reg1948) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1949 = primCar(exp);
+pushCont(co, 2, _35clofun1992, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#eval0"));
+__arg1 = _35reg1949;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+pushCont(co, 7, _35clofun1992, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#null?"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label9:
+{
+Obj _35val1929 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1929) {
+if (True == True) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun1992) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg1930 = primIsCons(exp);
+if (True == _35reg1930) {
+Obj _35reg1931 = primCar(exp);
+Obj _35reg1932 = primEQ(_35reg1931, intern("quote"));
+if (True == _35reg1932) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1933 = primCar(exp);
+pushCont(co, 19, _35clofun1991, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#eval0"));
+__arg1 = _35reg1933;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+Obj _35reg1937 = primIsString(exp);
+if (True == _35reg1937) {
+if (True == True) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != _35clofun1992) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg1938 = primIsCons(exp);
+if (True == _35reg1938) {
+Obj _35reg1939 = primCar(exp);
+Obj _35reg1940 = primEQ(_35reg1939, intern("quote"));
+if (True == _35reg1940) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg1941 = primCar(exp);
+pushCont(co, 0, _35clofun1992, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#eval0"));
+__arg1 = _35reg1941;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+pushCont(co, 8, _35clofun1992, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#boolean?"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label10:
+{
+Obj exp = __arg1;
+Obj _35reg1928 = primIsSymbol(exp);
+if (True == _35reg1928) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#value"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 9, _35clofun1992, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#number?"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2020) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label1:
+label11:
 {
 Obj _35val1768 = __arg1;
-Obj _35reg1773 = primSet(co, intern("cora/lib/toc#compile"), makeNative(4, _35clofun2015, 1, 0));
-Obj _35reg1779 = primSet(co, intern("cora/lib/toc#for-each"), makeNative(8, _35clofun2015, 2, 0));
-Obj _35reg1786 = primSet(co, intern("cora/lib/toc#generate-jumptable"), makeNative(12, _35clofun2015, 3, 0));
-Obj _35reg1807 = primSet(co, intern("cora/lib/toc#generate-toplevel-group"), makeNative(13, _35clofun2016, 2, 0));
-Obj _35reg1814 = primSet(co, intern("cora/lib/toc#generate-c"), makeNative(1, _35clofun2017, 2, 0));
-Obj _35reg1846 = primSet(co, intern("cora/lib/toc#handle-import-eagerly"), makeNative(7, _35clofun2017, 1, 0));
-Obj _35reg1887 = primSet(co, intern("cora/lib/toc#split-type-and-code"), makeNative(14, _35clofun2017, 4, 0));
+Obj _35reg1773 = primSet(co, intern("cora/lib/toc#compile"), makeNative(4, _35clofun1988, 1, 0));
+Obj _35reg1779 = primSet(co, intern("cora/lib/toc#for-each"), makeNative(8, _35clofun1988, 2, 0));
+Obj _35reg1786 = primSet(co, intern("cora/lib/toc#generate-jumptable"), makeNative(12, _35clofun1988, 3, 0));
+Obj _35reg1807 = primSet(co, intern("cora/lib/toc#generate-toplevel-group"), makeNative(13, _35clofun1989, 2, 0));
+Obj _35reg1814 = primSet(co, intern("cora/lib/toc#generate-c"), makeNative(1, _35clofun1990, 2, 0));
+Obj _35reg1846 = primSet(co, intern("cora/lib/toc#handle-import-eagerly"), makeNative(7, _35clofun1990, 1, 0));
+Obj _35reg1887 = primSet(co, intern("cora/lib/toc#split-type-and-code"), makeNative(14, _35clofun1990, 4, 0));
 Obj _35reg1888 = primSet(co, intern("cora/lib/infer#*typecheck*"), False);
-Obj _35reg1891 = primSet(co, intern("cora/lib/toc#preprocess"), makeNative(17, _35clofun2017, 1, 0));
-Obj _35reg1897 = primSet(co, intern("cora/lib/toc#compile-to-c"), makeNative(2, _35clofun2018, 2, 0));
-Obj _35reg1899 = primSet(co, intern("set"), makeNative(3, _35clofun2018, 2, 0));
-Obj _35reg1901 = primSet(co, intern("car"), makeNative(4, _35clofun2018, 1, 0));
-Obj _35reg1903 = primSet(co, intern("cdr"), makeNative(5, _35clofun2018, 1, 0));
-Obj _35reg1905 = primSet(co, intern("cons"), makeNative(6, _35clofun2018, 2, 0));
-Obj _35reg1907 = primSet(co, intern("+"), makeNative(7, _35clofun2018, 2, 0));
-Obj _35reg1909 = primSet(co, intern("-"), makeNative(8, _35clofun2018, 2, 0));
-Obj _35reg1911 = primSet(co, intern("*"), makeNative(9, _35clofun2018, 2, 0));
-Obj _35reg1913 = primSet(co, intern("/"), makeNative(10, _35clofun2018, 2, 0));
-Obj _35reg1915 = primSet(co, intern("="), makeNative(11, _35clofun2018, 2, 0));
-Obj _35reg1917 = primSet(co, intern(">"), makeNative(12, _35clofun2018, 2, 0));
-Obj _35reg1919 = primSet(co, intern("<"), makeNative(13, _35clofun2018, 2, 0));
-Obj _35reg1921 = primSet(co, intern("gensym"), makeNative(14, _35clofun2018, 1, 0));
-Obj _35reg1923 = primSet(co, intern("symbol?"), makeNative(15, _35clofun2018, 1, 0));
-Obj _35reg1925 = primSet(co, intern("not"), makeNative(16, _35clofun2018, 1, 0));
-Obj _35reg1927 = primSet(co, intern("string?"), makeNative(17, _35clofun2018, 1, 0));
-Obj _35reg1928 = primSet(co, intern("cora/lib/toc#*repl-ns*"), Nil);
-Obj _35reg1995 = primSet(co, intern("cora/lib/toc#eval0"), makeNative(0, _35clofun2020, 1, 0));
+Obj _35reg1891 = primSet(co, intern("cora/lib/toc#preprocess"), makeNative(17, _35clofun1990, 1, 0));
+Obj _35reg1897 = primSet(co, intern("cora/lib/toc#compile-to-c"), makeNative(2, _35clofun1991, 2, 0));
+Obj _35reg1899 = primSet(co, intern("set"), makeNative(3, _35clofun1991, 2, 0));
+Obj _35reg1901 = primSet(co, intern("car"), makeNative(4, _35clofun1991, 1, 0));
+Obj _35reg1903 = primSet(co, intern("cdr"), makeNative(5, _35clofun1991, 1, 0));
+Obj _35reg1905 = primSet(co, intern("cons"), makeNative(6, _35clofun1991, 2, 0));
+Obj _35reg1907 = primSet(co, intern("+"), makeNative(7, _35clofun1991, 2, 0));
+Obj _35reg1909 = primSet(co, intern("-"), makeNative(8, _35clofun1991, 2, 0));
+Obj _35reg1911 = primSet(co, intern("*"), makeNative(9, _35clofun1991, 2, 0));
+Obj _35reg1913 = primSet(co, intern("/"), makeNative(10, _35clofun1991, 2, 0));
+Obj _35reg1915 = primSet(co, intern("="), makeNative(11, _35clofun1991, 2, 0));
+Obj _35reg1917 = primSet(co, intern(">"), makeNative(12, _35clofun1991, 2, 0));
+Obj _35reg1919 = primSet(co, intern("<"), makeNative(13, _35clofun1991, 2, 0));
+Obj _35reg1921 = primSet(co, intern("gensym"), makeNative(14, _35clofun1991, 1, 0));
+Obj _35reg1923 = primSet(co, intern("symbol?"), makeNative(15, _35clofun1991, 1, 0));
+Obj _35reg1925 = primSet(co, intern("not"), makeNative(16, _35clofun1991, 1, 0));
+Obj _35reg1927 = primSet(co, intern("string?"), makeNative(17, _35clofun1991, 1, 0));
+Obj _35reg1968 = primSet(co, intern("cora/lib/toc#eval0"), makeNative(10, _35clofun1992, 1, 0));
 __nargs = 2;
-__arg1 = _35reg1995;
+__arg1 = _35reg1968;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2020) { goto fail; }
+if (co->ctx.pc.func != _35clofun1992) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label2:
+label12:
 {
 Obj _35val200 = __arg1;
 Obj _35reg201 = primSet(co, intern("cora/lib/toc#*ns-export*"), Nil);
-Obj _35reg216 = primSet(co, intern("cora/lib/toc#assq"), makeNative(3, _35clofun1996, 2, 0));
-Obj _35reg222 = primSet(co, intern("cora/lib/toc#foldl"), makeNative(7, _35clofun1996, 3, 0));
-Obj _35reg232 = primSet(co, intern("cora/lib/toc#pos-in-list0"), makeNative(11, _35clofun1996, 3, 0));
-Obj _35reg233 = primSet(co, intern("cora/lib/toc#index"), makeNative(12, _35clofun1996, 2, 0));
-Obj _35reg240 = primSet(co, intern("cora/lib/toc#exist-in-env"), makeNative(16, _35clofun1996, 2, 0));
+Obj _35reg216 = primSet(co, intern("cora/lib/toc#assq"), makeNative(3, _35clofun1969, 2, 0));
+Obj _35reg222 = primSet(co, intern("cora/lib/toc#foldl"), makeNative(7, _35clofun1969, 3, 0));
+Obj _35reg232 = primSet(co, intern("cora/lib/toc#pos-in-list0"), makeNative(11, _35clofun1969, 3, 0));
+Obj _35reg233 = primSet(co, intern("cora/lib/toc#index"), makeNative(12, _35clofun1969, 2, 0));
+Obj _35reg240 = primSet(co, intern("cora/lib/toc#exist-in-env"), makeNative(16, _35clofun1969, 2, 0));
 Obj _35reg241 = primCons(intern("primSet"), Nil);
 Obj _35reg242 = primCons(makeNumber(2), _35reg241);
 Obj _35reg243 = primCons(intern("set"), _35reg242);
@@ -217,64 +589,64 @@ Obj _35reg306 = primCons(_35reg249, _35reg305);
 Obj _35reg307 = primCons(_35reg246, _35reg306);
 Obj _35reg308 = primCons(_35reg243, _35reg307);
 Obj _35reg309 = primSet(co, intern("cora/lib/toc#*builtin-prims*"), _35reg308);
-Obj _35reg313 = primSet(co, intern("cora/lib/toc#builtin?"), makeNative(19, _35clofun1996, 1, 0));
-Obj _35reg316 = primSet(co, intern("cora/lib/toc#builtin->name"), makeNative(1, _35clofun1997, 1, 0));
-Obj _35reg319 = primSet(co, intern("cora/lib/toc#builtin->args"), makeNative(4, _35clofun1997, 1, 0));
-Obj _35reg324 = primSet(co, intern("cora/lib/toc#temp-list"), makeNative(7, _35clofun1997, 2, 0));
-Obj _35reg330 = primSet(co, intern("cora/lib/toc#var-with-ns"), makeNative(12, _35clofun1997, 2, 0));
-Obj _35reg342 = primSet(co, intern("cora/lib/toc#lookup-var"), makeNative(1, _35clofun1998, 3, 0));
-Obj _35reg531 = primSet(co, intern("cora/lib/toc#parse"), makeNative(15, _35clofun1999, 4, 0));
-Obj _35reg542 = primSet(co, intern("cora/lib/toc#union"), makeNative(0, _35clofun2000, 2, 0));
-Obj _35reg553 = primSet(co, intern("cora/lib/toc#diff"), makeNative(6, _35clofun2000, 2, 0));
-Obj _35reg604 = primSet(co, intern("cora/lib/toc#convert-protect?"), makeNative(13, _35clofun2000, 1, 0));
-Obj _35reg779 = primSet(co, intern("cora/lib/toc#free-vars"), makeNative(15, _35clofun2001, 1, 0));
-Obj _35reg852 = primSet(co, intern("cora/lib/toc#closure-convert"), makeNative(9, _35clofun2002, 2, 0));
-Obj _35reg855 = primSet(co, intern("cora/lib/toc#id"), makeNative(10, _35clofun2002, 1, 0));
-Obj _35reg992 = primSet(co, intern("cora/lib/toc#tailify"), makeNative(7, _35clofun2003, 2, 0));
-Obj _35reg1039 = primSet(co, intern("cora/lib/toc#tailify-list"), makeNative(17, _35clofun2003, 3, 0));
-Obj _35reg1118 = primSet(co, intern("cora/lib/toc#explicit-stack"), makeNative(14, _35clofun2004, 2, 0));
-Obj _35reg1294 = primSet(co, intern("cora/lib/toc#collect-lambda"), makeNative(7, _35clofun2006, 2, 0));
-Obj _35reg1307 = primSet(co, intern("cora/lib/toc#append-result"), makeNative(13, _35clofun2006, 5, 0));
-Obj _35reg1314 = primSet(co, intern("cora/lib/toc#wrap-var"), makeNative(15, _35clofun2006, 2, 0));
-Obj _35reg1334 = primSet(co, intern("cora/lib/toc#generate-call-list"), makeNative(8, _35clofun2007, 4, 0));
-Obj _35reg1604 = primSet(co, intern("cora/lib/toc#generate-inst"), makeNative(11, _35clofun2011, 4, 0));
-Obj _35reg1627 = primSet(co, intern("cora/lib/toc#generate-cont"), makeNative(3, _35clofun2012, 3, 0));
-Obj _35reg1636 = primSet(co, intern("cora/lib/toc#generate-inst-list-h"), makeNative(9, _35clofun2012, 5, 0));
-Obj _35reg1637 = primSet(co, intern("cora/lib/toc#generate-inst-list"), makeNative(10, _35clofun2012, 4, 0));
-Obj _35reg1642 = primSet(co, intern("cora/lib/toc#code-gen-func-declare"), makeNative(14, _35clofun2012, 2, 0));
-Obj _35reg1650 = primSet(co, intern("cora/lib/toc#local-from-params"), makeNative(0, _35clofun2013, 3, 0));
-Obj _35reg1655 = primSet(co, intern("cora/lib/toc#local-from-cont"), makeNative(5, _35clofun2013, 3, 0));
-Obj _35reg1662 = primSet(co, intern("cora/lib/toc#generate-call-args-reverse"), makeNative(9, _35clofun2013, 4, 0));
-Obj _35reg1724 = primSet(co, intern("cora/lib/toc#code-gen-toplevel"), makeNative(20, _35clofun2013, 2, 0));
-Obj _35reg1725 = primSet(co, intern("cora/lib/toc#parse-pass"), makeNative(0, _35clofun2014, 1, 0));
-Obj _35reg1726 = primSet(co, intern("cora/lib/toc#closure-convert-pass"), makeNative(1, _35clofun2014, 1, 0));
-Obj _35reg1727 = primSet(co, intern("cora/lib/toc#tailify-pass"), makeNative(2, _35clofun2014, 1, 0));
-Obj _35reg1728 = primSet(co, intern("cora/lib/toc#explicit-stack-pass"), makeNative(3, _35clofun2014, 1, 0));
-Obj _35reg1758 = primSet(co, intern("cora/lib/toc#collect-lambda-pass"), makeNative(14, _35clofun2014, 1, 0));
-Obj _35reg1765 = primSet(co, intern("cora/lib/toc#rewrite-->macro"), makeNative(17, _35clofun2014, 2, 0));
-pushCont(co, 1, _35clofun2020, 0);
+Obj _35reg313 = primSet(co, intern("cora/lib/toc#builtin?"), makeNative(19, _35clofun1969, 1, 0));
+Obj _35reg316 = primSet(co, intern("cora/lib/toc#builtin->name"), makeNative(1, _35clofun1970, 1, 0));
+Obj _35reg319 = primSet(co, intern("cora/lib/toc#builtin->args"), makeNative(4, _35clofun1970, 1, 0));
+Obj _35reg324 = primSet(co, intern("cora/lib/toc#temp-list"), makeNative(7, _35clofun1970, 2, 0));
+Obj _35reg330 = primSet(co, intern("cora/lib/toc#var-with-ns"), makeNative(12, _35clofun1970, 2, 0));
+Obj _35reg342 = primSet(co, intern("cora/lib/toc#lookup-var"), makeNative(1, _35clofun1971, 3, 0));
+Obj _35reg531 = primSet(co, intern("cora/lib/toc#parse"), makeNative(15, _35clofun1972, 4, 0));
+Obj _35reg542 = primSet(co, intern("cora/lib/toc#union"), makeNative(0, _35clofun1973, 2, 0));
+Obj _35reg553 = primSet(co, intern("cora/lib/toc#diff"), makeNative(6, _35clofun1973, 2, 0));
+Obj _35reg604 = primSet(co, intern("cora/lib/toc#convert-protect?"), makeNative(13, _35clofun1973, 1, 0));
+Obj _35reg779 = primSet(co, intern("cora/lib/toc#free-vars"), makeNative(15, _35clofun1974, 1, 0));
+Obj _35reg852 = primSet(co, intern("cora/lib/toc#closure-convert"), makeNative(9, _35clofun1975, 2, 0));
+Obj _35reg855 = primSet(co, intern("cora/lib/toc#id"), makeNative(10, _35clofun1975, 1, 0));
+Obj _35reg992 = primSet(co, intern("cora/lib/toc#tailify"), makeNative(7, _35clofun1976, 2, 0));
+Obj _35reg1039 = primSet(co, intern("cora/lib/toc#tailify-list"), makeNative(17, _35clofun1976, 3, 0));
+Obj _35reg1118 = primSet(co, intern("cora/lib/toc#explicit-stack"), makeNative(14, _35clofun1977, 2, 0));
+Obj _35reg1294 = primSet(co, intern("cora/lib/toc#collect-lambda"), makeNative(7, _35clofun1979, 2, 0));
+Obj _35reg1307 = primSet(co, intern("cora/lib/toc#append-result"), makeNative(13, _35clofun1979, 5, 0));
+Obj _35reg1314 = primSet(co, intern("cora/lib/toc#wrap-var"), makeNative(15, _35clofun1979, 2, 0));
+Obj _35reg1334 = primSet(co, intern("cora/lib/toc#generate-call-list"), makeNative(8, _35clofun1980, 4, 0));
+Obj _35reg1604 = primSet(co, intern("cora/lib/toc#generate-inst"), makeNative(11, _35clofun1984, 4, 0));
+Obj _35reg1627 = primSet(co, intern("cora/lib/toc#generate-cont"), makeNative(3, _35clofun1985, 3, 0));
+Obj _35reg1636 = primSet(co, intern("cora/lib/toc#generate-inst-list-h"), makeNative(9, _35clofun1985, 5, 0));
+Obj _35reg1637 = primSet(co, intern("cora/lib/toc#generate-inst-list"), makeNative(10, _35clofun1985, 4, 0));
+Obj _35reg1642 = primSet(co, intern("cora/lib/toc#code-gen-func-declare"), makeNative(14, _35clofun1985, 2, 0));
+Obj _35reg1650 = primSet(co, intern("cora/lib/toc#local-from-params"), makeNative(0, _35clofun1986, 3, 0));
+Obj _35reg1655 = primSet(co, intern("cora/lib/toc#local-from-cont"), makeNative(5, _35clofun1986, 3, 0));
+Obj _35reg1662 = primSet(co, intern("cora/lib/toc#generate-call-args-reverse"), makeNative(9, _35clofun1986, 4, 0));
+Obj _35reg1724 = primSet(co, intern("cora/lib/toc#code-gen-toplevel"), makeNative(20, _35clofun1986, 2, 0));
+Obj _35reg1725 = primSet(co, intern("cora/lib/toc#parse-pass"), makeNative(0, _35clofun1987, 1, 0));
+Obj _35reg1726 = primSet(co, intern("cora/lib/toc#closure-convert-pass"), makeNative(1, _35clofun1987, 1, 0));
+Obj _35reg1727 = primSet(co, intern("cora/lib/toc#tailify-pass"), makeNative(2, _35clofun1987, 1, 0));
+Obj _35reg1728 = primSet(co, intern("cora/lib/toc#explicit-stack-pass"), makeNative(3, _35clofun1987, 1, 0));
+Obj _35reg1758 = primSet(co, intern("cora/lib/toc#collect-lambda-pass"), makeNative(14, _35clofun1987, 1, 0));
+Obj _35reg1765 = primSet(co, intern("cora/lib/toc#rewrite-->macro"), makeNative(17, _35clofun1987, 2, 0));
+pushCont(co, 11, _35clofun1992, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#add-to-*macros*"));
 __arg1 = intern("->");
-__arg2 = makeNative(20, _35clofun2014, 1, 0);
+__arg2 = makeNative(20, _35clofun1987, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2020) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label3:
+label13:
 {
 Obj _35val199 = __arg1;
-pushCont(co, 2, _35clofun2020, 0);
+pushCont(co, 12, _35clofun1992, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#import"));
 __arg1 = makeCString("cora/lib/io");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2020) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1992) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -287,581 +659,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2019(struct Cora* co){
-int __nargs = co->nargs;
-Obj __arg0 = co->args[0];
-Obj __arg1 = co->args[1];
-Obj __arg2 = co->args[2];
-Obj __arg3 = co->args[3];
-
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
-
-goto *jumpTable[co->ctx.pc.label];
-
-label0:
-{
-Obj _35val1943 = __arg1;
-Obj _35val1941= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val1941;
-__arg2 = _35val1943;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35val1941 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1942 = primCdr(exp);
-pushCont(co, 0, _35clofun2019, 1, _35val1941);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg1942;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj _35val1952 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#import"));
-__arg1 = _35val1952;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj _35val1949 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1950 = primCons(_35val1949, globalRef(intern("cora/lib/toc#*repl-ns*")));
-Obj _35reg1951 = primSet(co, intern("cora/lib/toc#*repl-ns*"), _35reg1950);
-pushCont(co, 2, _35clofun2019, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj _35val1956 = __arg1;
-Obj _35val1954= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val1954;
-__arg2 = _35val1956;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35val1954 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1955 = primCdr(exp);
-pushCont(co, 4, _35clofun2019, 1, _35val1954);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg1955;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val1965 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#import"));
-__arg1 = _35val1965;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val1962 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1963 = primCons(_35val1962, globalRef(intern("cora/lib/toc#*repl-ns*")));
-Obj _35reg1964 = primSet(co, intern("cora/lib/toc#*repl-ns*"), _35reg1963);
-pushCont(co, 6, _35clofun2019, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35val1969 = __arg1;
-Obj _35val1967= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val1967;
-__arg2 = _35val1969;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val1967 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1968 = primCdr(exp);
-pushCont(co, 8, _35clofun2019, 1, _35val1967);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg1968;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35val1978 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#import"));
-__arg1 = _35val1978;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val1975 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1976 = primCons(_35val1975, globalRef(intern("cora/lib/toc#*repl-ns*")));
-Obj _35reg1977 = primSet(co, intern("cora/lib/toc#*repl-ns*"), _35reg1976);
-pushCont(co, 10, _35clofun2019, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35val1982 = __arg1;
-Obj _35val1980= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val1980;
-__arg2 = _35val1982;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35val1980 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1981 = primCdr(exp);
-pushCont(co, 12, _35clofun2019, 1, _35val1980);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg1981;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35val1990 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#import"));
-__arg1 = _35val1990;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35val1987 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1988 = primCons(_35val1987, globalRef(intern("cora/lib/toc#*repl-ns*")));
-Obj _35reg1989 = primSet(co, intern("cora/lib/toc#*repl-ns*"), _35reg1988);
-pushCont(co, 14, _35clofun2019, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val1994 = __arg1;
-Obj _35val1992= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#apply"));
-__arg1 = _35val1992;
-__arg2 = _35val1994;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val1992 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1993 = primCdr(exp);
-pushCont(co, 16, _35clofun2019, 1, _35val1992);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#eval0"));
-__arg2 = _35reg1993;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val1970 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1970) {
-if (True == True) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2019) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg1971 = primCar(exp);
-Obj _35reg1972 = primEQ(_35reg1971, intern("quote"));
-if (True == _35reg1972) {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1973 = primCar(exp);
-Obj _35reg1974 = primEQ(_35reg1973, intern("import"));
-if (True == _35reg1974) {
-pushCont(co, 11, _35clofun2019, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1979 = primCar(exp);
-pushCont(co, 13, _35clofun2019, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg1979;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-} else {
-if (True == False) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2019) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg1983 = primCar(exp);
-Obj _35reg1984 = primEQ(_35reg1983, intern("quote"));
-if (True == _35reg1984) {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1985 = primCar(exp);
-Obj _35reg1986 = primEQ(_35reg1985, intern("import"));
-if (True == _35reg1986) {
-pushCont(co, 15, _35clofun2019, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1991 = primCar(exp);
-pushCont(co, 17, _35clofun2019, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg1991;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-}
-}
-
-label19:
-{
-Obj _35val1957 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1957) {
-if (True == True) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2019) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg1958 = primCar(exp);
-Obj _35reg1959 = primEQ(_35reg1958, intern("quote"));
-if (True == _35reg1959) {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1960 = primCar(exp);
-Obj _35reg1961 = primEQ(_35reg1960, intern("import"));
-if (True == _35reg1961) {
-pushCont(co, 7, _35clofun2019, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1966 = primCar(exp);
-pushCont(co, 9, _35clofun2019, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg1966;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-} else {
-pushCont(co, 18, _35clofun2019, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#null?"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
-{
-Obj _35val1931 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1931) {
-if (True == True) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2019) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg1932 = primCar(exp);
-Obj _35reg1933 = primEQ(_35reg1932, intern("quote"));
-if (True == _35reg1933) {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1934 = primCar(exp);
-Obj _35reg1935 = primEQ(_35reg1934, intern("import"));
-if (True == _35reg1935) {
-pushCont(co, 20, _35clofun2018, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1940 = primCar(exp);
-pushCont(co, 1, _35clofun2019, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg1940;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-} else {
-Obj _35reg1944 = primIsString(exp);
-if (True == _35reg1944) {
-if (True == True) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2019) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg1945 = primCar(exp);
-Obj _35reg1946 = primEQ(_35reg1945, intern("quote"));
-if (True == _35reg1946) {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1947 = primCar(exp);
-Obj _35reg1948 = primEQ(_35reg1947, intern("import"));
-if (True == _35reg1948) {
-pushCont(co, 3, _35clofun2019, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1953 = primCar(exp);
-pushCont(co, 5, _35clofun2019, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#eval0"));
-__arg1 = _35reg1953;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-} else {
-pushCont(co, 19, _35clofun2019, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#boolean?"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2019) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-fail:
-co->nargs = __nargs;
-co->args[0] = __arg0;
-co->args[1] = __arg1;
-co->args[2] = __arg2;
-co->args[3] = __arg3;
-
-}
-
-void _35clofun2018(struct Cora* co){
+void _35clofun1991(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -876,14 +674,14 @@ label0:
 {
 Obj _35val1893 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 20, _35clofun2017, 1, to);
+pushCont(co, 20, _35clofun1990, 1, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#compile"));
 __arg1 = _35val1893;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1991) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -891,14 +689,14 @@ label1:
 {
 Obj _35val1892 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun2018, 1, to);
+pushCont(co, 0, _35clofun1991, 1, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#macroexpand"));
 __arg1 = _35val1892;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1991) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -906,14 +704,14 @@ label2:
 {
 Obj from = __arg1;
 Obj to = __arg2;
-pushCont(co, 1, _35clofun2018, 1, to);
+pushCont(co, 1, _35clofun1991, 1, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#preprocess"));
 __arg1 = from;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1991) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -925,7 +723,7 @@ Obj _35reg1898 = primSet(co, _35tmp176, _35tmp175);
 __nargs = 2;
 __arg1 = _35reg1898;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -936,7 +734,7 @@ Obj _35reg1900 = primCar(_35tmp177);
 __nargs = 2;
 __arg1 = _35reg1900;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -947,7 +745,7 @@ Obj _35reg1902 = primCdr(_35tmp178);
 __nargs = 2;
 __arg1 = _35reg1902;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -959,7 +757,7 @@ Obj _35reg1904 = primCons(_35tmp180, _35tmp179);
 __nargs = 2;
 __arg1 = _35reg1904;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -971,7 +769,7 @@ Obj _35reg1906 = primAdd(_35tmp182, _35tmp181);
 __nargs = 2;
 __arg1 = _35reg1906;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -983,7 +781,7 @@ Obj _35reg1908 = primSub(_35tmp184, _35tmp183);
 __nargs = 2;
 __arg1 = _35reg1908;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -995,7 +793,7 @@ Obj _35reg1910 = primMul(_35tmp186, _35tmp185);
 __nargs = 2;
 __arg1 = _35reg1910;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -1007,7 +805,7 @@ Obj _35reg1912 = primDiv(_35tmp188, _35tmp187);
 __nargs = 2;
 __arg1 = _35reg1912;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -1019,7 +817,7 @@ Obj _35reg1914 = primEQ(_35tmp190, _35tmp189);
 __nargs = 2;
 __arg1 = _35reg1914;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -1031,7 +829,7 @@ Obj _35reg1916 = primGT(_35tmp192, _35tmp191);
 __nargs = 2;
 __arg1 = _35reg1916;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -1043,7 +841,7 @@ Obj _35reg1918 = primLT(_35tmp194, _35tmp193);
 __nargs = 2;
 __arg1 = _35reg1918;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -1054,7 +852,7 @@ Obj _35reg1920 = primGenSym(_35tmp195);
 __nargs = 2;
 __arg1 = _35reg1920;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -1065,7 +863,7 @@ Obj _35reg1922 = primIsSymbol(_35tmp196);
 __nargs = 2;
 __arg1 = _35reg1922;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -1076,7 +874,7 @@ Obj _35reg1924 = primNot(_35tmp197);
 __nargs = 2;
 __arg1 = _35reg1924;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -1087,50 +885,54 @@ Obj _35reg1926 = primIsString(_35tmp198);
 __nargs = 2;
 __arg1 = _35reg1926;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2018) { goto fail; }
+if (co->ctx.pc.func != _35clofun1991) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label18:
 {
-Obj _35val1930 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#value"));
-__arg1 = _35val1930;
+Obj _35val1936 = __arg1;
+Obj _35val1934= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val1934;
+__arg2 = _35val1936;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1991) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35val1939 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#import"));
-__arg1 = _35val1939;
+Obj _35val1934 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1935 = primCdr(exp);
+pushCont(co, 18, _35clofun1991, 1, _35val1934);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#eval0"));
+__arg2 = _35reg1935;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1991) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35val1936 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1937 = primCons(_35val1936, globalRef(intern("cora/lib/toc#*repl-ns*")));
-Obj _35reg1938 = primSet(co, intern("cora/lib/toc#*repl-ns*"), _35reg1937);
-pushCont(co, 19, _35clofun2018, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
+Obj _35val1944 = __arg1;
+Obj _35val1942= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#apply"));
+__arg1 = _35val1942;
+__arg2 = _35val1944;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2018) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1991) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1143,7 +945,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2017(struct Cora* co){
+void _35clofun1990(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -1159,7 +961,7 @@ label0:
 Obj _35val1808 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 20, _35clofun2016, 2, to, bc);
+pushCont(co, 20, _35clofun1989, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1167,7 +969,7 @@ __arg2 = makeCString("#include \"runtime.h\"\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1175,7 +977,7 @@ label1:
 {
 Obj to = __arg1;
 Obj bc = __arg2;
-pushCont(co, 0, _35clofun2017, 2, to, bc);
+pushCont(co, 0, _35clofun1990, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1183,7 +985,7 @@ __arg2 = makeCString("#include \"types.h\"\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1195,18 +997,18 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc166 = makeNative(2, _35clofun2017, 0, 0);
+Obj _35cc166 = makeNative(2, _35clofun1990, 0, 0);
 Obj __ = closureRef(co, 0);
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1990) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -1220,13 +1022,13 @@ __arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35cc165 = makeNative(3, _35clofun2017, 0, 1, closureRef(co, 0));
+Obj _35cc165 = makeNative(3, _35clofun1990, 0, 1, closureRef(co, 0));
 Obj _35reg1815 = primIsCons(closureRef(co, 0));
 if (True == _35reg1815) {
 Obj _35reg1816 = primCar(closureRef(co, 0));
@@ -1251,14 +1053,14 @@ Obj _35reg1830 = primEQ(Nil, _35reg1829);
 if (True == _35reg1830) {
 Obj _35reg1831 = primCdr(closureRef(co, 0));
 Obj remain = _35reg1831;
-pushCont(co, 4, _35clofun2017, 1, remain);
+pushCont(co, 4, _35clofun1990, 1, remain);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#import"));
 __arg1 = pkg;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -1266,16 +1068,7 @@ __arg0 = _35cc165;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc165;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1284,7 +1077,7 @@ __arg0 = _35cc165;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1293,7 +1086,7 @@ __arg0 = _35cc165;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1302,14 +1095,23 @@ __arg0 = _35cc165;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc165;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label6:
 {
-Obj _35cc164 = makeNative(5, _35clofun2017, 0, 1, closureRef(co, 0));
+Obj _35cc164 = makeNative(5, _35clofun1990, 0, 1, closureRef(co, 0));
 Obj _35reg1833 = primIsCons(closureRef(co, 0));
 if (True == _35reg1833) {
 Obj _35reg1834 = primCar(closureRef(co, 0));
@@ -1323,7 +1125,7 @@ __arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -1331,7 +1133,7 @@ __arg0 = _35cc164;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1340,7 +1142,7 @@ __arg0 = _35cc164;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -1348,7 +1150,7 @@ goto *jumpTable[ps.label];
 label7:
 {
 Obj _35p162 = __arg1;
-Obj _35cc163 = makeNative(6, _35clofun2017, 0, 1, _35p162);
+Obj _35cc163 = makeNative(6, _35clofun1990, 0, 1, _35p162);
 Obj _35reg1837 = primIsCons(_35p162);
 if (True == _35reg1837) {
 Obj _35reg1838 = primCar(_35p162);
@@ -1369,7 +1171,7 @@ __arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -1377,16 +1179,7 @@ __arg0 = _35cc163;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc163;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1395,7 +1188,16 @@ __arg0 = _35cc163;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc163;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -1408,13 +1210,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35cc174 = makeNative(8, _35clofun2017, 0, 0);
+Obj _35cc174 = makeNative(8, _35clofun1990, 0, 0);
 Obj _35reg1847 = primIsCons(closureRef(co, 0));
 if (True == _35reg1847) {
 Obj _35reg1848 = primCar(closureRef(co, 0));
@@ -1445,7 +1247,7 @@ co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -1453,14 +1255,14 @@ __arg0 = _35cc174;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35cc173 = makeNative(9, _35clofun2017, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc173 = makeNative(9, _35clofun1990, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj _35reg1862 = primIsCons(closureRef(co, 0));
 if (True == _35reg1862) {
 Obj _35reg1863 = primCar(closureRef(co, 0));
@@ -1489,7 +1291,7 @@ co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -1497,16 +1299,7 @@ __arg0 = _35cc173;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc173;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1515,14 +1308,23 @@ __arg0 = _35cc173;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc173;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35cc172 = makeNative(10, _35clofun2017, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc172 = makeNative(10, _35clofun1990, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj _35reg1873 = primIsCons(closureRef(co, 0));
 if (True == _35reg1873) {
 Obj _35reg1874 = primCar(closureRef(co, 0));
@@ -1551,7 +1353,7 @@ co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -1559,16 +1361,7 @@ __arg0 = _35cc172;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc172;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -1577,7 +1370,16 @@ __arg0 = _35cc172;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc172;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -1594,7 +1396,7 @@ __arg2 = _35val1886;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1603,14 +1405,14 @@ label13:
 Obj _35val1885 = __arg1;
 Obj code= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj k= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun2017, 2, k, _35val1885);
+pushCont(co, 12, _35clofun1990, 2, k, _35val1885);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = code;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1620,20 +1422,20 @@ Obj _35p167 = __arg1;
 Obj _35p168 = __arg2;
 Obj _35p169 = __arg3;
 Obj _35p170 = co->args[4];
-Obj _35cc171 = makeNative(11, _35clofun2017, 0, 4, _35p167, _35p168, _35p169, _35p170);
+Obj _35cc171 = makeNative(11, _35clofun1990, 0, 4, _35p167, _35p168, _35p169, _35p170);
 Obj _35reg1884 = primEQ(Nil, _35p167);
 if (True == _35reg1884) {
 Obj type = _35p168;
 Obj code = _35p169;
 Obj k = _35p170;
-pushCont(co, 13, _35clofun2017, 2, code, k);
+pushCont(co, 13, _35clofun1990, 2, code, k);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = type;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -1641,7 +1443,7 @@ __arg0 = _35cc171;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -1653,7 +1455,7 @@ Obj sexp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg1 = sexp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2017) { goto fail; }
+if (co->ctx.pc.func != _35clofun1990) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -1661,28 +1463,28 @@ label16:
 {
 Obj _35val1889 = __arg1;
 Obj sexp = _35val1889;
-pushCont(co, 15, _35clofun2017, 1, sexp);
+pushCont(co, 15, _35clofun1990, 1, sexp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
 __arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
 Obj file_45path = __arg1;
-pushCont(co, 16, _35clofun2017, 0);
+pushCont(co, 16, _35clofun1990, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#read-file-as-sexp"));
 __arg1 = file_45path;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1696,7 +1498,7 @@ __arg1 = stream;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1705,7 +1507,7 @@ label19:
 Obj _35val1895 = __arg1;
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stream = _35val1895;
-pushCont(co, 18, _35clofun2017, 1, stream);
+pushCont(co, 18, _35clofun1990, 1, stream);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#generate-c"));
 __arg1 = stream;
@@ -1713,7 +1515,7 @@ __arg2 = bc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1722,14 +1524,14 @@ label20:
 Obj _35val1894 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc = _35val1894;
-pushCont(co, 19, _35clofun2017, 1, bc);
+pushCont(co, 19, _35clofun1990, 1, bc);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io#open-output-file"));
 __arg1 = to;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2017) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1990) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1742,7 +1544,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2016(struct Cora* co){
+void _35clofun1989(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -1758,15 +1560,15 @@ label0:
 Obj _35val1799 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 20, _35clofun2015, 1, to);
+pushCont(co, 20, _35clofun1988, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(13, _35clofun2015, 1, 1, to);
+__arg1 = makeNative(13, _35clofun1988, 1, 1, to);
 __arg2 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1775,7 +1577,7 @@ label1:
 Obj _35val1798 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2016, 2, group, to);
+pushCont(co, 0, _35clofun1989, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1783,7 +1585,7 @@ __arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1792,7 +1594,7 @@ label2:
 Obj _35val1797 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun2016, 2, group, to);
+pushCont(co, 1, _35clofun1989, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1800,7 +1602,7 @@ __arg2 = makeCString("};\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1809,7 +1611,7 @@ label3:
 Obj _35val1796 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun2016, 2, group, to);
+pushCont(co, 2, _35clofun1989, 2, group, to);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#generate-jumptable"));
 __arg1 = to;
@@ -1818,7 +1620,7 @@ __arg3 = _35val1796;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1827,14 +1629,14 @@ label4:
 Obj _35val1795 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 3, _35clofun2016, 2, group, to);
+pushCont(co, 3, _35clofun1989, 2, group, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1843,7 +1645,7 @@ label5:
 Obj _35val1794 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun2016, 2, group, to);
+pushCont(co, 4, _35clofun1989, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1851,7 +1653,7 @@ __arg2 = makeCString("static void* jumpTable[] = {");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1860,7 +1662,7 @@ label6:
 Obj _35val1793 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun2016, 2, group, to);
+pushCont(co, 5, _35clofun1989, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1868,7 +1670,7 @@ __arg2 = makeCString("Obj __arg3 = co->args[3];\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1877,7 +1679,7 @@ label7:
 Obj _35val1792 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 6, _35clofun2016, 2, group, to);
+pushCont(co, 6, _35clofun1989, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1885,7 +1687,7 @@ __arg2 = makeCString("Obj __arg2 = co->args[2];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1894,7 +1696,7 @@ label8:
 Obj _35val1791 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun2016, 2, group, to);
+pushCont(co, 7, _35clofun1989, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1902,7 +1704,7 @@ __arg2 = makeCString("Obj __arg1 = co->args[1];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1911,7 +1713,7 @@ label9:
 Obj _35val1790 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun2016, 2, group, to);
+pushCont(co, 8, _35clofun1989, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1919,7 +1721,7 @@ __arg2 = makeCString("Obj __arg0 = co->args[0];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1928,7 +1730,7 @@ label10:
 Obj _35val1789 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun2016, 2, group, to);
+pushCont(co, 9, _35clofun1989, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1936,7 +1738,7 @@ __arg2 = makeCString("int __nargs = co->nargs;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1945,7 +1747,7 @@ label11:
 Obj _35val1788 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun2016, 2, group, to);
+pushCont(co, 10, _35clofun1989, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -1953,7 +1755,7 @@ __arg2 = makeCString("{\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1962,7 +1764,7 @@ label12:
 Obj _35val1787 = __arg1;
 Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun2016, 2, group, to);
+pushCont(co, 11, _35clofun1989, 2, group, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#code-gen-func-declare"));
 __arg1 = to;
@@ -1970,7 +1772,7 @@ __arg2 = _35val1787;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1978,14 +1780,14 @@ label13:
 {
 Obj to = __arg1;
 Obj group = __arg2;
-pushCont(co, 12, _35clofun2016, 2, group, to);
+pushCont(co, 12, _35clofun1989, 2, group, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1999,14 +1801,14 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
 Obj _35val1810 = __arg1;
-pushCont(co, 14, _35clofun2016, 0);
+pushCont(co, 14, _35clofun1989, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#code-gen-func-declare"));
 __arg1 = closureRef(co, 0);
@@ -2014,21 +1816,21 @@ __arg2 = _35val1810;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
 Obj group = __arg1;
-pushCont(co, 15, _35clofun2016, 0);
+pushCont(co, 15, _35clofun1989, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2042,7 +1844,7 @@ __arg2 = group;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2053,12 +1855,12 @@ Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(17, _35clofun2016, 1, 1, to);
+__arg1 = makeNative(17, _35clofun1989, 1, 1, to);
 __arg2 = bc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2067,7 +1869,7 @@ label19:
 Obj _35val1812 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 18, _35clofun2016, 2, to, bc);
+pushCont(co, 18, _35clofun1989, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2075,7 +1877,7 @@ __arg2 = makeCString("\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2084,15 +1886,15 @@ label20:
 Obj _35val1809 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 19, _35clofun2016, 2, to, bc);
+pushCont(co, 19, _35clofun1989, 2, to, bc);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(16, _35clofun2016, 1, 1, to);
+__arg1 = makeNative(16, _35clofun1989, 1, 1, to);
 __arg2 = bc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2016) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1989) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2105,7 +1907,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2015(struct Cora* co){
+void _35clofun1988(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -2125,63 +1927,63 @@ __arg1 = _35val1772;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
 Obj _35val1771 = __arg1;
-pushCont(co, 0, _35clofun2015, 0);
+pushCont(co, 0, _35clofun1988, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack-pass"));
 __arg1 = _35val1771;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
 Obj _35val1770 = __arg1;
-pushCont(co, 1, _35clofun2015, 0);
+pushCont(co, 1, _35clofun1988, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#tailify-pass"));
 __arg1 = _35val1770;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
 Obj _35val1769 = __arg1;
-pushCont(co, 2, _35clofun2015, 0);
+pushCont(co, 2, _35clofun1988, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert-pass"));
 __arg1 = _35val1769;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
 Obj exp = __arg1;
-pushCont(co, 3, _35clofun2015, 0);
+pushCont(co, 3, _35clofun1988, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#parse-pass"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2193,7 +1995,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2209,13 +2011,13 @@ __arg2 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35cc161 = makeNative(5, _35clofun2015, 0, 0);
+Obj _35cc161 = makeNative(5, _35clofun1988, 0, 0);
 Obj fn = closureRef(co, 0);
 Obj _35reg1774 = primIsCons(closureRef(co, 1));
 if (True == _35reg1774) {
@@ -2223,14 +2025,14 @@ Obj _35reg1775 = primCar(closureRef(co, 1));
 Obj x = _35reg1775;
 Obj _35reg1776 = primCdr(closureRef(co, 1));
 Obj y = _35reg1776;
-pushCont(co, 6, _35clofun2015, 2, fn, y);
+pushCont(co, 6, _35clofun1988, 2, fn, y);
 __nargs = 2;
 __arg0 = fn;
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -2238,7 +2040,7 @@ __arg0 = _35cc161;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2247,14 +2049,14 @@ label8:
 {
 Obj _35p158 = __arg1;
 Obj _35p159 = __arg2;
-Obj _35cc160 = makeNative(7, _35clofun2015, 0, 2, _35p158, _35p159);
+Obj _35cc160 = makeNative(7, _35clofun1988, 0, 2, _35p158, _35p159);
 Obj fn = _35p158;
 Obj _35reg1778 = primEQ(Nil, _35p159);
 if (True == _35reg1778) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2015) { goto fail; }
+if (co->ctx.pc.func != _35clofun1988) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -2262,7 +2064,7 @@ __arg0 = _35cc160;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2280,7 +2082,7 @@ __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2299,7 +2101,7 @@ __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2309,7 +2111,7 @@ Obj _35val1783 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj n= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 10, _35clofun2015, 3, i, to, n);
+pushCont(co, 10, _35clofun1988, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = to;
@@ -2317,7 +2119,7 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2328,7 +2130,7 @@ Obj i = __arg2;
 Obj n = __arg3;
 Obj _35reg1780 = primEQ(i, makeNumber(0));
 if (True == _35reg1780) {
-pushCont(co, 9, _35clofun2015, 2, to, n);
+pushCont(co, 9, _35clofun1988, 2, to, n);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2336,12 +2138,12 @@ __arg2 = makeCString("&&label0");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1782 = primLT(i, n);
 if (True == _35reg1782) {
-pushCont(co, 11, _35clofun2015, 3, i, to, n);
+pushCont(co, 11, _35clofun1988, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2349,13 +2151,13 @@ __arg2 = makeCString(", &&label");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2015) { goto fail; }
+if (co->ctx.pc.func != _35clofun1988) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
@@ -2371,7 +2173,7 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2386,7 +2188,7 @@ __arg2 = makeCString("\n}\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2394,7 +2196,7 @@ label15:
 {
 Obj _35val1805 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 14, _35clofun2015, 1, to);
+pushCont(co, 14, _35clofun1988, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2402,7 +2204,7 @@ __arg2 = makeCString("co->args[3] = __arg3;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2410,7 +2212,7 @@ label16:
 {
 Obj _35val1804 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 15, _35clofun2015, 1, to);
+pushCont(co, 15, _35clofun1988, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2418,7 +2220,7 @@ __arg2 = makeCString("co->args[2] = __arg2;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2426,7 +2228,7 @@ label17:
 {
 Obj _35val1803 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 16, _35clofun2015, 1, to);
+pushCont(co, 16, _35clofun1988, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2434,7 +2236,7 @@ __arg2 = makeCString("co->args[1] = __arg1;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2442,7 +2244,7 @@ label18:
 {
 Obj _35val1802 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 17, _35clofun2015, 1, to);
+pushCont(co, 17, _35clofun1988, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2450,7 +2252,7 @@ __arg2 = makeCString("co->args[0] = __arg0;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2458,7 +2260,7 @@ label19:
 {
 Obj _35val1801 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 18, _35clofun2015, 1, to);
+pushCont(co, 18, _35clofun1988, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2466,7 +2268,7 @@ __arg2 = makeCString("co->nargs = __nargs;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2474,7 +2276,7 @@ label20:
 {
 Obj _35val1800 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 19, _35clofun2015, 1, to);
+pushCont(co, 19, _35clofun1988, 1, to);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = to;
@@ -2482,7 +2284,7 @@ __arg2 = makeCString("fail:\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2015) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1988) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2495,7 +2297,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2014(struct Cora* co){
+void _35clofun1987(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -2518,7 +2320,7 @@ co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2532,7 +2334,7 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2546,7 +2348,7 @@ __arg2 = globalRef(intern("cora/lib/toc#id"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2560,7 +2362,7 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2581,7 +2383,7 @@ Obj _35reg1745 = primCons(_35reg1744, res);
 __nargs = 2;
 __arg1 = _35reg1745;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2014) { goto fail; }
+if (co->ctx.pc.func != _35clofun1987) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -2604,7 +2406,7 @@ Obj _35reg1757 = primCons(_35reg1756, res);
 __nargs = 2;
 __arg1 = _35reg1757;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2014) { goto fail; }
+if (co->ctx.pc.func != _35clofun1987) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -2613,7 +2415,7 @@ label6:
 Obj _35val1746 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun2014, 2, _35val1746, e1);
+pushCont(co, 5, _35clofun1987, 2, _35val1746, e1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -2621,7 +2423,7 @@ __arg2 = makeNumber(2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2632,7 +2434,7 @@ Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 2];
 if (True == _35val1735) {
-pushCont(co, 4, _35clofun2014, 1, e1);
+pushCont(co, 4, _35clofun1987, 1, e1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -2640,17 +2442,17 @@ __arg2 = makeNumber(2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 6, _35clofun2014, 2, v, e1);
+pushCont(co, 6, _35clofun1987, 2, v, e1);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2661,14 +2463,14 @@ Obj _35val1734 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cur = _35val1734;
-pushCont(co, 7, _35clofun2014, 3, cur, v, e1);
+pushCont(co, 7, _35clofun1987, 3, cur, v, e1);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2677,7 +2479,7 @@ label9:
 Obj _35val1733 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1 = _35val1733;
-pushCont(co, 8, _35clofun2014, 2, v, e1);
+pushCont(co, 8, _35clofun1987, 2, v, e1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -2685,7 +2487,7 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2694,7 +2496,7 @@ label10:
 Obj _35val1732 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun2014, 1, v);
+pushCont(co, 9, _35clofun1987, 1, v);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
 __arg1 = v;
@@ -2702,7 +2504,7 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2711,7 +2513,7 @@ label11:
 Obj _35val1731 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun2014, 2, exp, v);
+pushCont(co, 10, _35clofun1987, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -2720,7 +2522,7 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2729,7 +2531,7 @@ label12:
 Obj _35val1730 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun2014, 2, exp, v);
+pushCont(co, 11, _35clofun1987, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -2738,7 +2540,7 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2747,7 +2549,7 @@ label13:
 Obj _35val1729 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v = _35val1729;
-pushCont(co, 12, _35clofun2014, 2, exp, v);
+pushCont(co, 12, _35clofun1987, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -2756,21 +2558,21 @@ __arg3 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
 Obj exp = __arg1;
-pushCont(co, 13, _35clofun2014, 1, exp);
+pushCont(co, 13, _35clofun1987, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#vector"));
 __arg1 = makeNumber(3);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2782,13 +2584,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35cc157 = makeNative(15, _35clofun2014, 0, 0);
+Obj _35cc157 = makeNative(15, _35clofun1987, 0, 0);
 Obj obj = closureRef(co, 0);
 Obj _35reg1759 = primIsCons(closureRef(co, 1));
 if (True == _35reg1759) {
@@ -2805,7 +2607,7 @@ __arg2 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -2813,7 +2615,7 @@ __arg0 = _35cc157;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2822,14 +2624,14 @@ label17:
 {
 Obj _35p154 = __arg1;
 Obj _35p155 = __arg2;
-Obj _35cc156 = makeNative(16, _35clofun2014, 0, 2, _35p154, _35p155);
+Obj _35cc156 = makeNative(16, _35clofun1987, 0, 2, _35p154, _35p155);
 Obj obj = _35p154;
 Obj _35reg1764 = primEQ(Nil, _35p155);
 if (True == _35reg1764) {
 __nargs = 2;
 __arg1 = obj;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2014) { goto fail; }
+if (co->ctx.pc.func != _35clofun1987) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -2837,7 +2639,7 @@ __arg0 = _35cc156;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2854,7 +2656,7 @@ __arg2 = fns;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2863,28 +2665,28 @@ label19:
 Obj _35val1766 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj obj = _35val1766;
-pushCont(co, 18, _35clofun2014, 1, obj);
+pushCont(co, 18, _35clofun1987, 1, obj);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
 Obj exp = __arg1;
-pushCont(co, 19, _35clofun2014, 1, exp);
+pushCont(co, 19, _35clofun1987, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#cadr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2014) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1987) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2897,7 +2699,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2013(struct Cora* co){
+void _35clofun1986(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -2913,7 +2715,7 @@ label0:
 Obj w = __arg1;
 Obj i = __arg2;
 Obj var = __arg3;
-pushCont(co, 20, _35clofun2012, 3, var, i, w);
+pushCont(co, 20, _35clofun1985, 3, var, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -2921,7 +2723,7 @@ __arg2 = makeCString("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2936,7 +2738,7 @@ __arg2 = makeCString("];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2945,7 +2747,7 @@ label2:
 Obj _35val1653 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun2013, 1, w);
+pushCont(co, 1, _35clofun1986, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -2953,7 +2755,7 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2962,7 +2764,7 @@ label3:
 Obj _35val1652 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun2013, 2, i, w);
+pushCont(co, 2, _35clofun1986, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -2970,7 +2772,7 @@ __arg2 = makeCString("= co->ctx.stk.stack[co->ctx.stk.base + ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2980,7 +2782,7 @@ Obj _35val1651 = __arg1;
 Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 3, _35clofun2013, 2, i, w);
+pushCont(co, 3, _35clofun1986, 2, i, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = intern("ignore");
@@ -2990,7 +2792,7 @@ co->args[4] = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -2999,7 +2801,7 @@ label5:
 Obj w = __arg1;
 Obj i = __arg2;
 Obj var = __arg3;
-pushCont(co, 4, _35clofun2013, 3, var, i, w);
+pushCont(co, 4, _35clofun1986, 3, var, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3007,7 +2809,7 @@ __arg2 = makeCString("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3019,7 +2821,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3040,13 +2842,13 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35cc149 = makeNative(6, _35clofun2013, 0, 0);
+Obj _35cc149 = makeNative(6, _35clofun1986, 0, 0);
 Obj fn = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj idx = closureRef(co, 2);
@@ -3056,7 +2858,7 @@ Obj _35reg1657 = primCar(closureRef(co, 3));
 Obj a = _35reg1657;
 Obj _35reg1658 = primCdr(closureRef(co, 3));
 Obj b = _35reg1658;
-pushCont(co, 7, _35clofun2013, 4, idx, fn, w, b);
+pushCont(co, 7, _35clofun1986, 4, idx, fn, w, b);
 __nargs = 4;
 __arg0 = fn;
 __arg1 = w;
@@ -3065,7 +2867,7 @@ __arg3 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -3073,7 +2875,7 @@ __arg0 = _35cc149;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3084,7 +2886,7 @@ Obj _35p144 = __arg1;
 Obj _35p145 = __arg2;
 Obj _35p146 = __arg3;
 Obj _35p147 = co->args[4];
-Obj _35cc148 = makeNative(8, _35clofun2013, 0, 4, _35p144, _35p145, _35p146, _35p147);
+Obj _35cc148 = makeNative(8, _35clofun1986, 0, 4, _35p144, _35p145, _35p146, _35p147);
 Obj fn = _35p144;
 Obj w = _35p145;
 Obj idx = _35p146;
@@ -3093,7 +2895,7 @@ if (True == _35reg1661) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2013) { goto fail; }
+if (co->ctx.pc.func != _35clofun1986) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -3101,7 +2903,7 @@ __arg0 = _35cc148;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3114,7 +2916,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3127,7 +2929,7 @@ __arg1 = makeCString("\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3135,30 +2937,30 @@ label12:
 {
 Obj _35val1663 = __arg1;
 Obj other= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 11, _35clofun2013, 0);
+pushCont(co, 11, _35clofun1986, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io#display"));
 __arg1 = other;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label13:
 {
-Obj _35cc153 = makeNative(10, _35clofun2013, 0, 0);
+Obj _35cc153 = makeNative(10, _35clofun1986, 0, 0);
 Obj w = closureRef(co, 0);
 Obj other = closureRef(co, 1);
-pushCont(co, 12, _35clofun2013, 1, other);
+pushCont(co, 12, _35clofun1986, 1, other);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/io#display"));
 __arg1 = makeCString("wrong format of toplevel\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3173,7 +2975,7 @@ __arg2 = makeCString("}\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3185,7 +2987,7 @@ Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj _35reg1722 = primCar(label);
-pushCont(co, 14, _35clofun2013, 1, w);
+pushCont(co, 14, _35clofun1986, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = _35reg1722;
@@ -3195,7 +2997,7 @@ co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3207,7 +3009,7 @@ Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 15, _35clofun2013, 4, label, params, body, w);
+pushCont(co, 15, _35clofun1986, 4, label, params, body, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
 __arg1 = globalRef(intern("cora/lib/toc#local-from-cont"));
@@ -3217,7 +3019,7 @@ co->args[4] = actives;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3229,7 +3031,7 @@ Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 16, _35clofun2013, 5, actives, label, params, body, w);
+pushCont(co, 16, _35clofun1986, 5, actives, label, params, body, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
 __arg1 = globalRef(intern("cora/lib/toc#local-from-params"));
@@ -3239,7 +3041,7 @@ co->args[4] = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3251,7 +3053,7 @@ Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 17, _35clofun2013, 5, actives, label, params, body, w);
+pushCont(co, 17, _35clofun1986, 5, actives, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3259,7 +3061,7 @@ __arg2 = makeCString(":\n{\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3272,7 +3074,7 @@ Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj _35reg1717 = primCdr(label);
-pushCont(co, 18, _35clofun2013, 5, actives, label, params, body, w);
+pushCont(co, 18, _35clofun1986, 5, actives, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -3280,7 +3082,7 @@ __arg2 = _35reg1717;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3288,7 +3090,7 @@ label20:
 {
 Obj _35p150 = __arg1;
 Obj _35p151 = __arg2;
-Obj _35cc152 = makeNative(13, _35clofun2013, 0, 2, _35p150, _35p151);
+Obj _35cc152 = makeNative(13, _35clofun1986, 0, 2, _35p150, _35p151);
 Obj w = _35p150;
 Obj _35reg1665 = primIsCons(_35p151);
 if (True == _35reg1665) {
@@ -3354,7 +3156,7 @@ Obj _35reg1713 = primCdr(_35p151);
 Obj _35reg1714 = primCdr(_35reg1713);
 Obj _35reg1715 = primEQ(Nil, _35reg1714);
 if (True == _35reg1715) {
-pushCont(co, 19, _35clofun2013, 5, actives, label, params, body, w);
+pushCont(co, 19, _35clofun1986, 5, actives, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3362,7 +3164,7 @@ __arg2 = makeCString("label");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -3370,16 +3172,7 @@ __arg0 = _35cc152;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc152;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3388,7 +3181,7 @@ __arg0 = _35cc152;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3397,7 +3190,7 @@ __arg0 = _35cc152;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3406,7 +3199,7 @@ __arg0 = _35cc152;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3415,7 +3208,7 @@ __arg0 = _35cc152;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3424,7 +3217,7 @@ __arg0 = _35cc152;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3433,7 +3226,7 @@ __arg0 = _35cc152;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3442,7 +3235,16 @@ __arg0 = _35cc152;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2013) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc152;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1986) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3456,7 +3258,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2012(struct Cora* co){
+void _35clofun1985(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -3475,7 +3277,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj _35reg1618 = primCar(label);
-pushCont(co, 20, _35clofun2011, 3, self, stacks, w);
+pushCont(co, 20, _35clofun1984, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -3483,7 +3285,7 @@ __arg2 = _35reg1618;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3494,7 +3296,7 @@ Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun2012, 4, label, self, stacks, w);
+pushCont(co, 0, _35clofun1985, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3502,7 +3304,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3514,7 +3316,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj _35reg1615 = primCdr(label);
-pushCont(co, 1, _35clofun2012, 4, label, self, stacks, w);
+pushCont(co, 1, _35clofun1985, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -3522,7 +3324,7 @@ __arg2 = _35reg1615;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3531,7 +3333,7 @@ label3:
 Obj _35p133 = __arg1;
 Obj _35p134 = __arg2;
 Obj _35p135 = __arg3;
-Obj _35cc136 = makeNative(12, _35clofun2011, 0, 0);
+Obj _35cc136 = makeNative(12, _35clofun1984, 0, 0);
 Obj self = _35p133;
 Obj w = _35p134;
 Obj _35reg1605 = primIsCons(_35p135);
@@ -3548,7 +3350,7 @@ Obj label = _35reg1611;
 Obj _35reg1612 = primCdr(_35p135);
 Obj _35reg1613 = primCdr(_35reg1612);
 Obj stacks = _35reg1613;
-pushCont(co, 2, _35clofun2012, 4, label, self, stacks, w);
+pushCont(co, 2, _35clofun1985, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3556,7 +3358,7 @@ __arg2 = makeCString("pushCont(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -3564,16 +3366,7 @@ __arg0 = _35cc136;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc136;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -3582,7 +3375,16 @@ __arg0 = _35cc136;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc136;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3595,7 +3397,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3617,7 +3419,7 @@ co->args[5] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3631,7 +3433,7 @@ Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj _35reg1633 = primNot(_35val1632);
 if (True == _35reg1633) {
-pushCont(co, 5, _35clofun2012, 5, self, env, fn, w, b);
+pushCont(co, 5, _35clofun1985, 5, self, env, fn, w, b);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3639,7 +3441,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
@@ -3653,7 +3455,7 @@ co->args[5] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3666,20 +3468,20 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 6, _35clofun2012, 5, self, env, fn, w, b);
+pushCont(co, 6, _35clofun1985, 5, self, env, fn, w, b);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35cc143 = makeNative(4, _35clofun2012, 0, 0);
+Obj _35cc143 = makeNative(4, _35clofun1985, 0, 0);
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj fn = closureRef(co, 2);
@@ -3690,7 +3492,7 @@ Obj _35reg1629 = primCar(closureRef(co, 4));
 Obj a = _35reg1629;
 Obj _35reg1630 = primCdr(closureRef(co, 4));
 Obj b = _35reg1630;
-pushCont(co, 7, _35clofun2012, 5, self, env, fn, w, b);
+pushCont(co, 7, _35clofun1985, 5, self, env, fn, w, b);
 __nargs = 5;
 __arg0 = fn;
 __arg1 = self;
@@ -3700,7 +3502,7 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -3708,7 +3510,7 @@ __arg0 = _35cc143;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3720,7 +3522,7 @@ Obj _35p138 = __arg2;
 Obj _35p139 = __arg3;
 Obj _35p140 = co->args[4];
 Obj _35p141 = co->args[5];
-Obj _35cc142 = makeNative(8, _35clofun2012, 0, 5, _35p137, _35p138, _35p139, _35p140, _35p141);
+Obj _35cc142 = makeNative(8, _35clofun1985, 0, 5, _35p137, _35p138, _35p139, _35p140, _35p141);
 Obj self = _35p137;
 Obj env = _35p138;
 Obj fn = _35p139;
@@ -3730,7 +3532,7 @@ if (True == _35reg1635) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2012) { goto fail; }
+if (co->ctx.pc.func != _35clofun1985) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -3738,7 +3540,7 @@ __arg0 = _35cc142;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3759,7 +3561,7 @@ co->args[5] = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3774,7 +3576,7 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3782,7 +3584,7 @@ label12:
 {
 Obj _35val1640 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 11, _35clofun2012, 1, w);
+pushCont(co, 11, _35clofun1985, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3790,7 +3592,7 @@ __arg2 = makeCString("(struct Cora* co");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3800,7 +3602,7 @@ Obj _35val1638 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg1639 = primCar(label);
-pushCont(co, 12, _35clofun2012, 1, w);
+pushCont(co, 12, _35clofun1985, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -3808,7 +3610,7 @@ __arg2 = _35reg1639;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3816,7 +3618,7 @@ label14:
 {
 Obj w = __arg1;
 Obj label = __arg2;
-pushCont(co, 13, _35clofun2012, 2, label, w);
+pushCont(co, 13, _35clofun1985, 2, label, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3824,7 +3626,7 @@ __arg2 = makeCString("void ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3839,7 +3641,7 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3848,7 +3650,7 @@ label16:
 Obj _35val1646 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 15, _35clofun2012, 1, w);
+pushCont(co, 15, _35clofun1985, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -3856,7 +3658,7 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3871,7 +3673,7 @@ __arg2 = makeCString("];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3880,7 +3682,7 @@ label18:
 Obj _35val1648 = __arg1;
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 17, _35clofun2012, 1, w);
+pushCont(co, 17, _35clofun1985, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -3888,7 +3690,7 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3899,7 +3701,7 @@ Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg1645 = primLT(i, makeNumber(4));
 if (True == _35reg1645) {
-pushCont(co, 16, _35clofun2012, 2, i, w);
+pushCont(co, 16, _35clofun1985, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3907,10 +3709,10 @@ __arg2 = makeCString(" = __arg");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 18, _35clofun2012, 2, i, w);
+pushCont(co, 18, _35clofun1985, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3918,7 +3720,7 @@ __arg2 = makeCString(" = co->args[");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -3929,7 +3731,7 @@ Obj _35val1643 = __arg1;
 Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 19, _35clofun2012, 2, i, w);
+pushCont(co, 19, _35clofun1985, 2, i, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = intern("ignore");
@@ -3939,7 +3741,7 @@ co->args[4] = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2012) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1985) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3952,7 +3754,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2011(struct Cora* co){
+void _35clofun1984(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -3965,7 +3767,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc123 = makeNative(11, _35clofun2010, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc123 = makeNative(11, _35clofun1983, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -3986,7 +3788,7 @@ Obj _35reg1551 = primEQ(Nil, _35reg1550);
 if (True == _35reg1551) {
 Obj _35reg1552 = primIsSymbol(x);
 if (True == _35reg1552) {
-pushCont(co, 14, _35clofun2010, 2, x, w);
+pushCont(co, 14, _35clofun1983, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -3994,17 +3796,17 @@ __arg2 = makeCString("intern(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 20, _35clofun2010, 2, x, w);
+pushCont(co, 20, _35clofun1983, 2, x, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#number?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4013,7 +3815,7 @@ __arg0 = _35cc123;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4022,7 +3824,7 @@ __arg0 = _35cc123;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4031,7 +3833,7 @@ __arg0 = _35cc123;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4040,7 +3842,7 @@ __arg0 = _35cc123;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4056,7 +3858,7 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4065,7 +3867,7 @@ label2:
 Obj _35val1576 = __arg1;
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun2011, 1, w);
+pushCont(co, 1, _35clofun1984, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -4073,13 +3875,13 @@ __arg2 = idx;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc122 = makeNative(0, _35clofun2011, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc122 = makeNative(0, _35clofun1984, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -4098,7 +3900,7 @@ Obj _35reg1573 = primCdr(closureRef(co, 3));
 Obj _35reg1574 = primCdr(_35reg1573);
 Obj _35reg1575 = primEQ(Nil, _35reg1574);
 if (True == _35reg1575) {
-pushCont(co, 2, _35clofun2011, 2, idx, w);
+pushCont(co, 2, _35clofun1984, 2, idx, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4106,7 +3908,7 @@ __arg2 = makeCString("stackRef(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -4114,16 +3916,7 @@ __arg0 = _35cc122;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc122;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4132,7 +3925,7 @@ __arg0 = _35cc122;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4141,7 +3934,16 @@ __arg0 = _35cc122;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc122;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4157,7 +3959,7 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4166,7 +3968,7 @@ label5:
 Obj _35val1588 = __arg1;
 Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun2011, 1, w);
+pushCont(co, 4, _35clofun1984, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -4174,13 +3976,13 @@ __arg2 = idx;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc121 = makeNative(3, _35clofun2011, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc121 = makeNative(3, _35clofun1984, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -4199,7 +4001,7 @@ Obj _35reg1585 = primCdr(closureRef(co, 3));
 Obj _35reg1586 = primCdr(_35reg1585);
 Obj _35reg1587 = primEQ(Nil, _35reg1586);
 if (True == _35reg1587) {
-pushCont(co, 5, _35clofun2011, 2, idx, w);
+pushCont(co, 5, _35clofun1984, 2, idx, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4207,7 +4009,7 @@ __arg2 = makeCString("closureRef(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -4215,16 +4017,7 @@ __arg0 = _35cc121;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc121;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4233,7 +4026,7 @@ __arg0 = _35cc121;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4242,7 +4035,16 @@ __arg0 = _35cc121;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc121;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4258,7 +4060,7 @@ __arg2 = makeCString("\"))");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4266,7 +4068,7 @@ label8:
 {
 Obj _35val1601 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 7, _35clofun2011, 1, w);
+pushCont(co, 7, _35clofun1984, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4274,7 +4076,7 @@ __arg2 = _35val1601;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4283,20 +4085,20 @@ label9:
 Obj _35val1600 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun2011, 1, w);
+pushCont(co, 8, _35clofun1984, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35cc120 = makeNative(6, _35clofun2011, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc120 = makeNative(6, _35clofun1984, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -4315,7 +4117,7 @@ Obj _35reg1597 = primCdr(closureRef(co, 3));
 Obj _35reg1598 = primCdr(_35reg1597);
 Obj _35reg1599 = primEQ(Nil, _35reg1598);
 if (True == _35reg1599) {
-pushCont(co, 9, _35clofun2011, 2, x, w);
+pushCont(co, 9, _35clofun1984, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4323,7 +4125,7 @@ __arg2 = makeCString("globalRef(intern(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -4331,16 +4133,7 @@ __arg0 = _35cc120;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc120;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4349,7 +4142,7 @@ __arg0 = _35cc120;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4358,7 +4151,16 @@ __arg0 = _35cc120;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc120;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4369,7 +4171,7 @@ Obj _35p115 = __arg1;
 Obj _35p116 = __arg2;
 Obj _35p117 = __arg3;
 Obj _35p118 = co->args[4];
-Obj _35cc119 = makeNative(10, _35clofun2011, 0, 4, _35p115, _35p116, _35p117, _35p118);
+Obj _35cc119 = makeNative(10, _35clofun1984, 0, 4, _35p115, _35p116, _35p117, _35p118);
 Obj self = _35p115;
 Obj env = _35p116;
 Obj w = _35p117;
@@ -4383,7 +4185,7 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -4391,7 +4193,7 @@ __arg0 = _35cc119;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4404,7 +4206,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4421,14 +4223,14 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
 Obj x = __arg1;
-pushCont(co, 13, _35clofun2011, 1, x);
+pushCont(co, 13, _35clofun1984, 1, x);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = closureRef(co, 1);
@@ -4436,7 +4238,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4451,7 +4253,7 @@ __arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4463,15 +4265,15 @@ Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg1624 = primNot(_35val1623);
 if (True == _35reg1624) {
-pushCont(co, 15, _35clofun2011, 1, w);
+pushCont(co, 15, _35clofun1984, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(14, _35clofun2011, 1, 2, self, w);
+__arg1 = makeNative(14, _35clofun1984, 1, 2, self, w);
 __arg2 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
@@ -4482,7 +4284,7 @@ __arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4493,14 +4295,14 @@ Obj _35val1622 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 16, _35clofun2011, 3, self, stacks, w);
+pushCont(co, 16, _35clofun1984, 3, self, stacks, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4510,7 +4312,7 @@ Obj _35val1621 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 17, _35clofun2011, 3, self, stacks, w);
+pushCont(co, 17, _35clofun1984, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -4518,7 +4320,7 @@ __arg2 = _35val1621;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4528,14 +4330,14 @@ Obj _35val1620 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 18, _35clofun2011, 3, self, stacks, w);
+pushCont(co, 18, _35clofun1984, 3, self, stacks, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4545,7 +4347,7 @@ Obj _35val1619 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 19, _35clofun2011, 3, self, stacks, w);
+pushCont(co, 19, _35clofun1984, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4553,7 +4355,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2011) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1984) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4566,7 +4368,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2010(struct Cora* co){
+void _35clofun1983(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -4579,7 +4381,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc125 = makeNative(14, _35clofun2009, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc125 = makeNative(14, _35clofun1982, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -4607,14 +4409,14 @@ Obj _35reg1494 = primEQ(Nil, _35reg1493);
 if (True == _35reg1494) {
 Obj _35reg1495 = primCdr(closureRef(co, 3));
 Obj args = _35reg1495;
-pushCont(co, 20, _35clofun2009, 5, f, self, env, args, w);
+pushCont(co, 20, _35clofun1982, 5, f, self, env, args, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#builtin->name"));
 __arg1 = f;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -4622,16 +4424,7 @@ __arg0 = _35cc125;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc125;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4640,7 +4433,7 @@ __arg0 = _35cc125;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4649,7 +4442,7 @@ __arg0 = _35cc125;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4658,7 +4451,16 @@ __arg0 = _35cc125;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc125;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -4681,7 +4483,7 @@ co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4693,7 +4495,7 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 1, _35clofun2010, 5, a, env, self, w, c);
+pushCont(co, 1, _35clofun1983, 5, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4701,7 +4503,7 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4714,7 +4516,7 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 2, _35clofun2010, 5, a, env, self, w, c);
+pushCont(co, 2, _35clofun1983, 5, a, env, self, w, c);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -4724,7 +4526,7 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4737,7 +4539,7 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 3, _35clofun2010, 6, b, a, env, self, w, c);
+pushCont(co, 3, _35clofun1983, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4745,7 +4547,7 @@ __arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4758,7 +4560,7 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 4, _35clofun2010, 6, b, a, env, self, w, c);
+pushCont(co, 4, _35clofun1983, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -4766,7 +4568,7 @@ __arg2 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4788,7 +4590,7 @@ co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4800,7 +4602,7 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 6, _35clofun2010, 5, a, env, self, w, c);
+pushCont(co, 6, _35clofun1983, 5, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4808,7 +4610,7 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4821,7 +4623,7 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 7, _35clofun2010, 5, a, env, self, w, c);
+pushCont(co, 7, _35clofun1983, 5, a, env, self, w, c);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -4831,7 +4633,7 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4844,7 +4646,7 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 8, _35clofun2010, 6, b, a, env, self, w, c);
+pushCont(co, 8, _35clofun1983, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4852,7 +4654,7 @@ __arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4868,7 +4670,7 @@ Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
 Obj idx = _35val1529;
 Obj _35reg1530 = primLT(idx, makeNumber(0));
 if (True == _35reg1530) {
-pushCont(co, 5, _35clofun2010, 6, b, a, env, self, w, c);
+pushCont(co, 5, _35clofun1983, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -4876,11 +4678,11 @@ __arg2 = makeCString("Obj ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
-pushCont(co, 9, _35clofun2010, 6, b, a, env, self, w, c);
+pushCont(co, 9, _35clofun1983, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -4888,14 +4690,14 @@ __arg2 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35cc124 = makeNative(0, _35clofun2010, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc124 = makeNative(0, _35clofun1983, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -4934,7 +4736,7 @@ Obj _35reg1526 = primCdr(_35reg1525);
 Obj _35reg1527 = primCdr(_35reg1526);
 Obj _35reg1528 = primEQ(Nil, _35reg1527);
 if (True == _35reg1528) {
-pushCont(co, 10, _35clofun2010, 6, b, a, env, self, w, c);
+pushCont(co, 10, _35clofun1983, 6, b, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#index"));
 __arg1 = a;
@@ -4942,7 +4744,7 @@ __arg2 = env;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -4950,16 +4752,7 @@ __arg0 = _35cc124;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc124;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4968,7 +4761,7 @@ __arg0 = _35cc124;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4977,7 +4770,7 @@ __arg0 = _35cc124;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4986,7 +4779,7 @@ __arg0 = _35cc124;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -4995,7 +4788,16 @@ __arg0 = _35cc124;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc124;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5011,7 +4813,7 @@ __arg2 = makeCString("\")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5019,7 +4821,7 @@ label13:
 {
 Obj _35val1554 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 12, _35clofun2010, 1, w);
+pushCont(co, 12, _35clofun1983, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5027,7 +4829,7 @@ __arg2 = _35val1554;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5036,14 +4838,14 @@ label14:
 Obj _35val1553 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 13, _35clofun2010, 1, w);
+pushCont(co, 13, _35clofun1983, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5058,7 +4860,7 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5067,7 +4869,7 @@ label16:
 Obj _35val1557 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 15, _35clofun2010, 1, w);
+pushCont(co, 15, _35clofun1983, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -5075,7 +4877,7 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5090,7 +4892,7 @@ __arg2 = makeCString("\")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5098,7 +4900,7 @@ label18:
 {
 Obj _35val1561 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 17, _35clofun2010, 1, w);
+pushCont(co, 17, _35clofun1983, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5106,7 +4908,7 @@ __arg2 = _35val1561;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5115,14 +4917,14 @@ label19:
 Obj _35val1560 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 18, _35clofun2010, 1, w);
+pushCont(co, 18, _35clofun1983, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc/internal#escape-str"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5132,7 +4934,7 @@ Obj _35val1556 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val1556) {
-pushCont(co, 16, _35clofun2010, 2, x, w);
+pushCont(co, 16, _35clofun1983, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5140,12 +4942,12 @@ __arg2 = makeCString("makeNumber(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1559 = primIsString(x);
 if (True == _35reg1559) {
-pushCont(co, 19, _35clofun2010, 2, x, w);
+pushCont(co, 19, _35clofun1983, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5153,7 +4955,7 @@ __arg2 = makeCString("makeCString(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1563 = primEQ(x, Nil);
@@ -5165,7 +4967,7 @@ __arg2 = makeCString("Nil");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1564 = primEQ(x, True);
@@ -5177,7 +4979,7 @@ __arg2 = makeCString("True");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1565 = primEQ(x, False);
@@ -5189,7 +4991,7 @@ __arg2 = makeCString("False");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -5198,7 +5000,7 @@ __arg1 = makeCString("no cond match");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2010) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1983) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5216,7 +5018,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2009(struct Cora* co){
+void _35clofun1982(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -5234,14 +5036,14 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 20, _35clofun2008, 4, self, env, frees, w);
+pushCont(co, 20, _35clofun1981, 4, self, env, frees, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5252,7 +5054,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun2009, 4, self, env, frees, w);
+pushCont(co, 0, _35clofun1982, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5260,7 +5062,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5272,7 +5074,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 1, _35clofun2009, 4, self, env, frees, w);
+pushCont(co, 1, _35clofun1982, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -5280,7 +5082,7 @@ __arg2 = nargs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5292,7 +5094,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 2, _35clofun2009, 5, nargs, self, env, frees, w);
+pushCont(co, 2, _35clofun1982, 5, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5300,7 +5102,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5314,7 +5116,7 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
 Obj _35reg1436 = primCar(label);
-pushCont(co, 3, _35clofun2009, 5, nargs, self, env, frees, w);
+pushCont(co, 3, _35clofun1982, 5, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -5322,7 +5124,7 @@ __arg2 = _35reg1436;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5335,7 +5137,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 4, _35clofun2009, 6, label, nargs, self, env, frees, w);
+pushCont(co, 4, _35clofun1982, 6, label, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5343,7 +5145,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5357,7 +5159,7 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
 Obj _35reg1433 = primCdr(label);
-pushCont(co, 5, _35clofun2009, 6, label, nargs, self, env, frees, w);
+pushCont(co, 5, _35clofun1982, 6, label, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -5365,13 +5167,13 @@ __arg2 = _35reg1433;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35cc127 = makeNative(15, _35clofun2008, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc127 = makeNative(15, _35clofun1981, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -5398,7 +5200,7 @@ Obj _35reg1429 = primCdr(closureRef(co, 3));
 Obj _35reg1430 = primCdr(_35reg1429);
 Obj _35reg1431 = primCdr(_35reg1430);
 Obj frees = _35reg1431;
-pushCont(co, 6, _35clofun2009, 6, label, nargs, self, env, frees, w);
+pushCont(co, 6, _35clofun1982, 6, label, nargs, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5406,7 +5208,7 @@ __arg2 = makeCString("makeNative(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -5414,16 +5216,7 @@ __arg0 = _35cc127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc127;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -5432,7 +5225,7 @@ __arg0 = _35cc127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -5441,7 +5234,16 @@ __arg0 = _35cc127;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc127;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5457,7 +5259,7 @@ __arg2 = makeCString("}\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5468,7 +5270,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 8, _35clofun2009, 1, w);
+pushCont(co, 8, _35clofun1982, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5478,7 +5280,7 @@ co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5489,7 +5291,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 9, _35clofun2009, 4, self, env, c, w);
+pushCont(co, 9, _35clofun1982, 4, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5497,7 +5299,7 @@ __arg2 = makeCString("} else {\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5509,7 +5311,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 10, _35clofun2009, 4, self, env, c, w);
+pushCont(co, 10, _35clofun1982, 4, self, env, c, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5519,7 +5321,7 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5531,7 +5333,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 11, _35clofun2009, 5, b, self, env, c, w);
+pushCont(co, 11, _35clofun1982, 5, b, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5539,7 +5341,7 @@ __arg2 = makeCString(") {\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5552,7 +5354,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 12, _35clofun2009, 5, b, self, env, c, w);
+pushCont(co, 12, _35clofun1982, 5, b, self, env, c, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5562,13 +5364,13 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35cc126 = makeNative(7, _35clofun2009, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc126 = makeNative(7, _35clofun1982, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -5607,7 +5409,7 @@ Obj _35reg1470 = primCdr(_35reg1469);
 Obj _35reg1471 = primCdr(_35reg1470);
 Obj _35reg1472 = primEQ(Nil, _35reg1471);
 if (True == _35reg1472) {
-pushCont(co, 13, _35clofun2009, 6, a, b, self, env, c, w);
+pushCont(co, 13, _35clofun1982, 6, a, b, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5615,7 +5417,7 @@ __arg2 = makeCString("if (True == ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -5623,16 +5425,7 @@ __arg0 = _35cc126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc126;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -5641,7 +5434,7 @@ __arg0 = _35cc126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -5650,7 +5443,7 @@ __arg0 = _35cc126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -5659,7 +5452,7 @@ __arg0 = _35cc126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -5668,7 +5461,16 @@ __arg0 = _35cc126;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc126;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5684,7 +5486,7 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5695,7 +5497,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 15, _35clofun2009, 1, w);
+pushCont(co, 15, _35clofun1982, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
 __arg1 = self;
@@ -5705,7 +5507,7 @@ co->args[4] = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5720,7 +5522,7 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5731,7 +5533,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 17, _35clofun2009, 1, w);
+pushCont(co, 17, _35clofun1982, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
 __arg1 = self;
@@ -5741,7 +5543,7 @@ co->args[4] = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5755,7 +5557,7 @@ Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj _35reg1498 = primEQ(f, intern("set"));
 if (True == _35reg1498) {
-pushCont(co, 16, _35clofun2009, 4, self, env, args, w);
+pushCont(co, 16, _35clofun1982, 4, self, env, args, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5763,10 +5565,10 @@ __arg2 = makeCString("(co, ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 18, _35clofun2009, 4, self, env, args, w);
+pushCont(co, 18, _35clofun1982, 4, self, env, args, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5774,7 +5576,7 @@ __arg2 = makeCString("(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5787,7 +5589,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 19, _35clofun2009, 5, f, self, env, args, w);
+pushCont(co, 19, _35clofun1982, 5, f, self, env, args, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -5795,7 +5597,7 @@ __arg2 = _35val1496;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2009) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1982) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5808,7 +5610,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2008(struct Cora* co){
+void _35clofun1981(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -5821,7 +5623,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc132 = makeNative(9, _35clofun2007, 0, 0);
+Obj _35cc132 = makeNative(9, _35clofun1980, 0, 0);
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -5831,7 +5633,7 @@ Obj _35reg1336 = primCar(closureRef(co, 3));
 Obj f = _35reg1336;
 Obj _35reg1337 = primCdr(closureRef(co, 3));
 Obj args = _35reg1337;
-pushCont(co, 20, _35clofun2007, 4, f, args, self, w);
+pushCont(co, 20, _35clofun1980, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5839,7 +5641,7 @@ __arg2 = makeCString("__nargs = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -5847,7 +5649,7 @@ __arg0 = _35cc132;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -5868,13 +5670,13 @@ co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35cc131 = makeNative(0, _35clofun2008, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc131 = makeNative(0, _35clofun1981, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -5902,7 +5704,7 @@ Obj _35reg1365 = primCdr(_35reg1364);
 Obj _35reg1366 = primCdr(_35reg1365);
 Obj _35reg1367 = primEQ(Nil, _35reg1366);
 if (True == _35reg1367) {
-pushCont(co, 1, _35clofun2008, 4, self, env, w, exp);
+pushCont(co, 1, _35clofun1981, 4, self, env, w, exp);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#generate-cont"));
 __arg1 = self;
@@ -5911,7 +5713,7 @@ __arg3 = cont;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -5919,16 +5721,7 @@ __arg0 = _35cc131;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc131;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -5937,7 +5730,7 @@ __arg0 = _35cc131;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -5946,7 +5739,7 @@ __arg0 = _35cc131;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -5955,14 +5748,23 @@ __arg0 = _35cc131;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc131;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35cc130 = makeNative(2, _35clofun2008, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc130 = makeNative(2, _35clofun1981, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -5990,7 +5792,7 @@ co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -5998,16 +5800,7 @@ __arg0 = _35cc130;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc130;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -6016,7 +5809,7 @@ __arg0 = _35cc130;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -6025,7 +5818,16 @@ __arg0 = _35cc130;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc130;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -6041,7 +5843,7 @@ __arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6049,7 +5851,7 @@ label5:
 {
 Obj _35val1395 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 4, _35clofun2008, 1, w);
+pushCont(co, 4, _35clofun1981, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6057,7 +5859,7 @@ __arg2 = makeCString(") { goto fail; }\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6066,7 +5868,7 @@ label6:
 Obj _35val1394 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun2008, 1, w);
+pushCont(co, 5, _35clofun1981, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -6074,7 +5876,7 @@ __arg2 = self;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6083,7 +5885,7 @@ label7:
 Obj _35val1393 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 6, _35clofun2008, 2, self, w);
+pushCont(co, 6, _35clofun1981, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6091,7 +5893,7 @@ __arg2 = makeCString("if (co->ctx.pc.func != ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6100,7 +5902,7 @@ label8:
 Obj _35val1392 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun2008, 2, self, w);
+pushCont(co, 7, _35clofun1981, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6108,7 +5910,7 @@ __arg2 = makeCString("co->ctx = co->callstack.data[--co->callstack.len];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6117,7 +5919,7 @@ label9:
 Obj _35val1391 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun2008, 2, self, w);
+pushCont(co, 8, _35clofun1981, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6125,7 +5927,7 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6136,7 +5938,7 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 9, _35clofun2008, 2, self, w);
+pushCont(co, 9, _35clofun1981, 2, self, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -6146,7 +5948,7 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6157,7 +5959,7 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 10, _35clofun2008, 4, env, x, self, w);
+pushCont(co, 10, _35clofun1981, 4, env, x, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6165,13 +5967,13 @@ __arg2 = makeCString("__arg1 = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35cc129 = makeNative(3, _35clofun2008, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc129 = makeNative(3, _35clofun1981, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -6190,7 +5992,7 @@ Obj _35reg1386 = primCdr(closureRef(co, 3));
 Obj _35reg1387 = primCdr(_35reg1386);
 Obj _35reg1388 = primEQ(Nil, _35reg1387);
 if (True == _35reg1388) {
-pushCont(co, 11, _35clofun2008, 4, env, x, self, w);
+pushCont(co, 11, _35clofun1981, 4, env, x, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6198,7 +6000,7 @@ __arg2 = makeCString("__nargs = 2;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -6206,16 +6008,7 @@ __arg0 = _35cc129;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc129;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -6224,7 +6017,7 @@ __arg0 = _35cc129;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -6233,7 +6026,16 @@ __arg0 = _35cc129;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc129;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -6254,7 +6056,7 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6265,7 +6067,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 13, _35clofun2008, 4, self, env, w, b);
+pushCont(co, 13, _35clofun1981, 4, self, env, w, b);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6273,13 +6075,13 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35cc128 = makeNative(12, _35clofun2008, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc128 = makeNative(12, _35clofun1981, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
@@ -6307,7 +6109,7 @@ Obj _35reg1411 = primCdr(_35reg1410);
 Obj _35reg1412 = primCdr(_35reg1411);
 Obj _35reg1413 = primEQ(Nil, _35reg1412);
 if (True == _35reg1413) {
-pushCont(co, 14, _35clofun2008, 4, self, env, w, b);
+pushCont(co, 14, _35clofun1981, 4, self, env, w, b);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -6317,7 +6119,7 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -6325,16 +6127,7 @@ __arg0 = _35cc128;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc128;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -6343,7 +6136,7 @@ __arg0 = _35cc128;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -6352,7 +6145,7 @@ __arg0 = _35cc128;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -6361,7 +6154,16 @@ __arg0 = _35cc128;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc128;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -6377,7 +6179,7 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6388,7 +6190,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 16, _35clofun2008, 1, w);
+pushCont(co, 16, _35clofun1981, 1, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
 __arg1 = self;
@@ -6398,7 +6200,7 @@ co->args[4] = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6411,7 +6213,7 @@ Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj _35reg1444 = primNot(_35val1443);
 if (True == _35reg1444) {
-pushCont(co, 17, _35clofun2008, 4, self, env, frees, w);
+pushCont(co, 17, _35clofun1981, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6419,7 +6221,7 @@ __arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Nil;
@@ -6430,7 +6232,7 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -6442,14 +6244,14 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun2008, 4, self, env, frees, w);
+pushCont(co, 18, _35clofun1981, 4, self, env, frees, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = frees;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6460,7 +6262,7 @@ Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun2008, 4, self, env, frees, w);
+pushCont(co, 19, _35clofun1981, 4, self, env, frees, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -6468,7 +6270,7 @@ __arg2 = _35val1441;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2008) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1981) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6481,7 +6283,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2007(struct Cora* co){
+void _35clofun1980(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -6500,7 +6302,7 @@ Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 20, _35clofun2006, 5, x, i, self, w, more);
+pushCont(co, 20, _35clofun1979, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -6508,7 +6310,7 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6529,7 +6331,7 @@ co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6540,7 +6342,7 @@ Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 1, _35clofun2007, 4, i, self, w, more);
+pushCont(co, 1, _35clofun1980, 4, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6548,7 +6350,7 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6560,7 +6362,7 @@ Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 2, _35clofun2007, 4, i, self, w, more);
+pushCont(co, 2, _35clofun1980, 4, i, self, w, more);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -6570,7 +6372,7 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6582,7 +6384,7 @@ Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 3, _35clofun2007, 5, x, i, self, w, more);
+pushCont(co, 3, _35clofun1980, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6590,7 +6392,7 @@ __arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6602,7 +6404,7 @@ Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 4, _35clofun2007, 5, x, i, self, w, more);
+pushCont(co, 4, _35clofun1980, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6610,7 +6412,7 @@ __arg2 = makeCString("]");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6622,7 +6424,7 @@ Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 5, _35clofun2007, 5, x, i, self, w, more);
+pushCont(co, 5, _35clofun1980, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -6630,13 +6432,13 @@ __arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35cc114 = makeNative(16, _35clofun2006, 0, 0);
+Obj _35cc114 = makeNative(16, _35clofun1979, 0, 0);
 Obj self = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj i = closureRef(co, 2);
@@ -6649,7 +6451,7 @@ Obj more = _35reg1317;
 Obj _35reg1318 = primGT(i, makeNumber(3));
 Obj _35reg1319 = primNot(_35reg1318);
 if (True == _35reg1319) {
-pushCont(co, 0, _35clofun2007, 5, x, i, self, w, more);
+pushCont(co, 0, _35clofun1980, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6657,10 +6459,10 @@ __arg2 = makeCString("__arg");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 6, _35clofun2007, 5, x, i, self, w, more);
+pushCont(co, 6, _35clofun1980, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6668,7 +6470,7 @@ __arg2 = makeCString("co->args[");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -6677,7 +6479,7 @@ __arg0 = _35cc114;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -6688,7 +6490,7 @@ Obj _35p109 = __arg1;
 Obj _35p110 = __arg2;
 Obj _35p111 = __arg3;
 Obj _35p112 = co->args[4];
-Obj _35cc113 = makeNative(7, _35clofun2007, 0, 4, _35p109, _35p110, _35p111, _35p112);
+Obj _35cc113 = makeNative(7, _35clofun1980, 0, 4, _35p109, _35p110, _35p111, _35p112);
 Obj self = _35p109;
 Obj w = _35p110;
 Obj i = _35p111;
@@ -6697,7 +6499,7 @@ if (True == _35reg1333) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2007) { goto fail; }
+if (co->ctx.pc.func != _35clofun1980) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -6705,7 +6507,7 @@ __arg0 = _35cc113;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -6718,7 +6520,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6733,7 +6535,7 @@ __arg2 = makeCString("goto *jumpTable[ps.label];\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6741,7 +6543,7 @@ label11:
 {
 Obj _35val1349 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 10, _35clofun2007, 1, w);
+pushCont(co, 10, _35clofun1980, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6749,7 +6551,7 @@ __arg2 = makeCString(") { co->ctx.pc = ps; goto fail; };\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6758,7 +6560,7 @@ label12:
 Obj _35val1348 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun2007, 1, w);
+pushCont(co, 11, _35clofun1980, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
 __arg1 = w;
@@ -6766,7 +6568,7 @@ __arg2 = self;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6775,7 +6577,7 @@ label13:
 Obj _35val1347 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun2007, 2, self, w);
+pushCont(co, 12, _35clofun1980, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6783,7 +6585,7 @@ __arg2 = makeCString("if (ps.func != ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6792,7 +6594,7 @@ label14:
 Obj _35val1346 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 13, _35clofun2007, 2, self, w);
+pushCont(co, 13, _35clofun1980, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6800,7 +6602,7 @@ __arg2 = makeCString("if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) {
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6809,7 +6611,7 @@ label15:
 Obj _35val1345 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 14, _35clofun2007, 2, self, w);
+pushCont(co, 14, _35clofun1980, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6817,7 +6619,7 @@ __arg2 = makeCString("struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n"
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6826,7 +6628,7 @@ label16:
 Obj _35val1344 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 15, _35clofun2007, 2, self, w);
+pushCont(co, 15, _35clofun1980, 2, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6834,7 +6636,7 @@ __arg2 = makeCString("co->ctx.frees = __arg0;\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6846,7 +6648,7 @@ Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj _35reg1343 = primCons(f, args);
-pushCont(co, 16, _35clofun2007, 2, self, w);
+pushCont(co, 16, _35clofun1980, 2, self, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
 __arg1 = self;
@@ -6856,7 +6658,7 @@ co->args[4] = _35reg1343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6867,7 +6669,7 @@ Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 17, _35clofun2007, 4, f, args, self, w);
+pushCont(co, 17, _35clofun1980, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6875,7 +6677,7 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6887,7 +6689,7 @@ Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj _35reg1340 = primAdd(makeNumber(1), _35val1339);
-pushCont(co, 18, _35clofun2007, 4, f, args, self, w);
+pushCont(co, 18, _35clofun1980, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
@@ -6895,7 +6697,7 @@ __arg2 = _35reg1340;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6906,14 +6708,14 @@ Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun2007, 4, f, args, self, w);
+pushCont(co, 19, _35clofun1980, 4, f, args, self, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2007) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1980) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6926,7 +6728,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2006(struct Cora* co){
+void _35clofun1979(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -6949,7 +6751,7 @@ Obj _35reg1285 = primCons(clo_45or_45cont, _35reg1284);
 __nargs = 2;
 __arg1 = _35reg1285;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2006) { goto fail; }
+if (co->ctx.pc.func != _35clofun1979) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -6962,14 +6764,14 @@ Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj _35reg1281 = primCons(name, idx);
-pushCont(co, 0, _35clofun2006, 3, fvs, _35reg1281, clo_45or_45cont);
+pushCont(co, 0, _35clofun1979, 3, fvs, _35reg1281, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6986,7 +6788,7 @@ Obj _35reg1293 = primCons(clo_45or_45cont, _35reg1292);
 __nargs = 2;
 __arg1 = _35reg1293;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2006) { goto fail; }
+if (co->ctx.pc.func != _35clofun1979) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -7008,7 +6810,7 @@ Obj _35reg1276 = primCons(body1, Nil);
 Obj _35reg1277 = primCons(Nil, _35reg1276);
 Obj _35reg1278 = primCons(params, _35reg1277);
 Obj _35reg1279 = primCons(intern("lambda"), _35reg1278);
-pushCont(co, 1, _35clofun2006, 5, name, idx, params, fvs, clo_45or_45cont);
+pushCont(co, 1, _35clofun1979, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
@@ -7019,14 +6821,14 @@ co->args[5] = _35reg1279;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1286 = primCons(body1, Nil);
 Obj _35reg1287 = primCons(fvs, _35reg1286);
 Obj _35reg1288 = primCons(params, _35reg1287);
 Obj _35reg1289 = primCons(intern("lambda"), _35reg1288);
-pushCont(co, 2, _35clofun2006, 4, name, idx, fvs, clo_45or_45cont);
+pushCont(co, 2, _35clofun1979, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
@@ -7037,7 +6839,7 @@ co->args[5] = _35reg1289;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -7062,7 +6864,7 @@ Obj _35reg1255 = primCons(body1, Nil);
 Obj _35reg1256 = primCons(Nil, _35reg1255);
 Obj _35reg1257 = primCons(params, _35reg1256);
 Obj _35reg1258 = primCons(intern("lambda"), _35reg1257);
-pushCont(co, 19, _35clofun2005, 5, name, idx, params, fvs, clo_45or_45cont);
+pushCont(co, 19, _35clofun1978, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
@@ -7073,14 +6875,14 @@ co->args[5] = _35reg1258;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1265 = primCons(body1, Nil);
 Obj _35reg1266 = primCons(fvs, _35reg1265);
 Obj _35reg1267 = primCons(params, _35reg1266);
 Obj _35reg1268 = primCons(intern("lambda"), _35reg1267);
-pushCont(co, 20, _35clofun2005, 4, name, idx, fvs, clo_45or_45cont);
+pushCont(co, 20, _35clofun1978, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
@@ -7091,18 +6893,18 @@ co->args[5] = _35reg1268;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 3, _35clofun2006, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
+pushCont(co, 3, _35clofun1979, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -7116,7 +6918,7 @@ Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj idx = _35val1250;
-pushCont(co, 4, _35clofun2006, 6, body1, params, v, idx, fvs, clo_45or_45cont);
+pushCont(co, 4, _35clofun1979, 6, body1, params, v, idx, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7124,7 +6926,7 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7136,7 +6938,7 @@ Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj body1 = _35val1249;
-pushCont(co, 5, _35clofun2006, 5, body1, params, v, fvs, clo_45or_45cont);
+pushCont(co, 5, _35clofun1979, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7144,7 +6946,7 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7152,7 +6954,7 @@ label7:
 {
 Obj _35p104 = __arg1;
 Obj _35p105 = __arg2;
-Obj _35cc106 = makeNative(18, _35clofun2004, 0, 2, _35p104, _35p105);
+Obj _35cc106 = makeNative(18, _35clofun1977, 0, 2, _35p104, _35p105);
 Obj v = _35p104;
 Obj _35reg1120 = primIsCons(_35p105);
 if (True == _35reg1120) {
@@ -7205,7 +7007,7 @@ Obj fvs = _35reg1156;
 Obj _35reg1157 = primEQ(clo_45or_45cont, intern("%closure"));
 if (True == _35reg1157) {
 if (True == True) {
-pushCont(co, 7, _35clofun2005, 4, params, v, fvs, clo_45or_45cont);
+pushCont(co, 7, _35clofun1978, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
 __arg1 = v;
@@ -7213,7 +7015,7 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -7221,14 +7023,14 @@ __arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 Obj _35reg1203 = primEQ(clo_45or_45cont, intern("%continuation"));
 if (True == _35reg1203) {
 if (True == True) {
-pushCont(co, 17, _35clofun2005, 4, params, v, fvs, clo_45or_45cont);
+pushCont(co, 17, _35clofun1978, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
 __arg1 = v;
@@ -7236,7 +7038,7 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -7244,12 +7046,12 @@ __arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-pushCont(co, 6, _35clofun2006, 4, params, v, fvs, clo_45or_45cont);
+pushCont(co, 6, _35clofun1979, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
 __arg1 = v;
@@ -7257,7 +7059,7 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -7265,7 +7067,7 @@ __arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -7276,16 +7078,7 @@ __arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc106;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -7294,7 +7087,7 @@ __arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -7303,7 +7096,7 @@ __arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -7312,7 +7105,7 @@ __arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -7321,7 +7114,7 @@ __arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -7330,7 +7123,16 @@ __arg0 = _35cc106;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc106;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -7348,7 +7150,7 @@ __arg3 = cur1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7366,7 +7168,7 @@ __arg3 = _35reg1306;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7376,14 +7178,14 @@ Obj _35val1304 = __arg1;
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj res = _35val1304;
-pushCont(co, 9, _35clofun2006, 2, res, v);
+pushCont(co, 9, _35clofun1979, 2, res, v);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = cur1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7392,7 +7194,7 @@ label11:
 Obj _35val1303 = __arg1;
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun2006, 2, cur1, v);
+pushCont(co, 10, _35clofun1979, 2, cur1, v);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7400,7 +7202,7 @@ __arg2 = makeNumber(2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7409,7 +7211,7 @@ label12:
 Obj _35val1302 = __arg1;
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun2006, 2, cur1, v);
+pushCont(co, 11, _35clofun1979, 2, cur1, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -7418,7 +7220,7 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7437,7 +7239,7 @@ Obj cur1 = _35reg1298;
 Obj _35reg1299 = primLT(idx, makeNumber(20));
 if (True == _35reg1299) {
 Obj _35reg1300 = primAdd(idx, makeNumber(1));
-pushCont(co, 8, _35clofun2006, 2, v, cur1);
+pushCont(co, 8, _35clofun1979, 2, v, cur1);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -7446,10 +7248,10 @@ __arg3 = _35reg1300;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 12, _35clofun2006, 2, cur1, v);
+pushCont(co, 12, _35clofun1979, 2, cur1, v);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/init#vector-set!"));
 __arg1 = v;
@@ -7458,7 +7260,7 @@ __arg3 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -7475,7 +7277,7 @@ Obj _35reg1313 = primCons(intern("let"), _35reg1312);
 __nargs = 2;
 __arg1 = _35reg1313;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2006) { goto fail; }
+if (co->ctx.pc.func != _35clofun1979) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -7485,14 +7287,14 @@ Obj x = __arg1;
 Obj k = __arg2;
 Obj _35reg1308 = primGenSym(intern("reg"));
 Obj tmp = _35reg1308;
-pushCont(co, 14, _35clofun2006, 2, x, tmp);
+pushCont(co, 14, _35clofun1979, 2, x, tmp);
 __nargs = 2;
 __arg0 = k;
 __arg1 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7504,7 +7306,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7525,7 +7327,7 @@ co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7536,7 +7338,7 @@ Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 17, _35clofun2006, 4, i, self, w, more);
+pushCont(co, 17, _35clofun1979, 4, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -7544,7 +7346,7 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7556,7 +7358,7 @@ Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 18, _35clofun2006, 4, i, self, w, more);
+pushCont(co, 18, _35clofun1979, 4, i, self, w, more);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -7566,7 +7368,7 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7578,7 +7380,7 @@ Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 19, _35clofun2006, 5, x, i, self, w, more);
+pushCont(co, 19, _35clofun1979, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -7586,7 +7388,7 @@ __arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2006) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1979) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7599,7 +7401,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2005(struct Cora* co){
+void _35clofun1978(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -7623,7 +7425,7 @@ Obj _35reg1181 = primCons(clo_45or_45cont, _35reg1180);
 __nargs = 2;
 __arg1 = _35reg1181;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+if (co->ctx.pc.func != _35clofun1978) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -7639,7 +7441,7 @@ Obj _35reg1194 = primCons(clo_45or_45cont, _35reg1193);
 __nargs = 2;
 __arg1 = _35reg1194;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+if (co->ctx.pc.func != _35clofun1978) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -7652,14 +7454,14 @@ Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj _35reg1190 = primCons(name, idx);
-pushCont(co, 1, _35clofun2005, 3, fvs, _35reg1190, clo_45or_45cont);
+pushCont(co, 1, _35clofun1978, 3, fvs, _35reg1190, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7676,7 +7478,7 @@ Obj _35reg1202 = primCons(clo_45or_45cont, _35reg1201);
 __nargs = 2;
 __arg1 = _35reg1202;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+if (co->ctx.pc.func != _35clofun1978) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -7698,7 +7500,7 @@ Obj _35reg1185 = primCons(body1, Nil);
 Obj _35reg1186 = primCons(Nil, _35reg1185);
 Obj _35reg1187 = primCons(params, _35reg1186);
 Obj _35reg1188 = primCons(intern("lambda"), _35reg1187);
-pushCont(co, 2, _35clofun2005, 5, name, idx, params, fvs, clo_45or_45cont);
+pushCont(co, 2, _35clofun1978, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
@@ -7709,14 +7511,14 @@ co->args[5] = _35reg1188;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1195 = primCons(body1, Nil);
 Obj _35reg1196 = primCons(fvs, _35reg1195);
 Obj _35reg1197 = primCons(params, _35reg1196);
 Obj _35reg1198 = primCons(intern("lambda"), _35reg1197);
-pushCont(co, 3, _35clofun2005, 4, name, idx, fvs, clo_45or_45cont);
+pushCont(co, 3, _35clofun1978, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
@@ -7727,7 +7529,7 @@ co->args[5] = _35reg1198;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -7752,7 +7554,7 @@ Obj _35reg1164 = primCons(body1, Nil);
 Obj _35reg1165 = primCons(Nil, _35reg1164);
 Obj _35reg1166 = primCons(params, _35reg1165);
 Obj _35reg1167 = primCons(intern("lambda"), _35reg1166);
-pushCont(co, 20, _35clofun2004, 5, name, idx, params, fvs, clo_45or_45cont);
+pushCont(co, 20, _35clofun1977, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
@@ -7763,14 +7565,14 @@ co->args[5] = _35reg1167;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1174 = primCons(body1, Nil);
 Obj _35reg1175 = primCons(fvs, _35reg1174);
 Obj _35reg1176 = primCons(params, _35reg1175);
 Obj _35reg1177 = primCons(intern("lambda"), _35reg1176);
-pushCont(co, 0, _35clofun2005, 4, name, idx, fvs, clo_45or_45cont);
+pushCont(co, 0, _35clofun1978, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
@@ -7781,18 +7583,18 @@ co->args[5] = _35reg1177;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 4, _35clofun2005, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
+pushCont(co, 4, _35clofun1978, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -7806,7 +7608,7 @@ Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj idx = _35val1159;
-pushCont(co, 5, _35clofun2005, 6, body1, params, v, idx, fvs, clo_45or_45cont);
+pushCont(co, 5, _35clofun1978, 6, body1, params, v, idx, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7814,7 +7616,7 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7826,7 +7628,7 @@ Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj body1 = _35val1158;
-pushCont(co, 6, _35clofun2005, 5, body1, params, v, fvs, clo_45or_45cont);
+pushCont(co, 6, _35clofun1978, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -7834,7 +7636,7 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7850,7 +7652,7 @@ Obj _35reg1219 = primCons(clo_45or_45cont, _35reg1218);
 __nargs = 2;
 __arg1 = _35reg1219;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+if (co->ctx.pc.func != _35clofun1978) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -7863,14 +7665,14 @@ Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj _35reg1215 = primCons(name, idx);
-pushCont(co, 8, _35clofun2005, 3, fvs, _35reg1215, clo_45or_45cont);
+pushCont(co, 8, _35clofun1978, 3, fvs, _35reg1215, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7887,7 +7689,7 @@ Obj _35reg1227 = primCons(clo_45or_45cont, _35reg1226);
 __nargs = 2;
 __arg1 = _35reg1227;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+if (co->ctx.pc.func != _35clofun1978) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -7903,7 +7705,7 @@ Obj _35reg1240 = primCons(clo_45or_45cont, _35reg1239);
 __nargs = 2;
 __arg1 = _35reg1240;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+if (co->ctx.pc.func != _35clofun1978) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -7916,14 +7718,14 @@ Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj _35reg1236 = primCons(name, idx);
-pushCont(co, 11, _35clofun2005, 3, fvs, _35reg1236, clo_45or_45cont);
+pushCont(co, 11, _35clofun1978, 3, fvs, _35reg1236, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7940,7 +7742,7 @@ Obj _35reg1248 = primCons(clo_45or_45cont, _35reg1247);
 __nargs = 2;
 __arg1 = _35reg1248;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+if (co->ctx.pc.func != _35clofun1978) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -7962,7 +7764,7 @@ Obj _35reg1231 = primCons(body1, Nil);
 Obj _35reg1232 = primCons(Nil, _35reg1231);
 Obj _35reg1233 = primCons(params, _35reg1232);
 Obj _35reg1234 = primCons(intern("lambda"), _35reg1233);
-pushCont(co, 12, _35clofun2005, 5, name, idx, params, fvs, clo_45or_45cont);
+pushCont(co, 12, _35clofun1978, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
@@ -7973,14 +7775,14 @@ co->args[5] = _35reg1234;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1241 = primCons(body1, Nil);
 Obj _35reg1242 = primCons(fvs, _35reg1241);
 Obj _35reg1243 = primCons(params, _35reg1242);
 Obj _35reg1244 = primCons(intern("lambda"), _35reg1243);
-pushCont(co, 13, _35clofun2005, 4, name, idx, fvs, clo_45or_45cont);
+pushCont(co, 13, _35clofun1978, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
@@ -7991,7 +7793,7 @@ co->args[5] = _35reg1244;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -8016,7 +7818,7 @@ Obj _35reg1210 = primCons(body1, Nil);
 Obj _35reg1211 = primCons(Nil, _35reg1210);
 Obj _35reg1212 = primCons(params, _35reg1211);
 Obj _35reg1213 = primCons(intern("lambda"), _35reg1212);
-pushCont(co, 9, _35clofun2005, 5, name, idx, params, fvs, clo_45or_45cont);
+pushCont(co, 9, _35clofun1978, 5, name, idx, params, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
@@ -8027,14 +7829,14 @@ co->args[5] = _35reg1213;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1220 = primCons(body1, Nil);
 Obj _35reg1221 = primCons(fvs, _35reg1220);
 Obj _35reg1222 = primCons(params, _35reg1221);
 Obj _35reg1223 = primCons(intern("lambda"), _35reg1222);
-pushCont(co, 10, _35clofun2005, 4, name, idx, fvs, clo_45or_45cont);
+pushCont(co, 10, _35clofun1978, 4, name, idx, fvs, clo_45or_45cont);
 __nargs = 6;
 __arg0 = globalRef(intern("cora/lib/toc#append-result"));
 __arg1 = v;
@@ -8045,18 +7847,18 @@ co->args[5] = _35reg1223;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 14, _35clofun2005, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
+pushCont(co, 14, _35clofun1978, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = cur;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -8070,7 +7872,7 @@ Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj idx = _35val1205;
-pushCont(co, 15, _35clofun2005, 6, body1, params, v, idx, fvs, clo_45or_45cont);
+pushCont(co, 15, _35clofun1978, 6, body1, params, v, idx, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -8078,7 +7880,7 @@ __arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8090,7 +7892,7 @@ Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj body1 = _35val1204;
-pushCont(co, 16, _35clofun2005, 5, body1, params, v, fvs, clo_45or_45cont);
+pushCont(co, 16, _35clofun1978, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -8098,7 +7900,7 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8114,7 +7916,7 @@ Obj _35reg1264 = primCons(clo_45or_45cont, _35reg1263);
 __nargs = 2;
 __arg1 = _35reg1264;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+if (co->ctx.pc.func != _35clofun1978) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -8127,14 +7929,14 @@ Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj _35reg1260 = primCons(name, idx);
-pushCont(co, 18, _35clofun2005, 3, fvs, _35reg1260, clo_45or_45cont);
+pushCont(co, 18, _35clofun1978, 3, fvs, _35reg1260, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2005) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1978) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8151,7 +7953,7 @@ Obj _35reg1272 = primCons(clo_45or_45cont, _35reg1271);
 __nargs = 2;
 __arg1 = _35reg1272;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2005) { goto fail; }
+if (co->ctx.pc.func != _35clofun1978) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -8164,7 +7966,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2004(struct Cora* co){
+void _35clofun1977(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -8185,7 +7987,7 @@ Obj _35reg1067 = primCons(intern("call"), _35reg1066);
 __nargs = 2;
 __arg1 = _35reg1067;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2004) { goto fail; }
+if (co->ctx.pc.func != _35clofun1977) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -8194,7 +7996,7 @@ label1:
 Obj _35val1063 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun2004, 1, _35val1063);
+pushCont(co, 0, _35clofun1977, 1, _35val1063);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
@@ -8202,7 +8004,7 @@ __arg2 = cont;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8212,7 +8014,7 @@ Obj _35val1062 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 1, _35clofun2004, 2, fvs, cont);
+pushCont(co, 1, _35clofun1977, 2, fvs, cont);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = _35val1062;
@@ -8220,13 +8022,13 @@ __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc102 = makeNative(20, _35clofun2003, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc102 = makeNative(20, _35clofun1976, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj _35reg1045 = primIsCons(closureRef(co, 1));
 if (True == _35reg1045) {
@@ -8252,14 +8054,14 @@ Obj _35reg1059 = primCdr(_35reg1058);
 Obj _35reg1060 = primCdr(_35reg1059);
 Obj _35reg1061 = primEQ(Nil, _35reg1060);
 if (True == _35reg1061) {
-pushCont(co, 2, _35clofun2004, 3, exp, fvs, cont);
+pushCont(co, 2, _35clofun1977, 3, exp, fvs, cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -8267,16 +8069,7 @@ __arg0 = _35cc102;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc102;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8285,7 +8078,7 @@ __arg0 = _35cc102;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8294,7 +8087,7 @@ __arg0 = _35cc102;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8303,7 +8096,16 @@ __arg0 = _35cc102;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc102;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -8321,7 +8123,7 @@ Obj _35reg1094 = primCons(intern("%continuation"), _35reg1093);
 __nargs = 2;
 __arg1 = _35reg1094;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2004) { goto fail; }
+if (co->ctx.pc.func != _35clofun1977) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -8332,7 +8134,7 @@ Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs2 = _35val1088;
-pushCont(co, 4, _35clofun2004, 2, val, fvs2);
+pushCont(co, 4, _35clofun1977, 2, val, fvs2);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs1;
@@ -8340,7 +8142,7 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8350,7 +8152,7 @@ Obj _35val1087 = __arg1;
 Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 5, _35clofun2004, 3, fvs1, body, val);
+pushCont(co, 5, _35clofun1977, 3, fvs1, body, val);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = _35val1087;
@@ -8358,7 +8160,7 @@ __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8369,14 +8171,14 @@ Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs1 = _35val1086;
-pushCont(co, 6, _35clofun2004, 3, fvs1, body, val);
+pushCont(co, 6, _35clofun1977, 3, fvs1, body, val);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8386,7 +8188,7 @@ Obj _35val1085 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 7, _35clofun2004, 3, fvs, body, val);
+pushCont(co, 7, _35clofun1977, 3, fvs, body, val);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#diff"));
 __arg1 = _35val1085;
@@ -8394,13 +8196,13 @@ __arg2 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35cc101 = makeNative(3, _35clofun2004, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc101 = makeNative(3, _35clofun1977, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj _35reg1068 = primIsCons(closureRef(co, 1));
 if (True == _35reg1068) {
@@ -8426,14 +8228,14 @@ Obj _35reg1082 = primCdr(_35reg1081);
 Obj _35reg1083 = primCdr(_35reg1082);
 Obj _35reg1084 = primEQ(Nil, _35reg1083);
 if (True == _35reg1084) {
-pushCont(co, 8, _35clofun2004, 3, fvs, body, val);
+pushCont(co, 8, _35clofun1977, 3, fvs, body, val);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -8441,16 +8243,7 @@ __arg0 = _35cc101;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc101;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8459,7 +8252,7 @@ __arg0 = _35cc101;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8468,7 +8261,7 @@ __arg0 = _35cc101;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8477,7 +8270,16 @@ __arg0 = _35cc101;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc101;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -8492,13 +8294,13 @@ Obj _35reg1115 = primCons(intern("lambda"), _35reg1114);
 __nargs = 2;
 __arg1 = _35reg1115;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2004) { goto fail; }
+if (co->ctx.pc.func != _35clofun1977) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label11:
 {
-Obj _35cc100 = makeNative(9, _35clofun2004, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc100 = makeNative(9, _35clofun1977, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj _35reg1095 = primIsCons(closureRef(co, 1));
 if (True == _35reg1095) {
@@ -8524,7 +8326,7 @@ Obj _35reg1109 = primCdr(_35reg1108);
 Obj _35reg1110 = primCdr(_35reg1109);
 Obj _35reg1111 = primEQ(Nil, _35reg1110);
 if (True == _35reg1111) {
-pushCont(co, 10, _35clofun2004, 1, args);
+pushCont(co, 10, _35clofun1977, 1, args);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
@@ -8532,7 +8334,7 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -8540,16 +8342,7 @@ __arg0 = _35cc100;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc100;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8558,7 +8351,7 @@ __arg0 = _35cc100;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8567,7 +8360,7 @@ __arg0 = _35cc100;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8576,14 +8369,23 @@ __arg0 = _35cc100;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc100;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj _35cc99 = makeNative(11, _35clofun2004, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc99 = makeNative(11, _35clofun1977, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
 Obj _35reg1116 = primIsSymbol(var);
@@ -8591,7 +8393,7 @@ if (True == _35reg1116) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2004) { goto fail; }
+if (co->ctx.pc.func != _35clofun1977) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -8599,7 +8401,7 @@ __arg0 = _35cc99;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -8613,7 +8415,7 @@ if (True == _35val1117) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2004) { goto fail; }
+if (co->ctx.pc.func != _35clofun1977) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -8621,7 +8423,7 @@ __arg0 = _35cc98;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -8630,17 +8432,17 @@ label14:
 {
 Obj _35p96 = __arg1;
 Obj _35p97 = __arg2;
-Obj _35cc98 = makeNative(12, _35clofun2004, 0, 2, _35p96, _35p97);
+Obj _35cc98 = makeNative(12, _35clofun1977, 0, 2, _35p96, _35p97);
 Obj __ = _35p96;
 Obj x = _35p97;
-pushCont(co, 13, _35clofun2004, 2, x, _35cc98);
+pushCont(co, 13, _35clofun1977, 2, x, _35cc98);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8652,19 +8454,19 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35cc108 = makeNative(15, _35clofun2004, 0, 0);
+Obj _35cc108 = makeNative(15, _35clofun1977, 0, 0);
 Obj v = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2004) { goto fail; }
+if (co->ctx.pc.func != _35clofun1977) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -8678,25 +8480,25 @@ __arg2 = e;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35cc107 = makeNative(16, _35clofun2004, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc107 = makeNative(16, _35clofun1977, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj v = closureRef(co, 0);
 Obj f_45args = closureRef(co, 1);
 Obj _35reg1119 = primIsCons(f_45args);
 if (True == _35reg1119) {
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
-__arg1 = makeNative(17, _35clofun2004, 1, 1, v);
+__arg1 = makeNative(17, _35clofun1977, 1, 1, v);
 __arg2 = f_45args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -8704,7 +8506,7 @@ __arg0 = _35cc107;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -8721,7 +8523,7 @@ Obj _35reg1173 = primCons(clo_45or_45cont, _35reg1172);
 __nargs = 2;
 __arg1 = _35reg1173;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2004) { goto fail; }
+if (co->ctx.pc.func != _35clofun1977) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -8734,14 +8536,14 @@ Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj _35reg1169 = primCons(name, idx);
-pushCont(co, 19, _35clofun2004, 3, fvs, _35reg1169, clo_45or_45cont);
+pushCont(co, 19, _35clofun1977, 3, fvs, _35reg1169, clo_45or_45cont);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2004) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1977) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8754,7 +8556,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2003(struct Cora* co){
+void _35clofun1976(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -8777,7 +8579,7 @@ Obj _35reg988 = primCons(intern("if"), _35reg987);
 __nargs = 2;
 __arg1 = _35reg988;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2003) { goto fail; }
+if (co->ctx.pc.func != _35clofun1976) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -8785,7 +8587,7 @@ label1:
 {
 Obj _35val983 = __arg1;
 Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun2003, 2, _35val983, ra);
+pushCont(co, 0, _35clofun1976, 2, _35val983, ra);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 1);
@@ -8793,14 +8595,14 @@ __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
 Obj ra = __arg1;
-pushCont(co, 1, _35clofun2003, 1, ra);
+pushCont(co, 1, _35clofun1976, 1, ra);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 0);
@@ -8808,13 +8610,13 @@ __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc86 = makeNative(20, _35clofun2002, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc86 = makeNative(20, _35clofun1975, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg957 = primIsCons(closureRef(co, 0));
 if (True == _35reg957) {
 Obj _35reg958 = primCar(closureRef(co, 0));
@@ -8854,11 +8656,11 @@ Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = a;
-__arg2 = makeNative(2, _35clofun2003, 1, 3, b, c, next);
+__arg2 = makeNative(2, _35clofun1976, 1, 3, b, c, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -8866,16 +8668,7 @@ __arg0 = _35cc86;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc86;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8884,7 +8677,7 @@ __arg0 = _35cc86;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8893,7 +8686,7 @@ __arg0 = _35cc86;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8902,7 +8695,7 @@ __arg0 = _35cc86;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8911,7 +8704,16 @@ __arg0 = _35cc86;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc86;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -8925,7 +8727,7 @@ if (True == _35val989) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2003) { goto fail; }
+if (co->ctx.pc.func != _35clofun1976) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -8933,24 +8735,24 @@ __arg0 = _35cc85;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35cc85 = makeNative(3, _35clofun2003, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc85 = makeNative(3, _35clofun1976, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj x = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
-pushCont(co, 4, _35clofun2003, 2, x, _35cc85);
+pushCont(co, 4, _35clofun1976, 2, x, _35cc85);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -8968,7 +8770,7 @@ __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -8976,7 +8778,7 @@ __arg0 = _35cc84;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -8987,7 +8789,7 @@ __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -8995,7 +8797,7 @@ __arg0 = _35cc84;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9005,7 +8807,7 @@ label7:
 {
 Obj _35p82 = __arg1;
 Obj _35p83 = __arg2;
-Obj _35cc84 = makeNative(5, _35clofun2003, 0, 2, _35p82, _35p83);
+Obj _35cc84 = makeNative(5, _35clofun1976, 0, 2, _35p82, _35p83);
 Obj x = _35p82;
 Obj next = _35p83;
 Obj _35reg990 = primIsSymbol(x);
@@ -9017,7 +8819,7 @@ __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -9025,18 +8827,18 @@ __arg0 = _35cc84;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 6, _35clofun2003, 3, next, x, _35cc84);
+pushCont(co, 6, _35clofun1976, 3, next, x, _35cc84);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9049,7 +8851,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -9065,13 +8867,13 @@ __arg3 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35cc95 = makeNative(8, _35clofun2003, 0, 0);
+Obj _35cc95 = makeNative(8, _35clofun1976, 0, 0);
 Obj _35reg993 = primIsCons(closureRef(co, 0));
 if (True == _35reg993) {
 Obj _35reg994 = primCar(closureRef(co, 0));
@@ -9083,11 +8885,11 @@ Obj next = closureRef(co, 2);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = hd;
-__arg2 = makeNative(9, _35clofun2003, 1, 3, tl, ls, next);
+__arg2 = makeNative(9, _35clofun1976, 1, 3, tl, ls, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -9095,7 +8897,7 @@ __arg0 = _35cc95;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9114,7 +8916,7 @@ Obj _35reg1014 = primCons(intern("call"), _35reg1013);
 __nargs = 2;
 __arg1 = _35reg1014;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2003) { goto fail; }
+if (co->ctx.pc.func != _35clofun1976) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -9132,7 +8934,7 @@ Obj _35reg1026 = primCons(intern("call"), _35reg1025);
 __nargs = 2;
 __arg1 = _35reg1026;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2003) { goto fail; }
+if (co->ctx.pc.func != _35clofun1976) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -9151,7 +8953,7 @@ __arg2 = next;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1003 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
@@ -9161,20 +8963,20 @@ Obj _35reg1005 = primCons(intern("tailcall"), _35reg1004);
 __nargs = 2;
 __arg1 = _35reg1005;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2003) { goto fail; }
+if (co->ctx.pc.func != _35clofun1976) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg1006 = primGenSym(intern("val"));
 Obj val = _35reg1006;
 Obj _35reg1007 = primCons(val, Nil);
-pushCont(co, 11, _35clofun2003, 2, _35reg1007, exp);
+pushCont(co, 11, _35clofun1976, 2, _35reg1007, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9187,7 +8989,7 @@ __arg2 = next;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1015 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
@@ -9197,20 +8999,20 @@ Obj _35reg1017 = primCons(intern("tailcall"), _35reg1016);
 __nargs = 2;
 __arg1 = _35reg1017;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2003) { goto fail; }
+if (co->ctx.pc.func != _35clofun1976) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg1018 = primGenSym(intern("val"));
 Obj val = _35reg1018;
 Obj _35reg1019 = primCons(val, Nil);
-pushCont(co, 12, _35clofun2003, 2, _35reg1019, exp);
+pushCont(co, 12, _35clofun1976, 2, _35reg1019, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9231,7 +9033,7 @@ Obj _35reg1038 = primCons(intern("call"), _35reg1037);
 __nargs = 2;
 __arg1 = _35reg1038;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2003) { goto fail; }
+if (co->ctx.pc.func != _35clofun1976) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -9241,14 +9043,14 @@ Obj _35val1000 = __arg1;
 Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
 if (True == _35val1000) {
-pushCont(co, 13, _35clofun2003, 2, next, exp);
+pushCont(co, 13, _35clofun1976, 2, next, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#caar"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 if (True == False) {
@@ -9259,7 +9061,7 @@ __arg2 = next;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg1027 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
@@ -9269,20 +9071,20 @@ Obj _35reg1029 = primCons(intern("tailcall"), _35reg1028);
 __nargs = 2;
 __arg1 = _35reg1029;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2003) { goto fail; }
+if (co->ctx.pc.func != _35clofun1976) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg1030 = primGenSym(intern("val"));
 Obj val = _35reg1030;
 Obj _35reg1031 = primCons(val, Nil);
-pushCont(co, 14, _35clofun2003, 2, _35reg1031, exp);
+pushCont(co, 14, _35clofun1976, 2, _35reg1031, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9295,14 +9097,14 @@ Obj _35val998 = __arg1;
 Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj exp = _35val998;
 Obj _35reg999 = primCar(exp);
-pushCont(co, 15, _35clofun2003, 2, next, exp);
+pushCont(co, 15, _35clofun1976, 2, next, exp);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#pair?"));
 __arg1 = _35reg999;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -9311,19 +9113,19 @@ label17:
 Obj _35p91 = __arg1;
 Obj _35p92 = __arg2;
 Obj _35p93 = __arg3;
-Obj _35cc94 = makeNative(10, _35clofun2003, 0, 3, _35p91, _35p92, _35p93);
+Obj _35cc94 = makeNative(10, _35clofun1976, 0, 3, _35p91, _35p92, _35p93);
 Obj _35reg997 = primEQ(Nil, _35p91);
 if (True == _35reg997) {
 Obj ls = _35p92;
 Obj next = _35p93;
-pushCont(co, 16, _35clofun2003, 1, next);
+pushCont(co, 16, _35clofun1976, 1, next);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse"));
 __arg1 = ls;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -9331,7 +9133,7 @@ __arg0 = _35cc94;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9344,7 +9146,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -9361,13 +9163,13 @@ __arg2 = _35reg1044;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label20:
 {
-Obj _35cc103 = makeNative(18, _35clofun2003, 0, 0);
+Obj _35cc103 = makeNative(18, _35clofun1976, 0, 0);
 Obj fvs = closureRef(co, 0);
 Obj _35reg1040 = primIsCons(closureRef(co, 1));
 if (True == _35reg1040) {
@@ -9375,14 +9177,14 @@ Obj _35reg1041 = primCar(closureRef(co, 1));
 Obj f = _35reg1041;
 Obj _35reg1042 = primCdr(closureRef(co, 1));
 Obj args = _35reg1042;
-pushCont(co, 19, _35clofun2003, 2, f, args);
+pushCont(co, 19, _35clofun1976, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -9390,7 +9192,7 @@ __arg0 = _35cc103;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2003) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1976) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9404,7 +9206,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2002(struct Cora* co){
+void _35clofun1975(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -9417,7 +9219,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc80 = makeNative(18, _35clofun2001, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc80 = makeNative(18, _35clofun1974, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj _35reg785 = primIsCons(closureRef(co, 1));
 if (True == _35reg785) {
@@ -9454,7 +9256,7 @@ Obj _35reg808 = primCdr(_35reg807);
 Obj _35reg809 = primCdr(_35reg808);
 Obj _35reg810 = primEQ(Nil, _35reg809);
 if (True == _35reg810) {
-pushCont(co, 20, _35clofun2001, 3, fvs, c, a);
+pushCont(co, 20, _35clofun1974, 3, fvs, c, a);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs;
@@ -9462,7 +9264,7 @@ __arg2 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -9470,16 +9272,7 @@ __arg0 = _35cc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc80;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9488,7 +9281,7 @@ __arg0 = _35cc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9497,7 +9290,7 @@ __arg0 = _35cc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9506,7 +9299,7 @@ __arg0 = _35cc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9515,7 +9308,16 @@ __arg0 = _35cc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc80;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9529,7 +9331,7 @@ Obj _35reg845 = primCons(intern("%closure"), _35reg844);
 __nargs = 2;
 __arg1 = _35reg845;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+if (co->ctx.pc.func != _35clofun1975) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -9538,7 +9340,7 @@ label2:
 Obj _35val842 = __arg1;
 Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg841= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun2002, 1, _35reg841);
+pushCont(co, 1, _35clofun1975, 1, _35reg841);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = _35val842;
@@ -9546,7 +9348,7 @@ __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -9559,14 +9361,14 @@ Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj _35reg839 = primCons(_35val838, Nil);
 Obj _35reg840 = primCons(args, _35reg839);
 Obj _35reg841 = primCons(intern("lambda"), _35reg840);
-pushCont(co, 2, _35clofun2002, 2, fvs1, _35reg841);
+pushCont(co, 2, _35clofun1975, 2, fvs1, _35reg841);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -9577,7 +9379,7 @@ Obj body= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj fvs1 = _35val837;
-pushCont(co, 3, _35clofun2002, 3, args, fvs, fvs1);
+pushCont(co, 3, _35clofun1975, 3, args, fvs, fvs1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs1;
@@ -9585,13 +9387,13 @@ __arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35cc79 = makeNative(0, _35clofun2002, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc79 = makeNative(0, _35clofun1975, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj _35reg817 = primIsCons(closureRef(co, 1));
 if (True == _35reg817) {
@@ -9620,14 +9422,14 @@ if (True == _35reg833) {
 Obj _35reg834 = primCons(body, Nil);
 Obj _35reg835 = primCons(args, _35reg834);
 Obj _35reg836 = primCons(intern("lambda"), _35reg835);
-pushCont(co, 4, _35clofun2002, 3, body, args, fvs);
+pushCont(co, 4, _35clofun1975, 3, body, args, fvs);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = _35reg836;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -9635,16 +9437,7 @@ __arg0 = _35cc79;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc79;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9653,7 +9446,7 @@ __arg0 = _35cc79;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9662,7 +9455,7 @@ __arg0 = _35cc79;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9671,7 +9464,16 @@ __arg0 = _35cc79;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc79;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9686,7 +9488,7 @@ if (True == _35reg848) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+if (co->ctx.pc.func != _35clofun1975) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 Obj _35reg849 = primCons(pos, Nil);
@@ -9694,19 +9496,19 @@ Obj _35reg850 = primCons(intern("%closure-ref"), _35reg849);
 __nargs = 2;
 __arg1 = _35reg850;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+if (co->ctx.pc.func != _35clofun1975) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
 
 label7:
 {
-Obj _35cc78 = makeNative(5, _35clofun2002, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc78 = makeNative(5, _35clofun1975, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
 Obj _35reg846 = primIsSymbol(var);
 if (True == _35reg846) {
-pushCont(co, 6, _35clofun2002, 1, var);
+pushCont(co, 6, _35clofun1975, 1, var);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#index"));
 __arg1 = var;
@@ -9714,7 +9516,7 @@ __arg2 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -9722,7 +9524,7 @@ __arg0 = _35cc78;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9736,7 +9538,7 @@ if (True == _35val851) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+if (co->ctx.pc.func != _35clofun1975) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -9744,7 +9546,7 @@ __arg0 = _35cc77;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9753,17 +9555,17 @@ label9:
 {
 Obj _35p75 = __arg1;
 Obj _35p76 = __arg2;
-Obj _35cc77 = makeNative(7, _35clofun2002, 0, 2, _35p75, _35p76);
+Obj _35cc77 = makeNative(7, _35clofun1975, 0, 2, _35p75, _35p76);
 Obj __ = _35p75;
 Obj x = _35p76;
-pushCont(co, 8, _35clofun2002, 2, x, _35cc77);
+pushCont(co, 8, _35clofun1975, 2, x, _35cc77);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -9775,7 +9577,7 @@ Obj _35reg854 = primCons(intern("return"), _35reg853);
 __nargs = 2;
 __arg1 = _35reg854;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+if (co->ctx.pc.func != _35clofun1975) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -9787,13 +9589,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35cc90 = makeNative(11, _35clofun2002, 0, 0);
+Obj _35cc90 = makeNative(11, _35clofun1975, 0, 0);
 Obj _35reg856 = primIsCons(closureRef(co, 0));
 if (True == _35reg856) {
 Obj _35reg857 = primCar(closureRef(co, 0));
@@ -9810,7 +9612,7 @@ __arg3 = next;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -9818,7 +9620,7 @@ __arg0 = _35cc90;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9840,13 +9642,13 @@ __arg1 = _35reg903;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label14:
 {
-Obj _35cc89 = makeNative(12, _35clofun2002, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc89 = makeNative(12, _35clofun1975, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg860 = primIsCons(closureRef(co, 0));
 if (True == _35reg860) {
 Obj _35reg861 = primCar(closureRef(co, 0));
@@ -9897,7 +9699,7 @@ Obj _35reg896 = primCdr(closureRef(co, 0));
 Obj _35reg897 = primCdr(_35reg896);
 Obj frees = _35reg897;
 Obj next = closureRef(co, 1);
-pushCont(co, 13, _35clofun2002, 3, args, frees, next);
+pushCont(co, 13, _35clofun1975, 3, args, frees, next);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = body;
@@ -9905,7 +9707,7 @@ __arg2 = globalRef(intern("cora/lib/toc#id"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -9913,16 +9715,7 @@ __arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc89;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9931,7 +9724,7 @@ __arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9940,7 +9733,7 @@ __arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9949,7 +9742,7 @@ __arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9958,7 +9751,7 @@ __arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9967,7 +9760,7 @@ __arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -9976,7 +9769,16 @@ __arg0 = _35cc89;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc89;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9992,14 +9794,14 @@ Obj _35reg934 = primCons(intern("let"), _35reg933);
 __nargs = 2;
 __arg1 = _35reg934;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+if (co->ctx.pc.func != _35clofun1975) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label16:
 {
 Obj rb = __arg1;
-pushCont(co, 15, _35clofun2002, 1, rb);
+pushCont(co, 15, _35clofun1975, 1, rb);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 1);
@@ -10007,13 +9809,13 @@ __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label17:
 {
-Obj _35cc88 = makeNative(14, _35clofun2002, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc88 = makeNative(14, _35clofun1975, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg904 = primIsCons(closureRef(co, 0));
 if (True == _35reg904) {
 Obj _35reg905 = primCar(closureRef(co, 0));
@@ -10053,11 +9855,11 @@ Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = b;
-__arg2 = makeNative(16, _35clofun2002, 1, 3, a, c, next);
+__arg2 = makeNative(16, _35clofun1975, 1, 3, a, c, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -10065,16 +9867,7 @@ __arg0 = _35cc88;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc88;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10083,7 +9876,7 @@ __arg0 = _35cc88;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10092,7 +9885,7 @@ __arg0 = _35cc88;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10101,7 +9894,7 @@ __arg0 = _35cc88;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10110,7 +9903,16 @@ __arg0 = _35cc88;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc88;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -10125,7 +9927,7 @@ Obj _35reg956 = primCons(intern("do"), _35reg955);
 __nargs = 2;
 __arg1 = _35reg956;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2002) { goto fail; }
+if (co->ctx.pc.func != _35clofun1975) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -10141,10 +9943,10 @@ __arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-pushCont(co, 18, _35clofun2002, 1, ra);
+pushCont(co, 18, _35clofun1975, 1, ra);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 0);
@@ -10152,14 +9954,14 @@ __arg2 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label20:
 {
-Obj _35cc87 = makeNative(17, _35clofun2002, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc87 = makeNative(17, _35clofun1975, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg935 = primIsCons(closureRef(co, 0));
 if (True == _35reg935) {
 Obj _35reg936 = primCar(closureRef(co, 0));
@@ -10188,11 +9990,11 @@ Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = a;
-__arg2 = makeNative(19, _35clofun2002, 1, 2, b, next);
+__arg2 = makeNative(19, _35clofun1975, 1, 2, b, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -10200,16 +10002,7 @@ __arg0 = _35cc87;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc87;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10218,7 +10011,7 @@ __arg0 = _35cc87;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10227,7 +10020,7 @@ __arg0 = _35cc87;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10236,7 +10029,16 @@ __arg0 = _35cc87;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2002) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc87;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1975) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -10250,7 +10052,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2001(struct Cora* co){
+void _35clofun1974(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -10263,7 +10065,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc71 = makeNative(19, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35cc71 = makeNative(19, _35clofun1973, 0, 1, closureRef(co, 0));
 Obj _35reg638 = primIsCons(closureRef(co, 0));
 if (True == _35reg638) {
 Obj _35reg639 = primCar(closureRef(co, 0));
@@ -10290,7 +10092,7 @@ Obj _35reg654 = primEQ(Nil, _35reg653);
 if (True == _35reg654) {
 Obj _35reg655 = primCons(cont, Nil);
 Obj _35reg656 = primCons(exp, _35reg655);
-pushCont(co, 20, _35clofun2000, 0);
+pushCont(co, 20, _35clofun1973, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = globalRef(intern("cora/lib/toc#free-vars"));
@@ -10298,7 +10100,7 @@ __arg2 = _35reg656;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -10306,16 +10108,7 @@ __arg0 = _35cc71;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc71;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10324,7 +10117,7 @@ __arg0 = _35cc71;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10333,7 +10126,7 @@ __arg0 = _35cc71;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10342,14 +10135,23 @@ __arg0 = _35cc71;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc71;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35cc70 = makeNative(0, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35cc70 = makeNative(0, _35clofun1974, 0, 1, closureRef(co, 0));
 Obj _35reg658 = primIsCons(closureRef(co, 0));
 if (True == _35reg658) {
 Obj _35reg659 = primCar(closureRef(co, 0));
@@ -10371,7 +10173,7 @@ __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -10379,16 +10181,7 @@ __arg0 = _35cc70;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc70;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10397,7 +10190,7 @@ __arg0 = _35cc70;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10406,14 +10199,23 @@ __arg0 = _35cc70;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc70;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label2:
 {
-Obj _35cc69 = makeNative(1, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35cc69 = makeNative(1, _35clofun1974, 0, 1, closureRef(co, 0));
 Obj _35reg668 = primIsCons(closureRef(co, 0));
 if (True == _35reg668) {
 Obj _35reg669 = primCar(closureRef(co, 0));
@@ -10435,7 +10237,7 @@ __arg1 = _35reg677;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -10443,16 +10245,7 @@ __arg0 = _35cc69;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc69;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10461,7 +10254,16 @@ __arg0 = _35cc69;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc69;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -10477,7 +10279,7 @@ __arg2 = _35val707;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -10487,7 +10289,7 @@ Obj _35val705 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35val704= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj _35reg706 = primCons(a, Nil);
-pushCont(co, 3, _35clofun2001, 1, _35val704);
+pushCont(co, 3, _35clofun1974, 1, _35val704);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#diff"));
 __arg1 = _35val705;
@@ -10495,7 +10297,7 @@ __arg2 = _35reg706;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -10504,20 +10306,20 @@ label5:
 Obj _35val704 = __arg1;
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun2001, 2, a, _35val704);
+pushCont(co, 4, _35clofun1974, 2, a, _35val704);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc68 = makeNative(2, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35cc68 = makeNative(2, _35clofun1974, 0, 1, closureRef(co, 0));
 Obj _35reg678 = primIsCons(closureRef(co, 0));
 if (True == _35reg678) {
 Obj _35reg679 = primCar(closureRef(co, 0));
@@ -10553,14 +10355,14 @@ Obj _35reg701 = primCdr(_35reg700);
 Obj _35reg702 = primCdr(_35reg701);
 Obj _35reg703 = primEQ(Nil, _35reg702);
 if (True == _35reg703) {
-pushCont(co, 5, _35clofun2001, 2, c, a);
+pushCont(co, 5, _35clofun1974, 2, c, a);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -10568,16 +10370,7 @@ __arg0 = _35cc68;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc68;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10586,7 +10379,7 @@ __arg0 = _35cc68;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10595,7 +10388,7 @@ __arg0 = _35cc68;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10604,7 +10397,7 @@ __arg0 = _35cc68;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10613,7 +10406,16 @@ __arg0 = _35cc68;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc68;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -10629,13 +10431,13 @@ __arg3 = _35val727;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35cc67 = makeNative(6, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35cc67 = makeNative(6, _35clofun1974, 0, 1, closureRef(co, 0));
 Obj _35reg708 = primIsCons(closureRef(co, 0));
 if (True == _35reg708) {
 Obj _35reg709 = primCar(closureRef(co, 0));
@@ -10662,7 +10464,7 @@ Obj _35reg724 = primEQ(Nil, _35reg723);
 if (True == _35reg724) {
 Obj _35reg725 = primCons(y, Nil);
 Obj _35reg726 = primCons(x, _35reg725);
-pushCont(co, 7, _35clofun2001, 0);
+pushCont(co, 7, _35clofun1974, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = globalRef(intern("cora/lib/toc#free-vars"));
@@ -10670,7 +10472,7 @@ __arg2 = _35reg726;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -10678,16 +10480,7 @@ __arg0 = _35cc67;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc67;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10696,7 +10489,7 @@ __arg0 = _35cc67;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10705,7 +10498,7 @@ __arg0 = _35cc67;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10714,7 +10507,16 @@ __arg0 = _35cc67;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc67;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -10730,13 +10532,13 @@ __arg3 = _35val757;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label10:
 {
-Obj _35cc66 = makeNative(8, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35cc66 = makeNative(8, _35clofun1974, 0, 1, closureRef(co, 0));
 Obj _35reg728 = primIsCons(closureRef(co, 0));
 if (True == _35reg728) {
 Obj _35reg729 = primCar(closureRef(co, 0));
@@ -10775,7 +10577,7 @@ if (True == _35reg753) {
 Obj _35reg754 = primCons(z, Nil);
 Obj _35reg755 = primCons(y, _35reg754);
 Obj _35reg756 = primCons(x, _35reg755);
-pushCont(co, 9, _35clofun2001, 0);
+pushCont(co, 9, _35clofun1974, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = globalRef(intern("cora/lib/toc#free-vars"));
@@ -10783,7 +10585,7 @@ __arg2 = _35reg756;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -10791,16 +10593,7 @@ __arg0 = _35cc66;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc66;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10809,7 +10602,7 @@ __arg0 = _35cc66;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10818,7 +10611,7 @@ __arg0 = _35cc66;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10827,7 +10620,7 @@ __arg0 = _35cc66;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10836,7 +10629,16 @@ __arg0 = _35cc66;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc66;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -10852,13 +10654,13 @@ __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label12:
 {
-Obj _35cc65 = makeNative(10, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35cc65 = makeNative(10, _35clofun1974, 0, 1, closureRef(co, 0));
 Obj _35reg758 = primIsCons(closureRef(co, 0));
 if (True == _35reg758) {
 Obj _35reg759 = primCar(closureRef(co, 0));
@@ -10883,14 +10685,14 @@ Obj _35reg772 = primCdr(_35reg771);
 Obj _35reg773 = primCdr(_35reg772);
 Obj _35reg774 = primEQ(Nil, _35reg773);
 if (True == _35reg774) {
-pushCont(co, 11, _35clofun2001, 1, args);
+pushCont(co, 11, _35clofun1974, 1, args);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -10898,16 +10700,7 @@ __arg0 = _35cc65;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc65;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10916,7 +10709,7 @@ __arg0 = _35cc65;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10925,7 +10718,7 @@ __arg0 = _35cc65;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -10934,14 +10727,23 @@ __arg0 = _35cc65;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc65;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label13:
 {
-Obj _35cc64 = makeNative(12, _35clofun2001, 0, 1, closureRef(co, 0));
+Obj _35cc64 = makeNative(12, _35clofun1974, 0, 1, closureRef(co, 0));
 Obj x = closureRef(co, 0);
 Obj _35reg776 = primIsSymbol(x);
 if (True == _35reg776) {
@@ -10949,7 +10751,7 @@ Obj _35reg777 = primCons(x, Nil);
 __nargs = 2;
 __arg1 = _35reg777;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2001) { goto fail; }
+if (co->ctx.pc.func != _35clofun1974) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -10957,7 +10759,7 @@ __arg0 = _35cc64;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -10970,7 +10772,7 @@ if (True == _35val778) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2001) { goto fail; }
+if (co->ctx.pc.func != _35clofun1974) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -10978,7 +10780,7 @@ __arg0 = _35cc63;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -10986,16 +10788,16 @@ goto *jumpTable[ps.label];
 label15:
 {
 Obj _35p62 = __arg1;
-Obj _35cc63 = makeNative(13, _35clofun2001, 0, 1, _35p62);
+Obj _35cc63 = makeNative(13, _35clofun1974, 0, 1, _35p62);
 Obj x = _35p62;
-pushCont(co, 14, _35clofun2001, 1, _35cc63);
+pushCont(co, 14, _35clofun1974, 1, _35cc63);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -11007,7 +10809,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -11024,13 +10826,13 @@ __arg2 = _35reg784;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35cc81 = makeNative(16, _35clofun2001, 0, 0);
+Obj _35cc81 = makeNative(16, _35clofun1974, 0, 0);
 Obj fvs = closureRef(co, 0);
 Obj _35reg780 = primIsCons(closureRef(co, 1));
 if (True == _35reg780) {
@@ -11038,14 +10840,14 @@ Obj _35reg781 = primCar(closureRef(co, 1));
 Obj f = _35reg781;
 Obj _35reg782 = primCdr(closureRef(co, 1));
 Obj args = _35reg782;
-pushCont(co, 17, _35clofun2001, 2, f, args);
+pushCont(co, 17, _35clofun1974, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -11053,7 +10855,7 @@ __arg0 = _35cc81;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11070,7 +10872,7 @@ Obj _35reg816 = primCons(intern("let"), _35reg815);
 __nargs = 2;
 __arg1 = _35reg816;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2001) { goto fail; }
+if (co->ctx.pc.func != _35clofun1974) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -11080,7 +10882,7 @@ Obj _35val811 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 19, _35clofun2001, 2, _35val811, a);
+pushCont(co, 19, _35clofun1974, 2, _35val811, a);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs;
@@ -11088,7 +10890,7 @@ __arg2 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2001) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1974) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -11101,7 +10903,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun2000(struct Cora* co){
+void _35clofun1973(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -11116,14 +10918,14 @@ label0:
 {
 Obj _35p45 = __arg1;
 Obj _35p46 = __arg2;
-Obj _35cc47 = makeNative(20, _35clofun1999, 0, 2, _35p45, _35p46);
+Obj _35cc47 = makeNative(20, _35clofun1972, 0, 2, _35p45, _35p46);
 Obj _35reg541 = primEQ(Nil, _35p45);
 if (True == _35reg541) {
 Obj s2 = _35p46;
 __nargs = 2;
 __arg1 = s2;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+if (co->ctx.pc.func != _35clofun1973) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -11131,7 +10933,7 @@ __arg0 = _35cc47;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11144,7 +10946,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -11156,13 +10958,13 @@ Obj _35reg547 = primCons(x, _35val546);
 __nargs = 2;
 __arg1 = _35reg547;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+if (co->ctx.pc.func != _35clofun1973) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label3:
 {
-Obj _35cc54 = makeNative(1, _35clofun2000, 0, 0);
+Obj _35cc54 = makeNative(1, _35clofun1973, 0, 0);
 Obj _35reg543 = primIsCons(closureRef(co, 0));
 if (True == _35reg543) {
 Obj _35reg544 = primCar(closureRef(co, 0));
@@ -11170,7 +10972,7 @@ Obj x = _35reg544;
 Obj _35reg545 = primCdr(closureRef(co, 0));
 Obj y = _35reg545;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 2, _35clofun2000, 1, x);
+pushCont(co, 2, _35clofun1973, 1, x);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#diff"));
 __arg1 = y;
@@ -11178,7 +10980,7 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -11186,7 +10988,7 @@ __arg0 = _35cc54;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11205,7 +11007,7 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -11213,14 +11015,14 @@ __arg0 = _35cc53;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35cc53 = makeNative(3, _35clofun2000, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc53 = makeNative(3, _35clofun1973, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg548 = primIsCons(closureRef(co, 0));
 if (True == _35reg548) {
 Obj _35reg549 = primCar(closureRef(co, 0));
@@ -11228,7 +11030,7 @@ Obj x = _35reg549;
 Obj _35reg550 = primCdr(closureRef(co, 0));
 Obj y = _35reg550;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 4, _35clofun2000, 3, y, s2, _35cc53);
+pushCont(co, 4, _35clofun1973, 3, y, s2, _35cc53);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#elem?"));
 __arg1 = x;
@@ -11236,7 +11038,7 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -11244,7 +11046,7 @@ __arg0 = _35cc53;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11253,14 +11055,14 @@ label6:
 {
 Obj _35p50 = __arg1;
 Obj _35p51 = __arg2;
-Obj _35cc52 = makeNative(5, _35clofun2000, 0, 2, _35p50, _35p51);
+Obj _35cc52 = makeNative(5, _35clofun1973, 0, 2, _35p50, _35p51);
 Obj _35reg552 = primEQ(Nil, _35p50);
 if (True == _35reg552) {
 Obj __ = _35p51;
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+if (co->ctx.pc.func != _35clofun1973) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -11268,7 +11070,7 @@ __arg0 = _35cc52;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11281,24 +11083,24 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label8:
 {
-Obj _35cc61 = makeNative(7, _35clofun2000, 0, 0);
+Obj _35cc61 = makeNative(7, _35clofun1973, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+if (co->ctx.pc.func != _35clofun1973) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label9:
 {
-Obj _35cc60 = makeNative(8, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35cc60 = makeNative(8, _35clofun1973, 0, 1, closureRef(co, 0));
 Obj _35reg554 = primIsCons(closureRef(co, 0));
 if (True == _35reg554) {
 Obj _35reg555 = primCar(closureRef(co, 0));
@@ -11317,7 +11119,7 @@ if (True == _35reg563) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+if (co->ctx.pc.func != _35clofun1973) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -11325,7 +11127,7 @@ __arg0 = _35cc60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11334,7 +11136,7 @@ __arg0 = _35cc60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11343,7 +11145,7 @@ __arg0 = _35cc60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11352,14 +11154,14 @@ __arg0 = _35cc60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35cc59 = makeNative(9, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35cc59 = makeNative(9, _35clofun1973, 0, 1, closureRef(co, 0));
 Obj _35reg564 = primIsCons(closureRef(co, 0));
 if (True == _35reg564) {
 Obj _35reg565 = primCar(closureRef(co, 0));
@@ -11378,7 +11180,7 @@ if (True == _35reg573) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+if (co->ctx.pc.func != _35clofun1973) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -11386,7 +11188,7 @@ __arg0 = _35cc59;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11395,7 +11197,7 @@ __arg0 = _35cc59;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11404,7 +11206,7 @@ __arg0 = _35cc59;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11413,14 +11215,14 @@ __arg0 = _35cc59;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35cc58 = makeNative(10, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35cc58 = makeNative(10, _35clofun1973, 0, 1, closureRef(co, 0));
 Obj _35reg574 = primIsCons(closureRef(co, 0));
 if (True == _35reg574) {
 Obj _35reg575 = primCar(closureRef(co, 0));
@@ -11439,7 +11241,7 @@ if (True == _35reg583) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+if (co->ctx.pc.func != _35clofun1973) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -11447,7 +11249,7 @@ __arg0 = _35cc58;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11456,7 +11258,7 @@ __arg0 = _35cc58;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11465,7 +11267,7 @@ __arg0 = _35cc58;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11474,14 +11276,14 @@ __arg0 = _35cc58;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj _35cc57 = makeNative(11, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35cc57 = makeNative(11, _35clofun1973, 0, 1, closureRef(co, 0));
 Obj _35reg584 = primIsCons(closureRef(co, 0));
 if (True == _35reg584) {
 Obj _35reg585 = primCar(closureRef(co, 0));
@@ -11500,7 +11302,7 @@ if (True == _35reg593) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+if (co->ctx.pc.func != _35clofun1973) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -11508,7 +11310,7 @@ __arg0 = _35cc57;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11517,7 +11319,7 @@ __arg0 = _35cc57;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11526,7 +11328,7 @@ __arg0 = _35cc57;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11535,7 +11337,7 @@ __arg0 = _35cc57;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11543,7 +11345,7 @@ goto *jumpTable[ps.label];
 label13:
 {
 Obj _35p55 = __arg1;
-Obj _35cc56 = makeNative(12, _35clofun2000, 0, 1, _35p55);
+Obj _35cc56 = makeNative(12, _35clofun1973, 0, 1, _35p55);
 Obj _35reg594 = primIsCons(_35p55);
 if (True == _35reg594) {
 Obj _35reg595 = primCar(_35p55);
@@ -11562,7 +11364,7 @@ if (True == _35reg603) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun2000) { goto fail; }
+if (co->ctx.pc.func != _35clofun1973) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -11570,7 +11372,7 @@ __arg0 = _35cc56;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11579,7 +11381,7 @@ __arg0 = _35cc56;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11588,7 +11390,7 @@ __arg0 = _35cc56;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11597,7 +11399,7 @@ __arg0 = _35cc56;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11610,7 +11412,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -11625,13 +11427,13 @@ __arg3 = _35val609;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label16:
 {
-Obj _35cc74 = makeNative(14, _35clofun2000, 0, 0);
+Obj _35cc74 = makeNative(14, _35clofun1973, 0, 0);
 Obj _35reg605 = primIsCons(closureRef(co, 0));
 if (True == _35reg605) {
 Obj _35reg606 = primCar(closureRef(co, 0));
@@ -11639,7 +11441,7 @@ Obj f = _35reg606;
 Obj _35reg607 = primCdr(closureRef(co, 0));
 Obj args = _35reg607;
 Obj _35reg608 = primCons(f, args);
-pushCont(co, 15, _35clofun2000, 0);
+pushCont(co, 15, _35clofun1973, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = globalRef(intern("cora/lib/toc#free-vars"));
@@ -11647,7 +11449,7 @@ __arg2 = _35reg608;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -11655,7 +11457,7 @@ __arg0 = _35cc74;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11671,13 +11473,13 @@ __arg2 = arg;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label18:
 {
-Obj _35cc73 = makeNative(16, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35cc73 = makeNative(16, _35clofun1973, 0, 1, closureRef(co, 0));
 Obj _35reg610 = primIsCons(closureRef(co, 0));
 if (True == _35reg610) {
 Obj _35reg611 = primCar(closureRef(co, 0));
@@ -11702,14 +11504,14 @@ Obj _35reg624 = primCdr(_35reg623);
 Obj _35reg625 = primCdr(_35reg624);
 Obj _35reg626 = primEQ(Nil, _35reg625);
 if (True == _35reg626) {
-pushCont(co, 17, _35clofun2000, 1, arg);
+pushCont(co, 17, _35clofun1973, 1, arg);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#free-vars"));
 __arg1 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -11717,16 +11519,7 @@ __arg0 = _35cc73;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc73;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11735,7 +11528,7 @@ __arg0 = _35cc73;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11744,7 +11537,7 @@ __arg0 = _35cc73;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11753,14 +11546,23 @@ __arg0 = _35cc73;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc73;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label19:
 {
-Obj _35cc72 = makeNative(18, _35clofun2000, 0, 1, closureRef(co, 0));
+Obj _35cc72 = makeNative(18, _35clofun1973, 0, 1, closureRef(co, 0));
 Obj _35reg628 = primIsCons(closureRef(co, 0));
 if (True == _35reg628) {
 Obj _35reg629 = primCar(closureRef(co, 0));
@@ -11782,7 +11584,7 @@ __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -11790,16 +11592,7 @@ __arg0 = _35cc72;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc72;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11808,7 +11601,7 @@ __arg0 = _35cc72;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11817,7 +11610,16 @@ __arg0 = _35cc72;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc72;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11833,7 +11635,7 @@ __arg3 = _35val657;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun2000) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1973) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -11846,7 +11648,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1999(struct Cora* co){
+void _35clofun1972(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -11864,7 +11666,7 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 20, _35clofun1998, 1, _35val466);
+pushCont(co, 20, _35clofun1971, 1, _35val466);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -11874,13 +11676,13 @@ co->args[4] = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35cc39 = makeNative(19, _35clofun1998, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc39 = makeNative(19, _35clofun1971, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
@@ -11908,7 +11710,7 @@ Obj _35reg463 = primCdr(_35reg462);
 Obj _35reg464 = primCdr(_35reg463);
 Obj _35reg465 = primEQ(Nil, _35reg464);
 if (True == _35reg465) {
-pushCont(co, 0, _35clofun1999, 4, env, ns, import, y);
+pushCont(co, 0, _35clofun1972, 4, env, ns, import, y);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -11918,7 +11720,7 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -11926,16 +11728,7 @@ __arg0 = _35cc39;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc39;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11944,7 +11737,7 @@ __arg0 = _35cc39;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11953,7 +11746,7 @@ __arg0 = _35cc39;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -11962,7 +11755,16 @@ __arg0 = _35cc39;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc39;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -11974,7 +11776,7 @@ Obj _35reg477 = primCons(intern("if"), _35val476);
 __nargs = 2;
 __arg1 = _35reg477;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+if (co->ctx.pc.func != _35clofun1972) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -11982,7 +11784,7 @@ label3:
 {
 Obj _35val475 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 2, _35clofun1999, 0);
+pushCont(co, 2, _35clofun1972, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = _35val475;
@@ -11990,13 +11792,13 @@ __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35cc38 = makeNative(1, _35clofun1999, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc38 = makeNative(1, _35clofun1972, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
@@ -12007,7 +11809,7 @@ Obj _35reg473 = primEQ(intern("if"), _35reg472);
 if (True == _35reg473) {
 Obj _35reg474 = primCdr(closureRef(co, 3));
 Obj args = _35reg474;
-pushCont(co, 3, _35clofun1999, 1, args);
+pushCont(co, 3, _35clofun1972, 1, args);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -12016,7 +11818,7 @@ __arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12024,7 +11826,7 @@ __arg0 = _35cc38;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -12033,7 +11835,7 @@ __arg0 = _35cc38;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12048,7 +11850,7 @@ Obj _35reg499 = primCons(intern("lambda"), _35reg498);
 __nargs = 2;
 __arg1 = _35reg499;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+if (co->ctx.pc.func != _35clofun1972) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -12059,7 +11861,7 @@ Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 5, _35clofun1999, 1, args);
+pushCont(co, 5, _35clofun1972, 1, args);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = _35val495;
@@ -12069,13 +11871,13 @@ co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label7:
 {
-Obj _35cc37 = makeNative(4, _35clofun1999, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc37 = makeNative(4, _35clofun1972, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
@@ -12103,7 +11905,7 @@ Obj _35reg492 = primCdr(_35reg491);
 Obj _35reg493 = primCdr(_35reg492);
 Obj _35reg494 = primEQ(Nil, _35reg493);
 if (True == _35reg494) {
-pushCont(co, 6, _35clofun1999, 4, ns, import, body, args);
+pushCont(co, 6, _35clofun1972, 4, ns, import, body, args);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#append"));
 __arg1 = args;
@@ -12111,7 +11913,7 @@ __arg2 = env;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12119,16 +11921,7 @@ __arg0 = _35cc37;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc37;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -12137,7 +11930,7 @@ __arg0 = _35cc37;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -12146,7 +11939,7 @@ __arg0 = _35cc37;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -12155,7 +11948,16 @@ __arg0 = _35cc37;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc37;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12168,7 +11970,7 @@ Obj _35reg504 = primCons(intern("%global"), _35reg503);
 __nargs = 2;
 __arg1 = _35reg504;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+if (co->ctx.pc.func != _35clofun1972) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -12182,10 +11984,10 @@ if (True == _35val501) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+if (co->ctx.pc.func != _35clofun1972) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 8, _35clofun1999, 0);
+pushCont(co, 8, _35clofun1972, 0);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#lookup-var"));
 __arg1 = x;
@@ -12194,21 +11996,21 @@ __arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35cc36 = makeNative(7, _35clofun1999, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc36 = makeNative(7, _35clofun1972, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj x = closureRef(co, 3);
 Obj _35reg500 = primIsSymbol(x);
 if (True == _35reg500) {
-pushCont(co, 9, _35clofun1999, 3, x, ns, import);
+pushCont(co, 9, _35clofun1972, 3, x, ns, import);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#elem?"));
 __arg1 = x;
@@ -12216,7 +12018,7 @@ __arg2 = env;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12224,14 +12026,14 @@ __arg0 = _35cc36;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label11:
 {
-Obj _35cc35 = makeNative(10, _35clofun1999, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc35 = makeNative(10, _35clofun1972, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj __ = closureRef(co, 0);
 __ = closureRef(co, 1);
 __ = closureRef(co, 2);
@@ -12255,7 +12057,7 @@ Obj _35reg516 = primCons(intern("%const"), _35reg515);
 __nargs = 2;
 __arg1 = _35reg516;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+if (co->ctx.pc.func != _35clofun1972) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -12263,7 +12065,7 @@ __arg0 = _35cc35;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -12272,7 +12074,7 @@ __arg0 = _35cc35;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -12281,7 +12083,7 @@ __arg0 = _35cc35;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -12290,7 +12092,7 @@ __arg0 = _35cc35;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12307,7 +12109,7 @@ Obj _35reg528 = primCons(intern("%const"), _35reg527);
 __nargs = 2;
 __arg1 = _35reg528;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+if (co->ctx.pc.func != _35clofun1972) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -12315,7 +12117,7 @@ __arg0 = _35cc34;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -12325,7 +12127,7 @@ Obj _35reg530 = primCons(intern("%const"), _35reg529);
 __nargs = 2;
 __arg1 = _35reg530;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+if (co->ctx.pc.func != _35clofun1972) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -12333,7 +12135,7 @@ __arg0 = _35cc34;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12351,7 +12153,7 @@ Obj _35reg525 = primCons(intern("%const"), _35reg524);
 __nargs = 2;
 __arg1 = _35reg525;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+if (co->ctx.pc.func != _35clofun1972) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -12359,18 +12161,18 @@ __arg0 = _35cc34;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 12, _35clofun1999, 2, x, _35cc34);
+pushCont(co, 12, _35clofun1972, 2, x, _35cc34);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12387,7 +12189,7 @@ Obj _35reg519 = primCons(intern("%const"), _35reg518);
 __nargs = 2;
 __arg1 = _35reg519;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+if (co->ctx.pc.func != _35clofun1972) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -12395,7 +12197,7 @@ __arg0 = _35cc34;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -12407,7 +12209,7 @@ Obj _35reg522 = primCons(intern("%const"), _35reg521);
 __nargs = 2;
 __arg1 = _35reg522;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+if (co->ctx.pc.func != _35clofun1972) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -12415,18 +12217,18 @@ __arg0 = _35cc34;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 13, _35clofun1999, 2, x, _35cc34);
+pushCont(co, 13, _35clofun1972, 2, x, _35cc34);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#boolean?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12438,19 +12240,19 @@ Obj _35p30 = __arg1;
 Obj _35p31 = __arg2;
 Obj _35p32 = __arg3;
 Obj _35p33 = co->args[4];
-Obj _35cc34 = makeNative(11, _35clofun1999, 0, 4, _35p30, _35p31, _35p32, _35p33);
+Obj _35cc34 = makeNative(11, _35clofun1972, 0, 4, _35p30, _35p31, _35p32, _35p33);
 Obj __ = _35p30;
 __ = _35p31;
 __ = _35p32;
 Obj x = _35p33;
-pushCont(co, 14, _35clofun1999, 2, x, _35cc34);
+pushCont(co, 14, _35clofun1972, 2, x, _35cc34);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#number?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12462,7 +12264,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12474,13 +12276,13 @@ Obj _35reg536 = primCons(x, _35val535);
 __nargs = 2;
 __arg1 = _35reg536;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1999) { goto fail; }
+if (co->ctx.pc.func != _35clofun1972) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label18:
 {
-Obj _35cc49 = makeNative(16, _35clofun1999, 0, 0);
+Obj _35cc49 = makeNative(16, _35clofun1972, 0, 0);
 Obj _35reg532 = primIsCons(closureRef(co, 0));
 if (True == _35reg532) {
 Obj _35reg533 = primCar(closureRef(co, 0));
@@ -12488,7 +12290,7 @@ Obj x = _35reg533;
 Obj _35reg534 = primCdr(closureRef(co, 0));
 Obj y = _35reg534;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 17, _35clofun1999, 1, x);
+pushCont(co, 17, _35clofun1972, 1, x);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#union"));
 __arg1 = y;
@@ -12496,7 +12298,7 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12504,7 +12306,7 @@ __arg0 = _35cc49;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12523,7 +12325,7 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12531,14 +12333,14 @@ __arg0 = _35cc48;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label20:
 {
-Obj _35cc48 = makeNative(18, _35clofun1999, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc48 = makeNative(18, _35clofun1972, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj _35reg537 = primIsCons(closureRef(co, 0));
 if (True == _35reg537) {
 Obj _35reg538 = primCar(closureRef(co, 0));
@@ -12546,7 +12348,7 @@ Obj x = _35reg538;
 Obj _35reg539 = primCdr(closureRef(co, 0));
 Obj y = _35reg539;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 19, _35clofun1999, 3, y, s2, _35cc48);
+pushCont(co, 19, _35clofun1972, 3, y, s2, _35cc48);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#elem?"));
 __arg1 = x;
@@ -12554,7 +12356,7 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12562,7 +12364,7 @@ __arg0 = _35cc48;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1999) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1972) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12576,7 +12378,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1998(struct Cora* co){
+void _35clofun1971(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -12589,7 +12391,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc29 = makeNative(13, _35clofun1997, 0, 0);
+Obj _35cc29 = makeNative(13, _35clofun1970, 0, 0);
 Obj s = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj _35reg331 = primIsCons(closureRef(co, 2));
@@ -12598,7 +12400,7 @@ Obj _35reg332 = primCar(closureRef(co, 2));
 Obj import = _35reg332;
 Obj _35reg333 = primCdr(closureRef(co, 2));
 Obj more = _35reg333;
-pushCont(co, 20, _35clofun1997, 4, import, s, ns, more);
+pushCont(co, 20, _35clofun1970, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = import;
@@ -12606,7 +12408,7 @@ __arg2 = makeCString("#*ns-export*");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12614,7 +12416,7 @@ __arg0 = _35cc29;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12624,7 +12426,7 @@ label1:
 Obj _35p25 = __arg1;
 Obj _35p26 = __arg2;
 Obj _35p27 = __arg3;
-Obj _35cc28 = makeNative(0, _35clofun1998, 0, 3, _35p25, _35p26, _35p27);
+Obj _35cc28 = makeNative(0, _35clofun1971, 0, 3, _35p25, _35p26, _35p27);
 Obj s = _35p25;
 Obj ns = _35p26;
 Obj _35reg341 = primEQ(Nil, _35p27);
@@ -12636,7 +12438,7 @@ __arg2 = ns;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12644,7 +12446,7 @@ __arg0 = _35cc28;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12657,7 +12459,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12672,18 +12474,18 @@ __arg2 = ls;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35cc44 = makeNative(2, _35clofun1998, 0, 0);
+Obj _35cc44 = makeNative(2, _35clofun1971, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj ls = closureRef(co, 3);
-pushCont(co, 3, _35clofun1998, 1, ls);
+pushCont(co, 3, _35clofun1971, 1, ls);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -12692,7 +12494,7 @@ __arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12704,7 +12506,7 @@ Obj _35reg355 = primCons(_35reg352, _35val354);
 __nargs = 2;
 __arg1 = _35reg355;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1998) { goto fail; }
+if (co->ctx.pc.func != _35clofun1971) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -12713,7 +12515,7 @@ label6:
 Obj _35val353 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj _35reg352= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun1998, 1, _35reg352);
+pushCont(co, 5, _35clofun1971, 1, _35reg352);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#map"));
 __arg1 = _35val353;
@@ -12721,7 +12523,7 @@ __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12744,7 +12546,7 @@ co->args[4] = _35reg363;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12758,7 +12560,7 @@ Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj tmp = _35val358;
 Obj _35reg359 = primCons(op, args);
-pushCont(co, 7, _35clofun1998, 4, tmp, env, ns, import);
+pushCont(co, 7, _35clofun1971, 4, tmp, env, ns, import);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#append"));
 __arg1 = _35reg359;
@@ -12766,7 +12568,7 @@ __arg2 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12784,7 +12586,7 @@ Obj _35reg350 = primEQ(required, provided);
 if (True == _35reg350) {
 Obj _35reg351 = primCons(op, Nil);
 Obj _35reg352 = primCons(intern("%builtin"), _35reg351);
-pushCont(co, 6, _35clofun1998, 2, args, _35reg352);
+pushCont(co, 6, _35clofun1971, 2, args, _35reg352);
 __nargs = 4;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -12793,13 +12595,13 @@ __arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 Obj _35reg356 = primGT(required, provided);
 if (True == _35reg356) {
 Obj _35reg357 = primSub(required, provided);
-pushCont(co, 8, _35clofun1998, 5, op, args, env, ns, import);
+pushCont(co, 8, _35clofun1971, 5, op, args, env, ns, import);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#temp-list"));
 __arg1 = _35reg357;
@@ -12807,7 +12609,7 @@ __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -12816,7 +12618,7 @@ __arg1 = makeCString("primitive call mismatch");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12831,14 +12633,14 @@ Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj required = _35val348;
-pushCont(co, 9, _35clofun1998, 6, required, op, args, env, ns, import);
+pushCont(co, 9, _35clofun1971, 6, required, op, args, env, ns, import);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#length"));
 __arg1 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12852,14 +12654,14 @@ Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj _35cc43= co->ctx.stk.stack[co->ctx.stk.base + 5];
 if (True == _35val347) {
-pushCont(co, 10, _35clofun1998, 5, op, args, env, ns, import);
+pushCont(co, 10, _35clofun1971, 5, op, args, env, ns, import);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#builtin->args"));
 __arg1 = op;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12867,14 +12669,14 @@ __arg0 = _35cc43;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label12:
 {
-Obj _35cc43 = makeNative(4, _35clofun1998, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc43 = makeNative(4, _35clofun1971, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
@@ -12884,14 +12686,14 @@ Obj _35reg345 = primCar(closureRef(co, 3));
 Obj op = _35reg345;
 Obj _35reg346 = primCdr(closureRef(co, 3));
 Obj args = _35reg346;
-pushCont(co, 11, _35clofun1998, 6, op, args, env, ns, import, _35cc43);
+pushCont(co, 11, _35clofun1971, 6, op, args, env, ns, import, _35cc43);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#builtin?"));
 __arg1 = op;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12899,7 +12701,7 @@ __arg0 = _35cc43;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -12915,7 +12717,7 @@ Obj _35reg389 = primCons(_35reg383, _35reg388);
 __nargs = 2;
 __arg1 = _35reg389;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1998) { goto fail; }
+if (co->ctx.pc.func != _35clofun1971) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -12931,7 +12733,7 @@ Obj _35reg382 = primCons(intern("set"), Nil);
 Obj _35reg383 = primCons(intern("%builtin"), _35reg382);
 Obj _35reg384 = primCons(var1, Nil);
 Obj _35reg385 = primCons(intern("%const"), _35reg384);
-pushCont(co, 13, _35clofun1998, 2, _35reg385, _35reg383);
+pushCont(co, 13, _35clofun1971, 2, _35reg385, _35reg383);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -12941,13 +12743,13 @@ co->args[4] = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label15:
 {
-Obj _35cc42 = makeNative(12, _35clofun1998, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc42 = makeNative(12, _35clofun1971, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
@@ -12975,7 +12777,7 @@ Obj _35reg378 = primCdr(_35reg377);
 Obj _35reg379 = primCdr(_35reg378);
 Obj _35reg380 = primEQ(Nil, _35reg379);
 if (True == _35reg380) {
-pushCont(co, 14, _35clofun1998, 4, env, ns, import, val);
+pushCont(co, 14, _35clofun1971, 4, env, ns, import, val);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#var-with-ns"));
 __arg1 = var;
@@ -12983,7 +12785,7 @@ __arg2 = ns;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -12991,16 +12793,7 @@ __arg0 = _35cc42;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc42;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13009,7 +12802,7 @@ __arg0 = _35cc42;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13018,7 +12811,7 @@ __arg0 = _35cc42;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13027,14 +12820,23 @@ __arg0 = _35cc42;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc42;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label16:
 {
-Obj _35cc41 = makeNative(15, _35clofun1998, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc41 = makeNative(15, _35clofun1971, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
 __ = closureRef(co, 2);
@@ -13082,7 +12884,7 @@ co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -13090,16 +12892,7 @@ __arg0 = _35cc41;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc41;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13108,7 +12901,7 @@ __arg0 = _35cc41;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13117,7 +12910,7 @@ __arg0 = _35cc41;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13126,7 +12919,7 @@ __arg0 = _35cc41;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13135,7 +12928,16 @@ __arg0 = _35cc41;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc41;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13152,7 +12954,7 @@ Obj _35reg448 = primCons(intern("let"), _35reg447);
 __nargs = 2;
 __arg1 = _35reg448;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1998) { goto fail; }
+if (co->ctx.pc.func != _35clofun1971) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -13165,7 +12967,7 @@ Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj _35reg443 = primCons(a, env);
-pushCont(co, 17, _35clofun1998, 2, _35val442, a);
+pushCont(co, 17, _35clofun1971, 2, _35val442, a);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = _35reg443;
@@ -13175,13 +12977,13 @@ co->args[4] = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
-Obj _35cc40 = makeNative(16, _35clofun1998, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc40 = makeNative(16, _35clofun1971, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
@@ -13220,7 +13022,7 @@ Obj _35reg439 = primCdr(_35reg438);
 Obj _35reg440 = primCdr(_35reg439);
 Obj _35reg441 = primEQ(Nil, _35reg440);
 if (True == _35reg441) {
-pushCont(co, 18, _35clofun1998, 5, env, ns, import, c, a);
+pushCont(co, 18, _35clofun1971, 5, env, ns, import, c, a);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -13230,7 +13032,7 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -13238,16 +13040,7 @@ __arg0 = _35cc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc40;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13256,7 +13049,7 @@ __arg0 = _35cc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13265,7 +13058,7 @@ __arg0 = _35cc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13274,7 +13067,7 @@ __arg0 = _35cc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13283,7 +13076,16 @@ __arg0 = _35cc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1998) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc40;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != _35clofun1971) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13298,7 +13100,7 @@ Obj _35reg470 = primCons(intern("do"), _35reg469);
 __nargs = 2;
 __arg1 = _35reg470;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1998) { goto fail; }
+if (co->ctx.pc.func != _35clofun1971) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -13311,7 +13113,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1997(struct Cora* co){
+void _35clofun1970(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -13326,21 +13128,21 @@ label0:
 {
 Obj _35val314 = __arg1;
 Obj find = _35val314;
-pushCont(co, 20, _35clofun1996, 1, find);
+pushCont(co, 20, _35clofun1969, 1, find);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
 Obj x = __arg1;
-pushCont(co, 0, _35clofun1997, 0);
+pushCont(co, 0, _35clofun1970, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#assq"));
 __arg1 = x;
@@ -13348,7 +13150,7 @@ __arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13360,7 +13162,7 @@ if (True == _35val318) {
 __nargs = 2;
 __arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1997) { goto fail; }
+if (co->ctx.pc.func != _35clofun1970) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
@@ -13369,7 +13171,7 @@ __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13378,21 +13180,21 @@ label3:
 {
 Obj _35val317 = __arg1;
 Obj find = _35val317;
-pushCont(co, 2, _35clofun1997, 1, find);
+pushCont(co, 2, _35clofun1970, 1, find);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
 Obj x = __arg1;
-pushCont(co, 3, _35clofun1997, 0);
+pushCont(co, 3, _35clofun1970, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#assq"));
 __arg1 = x;
@@ -13400,7 +13202,7 @@ __arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13412,13 +13214,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc24 = makeNative(5, _35clofun1997, 0, 0);
+Obj _35cc24 = makeNative(5, _35clofun1970, 0, 0);
 Obj n = closureRef(co, 0);
 Obj res = closureRef(co, 1);
 Obj _35reg320 = primSub(n, makeNumber(1));
@@ -13431,7 +13233,7 @@ __arg2 = _35reg322;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13439,14 +13241,14 @@ label7:
 {
 Obj _35p21 = __arg1;
 Obj _35p22 = __arg2;
-Obj _35cc23 = makeNative(6, _35clofun1997, 0, 2, _35p21, _35p22);
+Obj _35cc23 = makeNative(6, _35clofun1970, 0, 2, _35p21, _35p22);
 Obj _35reg323 = primEQ(makeNumber(0), _35p21);
 if (True == _35reg323) {
 Obj res = _35p22;
 __nargs = 2;
 __arg1 = res;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1997) { goto fail; }
+if (co->ctx.pc.func != _35clofun1970) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -13454,7 +13256,7 @@ __arg0 = _35cc23;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13468,7 +13270,7 @@ __arg1 = _35val329;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13476,7 +13278,7 @@ label9:
 {
 Obj _35val328 = __arg1;
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 8, _35clofun1997, 0);
+pushCont(co, 8, _35clofun1970, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = ns;
@@ -13484,7 +13286,7 @@ __arg2 = _35val328;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13492,7 +13294,7 @@ label10:
 {
 Obj _35val327 = __arg1;
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 9, _35clofun1997, 1, ns);
+pushCont(co, 9, _35clofun1970, 1, ns);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = makeCString("#");
@@ -13500,7 +13302,7 @@ __arg2 = _35val327;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13513,17 +13315,17 @@ if (True == _35val326) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1997) { goto fail; }
+if (co->ctx.pc.func != _35clofun1970) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 10, _35clofun1997, 1, ns);
+pushCont(co, 10, _35clofun1970, 1, ns);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13537,17 +13339,17 @@ if (True == _35reg325) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1997) { goto fail; }
+if (co->ctx.pc.func != _35clofun1970) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-pushCont(co, 11, _35clofun1997, 2, var, ns);
+pushCont(co, 11, _35clofun1970, 2, var, ns);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol-cooked?"));
 __arg1 = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13560,7 +13362,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13573,7 +13375,7 @@ __arg1 = _35val340;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13581,7 +13383,7 @@ label15:
 {
 Obj _35val339 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 14, _35clofun1997, 0);
+pushCont(co, 14, _35clofun1970, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = import;
@@ -13589,7 +13391,7 @@ __arg2 = _35val339;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13597,7 +13399,7 @@ label16:
 {
 Obj _35val338 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 15, _35clofun1997, 1, import);
+pushCont(co, 15, _35clofun1970, 1, import);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = makeCString("#");
@@ -13605,7 +13407,7 @@ __arg2 = _35val338;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13617,14 +13419,14 @@ Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
 if (True == _35val337) {
-pushCont(co, 16, _35clofun1997, 1, import);
+pushCont(co, 16, _35clofun1970, 1, import);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = s;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 4;
@@ -13635,7 +13437,7 @@ __arg3 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13648,7 +13450,7 @@ Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj export = _35val336;
-pushCont(co, 17, _35clofun1997, 4, import, s, ns, more);
+pushCont(co, 17, _35clofun1970, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#elem?"));
 __arg1 = s;
@@ -13656,7 +13458,7 @@ __arg2 = export;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13667,7 +13469,7 @@ Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun1997, 4, import, s, ns, more);
+pushCont(co, 18, _35clofun1970, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#value-or"));
 __arg1 = _35val335;
@@ -13675,7 +13477,7 @@ __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13686,14 +13488,14 @@ Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun1997, 4, import, s, ns, more);
+pushCont(co, 19, _35clofun1970, 4, import, s, ns, more);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#intern"));
 __arg1 = _35val334;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1997) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1970) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13706,7 +13508,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1996(struct Cora* co){
+void _35clofun1969(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -13725,13 +13527,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35cc5 = makeNative(0, _35clofun1996, 0, 0);
+Obj _35cc5 = makeNative(0, _35clofun1969, 0, 0);
 Obj var = closureRef(co, 0);
 Obj _35reg202 = primIsCons(closureRef(co, 1));
 if (True == _35reg202) {
@@ -13746,7 +13548,7 @@ __arg2 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -13754,14 +13556,14 @@ __arg0 = _35cc5;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label2:
 {
-Obj _35cc4 = makeNative(1, _35clofun1996, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35cc4 = makeNative(1, _35clofun1969, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
 Obj _35reg205 = primIsCons(closureRef(co, 1));
 if (True == _35reg205) {
@@ -13782,7 +13584,7 @@ Obj _35reg214 = primCons(x, y);
 __nargs = 2;
 __arg1 = _35reg214;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1996) { goto fail; }
+if (co->ctx.pc.func != _35clofun1969) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -13790,7 +13592,7 @@ __arg0 = _35cc4;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13799,7 +13601,7 @@ __arg0 = _35cc4;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -13808,7 +13610,7 @@ __arg0 = _35cc4;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13817,14 +13619,14 @@ label3:
 {
 Obj _35p1 = __arg1;
 Obj _35p2 = __arg2;
-Obj _35cc3 = makeNative(2, _35clofun1996, 0, 2, _35p1, _35p2);
+Obj _35cc3 = makeNative(2, _35clofun1969, 0, 2, _35p1, _35p2);
 Obj var = _35p1;
 Obj _35reg215 = primEQ(Nil, _35p2);
 if (True == _35reg215) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1996) { goto fail; }
+if (co->ctx.pc.func != _35clofun1969) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -13832,7 +13634,7 @@ __arg0 = _35cc3;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13845,7 +13647,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -13862,13 +13664,13 @@ __arg3 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label6:
 {
-Obj _35cc10 = makeNative(4, _35clofun1996, 0, 0);
+Obj _35cc10 = makeNative(4, _35clofun1969, 0, 0);
 Obj f = closureRef(co, 0);
 Obj acc = closureRef(co, 1);
 Obj _35reg217 = primIsCons(closureRef(co, 2));
@@ -13877,7 +13679,7 @@ Obj _35reg218 = primCar(closureRef(co, 2));
 Obj x = _35reg218;
 Obj _35reg219 = primCdr(closureRef(co, 2));
 Obj y = _35reg219;
-pushCont(co, 5, _35clofun1996, 2, f, y);
+pushCont(co, 5, _35clofun1969, 2, f, y);
 __nargs = 3;
 __arg0 = f;
 __arg1 = acc;
@@ -13885,7 +13687,7 @@ __arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -13893,7 +13695,7 @@ __arg0 = _35cc10;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13903,7 +13705,7 @@ label7:
 Obj _35p6 = __arg1;
 Obj _35p7 = __arg2;
 Obj _35p8 = __arg3;
-Obj _35cc9 = makeNative(6, _35clofun1996, 0, 3, _35p6, _35p7, _35p8);
+Obj _35cc9 = makeNative(6, _35clofun1969, 0, 3, _35p6, _35p7, _35p8);
 Obj f = _35p6;
 Obj acc = _35p7;
 Obj _35reg221 = primEQ(Nil, _35p8);
@@ -13911,7 +13713,7 @@ if (True == _35reg221) {
 __nargs = 2;
 __arg1 = acc;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1996) { goto fail; }
+if (co->ctx.pc.func != _35clofun1969) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -13919,7 +13721,7 @@ __arg0 = _35cc9;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -13932,13 +13734,13 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label9:
 {
-Obj _35cc16 = makeNative(8, _35clofun1996, 0, 0);
+Obj _35cc16 = makeNative(8, _35clofun1969, 0, 0);
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 Obj _35reg223 = primIsCons(closureRef(co, 2));
@@ -13956,7 +13758,7 @@ __arg3 = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -13964,14 +13766,14 @@ __arg0 = _35cc16;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label10:
 {
-Obj _35cc15 = makeNative(9, _35clofun1996, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35cc15 = makeNative(9, _35clofun1969, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 Obj _35reg227 = primIsCons(closureRef(co, 2));
@@ -13985,7 +13787,7 @@ if (True == _35reg230) {
 __nargs = 2;
 __arg1 = pos;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1996) { goto fail; }
+if (co->ctx.pc.func != _35clofun1969) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -13993,7 +13795,7 @@ __arg0 = _35cc15;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
@@ -14002,7 +13804,7 @@ __arg0 = _35cc15;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -14012,7 +13814,7 @@ label11:
 Obj _35p11 = __arg1;
 Obj _35p12 = __arg2;
 Obj _35p13 = __arg3;
-Obj _35cc14 = makeNative(10, _35clofun1996, 0, 3, _35p11, _35p12, _35p13);
+Obj _35cc14 = makeNative(10, _35clofun1969, 0, 3, _35p11, _35p12, _35p13);
 Obj __ = _35p11;
 Obj x = _35p12;
 Obj _35reg231 = primEQ(Nil, _35p13);
@@ -14020,7 +13822,7 @@ if (True == _35reg231) {
 __nargs = 2;
 __arg1 = makeNumber(-1);
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1996) { goto fail; }
+if (co->ctx.pc.func != _35clofun1969) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -14028,7 +13830,7 @@ __arg0 = _35cc14;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -14045,7 +13847,7 @@ __arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -14057,7 +13859,7 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -14075,20 +13877,20 @@ __arg2 = tl;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1996) { goto fail; }
+if (co->ctx.pc.func != _35clofun1969) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 }
 
 label15:
 {
-Obj _35cc20 = makeNative(13, _35clofun1996, 0, 0);
+Obj _35cc20 = makeNative(13, _35clofun1969, 0, 0);
 Obj x = closureRef(co, 0);
 Obj _35reg234 = primIsCons(closureRef(co, 1));
 if (True == _35reg234) {
@@ -14096,7 +13898,7 @@ Obj _35reg235 = primCar(closureRef(co, 1));
 Obj hd = _35reg235;
 Obj _35reg236 = primCdr(closureRef(co, 1));
 Obj tl = _35reg236;
-pushCont(co, 14, _35clofun1996, 2, x, tl);
+pushCont(co, 14, _35clofun1969, 2, x, tl);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#index"));
 __arg1 = x;
@@ -14104,7 +13906,7 @@ __arg2 = hd;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
@@ -14112,7 +13914,7 @@ __arg0 = _35cc20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -14121,14 +13923,14 @@ label16:
 {
 Obj _35p17 = __arg1;
 Obj _35p18 = __arg2;
-Obj _35cc19 = makeNative(15, _35clofun1996, 0, 2, _35p17, _35p18);
+Obj _35cc19 = makeNative(15, _35clofun1969, 0, 2, _35p17, _35p18);
 Obj x = _35p17;
 Obj _35reg239 = primEQ(Nil, _35p18);
 if (True == _35reg239) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1996) { goto fail; }
+if (co->ctx.pc.func != _35clofun1969) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
@@ -14136,7 +13938,7 @@ __arg0 = _35cc19;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -14148,28 +13950,28 @@ Obj _35reg312 = primNot(_35val311);
 __nargs = 2;
 __arg1 = _35reg312;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1996) { goto fail; }
+if (co->ctx.pc.func != _35clofun1969) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label18:
 {
 Obj _35val310 = __arg1;
-pushCont(co, 17, _35clofun1996, 0);
+pushCont(co, 17, _35clofun1969, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#null?"));
 __arg1 = _35val310;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label19:
 {
 Obj x = __arg1;
-pushCont(co, 18, _35clofun1996, 0);
+pushCont(co, 18, _35clofun1969, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#assq"));
 __arg1 = x;
@@ -14177,7 +13979,7 @@ __arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -14189,7 +13991,7 @@ if (True == _35val315) {
 __nargs = 2;
 __arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1996) { goto fail; }
+if (co->ctx.pc.func != _35clofun1969) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 2;
@@ -14198,7 +14000,7 @@ __arg1 = find;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1996) { co->ctx.pc = ps; goto fail; };
+if (ps.func != _35clofun1969) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -575,9 +575,12 @@
 
   (defun eval0 (exp)
     (cond
-     ((symbol? exp) (value (lookup-var exp "" *imported*)))
+     ((symbol? exp) (value exp))
      ((or (number? exp) (string? exp) (boolean? exp) (null? exp))
       exp)
-     (if (= (car exp) 'quote) (cadr exp)
-	 (apply (eval0 (car exp)) (map eval0 (cdr exp))))))
+     ((cons? exp)
+      (if (= (car exp) 'quote)
+	  (cadr exp)
+	  (apply (eval0 (car exp)) (map eval0 (cdr exp)))))))
+
   )

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -575,12 +575,11 @@
 
   (defun eval0 (exp)
     (cond
-     ((symbol? exp) (value exp))
+     ((symbol? exp) (value (lookup-var exp "" cora/init#*imported*)))
      ((or (number? exp) (string? exp) (boolean? exp) (null? exp))
       exp)
-     ((cons? exp)
-      (if (= (car exp) 'quote)
-	  (cadr exp)
-	  (apply (eval0 (car exp)) (map eval0 (cdr exp)))))))
+     (true (if (= (car exp) 'quote)
+	       (cadr exp)
+	       (apply (eval0 (car exp)) (map eval0 (cdr exp)))))))
 
   )

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -56,18 +56,18 @@
      ((symbol-cooked? var) var)
      (true (intern (string-append ns (string-append "#" (symbol->string var)))))))
 
-  (func lookup-var-h
-	s ns [] => ['%global (var-with-ns s ns)]
+  (func lookup-var
+	s ns [] => (var-with-ns s ns)
 	s ns [import . more] => (let export (value-or (intern (string-append import "#*ns-export*")) ())
 				  (if (elem? s export)
-				      ['%global (intern (string-append import (string-append "#" (symbol->string s))))]
-				      (lookup-var-h s ns more))))
+				      (intern (string-append import (string-append "#" (symbol->string s))))
+				      (lookup-var s ns more))))
 
   (func parse
 	_ _ _ x => ['%const x] where (or (number? x) (string? x) (boolean? x) (null? x))
 	_ _ _ ['quote x] => ['%const x]
 	env ns import x => (if (elem? x env) x
-			       (lookup-var-h x ns import)) where (symbol? x)
+			       ['%global (lookup-var x ns import)]) where (symbol? x)
 			       env ns import ['lambda args body] => ['lambda args (parse (append args env) ns import body)]
 			       env ns import  ['if . args] => ['if . (map (parse env ns import) args)]
 			       env ns import ['do x y] => ['do (parse env ns import x) (parse env ns import y)]
@@ -575,12 +575,9 @@
 
   (defun eval0 (exp)
     (cond
-     ((symbol? exp) (value exp))
+     ((symbol? exp) (value (lookup-var exp "" *imported*)))
      ((or (number? exp) (string? exp) (boolean? exp) (null? exp))
       exp)
-     ((cons? exp)
-      (if (= (car exp) 'quote)
-	  (cadr exp)
-	  (apply (eval0 (car exp)) (map eval0 (cdr exp)))))))
-
+     (if (= (car exp) 'quote) (cadr exp)
+	 (apply (eval0 (car exp)) (map eval0 (cdr exp))))))
   )

--- a/main.c
+++ b/main.c
@@ -8,23 +8,15 @@ int main(int argc, char *argv[]) {
   uintptr_t dummy;
   struct Cora* co = coraNew();
   coraInit(co, &dummy);
-  Obj imported = intern("*imported*");
-
-  co->args[1] = makeCString("init.so");
-  co->args[2] = makeCString("cora/init");
-  co->nargs = 3;
-  trampoline(co, 0, builtinLoadSo);
-  primSet(co, imported, cons(makeCString("cora/init"), Nil));
-  /* primSet(co, imported, cons(makeCString("cora/lib/toc/internal"), symbolGet(imported))); */
-  
-  co->args[1] = makeCString("cora/lib/toc");
-  /* co->args[2] = makeCString(""); */
-  /* co->nargs = 3; */
+  co->args[1] = makeCString("cora/init");
   co->nargs = 2;
   trampoline(co, 0, builtinImport);
-  /* primSet(co, imported, cons(makeCString("cora/lib/toc"), symbolGet(imported))); */
   
-		struct SexpReader r = {co: co};
+  co->args[1] = makeCString("cora/lib/toc");
+  co->nargs = 2;
+  trampoline(co, 0, builtinImport);
+  
+  struct SexpReader r = {co: co};
   int errCode = 0;
 
   for (int i=0; ; i++) {

--- a/main.c
+++ b/main.c
@@ -1,7 +1,6 @@
 #include "runtime.h"
 
 
-extern void builtinLoadSo(struct Cora *co);
 extern void builtinImport(struct Cora *co);
 
 int main(int argc, char *argv[]) {

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -643,7 +643,7 @@ void
 builtinImport(struct Cora *co) {
 	Obj pkg = co->args[1];
 	str pkgStr = stringStr(pkg);
-	Obj sym = intern("*imported*");
+	Obj sym = intern("cora/init#*imported*");
 	Obj imported = symbolGet(sym);
 
 	// Avoid repeated load.
@@ -858,7 +858,7 @@ coraInit(struct Cora *co, uintptr_t * mark) {
 		makeNative(0, builtinBytesLength, 1, 0));
 	primSet(co, intern("try"), makeNative(0, builtinTryCatch, 2, 0));
 	primSet(co, intern("throw"), makeNative(0, builtinThrow, 1, 0));
-	primSet(co, intern("*imported*"), Nil);
+	primSet(co, intern("cora/init#*imported*"), Nil);
 	primSet(co, intern("symbol-cooked?"),
 		makeNative(0, builtinSymbolCooked, 1, 0));
 }


### PR DESCRIPTION
Now the eval0 function will detect `cora/init#*imported*` variable to determine the namespace of a variable.
It means that `(import "lib-path")` now take effect in eval0.