### PR TITLE
lib/toc.cora: delay the group by labels operation to generation time

### DIFF
--- a/init.c
+++ b/init.c
@@ -2,17 +2,43 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun1365(struct Cora* co);
-void _35clofun1364(struct Cora* co);
-void _35clofun1363(struct Cora* co);
-void _35clofun1362(struct Cora* co);
-void _35clofun1361(struct Cora* co);
-void _35clofun1360(struct Cora* co);
-void _35clofun1359(struct Cora* co);
-void _35clofun1358(struct Cora* co);
-void _35clofun1357(struct Cora* co);
-void _35clofun1356(struct Cora* co);
-void _35clofun1355(struct Cora* co);
+void clofun1(struct Cora* co);
+void clofun2(struct Cora* co);
+void clofun3(struct Cora* co);
+void clofun4(struct Cora* co);
+void clofun5(struct Cora* co);
+void clofun6(struct Cora* co);
+void clofun7(struct Cora* co);
+void clofun8(struct Cora* co);
+void clofun9(struct Cora* co);
+void clofun10(struct Cora* co);
+void clofun11(struct Cora* co);
+void clofun12(struct Cora* co);
+void clofun13(struct Cora* co);
+void clofun14(struct Cora* co);
+void clofun15(struct Cora* co);
+void clofun16(struct Cora* co);
+void clofun17(struct Cora* co);
+void clofun18(struct Cora* co);
+void clofun19(struct Cora* co);
+void clofun20(struct Cora* co);
+void clofun21(struct Cora* co);
+void clofun22(struct Cora* co);
+void clofun23(struct Cora* co);
+void clofun24(struct Cora* co);
+void clofun25(struct Cora* co);
+void clofun26(struct Cora* co);
+void clofun27(struct Cora* co);
+void clofun28(struct Cora* co);
+void clofun29(struct Cora* co);
+void clofun30(struct Cora* co);
+void clofun31(struct Cora* co);
+void clofun32(struct Cora* co);
+void clofun33(struct Cora* co);
+void clofun34(struct Cora* co);
+void clofun35(struct Cora* co);
+void clofun36(struct Cora* co);
+void clofun37(struct Cora* co);
 
 
 void entry(struct Cora* co){
@@ -22,27 +48,117 @@ Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35reg266 = primSet(co, intern("null?"), makeNative(0, _35clofun1355, 1, 0));
-Obj _35reg269 = primSet(co, intern("cadr"), makeNative(1, _35clofun1355, 1, 0));
-Obj _35reg272 = primSet(co, intern("caar"), makeNative(2, _35clofun1355, 1, 0));
-Obj _35reg275 = primSet(co, intern("cdar"), makeNative(3, _35clofun1355, 1, 0));
-Obj _35reg278 = primSet(co, intern("cddr"), makeNative(4, _35clofun1355, 1, 0));
-Obj _35reg282 = primSet(co, intern("caddr"), makeNative(5, _35clofun1355, 1, 0));
-Obj _35reg287 = primSet(co, intern("cadddr"), makeNative(6, _35clofun1355, 1, 0));
-Obj _35reg291 = primSet(co, intern("cdddr"), makeNative(7, _35clofun1355, 1, 0));
-Obj _35reg299 = primSet(co, intern("rcons"), makeNative(9, _35clofun1355, 1, 0));
-Obj _35reg301 = primSet(co, intern("pair?"), makeNative(10, _35clofun1355, 1, 0));
-Obj _35reg306 = primSet(co, intern("cora/init#reverse-h"), makeNative(11, _35clofun1355, 2, 0));
-pushCont(co, 14, _35clofun1365, 0);
+Obj _35reg370 = primSet(co, intern("null?"), makeNative(3, clofun37, 1, 0));
+Obj _35reg373 = primSet(co, intern("cadr"), makeNative(2, clofun37, 1, 0));
+Obj _35reg376 = primSet(co, intern("caar"), makeNative(1, clofun37, 1, 0));
+Obj _35reg379 = primSet(co, intern("cdar"), makeNative(0, clofun37, 1, 0));
+Obj _35reg382 = primSet(co, intern("cddr"), makeNative(5, clofun36, 1, 0));
+Obj _35reg386 = primSet(co, intern("caddr"), makeNative(4, clofun36, 1, 0));
+Obj _35reg391 = primSet(co, intern("cadddr"), makeNative(3, clofun36, 1, 0));
+Obj _35reg395 = primSet(co, intern("cdddr"), makeNative(2, clofun36, 1, 0));
+Obj _35reg403 = primSet(co, intern("rcons"), makeNative(0, clofun36, 1, 0));
+Obj _35reg405 = primSet(co, intern("pair?"), makeNative(5, clofun35, 1, 0));
+Obj _35reg410 = primSet(co, intern("cora/init#reverse-h"), makeNative(4, clofun35, 2, 0));
+pushCont(co, 1, entry, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#reverse-h"));
 __arg1 = Nil;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != entry) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val411 = __arg1;
+Obj _35reg412 = primSet(co, intern("reverse"), _35val411);
+Obj _35reg418 = primSet(co, intern("map-h"), makeNative(2, clofun35, 3, 0));
+Obj _35reg419 = primSet(co, intern("map"), makeNative(1, clofun35, 2, 0));
+Obj _35reg420 = primSet(co, intern("*macros*"), Nil);
+Obj _35reg421 = primGenSym(intern("protect"));
+Obj _35reg422 = primSet(co, intern("*protect-symbol*"), _35reg421);
+Obj _35reg426 = primSet(co, intern("cora/init#add-to-*macros*"), makeNative(0, clofun35, 2, 0));
+Obj _35reg439 = primSet(co, intern("cora/init#macroexpand1-h"), makeNative(4, clofun34, 2, 0));
+Obj _35reg440 = primSet(co, intern("cora/init#macroexpand1"), makeNative(3, clofun34, 1, 0));
+Obj _35reg457 = primSet(co, intern("cora/init#macroexpand-boot"), makeNative(3, clofun33, 1, 0));
+Obj _35reg458 = primSet(co, intern("macroexpand"), globalRef(intern("cora/init#macroexpand-boot")));
+Obj _35reg469 = primSet(co, intern("defmacro-macro"), makeNative(5, clofun32, 1, 0));
+pushCont(co, 2, entry, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
+__arg1 = intern("defmacro");
+__arg2 = globalRef(intern("defmacro-macro"));
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != entry) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val470 = __arg1;
+pushCont(co, 3, entry, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
+__arg1 = intern("list");
+__arg2 = makeNative(4, clofun32, 1, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != entry) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val472 = __arg1;
+pushCont(co, 4, entry, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
+__arg1 = intern("defun");
+__arg2 = makeNative(0, clofun32, 1, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != entry) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val482 = __arg1;
+Obj _35reg487 = primSet(co, intern("elem?"), makeNative(5, clofun31, 2, 0));
+Obj _35reg490 = primSet(co, intern("atom?"), makeNative(4, clofun31, 1, 0));
+Obj _35reg502 = primSet(co, intern("cora/init#rewrite-let"), makeNative(5, clofun30, 1, 0));
+pushCont(co, 5, entry, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
+__arg1 = intern("let");
+__arg2 = makeNative(4, clofun30, 1, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != entry) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val504 = __arg1;
+pushCont(co, 0, clofun1, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
+__arg1 = intern("cond");
+__arg2 = makeNative(0, clofun30, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -59,349 +175,127 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1365(struct Cora* co){
+void clofun1(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj sexp = __arg1;
-pushCont(co, 20, _35clofun1364, 1, sexp);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = sexp;
+Obj _35val518 = __arg1;
+Obj _35reg530 = primSet(co, intern("cora/init#rewrite-or"), makeNative(4, clofun29, 1, 0));
+pushCont(co, 1, clofun1, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
+__arg1 = intern("or");
+__arg2 = makeNative(3, clofun29, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val1279 = __arg1;
-Obj _35reg1280 = primCons(intern("append"), Nil);
-Obj _35reg1281 = primCons(intern("filter"), _35reg1280);
-Obj _35reg1282 = primCons(intern("length"), _35reg1281);
-Obj _35reg1283 = primCons(intern("elem?"), _35reg1282);
-Obj _35reg1284 = primCons(intern("macroexpand"), _35reg1283);
-Obj _35reg1285 = primCons(intern("map"), _35reg1284);
-Obj _35reg1286 = primCons(intern("reverse"), _35reg1285);
-Obj _35reg1287 = primCons(intern("throw"), _35reg1286);
-Obj _35reg1288 = primCons(intern("try"), _35reg1287);
-Obj _35reg1289 = primCons(intern("load"), _35reg1288);
-Obj _35reg1290 = primCons(intern("import"), _35reg1289);
-Obj _35reg1291 = primCons(intern("load-so"), _35reg1290);
-Obj _35reg1292 = primCons(intern("apply"), _35reg1291);
-Obj _35reg1293 = primCons(intern("value-or"), _35reg1292);
-Obj _35reg1294 = primCons(intern("value"), _35reg1293);
-Obj _35reg1295 = primCons(intern("read-file-as-sexp"), _35reg1294);
-Obj _35reg1296 = primCons(intern("bytes-length"), _35reg1295);
-Obj _35reg1297 = primCons(intern("bytes"), _35reg1296);
-Obj _35reg1298 = primCons(intern("vector-length"), _35reg1297);
-Obj _35reg1299 = primCons(intern("vector-ref"), _35reg1298);
-Obj _35reg1300 = primCons(intern("vector-set!"), _35reg1299);
-Obj _35reg1301 = primCons(intern("vector"), _35reg1300);
-Obj _35reg1302 = primCons(intern("symbol->string"), _35reg1301);
-Obj _35reg1303 = primCons(intern("intern"), _35reg1302);
-Obj _35reg1304 = primCons(intern("string-append"), _35reg1303);
-Obj _35reg1305 = primCons(intern("null?"), _35reg1304);
-Obj _35reg1306 = primCons(intern("number?"), _35reg1305);
-Obj _35reg1307 = primCons(intern("boolean?"), _35reg1306);
-Obj _35reg1308 = primCons(intern("atom?"), _35reg1307);
-Obj _35reg1309 = primCons(intern("pair?"), _35reg1308);
-Obj _35reg1310 = primCons(intern("cdddr"), _35reg1309);
-Obj _35reg1311 = primCons(intern("cadddr"), _35reg1310);
-Obj _35reg1312 = primCons(intern("caddr"), _35reg1311);
-Obj _35reg1313 = primCons(intern("cddr"), _35reg1312);
-Obj _35reg1314 = primCons(intern("cdar"), _35reg1313);
-Obj _35reg1315 = primCons(intern("caar"), _35reg1314);
-Obj _35reg1316 = primCons(intern("cadr"), _35reg1315);
-Obj _35reg1317 = primSet(co, intern("cora/init#*ns-export*"), _35reg1316);
-Obj _35reg1318 = primSet(co, intern("cora/init#cadr"), globalRef(intern("cadr")));
-Obj _35reg1319 = primSet(co, intern("cora/init#caar"), globalRef(intern("caar")));
-Obj _35reg1320 = primSet(co, intern("cora/init#cdar"), globalRef(intern("cdar")));
-Obj _35reg1321 = primSet(co, intern("cora/init#cddr"), globalRef(intern("cddr")));
-Obj _35reg1322 = primSet(co, intern("cora/init#caddr"), globalRef(intern("caddr")));
-Obj _35reg1323 = primSet(co, intern("cora/init#cadddr"), globalRef(intern("cadddr")));
-Obj _35reg1324 = primSet(co, intern("cora/init#cdddr"), globalRef(intern("cdddr")));
-Obj _35reg1325 = primSet(co, intern("cora/init#pair?"), globalRef(intern("pair?")));
-Obj _35reg1326 = primSet(co, intern("cora/init#atom?"), globalRef(intern("atom?")));
-Obj _35reg1327 = primSet(co, intern("cora/init#boolean?"), globalRef(intern("boolean?")));
-Obj _35reg1328 = primSet(co, intern("cora/init#null?"), globalRef(intern("null?")));
-Obj _35reg1329 = primSet(co, intern("cora/init#number?"), globalRef(intern("number?")));
-Obj _35reg1330 = primSet(co, intern("cora/init#string-append"), globalRef(intern("string-append")));
-Obj _35reg1331 = primSet(co, intern("cora/init#intern"), globalRef(intern("intern")));
-Obj _35reg1332 = primSet(co, intern("cora/init#symbol->string"), globalRef(intern("symbol->string")));
-Obj _35reg1333 = primSet(co, intern("cora/init#vector"), globalRef(intern("vector")));
-Obj _35reg1334 = primSet(co, intern("cora/init#vector-set!"), globalRef(intern("vector-set!")));
-Obj _35reg1335 = primSet(co, intern("cora/init#vector-ref"), globalRef(intern("vector-ref")));
-Obj _35reg1336 = primSet(co, intern("cora/init#vector-length"), globalRef(intern("vector-length")));
-Obj _35reg1337 = primSet(co, intern("cora/init#bytes"), globalRef(intern("bytes")));
-Obj _35reg1338 = primSet(co, intern("cora/init#bytes-length"), globalRef(intern("bytes-length")));
-Obj _35reg1339 = primSet(co, intern("cora/init#value"), globalRef(intern("value")));
-Obj _35reg1340 = primSet(co, intern("cora/init#value-or"), globalRef(intern("value-or")));
-Obj _35reg1341 = primSet(co, intern("cora/init#read-file-as-sexp"), globalRef(intern("read-file-as-sexp")));
-Obj _35reg1342 = primSet(co, intern("cora/init#apply"), globalRef(intern("apply")));
-Obj _35reg1343 = primSet(co, intern("cora/init#load"), globalRef(intern("load")));
-Obj _35reg1344 = primSet(co, intern("cora/init#load-so"), globalRef(intern("load-so")));
-Obj _35reg1345 = primSet(co, intern("cora/init#import"), globalRef(intern("import")));
-Obj _35reg1346 = primSet(co, intern("cora/init#try"), globalRef(intern("try")));
-Obj _35reg1347 = primSet(co, intern("cora/init#throw"), globalRef(intern("throw")));
-Obj _35reg1348 = primSet(co, intern("cora/init#reverse"), globalRef(intern("reverse")));
-Obj _35reg1349 = primSet(co, intern("cora/init#map"), globalRef(intern("map")));
-Obj _35reg1350 = primSet(co, intern("cora/init#macroexpand"), globalRef(intern("macroexpand")));
-Obj _35reg1351 = primSet(co, intern("cora/init#elem?"), globalRef(intern("elem?")));
-Obj _35reg1352 = primSet(co, intern("cora/init#length"), globalRef(intern("length")));
-Obj _35reg1353 = primSet(co, intern("cora/init#filter"), globalRef(intern("filter")));
-Obj _35reg1354 = primSet(co, intern("cora/init#append"), globalRef(intern("append")));
-__nargs = 2;
-__arg1 = _35reg1354;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1365) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val532 = __arg1;
+Obj _35reg544 = primSet(co, intern("cora/init#rewrite-and"), makeNative(1, clofun29, 1, 0));
+pushCont(co, 2, clofun1, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
+__arg1 = intern("and");
+__arg2 = makeNative(0, clofun29, 1, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1229 = __arg1;
-Obj _35reg1258 = primSet(co, intern("cora/init#parse-define-library-h"), makeNative(12, _35clofun1364, 4, 0));
-Obj _35reg1259 = primSet(co, intern("cora/init#parse-define-library"), makeNative(13, _35clofun1364, 2, 0));
-pushCont(co, 1, _35clofun1365, 0);
+Obj _35val546 = __arg1;
+Obj _35reg549 = primSet(co, intern("boolean?"), makeNative(5, clofun28, 1, 0));
+Obj _35reg559 = primSet(co, intern("cora/init#rcons1"), makeNative(2, clofun28, 1, 0));
+pushCont(co, 3, clofun1, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("define-library");
-__arg2 = makeNative(0, _35clofun1365, 1, 0);
+__arg1 = intern("list-rest");
+__arg2 = makeNative(1, clofun28, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val1207 = __arg1;
-Obj _35reg1227 = primSet(co, intern("cora/init#rewrite-backquote"), makeNative(5, _35clofun1364, 1, 0));
-pushCont(co, 2, _35clofun1365, 0);
+Obj _35val561 = __arg1;
+Obj _35reg615 = primSet(co, intern("cora/init#match-cons-expander"), makeNative(1, clofun25, 4, 0));
+Obj _35reg648 = primSet(co, intern("cora/init#match1"), makeNative(1, clofun24, 4, 0));
+Obj _35reg675 = primSet(co, intern("cora/init#extract-rule-action"), makeNative(5, clofun22, 2, 0));
+Obj _35reg727 = primSet(co, intern("cora/init#match-helper"), makeNative(1, clofun20, 2, 0));
+Obj _35reg753 = primSet(co, intern("cora/init#rewrite-match"), makeNative(0, clofun19, 1, 0));
+pushCont(co, 4, clofun1, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("backquote");
-__arg2 = makeNative(7, _35clofun1364, 1, 0);
+__arg1 = intern("match");
+__arg2 = makeNative(5, clofun18, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val758 = __arg1;
-Obj _35reg1021 = primSet(co, intern("cora/init#propagate-boolean0"), makeNative(10, _35clofun1362, 1, 0));
-Obj _35reg1179 = primSet(co, intern("cora/init#propagate-boolean"), makeNative(12, _35clofun1363, 1, 0));
-Obj _35reg1181 = primSet(co, intern("macroexpand"), makeNative(14, _35clofun1363, 1, 0));
-Obj _35reg1205 = primSet(co, intern("cora/init#rewrite-begin"), makeNative(19, _35clofun1363, 1, 0));
-pushCont(co, 3, _35clofun1365, 0);
+Obj _35val754 = __arg1;
+Obj _35reg806 = primSet(co, intern("cora/init#extract-rules1"), makeNative(4, clofun17, 3, 0));
+Obj _35reg807 = primSet(co, intern("cora/init#extract-rules"), makeNative(3, clofun17, 1, 0));
+Obj _35reg812 = primSet(co, intern("cora/init#rules-patterns"), makeNative(0, clofun17, 2, 0));
+Obj _35reg816 = primSet(co, intern("cora/init#length-h"), makeNative(5, clofun16, 2, 0));
+Obj _35reg817 = primSet(co, intern("length"), makeNative(4, clofun16, 1, 0));
+Obj _35reg825 = primSet(co, intern("cora/init#filter-h"), makeNative(2, clofun16, 3, 0));
+Obj _35reg826 = primSet(co, intern("filter"), makeNative(1, clofun16, 2, 0));
+Obj _35reg832 = primSet(co, intern("append"), makeNative(5, clofun15, 2, 0));
+Obj _35reg843 = primSet(co, intern("cora/init#rules-arg-count"), makeNative(4, clofun14, 1, 0));
+Obj _35reg849 = primSet(co, intern("cora/init#gen-paramenters"), makeNative(2, clofun14, 1, 0));
+pushCont(co, 5, clofun1, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("begin");
-__arg2 = makeNative(20, _35clofun1363, 1, 0);
+__arg1 = intern("func");
+__arg2 = makeNative(2, clofun13, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val650 = __arg1;
-Obj _35reg702 = primSet(co, intern("cora/init#extract-rules1"), makeNative(14, _35clofun1360, 3, 0));
-Obj _35reg703 = primSet(co, intern("cora/init#extract-rules"), makeNative(15, _35clofun1360, 1, 0));
-Obj _35reg708 = primSet(co, intern("cora/init#rules-patterns"), makeNative(18, _35clofun1360, 2, 0));
-Obj _35reg712 = primSet(co, intern("cora/init#length-h"), makeNative(19, _35clofun1360, 2, 0));
-Obj _35reg713 = primSet(co, intern("length"), makeNative(20, _35clofun1360, 1, 0));
-Obj _35reg721 = primSet(co, intern("cora/init#filter-h"), makeNative(1, _35clofun1361, 3, 0));
-Obj _35reg722 = primSet(co, intern("filter"), makeNative(2, _35clofun1361, 2, 0));
-Obj _35reg728 = primSet(co, intern("append"), makeNative(4, _35clofun1361, 2, 0));
-Obj _35reg739 = primSet(co, intern("cora/init#rules-arg-count"), makeNative(11, _35clofun1361, 1, 0));
-Obj _35reg745 = primSet(co, intern("cora/init#gen-paramenters"), makeNative(13, _35clofun1361, 1, 0));
-pushCont(co, 4, _35clofun1365, 0);
+Obj _35val862 = __arg1;
+Obj _35reg1125 = primSet(co, intern("cora/init#propagate-boolean0"), makeNative(2, clofun11, 1, 0));
+Obj _35reg1283 = primSet(co, intern("cora/init#propagate-boolean"), makeNative(3, clofun7, 1, 0));
+Obj _35reg1285 = primSet(co, intern("macroexpand"), makeNative(1, clofun7, 1, 0));
+Obj _35reg1309 = primSet(co, intern("cora/init#rewrite-begin"), makeNative(2, clofun6, 1, 0));
+pushCont(co, 0, clofun2, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("func");
-__arg2 = makeNative(19, _35clofun1361, 1, 0);
+__arg1 = intern("begin");
+__arg2 = makeNative(1, clofun6, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val457 = __arg1;
-Obj _35reg511 = primSet(co, intern("cora/init#match-cons-expander"), makeNative(11, _35clofun1358, 4, 0));
-Obj _35reg544 = primSet(co, intern("cora/init#match1"), makeNative(17, _35clofun1358, 4, 0));
-Obj _35reg571 = primSet(co, intern("cora/init#extract-rule-action"), makeNative(4, _35clofun1359, 2, 0));
-Obj _35reg623 = primSet(co, intern("cora/init#match-helper"), makeNative(20, _35clofun1359, 2, 0));
-Obj _35reg649 = primSet(co, intern("cora/init#rewrite-match"), makeNative(6, _35clofun1360, 1, 0));
-pushCont(co, 5, _35clofun1365, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("match");
-__arg2 = makeNative(7, _35clofun1360, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val442 = __arg1;
-Obj _35reg445 = primSet(co, intern("boolean?"), makeNative(10, _35clofun1357, 1, 0));
-Obj _35reg455 = primSet(co, intern("cora/init#rcons1"), makeNative(13, _35clofun1357, 1, 0));
-pushCont(co, 6, _35clofun1365, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("list-rest");
-__arg2 = makeNative(14, _35clofun1357, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35val428 = __arg1;
-Obj _35reg440 = primSet(co, intern("cora/init#rewrite-and"), makeNative(8, _35clofun1357, 1, 0));
-pushCont(co, 7, _35clofun1365, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("and");
-__arg2 = makeNative(9, _35clofun1357, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val414 = __arg1;
-Obj _35reg426 = primSet(co, intern("cora/init#rewrite-or"), makeNative(5, _35clofun1357, 1, 0));
-pushCont(co, 8, _35clofun1365, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("or");
-__arg2 = makeNative(6, _35clofun1357, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35val400 = __arg1;
-pushCont(co, 9, _35clofun1365, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("cond");
-__arg2 = makeNative(3, _35clofun1357, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val378 = __arg1;
-Obj _35reg383 = primSet(co, intern("elem?"), makeNative(13, _35clofun1356, 2, 0));
-Obj _35reg386 = primSet(co, intern("atom?"), makeNative(14, _35clofun1356, 1, 0));
-Obj _35reg398 = primSet(co, intern("cora/init#rewrite-let"), makeNative(19, _35clofun1356, 1, 0));
-pushCont(co, 10, _35clofun1365, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("let");
-__arg2 = makeNative(20, _35clofun1356, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35val368 = __arg1;
-pushCont(co, 11, _35clofun1365, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("defun");
-__arg2 = makeNative(12, _35clofun1356, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35val366 = __arg1;
-pushCont(co, 12, _35clofun1365, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("list");
-__arg2 = makeNative(8, _35clofun1356, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35val307 = __arg1;
-Obj _35reg308 = primSet(co, intern("reverse"), _35val307);
-Obj _35reg314 = primSet(co, intern("map-h"), makeNative(13, _35clofun1355, 3, 0));
-Obj _35reg315 = primSet(co, intern("map"), makeNative(14, _35clofun1355, 2, 0));
-Obj _35reg316 = primSet(co, intern("*macros*"), Nil);
-Obj _35reg317 = primGenSym(intern("protect"));
-Obj _35reg318 = primSet(co, intern("*protect-symbol*"), _35reg317);
-Obj _35reg322 = primSet(co, intern("cora/init#add-to-*macros*"), makeNative(15, _35clofun1355, 2, 0));
-Obj _35reg335 = primSet(co, intern("cora/init#macroexpand1-h"), makeNative(17, _35clofun1355, 2, 0));
-Obj _35reg336 = primSet(co, intern("cora/init#macroexpand1"), makeNative(18, _35clofun1355, 1, 0));
-Obj _35reg353 = primSet(co, intern("cora/init#macroexpand-boot"), makeNative(3, _35clofun1356, 1, 0));
-Obj _35reg354 = primSet(co, intern("macroexpand"), globalRef(intern("cora/init#macroexpand-boot")));
-Obj _35reg365 = primSet(co, intern("defmacro-macro"), makeNative(7, _35clofun1356, 1, 0));
-pushCont(co, 13, _35clofun1365, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("defmacro");
-__arg2 = globalRef(intern("defmacro-macro"));
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1365) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -414,397 +308,285 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1364(struct Cora* co){
+void clofun2(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeCString("no match-help found!");
+Obj _35val1311 = __arg1;
+Obj _35reg1331 = primSet(co, intern("cora/init#rewrite-backquote"), makeNative(1, clofun5, 1, 0));
+pushCont(co, 1, clofun2, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
+__arg1 = intern("backquote");
+__arg2 = makeNative(5, clofun4, 1, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35cc257 = makeNative(0, _35clofun1364, 0, 0);
-Obj x = closureRef(co, 0);
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1364) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val1333 = __arg1;
+Obj _35reg1362 = primSet(co, intern("cora/init#parse-define-library-h"), makeNative(0, clofun4, 4, 0));
+Obj _35reg1363 = primSet(co, intern("cora/init#parse-define-library"), makeNative(5, clofun3, 2, 0));
+pushCont(co, 2, clofun2, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
+__arg1 = intern("define-library");
+__arg2 = makeNative(3, clofun2, 1, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val1212 = __arg1;
-Obj _35reg1213 = primCons(intern("list"), _35val1212);
+Obj _35val1383 = __arg1;
+Obj _35reg1384 = primCons(intern("append"), Nil);
+Obj _35reg1385 = primCons(intern("filter"), _35reg1384);
+Obj _35reg1386 = primCons(intern("length"), _35reg1385);
+Obj _35reg1387 = primCons(intern("elem?"), _35reg1386);
+Obj _35reg1388 = primCons(intern("macroexpand"), _35reg1387);
+Obj _35reg1389 = primCons(intern("map"), _35reg1388);
+Obj _35reg1390 = primCons(intern("reverse"), _35reg1389);
+Obj _35reg1391 = primCons(intern("throw"), _35reg1390);
+Obj _35reg1392 = primCons(intern("try"), _35reg1391);
+Obj _35reg1393 = primCons(intern("load"), _35reg1392);
+Obj _35reg1394 = primCons(intern("import"), _35reg1393);
+Obj _35reg1395 = primCons(intern("load-so"), _35reg1394);
+Obj _35reg1396 = primCons(intern("apply"), _35reg1395);
+Obj _35reg1397 = primCons(intern("value-or"), _35reg1396);
+Obj _35reg1398 = primCons(intern("value"), _35reg1397);
+Obj _35reg1399 = primCons(intern("read-file-as-sexp"), _35reg1398);
+Obj _35reg1400 = primCons(intern("bytes-length"), _35reg1399);
+Obj _35reg1401 = primCons(intern("bytes"), _35reg1400);
+Obj _35reg1402 = primCons(intern("vector-length"), _35reg1401);
+Obj _35reg1403 = primCons(intern("vector-ref"), _35reg1402);
+Obj _35reg1404 = primCons(intern("vector-set!"), _35reg1403);
+Obj _35reg1405 = primCons(intern("vector"), _35reg1404);
+Obj _35reg1406 = primCons(intern("symbol->string"), _35reg1405);
+Obj _35reg1407 = primCons(intern("intern"), _35reg1406);
+Obj _35reg1408 = primCons(intern("string-append"), _35reg1407);
+Obj _35reg1409 = primCons(intern("null?"), _35reg1408);
+Obj _35reg1410 = primCons(intern("number?"), _35reg1409);
+Obj _35reg1411 = primCons(intern("boolean?"), _35reg1410);
+Obj _35reg1412 = primCons(intern("atom?"), _35reg1411);
+Obj _35reg1413 = primCons(intern("pair?"), _35reg1412);
+Obj _35reg1414 = primCons(intern("cdddr"), _35reg1413);
+Obj _35reg1415 = primCons(intern("cadddr"), _35reg1414);
+Obj _35reg1416 = primCons(intern("caddr"), _35reg1415);
+Obj _35reg1417 = primCons(intern("cddr"), _35reg1416);
+Obj _35reg1418 = primCons(intern("cdar"), _35reg1417);
+Obj _35reg1419 = primCons(intern("caar"), _35reg1418);
+Obj _35reg1420 = primCons(intern("cadr"), _35reg1419);
+Obj _35reg1421 = primSet(co, intern("cora/init#*ns-export*"), _35reg1420);
+Obj _35reg1422 = primSet(co, intern("cora/init#cadr"), globalRef(intern("cadr")));
+Obj _35reg1423 = primSet(co, intern("cora/init#caar"), globalRef(intern("caar")));
+Obj _35reg1424 = primSet(co, intern("cora/init#cdar"), globalRef(intern("cdar")));
+Obj _35reg1425 = primSet(co, intern("cora/init#cddr"), globalRef(intern("cddr")));
+Obj _35reg1426 = primSet(co, intern("cora/init#caddr"), globalRef(intern("caddr")));
+Obj _35reg1427 = primSet(co, intern("cora/init#cadddr"), globalRef(intern("cadddr")));
+Obj _35reg1428 = primSet(co, intern("cora/init#cdddr"), globalRef(intern("cdddr")));
+Obj _35reg1429 = primSet(co, intern("cora/init#pair?"), globalRef(intern("pair?")));
+Obj _35reg1430 = primSet(co, intern("cora/init#atom?"), globalRef(intern("atom?")));
+Obj _35reg1431 = primSet(co, intern("cora/init#boolean?"), globalRef(intern("boolean?")));
+Obj _35reg1432 = primSet(co, intern("cora/init#null?"), globalRef(intern("null?")));
+Obj _35reg1433 = primSet(co, intern("cora/init#number?"), globalRef(intern("number?")));
+Obj _35reg1434 = primSet(co, intern("cora/init#string-append"), globalRef(intern("string-append")));
+Obj _35reg1435 = primSet(co, intern("cora/init#intern"), globalRef(intern("intern")));
+Obj _35reg1436 = primSet(co, intern("cora/init#symbol->string"), globalRef(intern("symbol->string")));
+Obj _35reg1437 = primSet(co, intern("cora/init#vector"), globalRef(intern("vector")));
+Obj _35reg1438 = primSet(co, intern("cora/init#vector-set!"), globalRef(intern("vector-set!")));
+Obj _35reg1439 = primSet(co, intern("cora/init#vector-ref"), globalRef(intern("vector-ref")));
+Obj _35reg1440 = primSet(co, intern("cora/init#vector-length"), globalRef(intern("vector-length")));
+Obj _35reg1441 = primSet(co, intern("cora/init#bytes"), globalRef(intern("bytes")));
+Obj _35reg1442 = primSet(co, intern("cora/init#bytes-length"), globalRef(intern("bytes-length")));
+Obj _35reg1443 = primSet(co, intern("cora/init#value"), globalRef(intern("value")));
+Obj _35reg1444 = primSet(co, intern("cora/init#value-or"), globalRef(intern("value-or")));
+Obj _35reg1445 = primSet(co, intern("cora/init#read-file-as-sexp"), globalRef(intern("read-file-as-sexp")));
+Obj _35reg1446 = primSet(co, intern("cora/init#apply"), globalRef(intern("apply")));
+Obj _35reg1447 = primSet(co, intern("cora/init#load"), globalRef(intern("load")));
+Obj _35reg1448 = primSet(co, intern("cora/init#load-so"), globalRef(intern("load-so")));
+Obj _35reg1449 = primSet(co, intern("cora/init#import"), globalRef(intern("import")));
+Obj _35reg1450 = primSet(co, intern("cora/init#try"), globalRef(intern("try")));
+Obj _35reg1451 = primSet(co, intern("cora/init#throw"), globalRef(intern("throw")));
+Obj _35reg1452 = primSet(co, intern("cora/init#reverse"), globalRef(intern("reverse")));
+Obj _35reg1453 = primSet(co, intern("cora/init#map"), globalRef(intern("map")));
+Obj _35reg1454 = primSet(co, intern("cora/init#macroexpand"), globalRef(intern("macroexpand")));
+Obj _35reg1455 = primSet(co, intern("cora/init#elem?"), globalRef(intern("elem?")));
+Obj _35reg1456 = primSet(co, intern("cora/init#length"), globalRef(intern("length")));
+Obj _35reg1457 = primSet(co, intern("cora/init#filter"), globalRef(intern("filter")));
+Obj _35reg1458 = primSet(co, intern("cora/init#append"), globalRef(intern("append")));
 __nargs = 2;
-__arg1 = _35reg1213;
+__arg1 = _35reg1458;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1364) { goto fail; }
+if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label3:
 {
-Obj _35cc256 = makeNative(1, _35clofun1364, 0, 1, closureRef(co, 0));
-Obj _35reg1208 = primIsCons(closureRef(co, 0));
-if (True == _35reg1208) {
-Obj _35reg1209 = primCar(closureRef(co, 0));
-Obj x = _35reg1209;
-Obj _35reg1210 = primCdr(closureRef(co, 0));
-Obj more = _35reg1210;
-Obj _35reg1211 = primCons(x, more);
-pushCont(co, 2, _35clofun1364, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = globalRef(intern("cora/init#rewrite-backquote"));
-__arg2 = _35reg1211;
+Obj sexp = __arg1;
+pushCont(co, 4, clofun2, 1, sexp);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc256;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label4:
 {
-Obj _35cc255 = makeNative(3, _35clofun1364, 0, 1, closureRef(co, 0));
-Obj _35reg1214 = primIsCons(closureRef(co, 0));
-if (True == _35reg1214) {
-Obj _35reg1215 = primCar(closureRef(co, 0));
-Obj _35reg1216 = primEQ(intern("unquote"), _35reg1215);
-if (True == _35reg1216) {
-Obj _35reg1217 = primCdr(closureRef(co, 0));
-Obj _35reg1218 = primIsCons(_35reg1217);
-if (True == _35reg1218) {
-Obj _35reg1219 = primCdr(closureRef(co, 0));
-Obj _35reg1220 = primCar(_35reg1219);
-Obj x = _35reg1220;
-Obj _35reg1221 = primCdr(closureRef(co, 0));
-Obj _35reg1222 = primCdr(_35reg1221);
-Obj _35reg1223 = primEQ(Nil, _35reg1222);
-if (True == _35reg1223) {
+Obj _35val1364 = __arg1;
+Obj sexp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj path = _35val1364;
+pushCont(co, 5, clofun2, 1, path);
 __nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1364) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc255;
+__arg0 = globalRef(intern("cddr"));
+__arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc255;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc255;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc255;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label5:
 {
-Obj _35p253 = __arg1;
-Obj _35cc254 = makeNative(4, _35clofun1364, 0, 1, _35p253);
-Obj x = _35p253;
-Obj _35reg1224 = primIsSymbol(x);
-if (True == _35reg1224) {
-Obj _35reg1225 = primCons(x, Nil);
-Obj _35reg1226 = primCons(intern("quote"), _35reg1225);
+Obj _35val1365 = __arg1;
+Obj path= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 0, clofun3, 1, path);
 __nargs = 2;
-__arg1 = _35reg1226;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1364) { goto fail; }
+__arg0 = globalRef(intern("cora/init#parse-define-library"));
+__arg1 = _35val1365;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun3(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc254;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
 
-label6:
+label0:
 {
-Obj _35val1228 = __arg1;
+Obj _35val1366 = __arg1;
+Obj path= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 2;
-__arg0 = globalRef(intern("cora/init#rewrite-backquote"));
-__arg1 = _35val1228;
+__arg0 = _35val1366;
+__arg1 = makeNative(1, clofun3, 3, 1, path);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label1:
 {
-Obj exp = __arg1;
-pushCont(co, 6, _35clofun1364, 0);
+Obj import = __arg1;
+Obj export = __arg2;
+Obj body = __arg3;
+Obj _35reg1367 = primCons(makeCString("cora/init"), import);
+pushCont(co, 2, clofun3, 3, export, body, _35reg1367);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = makeNative(4, clofun3, 1, 0);
+__arg2 = import;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val1370 = __arg1;
+Obj export= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1367= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg1371 = primCons(export, Nil);
+Obj _35reg1372 = primCons(intern("backquote"), _35reg1371);
+Obj _35reg1373 = primCons(_35reg1372, Nil);
+Obj _35reg1374 = primCons(intern("*ns-export*"), _35reg1373);
+Obj _35reg1375 = primCons(intern("def"), _35reg1374);
+Obj _35reg1376 = primCons(_35reg1375, body);
+pushCont(co, 3, clofun3, 1, _35reg1367);
+__nargs = 3;
+__arg0 = globalRef(intern("append"));
+__arg1 = _35val1370;
+__arg2 = _35reg1376;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val1377 = __arg1;
+Obj _35reg1367= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1378 = primCons(intern("begin"), _35val1377);
+Obj _35reg1379 = primCons(_35reg1378, Nil);
+Obj _35reg1380 = primCons(_35reg1367, _35reg1379);
+Obj _35reg1381 = primCons(closureRef(co, 0), _35reg1380);
+Obj _35reg1382 = primCons(intern("ns"), _35reg1381);
 __nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = _35reg1382;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
-label8:
+label4:
 {
+Obj imp = __arg1;
+Obj _35reg1368 = primCons(imp, Nil);
+Obj _35reg1369 = primCons(intern("import"), _35reg1368);
 __nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = _35reg1369;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun3) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
-label9:
-{
-Obj _35val1230 = __arg1;
-Obj k= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exports= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
-__nargs = 4;
-__arg0 = k;
-__arg1 = _35val1230;
-__arg2 = exports;
-__arg3 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35cc264 = makeNative(8, _35clofun1364, 0, 0);
-Obj body = closureRef(co, 0);
-Obj imports = closureRef(co, 1);
-Obj exports = closureRef(co, 2);
-Obj k = closureRef(co, 3);
-pushCont(co, 9, _35clofun1364, 3, k, exports, body);
-__nargs = 2;
-__arg0 = globalRef(intern("reverse"));
-__arg1 = imports;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35cc263 = makeNative(10, _35clofun1364, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg1231 = primIsCons(closureRef(co, 0));
-if (True == _35reg1231) {
-Obj _35reg1232 = primCar(closureRef(co, 0));
-Obj _35reg1233 = primIsCons(_35reg1232);
-if (True == _35reg1233) {
-Obj _35reg1234 = primCar(closureRef(co, 0));
-Obj _35reg1235 = primCar(_35reg1234);
-Obj _35reg1236 = primEQ(intern("export"), _35reg1235);
-if (True == _35reg1236) {
-Obj _35reg1237 = primCar(closureRef(co, 0));
-Obj _35reg1238 = primCdr(_35reg1237);
-Obj more = _35reg1238;
-Obj _35reg1239 = primCdr(closureRef(co, 0));
-Obj rest = _35reg1239;
-Obj imports = closureRef(co, 1);
-Obj exports = closureRef(co, 2);
-Obj k = closureRef(co, 3);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#parse-define-library-h"));
-__arg1 = rest;
-__arg2 = imports;
-__arg3 = more;
-co->args[4] = k;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc263;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc263;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc263;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35p258 = __arg1;
-Obj _35p259 = __arg2;
-Obj _35p260 = __arg3;
-Obj _35p261 = co->args[4];
-Obj _35cc262 = makeNative(11, _35clofun1364, 0, 4, _35p258, _35p259, _35p260, _35p261);
-Obj _35reg1240 = primIsCons(_35p258);
-if (True == _35reg1240) {
-Obj _35reg1241 = primCar(_35p258);
-Obj _35reg1242 = primIsCons(_35reg1241);
-if (True == _35reg1242) {
-Obj _35reg1243 = primCar(_35p258);
-Obj _35reg1244 = primCar(_35reg1243);
-Obj _35reg1245 = primEQ(intern("import"), _35reg1244);
-if (True == _35reg1245) {
-Obj _35reg1246 = primCar(_35p258);
-Obj _35reg1247 = primCdr(_35reg1246);
-Obj _35reg1248 = primIsCons(_35reg1247);
-if (True == _35reg1248) {
-Obj _35reg1249 = primCar(_35p258);
-Obj _35reg1250 = primCdr(_35reg1249);
-Obj _35reg1251 = primCar(_35reg1250);
-Obj lib = _35reg1251;
-Obj _35reg1252 = primCar(_35p258);
-Obj _35reg1253 = primCdr(_35reg1252);
-Obj _35reg1254 = primCdr(_35reg1253);
-Obj _35reg1255 = primEQ(Nil, _35reg1254);
-if (True == _35reg1255) {
-Obj _35reg1256 = primCdr(_35p258);
-Obj rest = _35reg1256;
-Obj imports = _35p259;
-Obj exports = _35p260;
-Obj k = _35p261;
-Obj _35reg1257 = primCons(lib, imports);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#parse-define-library-h"));
-__arg1 = rest;
-__arg2 = _35reg1257;
-__arg3 = exports;
-co->args[4] = k;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc262;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc262;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc262;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc262;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc262;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
+label5:
 {
 Obj data = __arg1;
 Obj k = __arg2;
@@ -817,122 +599,7 @@ co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj imp = __arg1;
-Obj _35reg1264 = primCons(imp, Nil);
-Obj _35reg1265 = primCons(intern("import"), _35reg1264);
-__nargs = 2;
-__arg1 = _35reg1265;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1364) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label15:
-{
-Obj _35val1273 = __arg1;
-Obj _35reg1263= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1274 = primCons(intern("begin"), _35val1273);
-Obj _35reg1275 = primCons(_35reg1274, Nil);
-Obj _35reg1276 = primCons(_35reg1263, _35reg1275);
-Obj _35reg1277 = primCons(closureRef(co, 0), _35reg1276);
-Obj _35reg1278 = primCons(intern("ns"), _35reg1277);
-__nargs = 2;
-__arg1 = _35reg1278;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1364) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label16:
-{
-Obj _35val1266 = __arg1;
-Obj export= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1263= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg1267 = primCons(export, Nil);
-Obj _35reg1268 = primCons(intern("backquote"), _35reg1267);
-Obj _35reg1269 = primCons(_35reg1268, Nil);
-Obj _35reg1270 = primCons(intern("*ns-export*"), _35reg1269);
-Obj _35reg1271 = primCons(intern("def"), _35reg1270);
-Obj _35reg1272 = primCons(_35reg1271, body);
-pushCont(co, 15, _35clofun1364, 1, _35reg1263);
-__nargs = 3;
-__arg0 = globalRef(intern("append"));
-__arg1 = _35val1266;
-__arg2 = _35reg1272;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj import = __arg1;
-Obj export = __arg2;
-Obj body = __arg3;
-Obj _35reg1263 = primCons(makeCString("cora/init"), import);
-pushCont(co, 16, _35clofun1364, 3, export, body, _35reg1263);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = makeNative(14, _35clofun1364, 1, 0);
-__arg2 = import;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val1262 = __arg1;
-Obj path= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 2;
-__arg0 = _35val1262;
-__arg1 = makeNative(17, _35clofun1364, 3, 1, path);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35val1261 = __arg1;
-Obj path= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 18, _35clofun1364, 1, path);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#parse-define-library"));
-__arg1 = _35val1261;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val1260 = __arg1;
-Obj sexp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj path = _35val1260;
-pushCont(co, 19, _35clofun1364, 1, path);
-__nargs = 2;
-__arg0 = globalRef(intern("cddr"));
-__arg1 = sexp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1364) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -945,2219 +612,784 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1363(struct Cora* co){
+void clofun4(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc244 = makeNative(19, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg1080 = primIsCons(closureRef(co, 0));
-if (True == _35reg1080) {
-Obj _35reg1081 = primCar(closureRef(co, 0));
-Obj _35reg1082 = primEQ(intern("not"), _35reg1081);
-if (True == _35reg1082) {
-Obj _35reg1083 = primCdr(closureRef(co, 0));
-Obj _35reg1084 = primIsCons(_35reg1083);
-if (True == _35reg1084) {
-Obj _35reg1085 = primCdr(closureRef(co, 0));
-Obj _35reg1086 = primCar(_35reg1085);
-Obj x = _35reg1086;
-Obj _35reg1087 = primCdr(closureRef(co, 0));
-Obj _35reg1088 = primCdr(_35reg1087);
-Obj _35reg1089 = primEQ(Nil, _35reg1088);
-if (True == _35reg1089) {
-pushCont(co, 20, _35clofun1362, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean"));
-__arg1 = x;
+Obj _35p362 = __arg1;
+Obj _35p363 = __arg2;
+Obj _35p364 = __arg3;
+Obj _35p365 = co->args[4];
+Obj _35cc366 = makeNative(1, clofun4, 0, 4, _35p362, _35p363, _35p364, _35p365);
+Obj _35reg1344 = primIsCons(_35p362);
+if (True == _35reg1344) {
+Obj _35reg1345 = primCar(_35p362);
+Obj _35reg1346 = primIsCons(_35reg1345);
+if (True == _35reg1346) {
+Obj _35reg1347 = primCar(_35p362);
+Obj _35reg1348 = primCar(_35reg1347);
+Obj _35reg1349 = primEQ(intern("import"), _35reg1348);
+if (True == _35reg1349) {
+Obj _35reg1350 = primCar(_35p362);
+Obj _35reg1351 = primCdr(_35reg1350);
+Obj _35reg1352 = primIsCons(_35reg1351);
+if (True == _35reg1352) {
+Obj _35reg1353 = primCar(_35p362);
+Obj _35reg1354 = primCdr(_35reg1353);
+Obj _35reg1355 = primCar(_35reg1354);
+Obj lib = _35reg1355;
+Obj _35reg1356 = primCar(_35p362);
+Obj _35reg1357 = primCdr(_35reg1356);
+Obj _35reg1358 = primCdr(_35reg1357);
+Obj _35reg1359 = primEQ(Nil, _35reg1358);
+if (True == _35reg1359) {
+Obj _35reg1360 = primCdr(_35p362);
+Obj rest = _35reg1360;
+Obj imports = _35p363;
+Obj exports = _35p364;
+Obj k = _35p365;
+Obj _35reg1361 = primCons(lib, imports);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#parse-define-library-h"));
+__arg1 = rest;
+__arg2 = _35reg1361;
+__arg3 = exports;
+co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc244;
+__arg0 = _35cc366;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc244;
+__arg0 = _35cc366;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc244;
+__arg0 = _35cc366;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc244;
+__arg0 = _35cc366;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc366;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35val1103 = __arg1;
-Obj x1 = _35val1103;
-Obj _35reg1104 = primCons(x1, Nil);
-Obj _35reg1105 = primCons(intern("null?"), _35reg1104);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean0"));
-__arg1 = _35reg1105;
+Obj _35cc367 = makeNative(2, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35reg1335 = primIsCons(closureRef(co, 0));
+if (True == _35reg1335) {
+Obj _35reg1336 = primCar(closureRef(co, 0));
+Obj _35reg1337 = primIsCons(_35reg1336);
+if (True == _35reg1337) {
+Obj _35reg1338 = primCar(closureRef(co, 0));
+Obj _35reg1339 = primCar(_35reg1338);
+Obj _35reg1340 = primEQ(intern("export"), _35reg1339);
+if (True == _35reg1340) {
+Obj _35reg1341 = primCar(closureRef(co, 0));
+Obj _35reg1342 = primCdr(_35reg1341);
+Obj more = _35reg1342;
+Obj _35reg1343 = primCdr(closureRef(co, 0));
+Obj rest = _35reg1343;
+Obj imports = closureRef(co, 1);
+Obj exports = closureRef(co, 2);
+Obj k = closureRef(co, 3);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#parse-define-library-h"));
+__arg1 = rest;
+__arg2 = imports;
+__arg3 = more;
+co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc367;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc367;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc367;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label2:
 {
-Obj _35cc243 = makeNative(0, _35clofun1363, 0, 1, closureRef(co, 0));
-Obj _35reg1093 = primIsCons(closureRef(co, 0));
-if (True == _35reg1093) {
-Obj _35reg1094 = primCar(closureRef(co, 0));
-Obj _35reg1095 = primEQ(intern("null?"), _35reg1094);
-if (True == _35reg1095) {
-Obj _35reg1096 = primCdr(closureRef(co, 0));
-Obj _35reg1097 = primIsCons(_35reg1096);
-if (True == _35reg1097) {
-Obj _35reg1098 = primCdr(closureRef(co, 0));
-Obj _35reg1099 = primCar(_35reg1098);
-Obj x = _35reg1099;
-Obj _35reg1100 = primCdr(closureRef(co, 0));
-Obj _35reg1101 = primCdr(_35reg1100);
-Obj _35reg1102 = primEQ(Nil, _35reg1101);
-if (True == _35reg1102) {
-pushCont(co, 1, _35clofun1363, 0);
+Obj _35cc368 = makeNative(4, clofun4, 0, 0);
+Obj body = closureRef(co, 0);
+Obj imports = closureRef(co, 1);
+Obj exports = closureRef(co, 2);
+Obj k = closureRef(co, 3);
+pushCont(co, 3, clofun4, 3, k, exports, body);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg0 = globalRef(intern("reverse"));
+__arg1 = imports;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val1334 = __arg1;
+Obj k= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exports= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
+__nargs = 4;
+__arg0 = k;
+__arg1 = _35val1334;
+__arg2 = exports;
+__arg3 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj exp = __arg1;
+pushCont(co, 0, clofun5, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun5(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val1332 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rewrite-backquote"));
+__arg1 = _35val1332;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35p357 = __arg1;
+Obj _35cc358 = makeNative(2, clofun5, 0, 1, _35p357);
+Obj x = _35p357;
+Obj _35reg1328 = primIsSymbol(x);
+if (True == _35reg1328) {
+Obj _35reg1329 = primCons(x, Nil);
+Obj _35reg1330 = primCons(intern("quote"), _35reg1329);
+__nargs = 2;
+__arg1 = _35reg1330;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc358;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35cc359 = makeNative(3, clofun5, 0, 1, closureRef(co, 0));
+Obj _35reg1318 = primIsCons(closureRef(co, 0));
+if (True == _35reg1318) {
+Obj _35reg1319 = primCar(closureRef(co, 0));
+Obj _35reg1320 = primEQ(intern("unquote"), _35reg1319);
+if (True == _35reg1320) {
+Obj _35reg1321 = primCdr(closureRef(co, 0));
+Obj _35reg1322 = primIsCons(_35reg1321);
+if (True == _35reg1322) {
+Obj _35reg1323 = primCdr(closureRef(co, 0));
+Obj _35reg1324 = primCar(_35reg1323);
+Obj x = _35reg1324;
+Obj _35reg1325 = primCdr(closureRef(co, 0));
+Obj _35reg1326 = primCdr(_35reg1325);
+Obj _35reg1327 = primEQ(Nil, _35reg1326);
+if (True == _35reg1327) {
+__nargs = 2;
 __arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc243;
+__arg0 = _35cc359;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc243;
+__arg0 = _35cc359;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc243;
+__arg0 = _35cc359;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc243;
+__arg0 = _35cc359;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35val1124 = __arg1;
-Obj x1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj y1 = _35val1124;
-Obj _35reg1125 = primCons(y1, Nil);
-Obj _35reg1126 = primCons(x1, _35reg1125);
-Obj _35reg1127 = primCons(intern("and"), _35reg1126);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean0"));
-__arg1 = _35reg1127;
+Obj _35cc360 = makeNative(5, clofun5, 0, 1, closureRef(co, 0));
+Obj _35reg1312 = primIsCons(closureRef(co, 0));
+if (True == _35reg1312) {
+Obj _35reg1313 = primCar(closureRef(co, 0));
+Obj x = _35reg1313;
+Obj _35reg1314 = primCdr(closureRef(co, 0));
+Obj more = _35reg1314;
+Obj _35reg1315 = primCons(x, more);
+pushCont(co, 4, clofun5, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = globalRef(intern("cora/init#rewrite-backquote"));
+__arg2 = _35reg1315;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc360;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label4:
 {
-Obj _35val1123 = __arg1;
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj x1 = _35val1123;
-pushCont(co, 3, _35clofun1363, 1, x1);
+Obj _35val1316 = __arg1;
+Obj _35reg1317 = primCons(intern("list"), _35val1316);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean"));
-__arg1 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = _35reg1317;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label5:
 {
-Obj _35cc242 = makeNative(2, _35clofun1363, 0, 1, closureRef(co, 0));
-Obj _35reg1106 = primIsCons(closureRef(co, 0));
-if (True == _35reg1106) {
-Obj _35reg1107 = primCar(closureRef(co, 0));
-Obj _35reg1108 = primEQ(intern("and"), _35reg1107);
-if (True == _35reg1108) {
-Obj _35reg1109 = primCdr(closureRef(co, 0));
-Obj _35reg1110 = primIsCons(_35reg1109);
-if (True == _35reg1110) {
-Obj _35reg1111 = primCdr(closureRef(co, 0));
-Obj _35reg1112 = primCar(_35reg1111);
-Obj x = _35reg1112;
-Obj _35reg1113 = primCdr(closureRef(co, 0));
-Obj _35reg1114 = primCdr(_35reg1113);
-Obj _35reg1115 = primIsCons(_35reg1114);
-if (True == _35reg1115) {
-Obj _35reg1116 = primCdr(closureRef(co, 0));
-Obj _35reg1117 = primCdr(_35reg1116);
-Obj _35reg1118 = primCar(_35reg1117);
-Obj y = _35reg1118;
-Obj _35reg1119 = primCdr(closureRef(co, 0));
-Obj _35reg1120 = primCdr(_35reg1119);
-Obj _35reg1121 = primCdr(_35reg1120);
-Obj _35reg1122 = primEQ(Nil, _35reg1121);
-if (True == _35reg1122) {
-pushCont(co, 4, _35clofun1363, 1, y);
+Obj _35cc361 = makeNative(0, clofun6, 0, 0);
+Obj x = closureRef(co, 0);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean"));
 __arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc242;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc242;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc242;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc242;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc242;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label6:
-{
-Obj _35val1138 = __arg1;
-Obj x1 = _35val1138;
-Obj _35reg1139 = primCons(x1, Nil);
-Obj _35reg1140 = primCons(intern("cdr"), _35reg1139);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean0"));
-__arg1 = _35reg1140;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35cc241 = makeNative(5, _35clofun1363, 0, 1, closureRef(co, 0));
-Obj _35reg1128 = primIsCons(closureRef(co, 0));
-if (True == _35reg1128) {
-Obj _35reg1129 = primCar(closureRef(co, 0));
-Obj _35reg1130 = primEQ(intern("cdr"), _35reg1129);
-if (True == _35reg1130) {
-Obj _35reg1131 = primCdr(closureRef(co, 0));
-Obj _35reg1132 = primIsCons(_35reg1131);
-if (True == _35reg1132) {
-Obj _35reg1133 = primCdr(closureRef(co, 0));
-Obj _35reg1134 = primCar(_35reg1133);
-Obj x = _35reg1134;
-Obj _35reg1135 = primCdr(closureRef(co, 0));
-Obj _35reg1136 = primCdr(_35reg1135);
-Obj _35reg1137 = primEQ(Nil, _35reg1136);
-if (True == _35reg1137) {
-pushCont(co, 6, _35clofun1363, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc241;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc241;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc241;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc241;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-Obj _35val1151 = __arg1;
-Obj x1 = _35val1151;
-Obj _35reg1152 = primCons(x1, Nil);
-Obj _35reg1153 = primCons(intern("car"), _35reg1152);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean0"));
-__arg1 = _35reg1153;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35cc240 = makeNative(7, _35clofun1363, 0, 1, closureRef(co, 0));
-Obj _35reg1141 = primIsCons(closureRef(co, 0));
-if (True == _35reg1141) {
-Obj _35reg1142 = primCar(closureRef(co, 0));
-Obj _35reg1143 = primEQ(intern("car"), _35reg1142);
-if (True == _35reg1143) {
-Obj _35reg1144 = primCdr(closureRef(co, 0));
-Obj _35reg1145 = primIsCons(_35reg1144);
-if (True == _35reg1145) {
-Obj _35reg1146 = primCdr(closureRef(co, 0));
-Obj _35reg1147 = primCar(_35reg1146);
-Obj x = _35reg1147;
-Obj _35reg1148 = primCdr(closureRef(co, 0));
-Obj _35reg1149 = primCdr(_35reg1148);
-Obj _35reg1150 = primEQ(Nil, _35reg1149);
-if (True == _35reg1150) {
-pushCont(co, 8, _35clofun1363, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc240;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc240;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc240;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc240;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj _35val1164 = __arg1;
-Obj x1 = _35val1164;
-Obj _35reg1165 = primCons(x1, Nil);
-Obj _35reg1166 = primCons(intern("cons?"), _35reg1165);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean0"));
-__arg1 = _35reg1166;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35cc239 = makeNative(9, _35clofun1363, 0, 1, closureRef(co, 0));
-Obj _35reg1154 = primIsCons(closureRef(co, 0));
-if (True == _35reg1154) {
-Obj _35reg1155 = primCar(closureRef(co, 0));
-Obj _35reg1156 = primEQ(intern("cons?"), _35reg1155);
-if (True == _35reg1156) {
-Obj _35reg1157 = primCdr(closureRef(co, 0));
-Obj _35reg1158 = primIsCons(_35reg1157);
-if (True == _35reg1158) {
-Obj _35reg1159 = primCdr(closureRef(co, 0));
-Obj _35reg1160 = primCar(_35reg1159);
-Obj x = _35reg1160;
-Obj _35reg1161 = primCdr(closureRef(co, 0));
-Obj _35reg1162 = primCdr(_35reg1161);
-Obj _35reg1163 = primEQ(Nil, _35reg1162);
-if (True == _35reg1163) {
-pushCont(co, 10, _35clofun1363, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc239;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc239;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc239;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc239;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35p237 = __arg1;
-Obj _35cc238 = makeNative(11, _35clofun1363, 0, 1, _35p237);
-Obj _35reg1167 = primIsCons(_35p237);
-if (True == _35reg1167) {
-Obj _35reg1168 = primCar(_35p237);
-Obj _35reg1169 = primEQ(intern("quote"), _35reg1168);
-if (True == _35reg1169) {
-Obj _35reg1170 = primCdr(_35p237);
-Obj _35reg1171 = primIsCons(_35reg1170);
-if (True == _35reg1171) {
-Obj _35reg1172 = primCdr(_35p237);
-Obj _35reg1173 = primCar(_35reg1172);
-Obj x = _35reg1173;
-Obj _35reg1174 = primCdr(_35p237);
-Obj _35reg1175 = primCdr(_35reg1174);
-Obj _35reg1176 = primEQ(Nil, _35reg1175);
-if (True == _35reg1176) {
-Obj _35reg1177 = primCons(x, Nil);
-Obj _35reg1178 = primCons(intern("quote"), _35reg1177);
-__nargs = 2;
-__arg1 = _35reg1178;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1363) { goto fail; }
+if (co->ctx.pc.func != clofun5) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun6(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj exp = __arg1;
+Obj _35reg1310 = primCdr(exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rewrite-begin"));
+__arg1 = _35reg1310;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35p353 = __arg1;
+Obj _35cc354 = makeNative(3, clofun6, 0, 1, _35p353);
+Obj _35reg1305 = primIsCons(_35p353);
+if (True == _35reg1305) {
+Obj _35reg1306 = primCar(_35p353);
+Obj x = _35reg1306;
+Obj _35reg1307 = primCdr(_35p353);
+Obj _35reg1308 = primEQ(Nil, _35reg1307);
+if (True == _35reg1308) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc238;
+__arg0 = _35cc354;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc238;
+__arg0 = _35cc354;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc238;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc238;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label13:
+label3:
 {
-Obj _35val1180 = __arg1;
+Obj _35cc355 = makeNative(4, clofun6, 0, 1, closureRef(co, 0));
+Obj _35reg1293 = primIsCons(closureRef(co, 0));
+if (True == _35reg1293) {
+Obj _35reg1294 = primCar(closureRef(co, 0));
+Obj x = _35reg1294;
+Obj _35reg1295 = primCdr(closureRef(co, 0));
+Obj _35reg1296 = primIsCons(_35reg1295);
+if (True == _35reg1296) {
+Obj _35reg1297 = primCdr(closureRef(co, 0));
+Obj _35reg1298 = primCar(_35reg1297);
+Obj y = _35reg1298;
+Obj _35reg1299 = primCdr(closureRef(co, 0));
+Obj _35reg1300 = primCdr(_35reg1299);
+Obj _35reg1301 = primEQ(Nil, _35reg1300);
+if (True == _35reg1301) {
+Obj _35reg1302 = primCons(y, Nil);
+Obj _35reg1303 = primCons(x, _35reg1302);
+Obj _35reg1304 = primCons(intern("do"), _35reg1303);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean"));
-__arg1 = _35val1180;
+__arg1 = _35reg1304;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc355;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc355;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc355;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35cc356 = makeNative(0, clofun7, 0, 0);
+Obj _35reg1286 = primIsCons(closureRef(co, 0));
+if (True == _35reg1286) {
+Obj _35reg1287 = primCar(closureRef(co, 0));
+Obj x = _35reg1287;
+Obj _35reg1288 = primCdr(closureRef(co, 0));
+Obj y = _35reg1288;
+pushCont(co, 5, clofun6, 1, x);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rewrite-begin"));
+__arg1 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc356;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35val1289 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1290 = primCons(_35val1289, Nil);
+Obj _35reg1291 = primCons(x, _35reg1290);
+Obj _35reg1292 = primCons(intern("do"), _35reg1291);
+__nargs = 2;
+__arg1 = _35reg1292;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun6) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun7(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label1:
 {
 Obj exp = __arg1;
-pushCont(co, 13, _35clofun1363, 0);
+pushCont(co, 2, clofun7, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#macroexpand-boot"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-
-label15:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val1185 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1186 = primCons(_35val1185, Nil);
-Obj _35reg1187 = primCons(x, _35reg1186);
-Obj _35reg1188 = primCons(intern("do"), _35reg1187);
-__nargs = 2;
-__arg1 = _35reg1188;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1363) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label17:
-{
-Obj _35cc252 = makeNative(15, _35clofun1363, 0, 0);
-Obj _35reg1182 = primIsCons(closureRef(co, 0));
-if (True == _35reg1182) {
-Obj _35reg1183 = primCar(closureRef(co, 0));
-Obj x = _35reg1183;
-Obj _35reg1184 = primCdr(closureRef(co, 0));
-Obj y = _35reg1184;
-pushCont(co, 16, _35clofun1363, 1, x);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#rewrite-begin"));
-__arg1 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc252;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label18:
-{
-Obj _35cc251 = makeNative(17, _35clofun1363, 0, 1, closureRef(co, 0));
-Obj _35reg1189 = primIsCons(closureRef(co, 0));
-if (True == _35reg1189) {
-Obj _35reg1190 = primCar(closureRef(co, 0));
-Obj x = _35reg1190;
-Obj _35reg1191 = primCdr(closureRef(co, 0));
-Obj _35reg1192 = primIsCons(_35reg1191);
-if (True == _35reg1192) {
-Obj _35reg1193 = primCdr(closureRef(co, 0));
-Obj _35reg1194 = primCar(_35reg1193);
-Obj y = _35reg1194;
-Obj _35reg1195 = primCdr(closureRef(co, 0));
-Obj _35reg1196 = primCdr(_35reg1195);
-Obj _35reg1197 = primEQ(Nil, _35reg1196);
-if (True == _35reg1197) {
-Obj _35reg1198 = primCons(y, Nil);
-Obj _35reg1199 = primCons(x, _35reg1198);
-Obj _35reg1200 = primCons(intern("do"), _35reg1199);
-__nargs = 2;
-__arg1 = _35reg1200;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1363) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc251;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc251;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc251;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label19:
-{
-Obj _35p249 = __arg1;
-Obj _35cc250 = makeNative(18, _35clofun1363, 0, 1, _35p249);
-Obj _35reg1201 = primIsCons(_35p249);
-if (True == _35reg1201) {
-Obj _35reg1202 = primCar(_35p249);
-Obj x = _35reg1202;
-Obj _35reg1203 = primCdr(_35p249);
-Obj _35reg1204 = primEQ(Nil, _35reg1203);
-if (True == _35reg1204) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1363) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc250;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc250;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
-{
-Obj exp = __arg1;
-Obj _35reg1206 = primCdr(exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#rewrite-begin"));
-__arg1 = _35reg1206;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1363) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-fail:
-co->nargs = __nargs;
-co->args[0] = __arg0;
-co->args[1] = __arg1;
-co->args[2] = __arg2;
-co->args[3] = __arg3;
-
-}
-
-void _35clofun1362(struct Cora* co){
-int __nargs = co->nargs;
-Obj __arg0 = co->args[0];
-Obj __arg1 = co->args[1];
-Obj __arg2 = co->args[2];
-Obj __arg3 = co->args[3];
-
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
-
-goto *jumpTable[co->ctx.pc.label];
-
-label0:
-{
-Obj _35cc236 = makeNative(20, _35clofun1361, 0, 0);
-Obj x = closureRef(co, 0);
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label1:
-{
-Obj _35cc235 = makeNative(0, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg759 = primIsCons(closureRef(co, 0));
-if (True == _35reg759) {
-Obj _35reg760 = primCar(closureRef(co, 0));
-Obj _35reg761 = primEQ(intern("if"), _35reg760);
-if (True == _35reg761) {
-Obj _35reg762 = primCdr(closureRef(co, 0));
-Obj _35reg763 = primIsCons(_35reg762);
-if (True == _35reg763) {
-Obj _35reg764 = primCdr(closureRef(co, 0));
-Obj _35reg765 = primCar(_35reg764);
-Obj _35reg766 = primEQ(False, _35reg765);
-if (True == _35reg766) {
-Obj _35reg767 = primCdr(closureRef(co, 0));
-Obj _35reg768 = primCdr(_35reg767);
-Obj _35reg769 = primIsCons(_35reg768);
-if (True == _35reg769) {
-Obj _35reg770 = primCdr(closureRef(co, 0));
-Obj _35reg771 = primCdr(_35reg770);
-Obj _35reg772 = primCar(_35reg771);
-Obj y = _35reg772;
-Obj _35reg773 = primCdr(closureRef(co, 0));
-Obj _35reg774 = primCdr(_35reg773);
-Obj _35reg775 = primCdr(_35reg774);
-Obj _35reg776 = primIsCons(_35reg775);
-if (True == _35reg776) {
-Obj _35reg777 = primCdr(closureRef(co, 0));
-Obj _35reg778 = primCdr(_35reg777);
-Obj _35reg779 = primCdr(_35reg778);
-Obj _35reg780 = primCar(_35reg779);
-Obj z = _35reg780;
-Obj _35reg781 = primCdr(closureRef(co, 0));
-Obj _35reg782 = primCdr(_35reg781);
-Obj _35reg783 = primCdr(_35reg782);
-Obj _35reg784 = primCdr(_35reg783);
-Obj _35reg785 = primEQ(Nil, _35reg784);
-if (True == _35reg785) {
-__nargs = 2;
-__arg1 = z;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc235;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc235;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc235;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc235;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc235;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc235;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc235;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label2:
 {
-Obj _35cc234 = makeNative(1, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg786 = primIsCons(closureRef(co, 0));
-if (True == _35reg786) {
-Obj _35reg787 = primCar(closureRef(co, 0));
-Obj _35reg788 = primEQ(intern("if"), _35reg787);
-if (True == _35reg788) {
-Obj _35reg789 = primCdr(closureRef(co, 0));
-Obj _35reg790 = primIsCons(_35reg789);
-if (True == _35reg790) {
-Obj _35reg791 = primCdr(closureRef(co, 0));
-Obj _35reg792 = primCar(_35reg791);
-Obj _35reg793 = primEQ(True, _35reg792);
-if (True == _35reg793) {
-Obj _35reg794 = primCdr(closureRef(co, 0));
-Obj _35reg795 = primCdr(_35reg794);
-Obj _35reg796 = primIsCons(_35reg795);
-if (True == _35reg796) {
-Obj _35reg797 = primCdr(closureRef(co, 0));
-Obj _35reg798 = primCdr(_35reg797);
-Obj _35reg799 = primCar(_35reg798);
-Obj y = _35reg799;
-Obj _35reg800 = primCdr(closureRef(co, 0));
-Obj _35reg801 = primCdr(_35reg800);
-Obj _35reg802 = primCdr(_35reg801);
-Obj _35reg803 = primIsCons(_35reg802);
-if (True == _35reg803) {
-Obj _35reg804 = primCdr(closureRef(co, 0));
-Obj _35reg805 = primCdr(_35reg804);
-Obj _35reg806 = primCdr(_35reg805);
-Obj _35reg807 = primCar(_35reg806);
-Obj z = _35reg807;
-Obj _35reg808 = primCdr(closureRef(co, 0));
-Obj _35reg809 = primCdr(_35reg808);
-Obj _35reg810 = primCdr(_35reg809);
-Obj _35reg811 = primCdr(_35reg810);
-Obj _35reg812 = primEQ(Nil, _35reg811);
-if (True == _35reg812) {
+Obj _35val1284 = __arg1;
 __nargs = 2;
-__arg1 = y;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc234;
+__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg1 = _35val1284;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc234;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc234;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc234;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc234;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc234;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc234;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label3:
 {
-Obj _35cc233 = makeNative(2, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg813 = primIsCons(closureRef(co, 0));
-if (True == _35reg813) {
-Obj _35reg814 = primCar(closureRef(co, 0));
-Obj _35reg815 = primEQ(intern("not"), _35reg814);
-if (True == _35reg815) {
-Obj _35reg816 = primCdr(closureRef(co, 0));
-Obj _35reg817 = primIsCons(_35reg816);
-if (True == _35reg817) {
-Obj _35reg818 = primCdr(closureRef(co, 0));
-Obj _35reg819 = primCar(_35reg818);
-Obj _35reg820 = primEQ(False, _35reg819);
-if (True == _35reg820) {
-Obj _35reg821 = primCdr(closureRef(co, 0));
-Obj _35reg822 = primCdr(_35reg821);
-Obj _35reg823 = primEQ(Nil, _35reg822);
-if (True == _35reg823) {
+Obj _35p341 = __arg1;
+Obj _35cc342 = makeNative(4, clofun7, 0, 1, _35p341);
+Obj _35reg1271 = primIsCons(_35p341);
+if (True == _35reg1271) {
+Obj _35reg1272 = primCar(_35p341);
+Obj _35reg1273 = primEQ(intern("quote"), _35reg1272);
+if (True == _35reg1273) {
+Obj _35reg1274 = primCdr(_35p341);
+Obj _35reg1275 = primIsCons(_35reg1274);
+if (True == _35reg1275) {
+Obj _35reg1276 = primCdr(_35p341);
+Obj _35reg1277 = primCar(_35reg1276);
+Obj x = _35reg1277;
+Obj _35reg1278 = primCdr(_35p341);
+Obj _35reg1279 = primCdr(_35reg1278);
+Obj _35reg1280 = primEQ(Nil, _35reg1279);
+if (True == _35reg1280) {
+Obj _35reg1281 = primCons(x, Nil);
+Obj _35reg1282 = primCons(intern("quote"), _35reg1281);
 __nargs = 2;
-__arg1 = True;
+__arg1 = _35reg1282;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
+if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc233;
+__arg0 = _35cc342;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc233;
+__arg0 = _35cc342;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc233;
+__arg0 = _35cc342;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc233;
+__arg0 = _35cc342;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc233;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35cc232 = makeNative(3, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg824 = primIsCons(closureRef(co, 0));
-if (True == _35reg824) {
-Obj _35reg825 = primCar(closureRef(co, 0));
-Obj _35reg826 = primEQ(intern("not"), _35reg825);
-if (True == _35reg826) {
-Obj _35reg827 = primCdr(closureRef(co, 0));
-Obj _35reg828 = primIsCons(_35reg827);
-if (True == _35reg828) {
-Obj _35reg829 = primCdr(closureRef(co, 0));
-Obj _35reg830 = primCar(_35reg829);
-Obj _35reg831 = primEQ(True, _35reg830);
-if (True == _35reg831) {
-Obj _35reg832 = primCdr(closureRef(co, 0));
-Obj _35reg833 = primCdr(_35reg832);
-Obj _35reg834 = primEQ(Nil, _35reg833);
-if (True == _35reg834) {
+Obj _35cc343 = makeNative(0, clofun8, 0, 1, closureRef(co, 0));
+Obj _35reg1258 = primIsCons(closureRef(co, 0));
+if (True == _35reg1258) {
+Obj _35reg1259 = primCar(closureRef(co, 0));
+Obj _35reg1260 = primEQ(intern("cons?"), _35reg1259);
+if (True == _35reg1260) {
+Obj _35reg1261 = primCdr(closureRef(co, 0));
+Obj _35reg1262 = primIsCons(_35reg1261);
+if (True == _35reg1262) {
+Obj _35reg1263 = primCdr(closureRef(co, 0));
+Obj _35reg1264 = primCar(_35reg1263);
+Obj x = _35reg1264;
+Obj _35reg1265 = primCdr(closureRef(co, 0));
+Obj _35reg1266 = primCdr(_35reg1265);
+Obj _35reg1267 = primEQ(Nil, _35reg1266);
+if (True == _35reg1267) {
+pushCont(co, 5, clofun7, 0);
 __nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc232;
+__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc343;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc232;
+__arg0 = _35cc343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc232;
+__arg0 = _35cc343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc232;
+__arg0 = _35cc343;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc232;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35cc231 = makeNative(4, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg835 = primIsCons(closureRef(co, 0));
-if (True == _35reg835) {
-Obj _35reg836 = primCar(closureRef(co, 0));
-Obj _35reg837 = primEQ(intern("null?"), _35reg836);
-if (True == _35reg837) {
-Obj _35reg838 = primCdr(closureRef(co, 0));
-Obj _35reg839 = primIsCons(_35reg838);
-if (True == _35reg839) {
-Obj _35reg840 = primCdr(closureRef(co, 0));
-Obj _35reg841 = primCar(_35reg840);
-Obj _35reg842 = primIsCons(_35reg841);
-if (True == _35reg842) {
-Obj _35reg843 = primCdr(closureRef(co, 0));
-Obj _35reg844 = primCar(_35reg843);
-Obj _35reg845 = primCar(_35reg844);
-Obj _35reg846 = primEQ(intern("cons"), _35reg845);
-if (True == _35reg846) {
-Obj _35reg847 = primCdr(closureRef(co, 0));
-Obj _35reg848 = primCar(_35reg847);
-Obj _35reg849 = primCdr(_35reg848);
-Obj _35reg850 = primIsCons(_35reg849);
-if (True == _35reg850) {
-Obj _35reg851 = primCdr(closureRef(co, 0));
-Obj _35reg852 = primCar(_35reg851);
-Obj _35reg853 = primCdr(_35reg852);
-Obj _35reg854 = primCar(_35reg853);
-Obj __ = _35reg854;
-Obj _35reg855 = primCdr(closureRef(co, 0));
-Obj _35reg856 = primCar(_35reg855);
-Obj _35reg857 = primCdr(_35reg856);
-Obj _35reg858 = primCdr(_35reg857);
-Obj _35reg859 = primIsCons(_35reg858);
-if (True == _35reg859) {
-Obj _35reg860 = primCdr(closureRef(co, 0));
-Obj _35reg861 = primCar(_35reg860);
-Obj _35reg862 = primCdr(_35reg861);
-Obj _35reg863 = primCdr(_35reg862);
-Obj _35reg864 = primCar(_35reg863);
-__ = _35reg864;
-Obj _35reg865 = primCdr(closureRef(co, 0));
-Obj _35reg866 = primCar(_35reg865);
-Obj _35reg867 = primCdr(_35reg866);
-Obj _35reg868 = primCdr(_35reg867);
-Obj _35reg869 = primCdr(_35reg868);
-Obj _35reg870 = primEQ(Nil, _35reg869);
-if (True == _35reg870) {
-Obj _35reg871 = primCdr(closureRef(co, 0));
-Obj _35reg872 = primCdr(_35reg871);
-Obj _35reg873 = primEQ(Nil, _35reg872);
-if (True == _35reg873) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc231;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label6:
-{
-Obj _35cc230 = makeNative(5, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg874 = primIsCons(closureRef(co, 0));
-if (True == _35reg874) {
-Obj _35reg875 = primCar(closureRef(co, 0));
-Obj _35reg876 = primEQ(intern("null?"), _35reg875);
-if (True == _35reg876) {
-Obj _35reg877 = primCdr(closureRef(co, 0));
-Obj _35reg878 = primIsCons(_35reg877);
-if (True == _35reg878) {
-Obj _35reg879 = primCdr(closureRef(co, 0));
-Obj _35reg880 = primCar(_35reg879);
-Obj _35reg881 = primEQ(Nil, _35reg880);
-if (True == _35reg881) {
-Obj _35reg882 = primCdr(closureRef(co, 0));
-Obj _35reg883 = primCdr(_35reg882);
-Obj _35reg884 = primEQ(Nil, _35reg883);
-if (True == _35reg884) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc230;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc230;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc230;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc230;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc230;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label7:
-{
-Obj _35cc229 = makeNative(6, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg885 = primIsCons(closureRef(co, 0));
-if (True == _35reg885) {
-Obj _35reg886 = primCar(closureRef(co, 0));
-Obj _35reg887 = primEQ(intern("and"), _35reg886);
-if (True == _35reg887) {
-Obj _35reg888 = primCdr(closureRef(co, 0));
-Obj _35reg889 = primIsCons(_35reg888);
-if (True == _35reg889) {
-Obj _35reg890 = primCdr(closureRef(co, 0));
-Obj _35reg891 = primCar(_35reg890);
-Obj _35reg892 = primEQ(True, _35reg891);
-if (True == _35reg892) {
-Obj _35reg893 = primCdr(closureRef(co, 0));
-Obj _35reg894 = primCdr(_35reg893);
-Obj _35reg895 = primIsCons(_35reg894);
-if (True == _35reg895) {
-Obj _35reg896 = primCdr(closureRef(co, 0));
-Obj _35reg897 = primCdr(_35reg896);
-Obj _35reg898 = primCar(_35reg897);
-Obj _35reg899 = primEQ(True, _35reg898);
-if (True == _35reg899) {
-Obj _35reg900 = primCdr(closureRef(co, 0));
-Obj _35reg901 = primCdr(_35reg900);
-Obj _35reg902 = primCdr(_35reg901);
-Obj _35reg903 = primEQ(Nil, _35reg902);
-if (True == _35reg903) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc229;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc229;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc229;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc229;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc229;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc229;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc229;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-Obj _35cc228 = makeNative(7, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg904 = primIsCons(closureRef(co, 0));
-if (True == _35reg904) {
-Obj _35reg905 = primCar(closureRef(co, 0));
-Obj _35reg906 = primEQ(intern("cons?"), _35reg905);
-if (True == _35reg906) {
-Obj _35reg907 = primCdr(closureRef(co, 0));
-Obj _35reg908 = primIsCons(_35reg907);
-if (True == _35reg908) {
-Obj _35reg909 = primCdr(closureRef(co, 0));
-Obj _35reg910 = primCar(_35reg909);
-Obj _35reg911 = primIsCons(_35reg910);
-if (True == _35reg911) {
-Obj _35reg912 = primCdr(closureRef(co, 0));
-Obj _35reg913 = primCar(_35reg912);
-Obj _35reg914 = primCar(_35reg913);
-Obj _35reg915 = primEQ(intern("cons"), _35reg914);
-if (True == _35reg915) {
-Obj _35reg916 = primCdr(closureRef(co, 0));
-Obj _35reg917 = primCar(_35reg916);
-Obj _35reg918 = primCdr(_35reg917);
-Obj _35reg919 = primIsCons(_35reg918);
-if (True == _35reg919) {
-Obj _35reg920 = primCdr(closureRef(co, 0));
-Obj _35reg921 = primCar(_35reg920);
-Obj _35reg922 = primCdr(_35reg921);
-Obj _35reg923 = primCar(_35reg922);
-Obj __ = _35reg923;
-Obj _35reg924 = primCdr(closureRef(co, 0));
-Obj _35reg925 = primCar(_35reg924);
-Obj _35reg926 = primCdr(_35reg925);
-Obj _35reg927 = primCdr(_35reg926);
-Obj _35reg928 = primIsCons(_35reg927);
-if (True == _35reg928) {
-Obj _35reg929 = primCdr(closureRef(co, 0));
-Obj _35reg930 = primCar(_35reg929);
-Obj _35reg931 = primCdr(_35reg930);
-Obj _35reg932 = primCdr(_35reg931);
-Obj _35reg933 = primCar(_35reg932);
-__ = _35reg933;
-Obj _35reg934 = primCdr(closureRef(co, 0));
-Obj _35reg935 = primCar(_35reg934);
-Obj _35reg936 = primCdr(_35reg935);
-Obj _35reg937 = primCdr(_35reg936);
-Obj _35reg938 = primCdr(_35reg937);
-Obj _35reg939 = primEQ(Nil, _35reg938);
-if (True == _35reg939) {
-Obj _35reg940 = primCdr(closureRef(co, 0));
-Obj _35reg941 = primCdr(_35reg940);
-Obj _35reg942 = primEQ(Nil, _35reg941);
-if (True == _35reg942) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc228;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc228;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc228;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc228;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc228;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc228;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc228;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc228;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc228;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label9:
-{
-Obj _35cc227 = makeNative(8, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg943 = primIsCons(closureRef(co, 0));
-if (True == _35reg943) {
-Obj _35reg944 = primCar(closureRef(co, 0));
-Obj _35reg945 = primEQ(intern("cdr"), _35reg944);
-if (True == _35reg945) {
-Obj _35reg946 = primCdr(closureRef(co, 0));
-Obj _35reg947 = primIsCons(_35reg946);
-if (True == _35reg947) {
-Obj _35reg948 = primCdr(closureRef(co, 0));
-Obj _35reg949 = primCar(_35reg948);
-Obj _35reg950 = primIsCons(_35reg949);
-if (True == _35reg950) {
-Obj _35reg951 = primCdr(closureRef(co, 0));
-Obj _35reg952 = primCar(_35reg951);
-Obj _35reg953 = primCar(_35reg952);
-Obj _35reg954 = primEQ(intern("cons"), _35reg953);
-if (True == _35reg954) {
-Obj _35reg955 = primCdr(closureRef(co, 0));
-Obj _35reg956 = primCar(_35reg955);
-Obj _35reg957 = primCdr(_35reg956);
-Obj _35reg958 = primIsCons(_35reg957);
-if (True == _35reg958) {
-Obj _35reg959 = primCdr(closureRef(co, 0));
-Obj _35reg960 = primCar(_35reg959);
-Obj _35reg961 = primCdr(_35reg960);
-Obj _35reg962 = primCar(_35reg961);
-Obj __ = _35reg962;
-Obj _35reg963 = primCdr(closureRef(co, 0));
-Obj _35reg964 = primCar(_35reg963);
-Obj _35reg965 = primCdr(_35reg964);
-Obj _35reg966 = primCdr(_35reg965);
-Obj _35reg967 = primIsCons(_35reg966);
-if (True == _35reg967) {
-Obj _35reg968 = primCdr(closureRef(co, 0));
-Obj _35reg969 = primCar(_35reg968);
-Obj _35reg970 = primCdr(_35reg969);
-Obj _35reg971 = primCdr(_35reg970);
-Obj _35reg972 = primCar(_35reg971);
-Obj x = _35reg972;
-Obj _35reg973 = primCdr(closureRef(co, 0));
-Obj _35reg974 = primCar(_35reg973);
-Obj _35reg975 = primCdr(_35reg974);
-Obj _35reg976 = primCdr(_35reg975);
-Obj _35reg977 = primCdr(_35reg976);
-Obj _35reg978 = primEQ(Nil, _35reg977);
-if (True == _35reg978) {
-Obj _35reg979 = primCdr(closureRef(co, 0));
-Obj _35reg980 = primCdr(_35reg979);
-Obj _35reg981 = primEQ(Nil, _35reg980);
-if (True == _35reg981) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc227;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc227;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc227;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc227;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc227;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc227;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc227;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc227;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc227;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj _35p225 = __arg1;
-Obj _35cc226 = makeNative(9, _35clofun1362, 0, 1, _35p225);
-Obj _35reg982 = primIsCons(_35p225);
-if (True == _35reg982) {
-Obj _35reg983 = primCar(_35p225);
-Obj _35reg984 = primEQ(intern("car"), _35reg983);
-if (True == _35reg984) {
-Obj _35reg985 = primCdr(_35p225);
-Obj _35reg986 = primIsCons(_35reg985);
-if (True == _35reg986) {
-Obj _35reg987 = primCdr(_35p225);
-Obj _35reg988 = primCar(_35reg987);
-Obj _35reg989 = primIsCons(_35reg988);
-if (True == _35reg989) {
-Obj _35reg990 = primCdr(_35p225);
-Obj _35reg991 = primCar(_35reg990);
-Obj _35reg992 = primCar(_35reg991);
-Obj _35reg993 = primEQ(intern("cons"), _35reg992);
-if (True == _35reg993) {
-Obj _35reg994 = primCdr(_35p225);
-Obj _35reg995 = primCar(_35reg994);
-Obj _35reg996 = primCdr(_35reg995);
-Obj _35reg997 = primIsCons(_35reg996);
-if (True == _35reg997) {
-Obj _35reg998 = primCdr(_35p225);
-Obj _35reg999 = primCar(_35reg998);
-Obj _35reg1000 = primCdr(_35reg999);
-Obj _35reg1001 = primCar(_35reg1000);
-Obj x = _35reg1001;
-Obj _35reg1002 = primCdr(_35p225);
-Obj _35reg1003 = primCar(_35reg1002);
-Obj _35reg1004 = primCdr(_35reg1003);
-Obj _35reg1005 = primCdr(_35reg1004);
-Obj _35reg1006 = primIsCons(_35reg1005);
-if (True == _35reg1006) {
-Obj _35reg1007 = primCdr(_35p225);
-Obj _35reg1008 = primCar(_35reg1007);
-Obj _35reg1009 = primCdr(_35reg1008);
-Obj _35reg1010 = primCdr(_35reg1009);
-Obj _35reg1011 = primCar(_35reg1010);
-Obj __ = _35reg1011;
-Obj _35reg1012 = primCdr(_35p225);
-Obj _35reg1013 = primCar(_35reg1012);
-Obj _35reg1014 = primCdr(_35reg1013);
-Obj _35reg1015 = primCdr(_35reg1014);
-Obj _35reg1016 = primCdr(_35reg1015);
-Obj _35reg1017 = primEQ(Nil, _35reg1016);
-if (True == _35reg1017) {
-Obj _35reg1018 = primCdr(_35p225);
-Obj _35reg1019 = primCdr(_35reg1018);
-Obj _35reg1020 = primEQ(Nil, _35reg1019);
-if (True == _35reg1020) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc226;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label11:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35cc248 = makeNative(11, _35clofun1362, 0, 0);
-Obj x = closureRef(co, 0);
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label13:
-{
-Obj _35cc247 = makeNative(12, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg1022 = primIsCons(closureRef(co, 0));
-if (True == _35reg1022) {
-Obj _35reg1023 = primCar(closureRef(co, 0));
-Obj f = _35reg1023;
-Obj _35reg1024 = primCdr(closureRef(co, 0));
-Obj args = _35reg1024;
-Obj _35reg1025 = primCons(f, args);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = globalRef(intern("cora/init#propagate-boolean"));
-__arg2 = _35reg1025;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc247;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label14:
-{
-Obj _35val1043 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1044 = primCons(_35val1043, Nil);
-Obj _35reg1045 = primCons(args, _35reg1044);
-Obj _35reg1046 = primCons(intern("lambda"), _35reg1045);
-__nargs = 2;
-__arg1 = _35reg1046;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1362) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label15:
-{
-Obj _35cc246 = makeNative(13, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg1026 = primIsCons(closureRef(co, 0));
-if (True == _35reg1026) {
-Obj _35reg1027 = primCar(closureRef(co, 0));
-Obj _35reg1028 = primEQ(intern("lambda"), _35reg1027);
-if (True == _35reg1028) {
-Obj _35reg1029 = primCdr(closureRef(co, 0));
-Obj _35reg1030 = primIsCons(_35reg1029);
-if (True == _35reg1030) {
-Obj _35reg1031 = primCdr(closureRef(co, 0));
-Obj _35reg1032 = primCar(_35reg1031);
-Obj args = _35reg1032;
-Obj _35reg1033 = primCdr(closureRef(co, 0));
-Obj _35reg1034 = primCdr(_35reg1033);
-Obj _35reg1035 = primIsCons(_35reg1034);
-if (True == _35reg1035) {
-Obj _35reg1036 = primCdr(closureRef(co, 0));
-Obj _35reg1037 = primCdr(_35reg1036);
-Obj _35reg1038 = primCar(_35reg1037);
-Obj body = _35reg1038;
-Obj _35reg1039 = primCdr(closureRef(co, 0));
-Obj _35reg1040 = primCdr(_35reg1039);
-Obj _35reg1041 = primCdr(_35reg1040);
-Obj _35reg1042 = primEQ(Nil, _35reg1041);
-if (True == _35reg1042) {
-pushCont(co, 14, _35clofun1362, 1, args);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean"));
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc246;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc246;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc246;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc246;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc246;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label16:
-{
-Obj _35val1075 = __arg1;
-Obj y1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj x1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj z1 = _35val1075;
-Obj _35reg1076 = primCons(z1, Nil);
-Obj _35reg1077 = primCons(y1, _35reg1076);
-Obj _35reg1078 = primCons(x1, _35reg1077);
-Obj _35reg1079 = primCons(intern("if"), _35reg1078);
+Obj _35val1268 = __arg1;
+Obj x1 = _35val1268;
+Obj _35reg1269 = primCons(x1, Nil);
+Obj _35reg1270 = primCons(intern("cons?"), _35reg1269);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#propagate-boolean0"));
-__arg1 = _35reg1079;
+__arg1 = _35reg1270;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val1074 = __arg1;
-Obj z= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj x1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj y1 = _35val1074;
-pushCont(co, 16, _35clofun1362, 2, y1, x1);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean"));
-__arg1 = z;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val1073 = __arg1;
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj z= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj x1 = _35val1073;
-pushCont(co, 17, _35clofun1362, 2, z, x1);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean"));
-__arg1 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35cc245 = makeNative(15, _35clofun1362, 0, 1, closureRef(co, 0));
-Obj _35reg1047 = primIsCons(closureRef(co, 0));
-if (True == _35reg1047) {
-Obj _35reg1048 = primCar(closureRef(co, 0));
-Obj _35reg1049 = primEQ(intern("if"), _35reg1048);
-if (True == _35reg1049) {
-Obj _35reg1050 = primCdr(closureRef(co, 0));
-Obj _35reg1051 = primIsCons(_35reg1050);
-if (True == _35reg1051) {
-Obj _35reg1052 = primCdr(closureRef(co, 0));
-Obj _35reg1053 = primCar(_35reg1052);
-Obj x = _35reg1053;
-Obj _35reg1054 = primCdr(closureRef(co, 0));
-Obj _35reg1055 = primCdr(_35reg1054);
-Obj _35reg1056 = primIsCons(_35reg1055);
-if (True == _35reg1056) {
-Obj _35reg1057 = primCdr(closureRef(co, 0));
-Obj _35reg1058 = primCdr(_35reg1057);
-Obj _35reg1059 = primCar(_35reg1058);
-Obj y = _35reg1059;
-Obj _35reg1060 = primCdr(closureRef(co, 0));
-Obj _35reg1061 = primCdr(_35reg1060);
-Obj _35reg1062 = primCdr(_35reg1061);
-Obj _35reg1063 = primIsCons(_35reg1062);
-if (True == _35reg1063) {
-Obj _35reg1064 = primCdr(closureRef(co, 0));
-Obj _35reg1065 = primCdr(_35reg1064);
-Obj _35reg1066 = primCdr(_35reg1065);
-Obj _35reg1067 = primCar(_35reg1066);
-Obj z = _35reg1067;
-Obj _35reg1068 = primCdr(closureRef(co, 0));
-Obj _35reg1069 = primCdr(_35reg1068);
-Obj _35reg1070 = primCdr(_35reg1069);
-Obj _35reg1071 = primCdr(_35reg1070);
-Obj _35reg1072 = primEQ(Nil, _35reg1071);
-if (True == _35reg1072) {
-pushCont(co, 18, _35clofun1362, 2, y, z);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc245;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc245;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc245;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc245;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc245;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc245;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
-{
-Obj _35val1090 = __arg1;
-Obj x1 = _35val1090;
-Obj _35reg1091 = primCons(x1, Nil);
-Obj _35reg1092 = primCons(intern("not"), _35reg1091);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#propagate-boolean0"));
-__arg1 = _35reg1092;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1362) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3170,82 +1402,2334 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1361(struct Cora* co){
+void clofun8(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val716 = __arg1;
-Obj l= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj res= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val716) {
-Obj _35reg717 = primCar(l);
-Obj _35reg718 = primCons(_35reg717, res);
-Obj _35reg719 = primCdr(l);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#filter-h"));
-__arg1 = _35reg718;
-__arg2 = fn;
-__arg3 = _35reg719;
+Obj _35cc344 = makeNative(2, clofun8, 0, 1, closureRef(co, 0));
+Obj _35reg1245 = primIsCons(closureRef(co, 0));
+if (True == _35reg1245) {
+Obj _35reg1246 = primCar(closureRef(co, 0));
+Obj _35reg1247 = primEQ(intern("car"), _35reg1246);
+if (True == _35reg1247) {
+Obj _35reg1248 = primCdr(closureRef(co, 0));
+Obj _35reg1249 = primIsCons(_35reg1248);
+if (True == _35reg1249) {
+Obj _35reg1250 = primCdr(closureRef(co, 0));
+Obj _35reg1251 = primCar(_35reg1250);
+Obj x = _35reg1251;
+Obj _35reg1252 = primCdr(closureRef(co, 0));
+Obj _35reg1253 = primCdr(_35reg1252);
+Obj _35reg1254 = primEQ(Nil, _35reg1253);
+if (True == _35reg1254) {
+pushCont(co, 1, clofun8, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg720 = primCdr(l);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#filter-h"));
-__arg1 = res;
-__arg2 = fn;
-__arg3 = _35reg720;
+__nargs = 1;
+__arg0 = _35cc344;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc344;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc344;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc344;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj res = __arg1;
-Obj fn = __arg2;
-Obj l = __arg3;
-Obj _35reg714 = primIsCons(l);
-if (True == _35reg714) {
-Obj _35reg715 = primCar(l);
-pushCont(co, 0, _35clofun1361, 3, l, res, fn);
+Obj _35val1255 = __arg1;
+Obj x1 = _35val1255;
+Obj _35reg1256 = primCons(x1, Nil);
+Obj _35reg1257 = primCons(intern("car"), _35reg1256);
 __nargs = 2;
-__arg0 = fn;
-__arg1 = _35reg715;
+__arg0 = globalRef(intern("cora/init#propagate-boolean0"));
+__arg1 = _35reg1257;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35cc345 = makeNative(4, clofun8, 0, 1, closureRef(co, 0));
+Obj _35reg1232 = primIsCons(closureRef(co, 0));
+if (True == _35reg1232) {
+Obj _35reg1233 = primCar(closureRef(co, 0));
+Obj _35reg1234 = primEQ(intern("cdr"), _35reg1233);
+if (True == _35reg1234) {
+Obj _35reg1235 = primCdr(closureRef(co, 0));
+Obj _35reg1236 = primIsCons(_35reg1235);
+if (True == _35reg1236) {
+Obj _35reg1237 = primCdr(closureRef(co, 0));
+Obj _35reg1238 = primCar(_35reg1237);
+Obj x = _35reg1238;
+Obj _35reg1239 = primCdr(closureRef(co, 0));
+Obj _35reg1240 = primCdr(_35reg1239);
+Obj _35reg1241 = primEQ(Nil, _35reg1240);
+if (True == _35reg1241) {
+pushCont(co, 3, clofun8, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 2;
-__arg0 = globalRef(intern("reverse"));
-__arg1 = res;
+__nargs = 1;
+__arg0 = _35cc345;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc345;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc345;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc345;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35val1242 = __arg1;
+Obj x1 = _35val1242;
+Obj _35reg1243 = primCons(x1, Nil);
+Obj _35reg1244 = primCons(intern("cdr"), _35reg1243);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean0"));
+__arg1 = _35reg1244;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35cc346 = makeNative(1, clofun9, 0, 1, closureRef(co, 0));
+Obj _35reg1210 = primIsCons(closureRef(co, 0));
+if (True == _35reg1210) {
+Obj _35reg1211 = primCar(closureRef(co, 0));
+Obj _35reg1212 = primEQ(intern("and"), _35reg1211);
+if (True == _35reg1212) {
+Obj _35reg1213 = primCdr(closureRef(co, 0));
+Obj _35reg1214 = primIsCons(_35reg1213);
+if (True == _35reg1214) {
+Obj _35reg1215 = primCdr(closureRef(co, 0));
+Obj _35reg1216 = primCar(_35reg1215);
+Obj x = _35reg1216;
+Obj _35reg1217 = primCdr(closureRef(co, 0));
+Obj _35reg1218 = primCdr(_35reg1217);
+Obj _35reg1219 = primIsCons(_35reg1218);
+if (True == _35reg1219) {
+Obj _35reg1220 = primCdr(closureRef(co, 0));
+Obj _35reg1221 = primCdr(_35reg1220);
+Obj _35reg1222 = primCar(_35reg1221);
+Obj y = _35reg1222;
+Obj _35reg1223 = primCdr(closureRef(co, 0));
+Obj _35reg1224 = primCdr(_35reg1223);
+Obj _35reg1225 = primCdr(_35reg1224);
+Obj _35reg1226 = primEQ(Nil, _35reg1225);
+if (True == _35reg1226) {
+pushCont(co, 5, clofun8, 1, y);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc346;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc346;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc346;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc346;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc346;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35val1227 = __arg1;
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x1 = _35val1227;
+pushCont(co, 0, clofun9, 1, x1);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg1 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun9(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val1228 = __arg1;
+Obj x1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y1 = _35val1228;
+Obj _35reg1229 = primCons(y1, Nil);
+Obj _35reg1230 = primCons(x1, _35reg1229);
+Obj _35reg1231 = primCons(intern("and"), _35reg1230);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean0"));
+__arg1 = _35reg1231;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35cc347 = makeNative(3, clofun9, 0, 1, closureRef(co, 0));
+Obj _35reg1197 = primIsCons(closureRef(co, 0));
+if (True == _35reg1197) {
+Obj _35reg1198 = primCar(closureRef(co, 0));
+Obj _35reg1199 = primEQ(intern("null?"), _35reg1198);
+if (True == _35reg1199) {
+Obj _35reg1200 = primCdr(closureRef(co, 0));
+Obj _35reg1201 = primIsCons(_35reg1200);
+if (True == _35reg1201) {
+Obj _35reg1202 = primCdr(closureRef(co, 0));
+Obj _35reg1203 = primCar(_35reg1202);
+Obj x = _35reg1203;
+Obj _35reg1204 = primCdr(closureRef(co, 0));
+Obj _35reg1205 = primCdr(_35reg1204);
+Obj _35reg1206 = primEQ(Nil, _35reg1205);
+if (True == _35reg1206) {
+pushCont(co, 2, clofun9, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc347;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc347;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc347;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc347;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label2:
+{
+Obj _35val1207 = __arg1;
+Obj x1 = _35val1207;
+Obj _35reg1208 = primCons(x1, Nil);
+Obj _35reg1209 = primCons(intern("null?"), _35reg1208);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean0"));
+__arg1 = _35reg1209;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35cc348 = makeNative(5, clofun9, 0, 1, closureRef(co, 0));
+Obj _35reg1184 = primIsCons(closureRef(co, 0));
+if (True == _35reg1184) {
+Obj _35reg1185 = primCar(closureRef(co, 0));
+Obj _35reg1186 = primEQ(intern("not"), _35reg1185);
+if (True == _35reg1186) {
+Obj _35reg1187 = primCdr(closureRef(co, 0));
+Obj _35reg1188 = primIsCons(_35reg1187);
+if (True == _35reg1188) {
+Obj _35reg1189 = primCdr(closureRef(co, 0));
+Obj _35reg1190 = primCar(_35reg1189);
+Obj x = _35reg1190;
+Obj _35reg1191 = primCdr(closureRef(co, 0));
+Obj _35reg1192 = primCdr(_35reg1191);
+Obj _35reg1193 = primEQ(Nil, _35reg1192);
+if (True == _35reg1193) {
+pushCont(co, 4, clofun9, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc348;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc348;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc348;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc348;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val1194 = __arg1;
+Obj x1 = _35val1194;
+Obj _35reg1195 = primCons(x1, Nil);
+Obj _35reg1196 = primCons(intern("not"), _35reg1195);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean0"));
+__arg1 = _35reg1196;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35cc349 = makeNative(3, clofun10, 0, 1, closureRef(co, 0));
+Obj _35reg1151 = primIsCons(closureRef(co, 0));
+if (True == _35reg1151) {
+Obj _35reg1152 = primCar(closureRef(co, 0));
+Obj _35reg1153 = primEQ(intern("if"), _35reg1152);
+if (True == _35reg1153) {
+Obj _35reg1154 = primCdr(closureRef(co, 0));
+Obj _35reg1155 = primIsCons(_35reg1154);
+if (True == _35reg1155) {
+Obj _35reg1156 = primCdr(closureRef(co, 0));
+Obj _35reg1157 = primCar(_35reg1156);
+Obj x = _35reg1157;
+Obj _35reg1158 = primCdr(closureRef(co, 0));
+Obj _35reg1159 = primCdr(_35reg1158);
+Obj _35reg1160 = primIsCons(_35reg1159);
+if (True == _35reg1160) {
+Obj _35reg1161 = primCdr(closureRef(co, 0));
+Obj _35reg1162 = primCdr(_35reg1161);
+Obj _35reg1163 = primCar(_35reg1162);
+Obj y = _35reg1163;
+Obj _35reg1164 = primCdr(closureRef(co, 0));
+Obj _35reg1165 = primCdr(_35reg1164);
+Obj _35reg1166 = primCdr(_35reg1165);
+Obj _35reg1167 = primIsCons(_35reg1166);
+if (True == _35reg1167) {
+Obj _35reg1168 = primCdr(closureRef(co, 0));
+Obj _35reg1169 = primCdr(_35reg1168);
+Obj _35reg1170 = primCdr(_35reg1169);
+Obj _35reg1171 = primCar(_35reg1170);
+Obj z = _35reg1171;
+Obj _35reg1172 = primCdr(closureRef(co, 0));
+Obj _35reg1173 = primCdr(_35reg1172);
+Obj _35reg1174 = primCdr(_35reg1173);
+Obj _35reg1175 = primCdr(_35reg1174);
+Obj _35reg1176 = primEQ(Nil, _35reg1175);
+if (True == _35reg1176) {
+pushCont(co, 0, clofun10, 2, y, z);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc349;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc349;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc349;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc349;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc349;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc349;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun10(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val1177 = __arg1;
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj z= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj x1 = _35val1177;
+pushCont(co, 1, clofun10, 2, z, x1);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg1 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val1178 = __arg1;
+Obj z= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x1= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj y1 = _35val1178;
+pushCont(co, 2, clofun10, 2, y1, x1);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg1 = z;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val1179 = __arg1;
+Obj y1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x1= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj z1 = _35val1179;
+Obj _35reg1180 = primCons(z1, Nil);
+Obj _35reg1181 = primCons(y1, _35reg1180);
+Obj _35reg1182 = primCons(x1, _35reg1181);
+Obj _35reg1183 = primCons(intern("if"), _35reg1182);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean0"));
+__arg1 = _35reg1183;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35cc350 = makeNative(5, clofun10, 0, 1, closureRef(co, 0));
+Obj _35reg1130 = primIsCons(closureRef(co, 0));
+if (True == _35reg1130) {
+Obj _35reg1131 = primCar(closureRef(co, 0));
+Obj _35reg1132 = primEQ(intern("lambda"), _35reg1131);
+if (True == _35reg1132) {
+Obj _35reg1133 = primCdr(closureRef(co, 0));
+Obj _35reg1134 = primIsCons(_35reg1133);
+if (True == _35reg1134) {
+Obj _35reg1135 = primCdr(closureRef(co, 0));
+Obj _35reg1136 = primCar(_35reg1135);
+Obj args = _35reg1136;
+Obj _35reg1137 = primCdr(closureRef(co, 0));
+Obj _35reg1138 = primCdr(_35reg1137);
+Obj _35reg1139 = primIsCons(_35reg1138);
+if (True == _35reg1139) {
+Obj _35reg1140 = primCdr(closureRef(co, 0));
+Obj _35reg1141 = primCdr(_35reg1140);
+Obj _35reg1142 = primCar(_35reg1141);
+Obj body = _35reg1142;
+Obj _35reg1143 = primCdr(closureRef(co, 0));
+Obj _35reg1144 = primCdr(_35reg1143);
+Obj _35reg1145 = primCdr(_35reg1144);
+Obj _35reg1146 = primEQ(Nil, _35reg1145);
+if (True == _35reg1146) {
+pushCont(co, 4, clofun10, 1, args);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#propagate-boolean"));
+__arg1 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc350;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc350;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc350;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc350;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc350;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val1147 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1148 = primCons(_35val1147, Nil);
+Obj _35reg1149 = primCons(args, _35reg1148);
+Obj _35reg1150 = primCons(intern("lambda"), _35reg1149);
+__nargs = 2;
+__arg1 = _35reg1150;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun10) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label5:
+{
+Obj _35cc351 = makeNative(0, clofun11, 0, 1, closureRef(co, 0));
+Obj _35reg1126 = primIsCons(closureRef(co, 0));
+if (True == _35reg1126) {
+Obj _35reg1127 = primCar(closureRef(co, 0));
+Obj f = _35reg1127;
+Obj _35reg1128 = primCdr(closureRef(co, 0));
+Obj args = _35reg1128;
+Obj _35reg1129 = primCons(f, args);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = globalRef(intern("cora/init#propagate-boolean"));
+__arg2 = _35reg1129;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc351;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun11(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc352 = makeNative(1, clofun11, 0, 0);
+Obj x = closureRef(co, 0);
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun11) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label1:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35p329 = __arg1;
+Obj _35cc330 = makeNative(3, clofun11, 0, 1, _35p329);
+Obj _35reg1086 = primIsCons(_35p329);
+if (True == _35reg1086) {
+Obj _35reg1087 = primCar(_35p329);
+Obj _35reg1088 = primEQ(intern("car"), _35reg1087);
+if (True == _35reg1088) {
+Obj _35reg1089 = primCdr(_35p329);
+Obj _35reg1090 = primIsCons(_35reg1089);
+if (True == _35reg1090) {
+Obj _35reg1091 = primCdr(_35p329);
+Obj _35reg1092 = primCar(_35reg1091);
+Obj _35reg1093 = primIsCons(_35reg1092);
+if (True == _35reg1093) {
+Obj _35reg1094 = primCdr(_35p329);
+Obj _35reg1095 = primCar(_35reg1094);
+Obj _35reg1096 = primCar(_35reg1095);
+Obj _35reg1097 = primEQ(intern("cons"), _35reg1096);
+if (True == _35reg1097) {
+Obj _35reg1098 = primCdr(_35p329);
+Obj _35reg1099 = primCar(_35reg1098);
+Obj _35reg1100 = primCdr(_35reg1099);
+Obj _35reg1101 = primIsCons(_35reg1100);
+if (True == _35reg1101) {
+Obj _35reg1102 = primCdr(_35p329);
+Obj _35reg1103 = primCar(_35reg1102);
+Obj _35reg1104 = primCdr(_35reg1103);
+Obj _35reg1105 = primCar(_35reg1104);
+Obj x = _35reg1105;
+Obj _35reg1106 = primCdr(_35p329);
+Obj _35reg1107 = primCar(_35reg1106);
+Obj _35reg1108 = primCdr(_35reg1107);
+Obj _35reg1109 = primCdr(_35reg1108);
+Obj _35reg1110 = primIsCons(_35reg1109);
+if (True == _35reg1110) {
+Obj _35reg1111 = primCdr(_35p329);
+Obj _35reg1112 = primCar(_35reg1111);
+Obj _35reg1113 = primCdr(_35reg1112);
+Obj _35reg1114 = primCdr(_35reg1113);
+Obj _35reg1115 = primCar(_35reg1114);
+Obj __ = _35reg1115;
+Obj _35reg1116 = primCdr(_35p329);
+Obj _35reg1117 = primCar(_35reg1116);
+Obj _35reg1118 = primCdr(_35reg1117);
+Obj _35reg1119 = primCdr(_35reg1118);
+Obj _35reg1120 = primCdr(_35reg1119);
+Obj _35reg1121 = primEQ(Nil, _35reg1120);
+if (True == _35reg1121) {
+Obj _35reg1122 = primCdr(_35p329);
+Obj _35reg1123 = primCdr(_35reg1122);
+Obj _35reg1124 = primEQ(Nil, _35reg1123);
+if (True == _35reg1124) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun11) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc330;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc330;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc330;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc330;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc330;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc330;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc330;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc330;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc330;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35cc331 = makeNative(4, clofun11, 0, 1, closureRef(co, 0));
+Obj _35reg1047 = primIsCons(closureRef(co, 0));
+if (True == _35reg1047) {
+Obj _35reg1048 = primCar(closureRef(co, 0));
+Obj _35reg1049 = primEQ(intern("cdr"), _35reg1048);
+if (True == _35reg1049) {
+Obj _35reg1050 = primCdr(closureRef(co, 0));
+Obj _35reg1051 = primIsCons(_35reg1050);
+if (True == _35reg1051) {
+Obj _35reg1052 = primCdr(closureRef(co, 0));
+Obj _35reg1053 = primCar(_35reg1052);
+Obj _35reg1054 = primIsCons(_35reg1053);
+if (True == _35reg1054) {
+Obj _35reg1055 = primCdr(closureRef(co, 0));
+Obj _35reg1056 = primCar(_35reg1055);
+Obj _35reg1057 = primCar(_35reg1056);
+Obj _35reg1058 = primEQ(intern("cons"), _35reg1057);
+if (True == _35reg1058) {
+Obj _35reg1059 = primCdr(closureRef(co, 0));
+Obj _35reg1060 = primCar(_35reg1059);
+Obj _35reg1061 = primCdr(_35reg1060);
+Obj _35reg1062 = primIsCons(_35reg1061);
+if (True == _35reg1062) {
+Obj _35reg1063 = primCdr(closureRef(co, 0));
+Obj _35reg1064 = primCar(_35reg1063);
+Obj _35reg1065 = primCdr(_35reg1064);
+Obj _35reg1066 = primCar(_35reg1065);
+Obj __ = _35reg1066;
+Obj _35reg1067 = primCdr(closureRef(co, 0));
+Obj _35reg1068 = primCar(_35reg1067);
+Obj _35reg1069 = primCdr(_35reg1068);
+Obj _35reg1070 = primCdr(_35reg1069);
+Obj _35reg1071 = primIsCons(_35reg1070);
+if (True == _35reg1071) {
+Obj _35reg1072 = primCdr(closureRef(co, 0));
+Obj _35reg1073 = primCar(_35reg1072);
+Obj _35reg1074 = primCdr(_35reg1073);
+Obj _35reg1075 = primCdr(_35reg1074);
+Obj _35reg1076 = primCar(_35reg1075);
+Obj x = _35reg1076;
+Obj _35reg1077 = primCdr(closureRef(co, 0));
+Obj _35reg1078 = primCar(_35reg1077);
+Obj _35reg1079 = primCdr(_35reg1078);
+Obj _35reg1080 = primCdr(_35reg1079);
+Obj _35reg1081 = primCdr(_35reg1080);
+Obj _35reg1082 = primEQ(Nil, _35reg1081);
+if (True == _35reg1082) {
+Obj _35reg1083 = primCdr(closureRef(co, 0));
+Obj _35reg1084 = primCdr(_35reg1083);
+Obj _35reg1085 = primEQ(Nil, _35reg1084);
+if (True == _35reg1085) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun11) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc331;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc331;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc331;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc331;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc331;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc331;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc331;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc331;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc331;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35cc332 = makeNative(5, clofun11, 0, 1, closureRef(co, 0));
+Obj _35reg1008 = primIsCons(closureRef(co, 0));
+if (True == _35reg1008) {
+Obj _35reg1009 = primCar(closureRef(co, 0));
+Obj _35reg1010 = primEQ(intern("cons?"), _35reg1009);
+if (True == _35reg1010) {
+Obj _35reg1011 = primCdr(closureRef(co, 0));
+Obj _35reg1012 = primIsCons(_35reg1011);
+if (True == _35reg1012) {
+Obj _35reg1013 = primCdr(closureRef(co, 0));
+Obj _35reg1014 = primCar(_35reg1013);
+Obj _35reg1015 = primIsCons(_35reg1014);
+if (True == _35reg1015) {
+Obj _35reg1016 = primCdr(closureRef(co, 0));
+Obj _35reg1017 = primCar(_35reg1016);
+Obj _35reg1018 = primCar(_35reg1017);
+Obj _35reg1019 = primEQ(intern("cons"), _35reg1018);
+if (True == _35reg1019) {
+Obj _35reg1020 = primCdr(closureRef(co, 0));
+Obj _35reg1021 = primCar(_35reg1020);
+Obj _35reg1022 = primCdr(_35reg1021);
+Obj _35reg1023 = primIsCons(_35reg1022);
+if (True == _35reg1023) {
+Obj _35reg1024 = primCdr(closureRef(co, 0));
+Obj _35reg1025 = primCar(_35reg1024);
+Obj _35reg1026 = primCdr(_35reg1025);
+Obj _35reg1027 = primCar(_35reg1026);
+Obj __ = _35reg1027;
+Obj _35reg1028 = primCdr(closureRef(co, 0));
+Obj _35reg1029 = primCar(_35reg1028);
+Obj _35reg1030 = primCdr(_35reg1029);
+Obj _35reg1031 = primCdr(_35reg1030);
+Obj _35reg1032 = primIsCons(_35reg1031);
+if (True == _35reg1032) {
+Obj _35reg1033 = primCdr(closureRef(co, 0));
+Obj _35reg1034 = primCar(_35reg1033);
+Obj _35reg1035 = primCdr(_35reg1034);
+Obj _35reg1036 = primCdr(_35reg1035);
+Obj _35reg1037 = primCar(_35reg1036);
+__ = _35reg1037;
+Obj _35reg1038 = primCdr(closureRef(co, 0));
+Obj _35reg1039 = primCar(_35reg1038);
+Obj _35reg1040 = primCdr(_35reg1039);
+Obj _35reg1041 = primCdr(_35reg1040);
+Obj _35reg1042 = primCdr(_35reg1041);
+Obj _35reg1043 = primEQ(Nil, _35reg1042);
+if (True == _35reg1043) {
+Obj _35reg1044 = primCdr(closureRef(co, 0));
+Obj _35reg1045 = primCdr(_35reg1044);
+Obj _35reg1046 = primEQ(Nil, _35reg1045);
+if (True == _35reg1046) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun11) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc332;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc332;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc332;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc332;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc332;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc332;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc332;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc332;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc332;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35cc333 = makeNative(0, clofun12, 0, 1, closureRef(co, 0));
+Obj _35reg989 = primIsCons(closureRef(co, 0));
+if (True == _35reg989) {
+Obj _35reg990 = primCar(closureRef(co, 0));
+Obj _35reg991 = primEQ(intern("and"), _35reg990);
+if (True == _35reg991) {
+Obj _35reg992 = primCdr(closureRef(co, 0));
+Obj _35reg993 = primIsCons(_35reg992);
+if (True == _35reg993) {
+Obj _35reg994 = primCdr(closureRef(co, 0));
+Obj _35reg995 = primCar(_35reg994);
+Obj _35reg996 = primEQ(True, _35reg995);
+if (True == _35reg996) {
+Obj _35reg997 = primCdr(closureRef(co, 0));
+Obj _35reg998 = primCdr(_35reg997);
+Obj _35reg999 = primIsCons(_35reg998);
+if (True == _35reg999) {
+Obj _35reg1000 = primCdr(closureRef(co, 0));
+Obj _35reg1001 = primCdr(_35reg1000);
+Obj _35reg1002 = primCar(_35reg1001);
+Obj _35reg1003 = primEQ(True, _35reg1002);
+if (True == _35reg1003) {
+Obj _35reg1004 = primCdr(closureRef(co, 0));
+Obj _35reg1005 = primCdr(_35reg1004);
+Obj _35reg1006 = primCdr(_35reg1005);
+Obj _35reg1007 = primEQ(Nil, _35reg1006);
+if (True == _35reg1007) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun11) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc333;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc333;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc333;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc333;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc333;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc333;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc333;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun12(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc334 = makeNative(1, clofun12, 0, 1, closureRef(co, 0));
+Obj _35reg978 = primIsCons(closureRef(co, 0));
+if (True == _35reg978) {
+Obj _35reg979 = primCar(closureRef(co, 0));
+Obj _35reg980 = primEQ(intern("null?"), _35reg979);
+if (True == _35reg980) {
+Obj _35reg981 = primCdr(closureRef(co, 0));
+Obj _35reg982 = primIsCons(_35reg981);
+if (True == _35reg982) {
+Obj _35reg983 = primCdr(closureRef(co, 0));
+Obj _35reg984 = primCar(_35reg983);
+Obj _35reg985 = primEQ(Nil, _35reg984);
+if (True == _35reg985) {
+Obj _35reg986 = primCdr(closureRef(co, 0));
+Obj _35reg987 = primCdr(_35reg986);
+Obj _35reg988 = primEQ(Nil, _35reg987);
+if (True == _35reg988) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun12) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc334;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc334;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc334;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc334;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc334;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35cc335 = makeNative(2, clofun12, 0, 1, closureRef(co, 0));
+Obj _35reg939 = primIsCons(closureRef(co, 0));
+if (True == _35reg939) {
+Obj _35reg940 = primCar(closureRef(co, 0));
+Obj _35reg941 = primEQ(intern("null?"), _35reg940);
+if (True == _35reg941) {
+Obj _35reg942 = primCdr(closureRef(co, 0));
+Obj _35reg943 = primIsCons(_35reg942);
+if (True == _35reg943) {
+Obj _35reg944 = primCdr(closureRef(co, 0));
+Obj _35reg945 = primCar(_35reg944);
+Obj _35reg946 = primIsCons(_35reg945);
+if (True == _35reg946) {
+Obj _35reg947 = primCdr(closureRef(co, 0));
+Obj _35reg948 = primCar(_35reg947);
+Obj _35reg949 = primCar(_35reg948);
+Obj _35reg950 = primEQ(intern("cons"), _35reg949);
+if (True == _35reg950) {
+Obj _35reg951 = primCdr(closureRef(co, 0));
+Obj _35reg952 = primCar(_35reg951);
+Obj _35reg953 = primCdr(_35reg952);
+Obj _35reg954 = primIsCons(_35reg953);
+if (True == _35reg954) {
+Obj _35reg955 = primCdr(closureRef(co, 0));
+Obj _35reg956 = primCar(_35reg955);
+Obj _35reg957 = primCdr(_35reg956);
+Obj _35reg958 = primCar(_35reg957);
+Obj __ = _35reg958;
+Obj _35reg959 = primCdr(closureRef(co, 0));
+Obj _35reg960 = primCar(_35reg959);
+Obj _35reg961 = primCdr(_35reg960);
+Obj _35reg962 = primCdr(_35reg961);
+Obj _35reg963 = primIsCons(_35reg962);
+if (True == _35reg963) {
+Obj _35reg964 = primCdr(closureRef(co, 0));
+Obj _35reg965 = primCar(_35reg964);
+Obj _35reg966 = primCdr(_35reg965);
+Obj _35reg967 = primCdr(_35reg966);
+Obj _35reg968 = primCar(_35reg967);
+__ = _35reg968;
+Obj _35reg969 = primCdr(closureRef(co, 0));
+Obj _35reg970 = primCar(_35reg969);
+Obj _35reg971 = primCdr(_35reg970);
+Obj _35reg972 = primCdr(_35reg971);
+Obj _35reg973 = primCdr(_35reg972);
+Obj _35reg974 = primEQ(Nil, _35reg973);
+if (True == _35reg974) {
+Obj _35reg975 = primCdr(closureRef(co, 0));
+Obj _35reg976 = primCdr(_35reg975);
+Obj _35reg977 = primEQ(Nil, _35reg976);
+if (True == _35reg977) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun12) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc335;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35cc336 = makeNative(3, clofun12, 0, 1, closureRef(co, 0));
+Obj _35reg928 = primIsCons(closureRef(co, 0));
+if (True == _35reg928) {
+Obj _35reg929 = primCar(closureRef(co, 0));
+Obj _35reg930 = primEQ(intern("not"), _35reg929);
+if (True == _35reg930) {
+Obj _35reg931 = primCdr(closureRef(co, 0));
+Obj _35reg932 = primIsCons(_35reg931);
+if (True == _35reg932) {
+Obj _35reg933 = primCdr(closureRef(co, 0));
+Obj _35reg934 = primCar(_35reg933);
+Obj _35reg935 = primEQ(True, _35reg934);
+if (True == _35reg935) {
+Obj _35reg936 = primCdr(closureRef(co, 0));
+Obj _35reg937 = primCdr(_35reg936);
+Obj _35reg938 = primEQ(Nil, _35reg937);
+if (True == _35reg938) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun12) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc336;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc336;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc336;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc336;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc336;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35cc337 = makeNative(4, clofun12, 0, 1, closureRef(co, 0));
+Obj _35reg917 = primIsCons(closureRef(co, 0));
+if (True == _35reg917) {
+Obj _35reg918 = primCar(closureRef(co, 0));
+Obj _35reg919 = primEQ(intern("not"), _35reg918);
+if (True == _35reg919) {
+Obj _35reg920 = primCdr(closureRef(co, 0));
+Obj _35reg921 = primIsCons(_35reg920);
+if (True == _35reg921) {
+Obj _35reg922 = primCdr(closureRef(co, 0));
+Obj _35reg923 = primCar(_35reg922);
+Obj _35reg924 = primEQ(False, _35reg923);
+if (True == _35reg924) {
+Obj _35reg925 = primCdr(closureRef(co, 0));
+Obj _35reg926 = primCdr(_35reg925);
+Obj _35reg927 = primEQ(Nil, _35reg926);
+if (True == _35reg927) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun12) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc337;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc337;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc337;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc337;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc337;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35cc338 = makeNative(5, clofun12, 0, 1, closureRef(co, 0));
+Obj _35reg890 = primIsCons(closureRef(co, 0));
+if (True == _35reg890) {
+Obj _35reg891 = primCar(closureRef(co, 0));
+Obj _35reg892 = primEQ(intern("if"), _35reg891);
+if (True == _35reg892) {
+Obj _35reg893 = primCdr(closureRef(co, 0));
+Obj _35reg894 = primIsCons(_35reg893);
+if (True == _35reg894) {
+Obj _35reg895 = primCdr(closureRef(co, 0));
+Obj _35reg896 = primCar(_35reg895);
+Obj _35reg897 = primEQ(True, _35reg896);
+if (True == _35reg897) {
+Obj _35reg898 = primCdr(closureRef(co, 0));
+Obj _35reg899 = primCdr(_35reg898);
+Obj _35reg900 = primIsCons(_35reg899);
+if (True == _35reg900) {
+Obj _35reg901 = primCdr(closureRef(co, 0));
+Obj _35reg902 = primCdr(_35reg901);
+Obj _35reg903 = primCar(_35reg902);
+Obj y = _35reg903;
+Obj _35reg904 = primCdr(closureRef(co, 0));
+Obj _35reg905 = primCdr(_35reg904);
+Obj _35reg906 = primCdr(_35reg905);
+Obj _35reg907 = primIsCons(_35reg906);
+if (True == _35reg907) {
+Obj _35reg908 = primCdr(closureRef(co, 0));
+Obj _35reg909 = primCdr(_35reg908);
+Obj _35reg910 = primCdr(_35reg909);
+Obj _35reg911 = primCar(_35reg910);
+Obj z = _35reg911;
+Obj _35reg912 = primCdr(closureRef(co, 0));
+Obj _35reg913 = primCdr(_35reg912);
+Obj _35reg914 = primCdr(_35reg913);
+Obj _35reg915 = primCdr(_35reg914);
+Obj _35reg916 = primEQ(Nil, _35reg915);
+if (True == _35reg916) {
+__nargs = 2;
+__arg1 = y;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun12) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc338;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc338;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc338;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc338;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc338;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc338;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc338;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35cc339 = makeNative(0, clofun13, 0, 1, closureRef(co, 0));
+Obj _35reg863 = primIsCons(closureRef(co, 0));
+if (True == _35reg863) {
+Obj _35reg864 = primCar(closureRef(co, 0));
+Obj _35reg865 = primEQ(intern("if"), _35reg864);
+if (True == _35reg865) {
+Obj _35reg866 = primCdr(closureRef(co, 0));
+Obj _35reg867 = primIsCons(_35reg866);
+if (True == _35reg867) {
+Obj _35reg868 = primCdr(closureRef(co, 0));
+Obj _35reg869 = primCar(_35reg868);
+Obj _35reg870 = primEQ(False, _35reg869);
+if (True == _35reg870) {
+Obj _35reg871 = primCdr(closureRef(co, 0));
+Obj _35reg872 = primCdr(_35reg871);
+Obj _35reg873 = primIsCons(_35reg872);
+if (True == _35reg873) {
+Obj _35reg874 = primCdr(closureRef(co, 0));
+Obj _35reg875 = primCdr(_35reg874);
+Obj _35reg876 = primCar(_35reg875);
+Obj y = _35reg876;
+Obj _35reg877 = primCdr(closureRef(co, 0));
+Obj _35reg878 = primCdr(_35reg877);
+Obj _35reg879 = primCdr(_35reg878);
+Obj _35reg880 = primIsCons(_35reg879);
+if (True == _35reg880) {
+Obj _35reg881 = primCdr(closureRef(co, 0));
+Obj _35reg882 = primCdr(_35reg881);
+Obj _35reg883 = primCdr(_35reg882);
+Obj _35reg884 = primCar(_35reg883);
+Obj z = _35reg884;
+Obj _35reg885 = primCdr(closureRef(co, 0));
+Obj _35reg886 = primCdr(_35reg885);
+Obj _35reg887 = primCdr(_35reg886);
+Obj _35reg888 = primCdr(_35reg887);
+Obj _35reg889 = primEQ(Nil, _35reg888);
+if (True == _35reg889) {
+__nargs = 2;
+__arg1 = z;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun12) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc339;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc339;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc339;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc339;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc339;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc339;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc339;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun13(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc340 = makeNative(1, clofun13, 0, 0);
+Obj x = closureRef(co, 0);
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun13) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label1:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun13) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj exp = __arg1;
+pushCont(co, 3, clofun13, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cddr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun13) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val850 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 4, clofun13, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#extract-rules"));
+__arg1 = _35val850;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun13) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val851 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body = _35val851;
+pushCont(co, 5, clofun13, 2, exp, body);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rules-arg-count"));
+__arg1 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun13) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val852 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj nargs = _35val852;
+pushCont(co, 0, clofun14, 2, exp, body);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#gen-paramenters"));
+__arg1 = nargs;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun13) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun14(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val853 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj args = _35val853;
+pushCont(co, 1, clofun14, 2, body, args);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun14) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val854 = __arg1;
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg855 = primCons(intern("list"), args);
+Obj _35reg856 = primCons(_35reg855, body);
+Obj _35reg857 = primCons(intern("match"), _35reg856);
+Obj _35reg858 = primCons(_35reg857, Nil);
+Obj _35reg859 = primCons(args, _35reg858);
+Obj _35reg860 = primCons(_35val854, _35reg859);
+Obj _35reg861 = primCons(intern("defun"), _35reg860);
+__nargs = 2;
+__arg1 = _35reg861;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun14) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label2:
+{
+Obj n = __arg1;
+Obj _35reg844 = primEQ(n, makeNumber(0));
+if (True == _35reg844) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun14) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg845 = primGenSym(intern("p"));
+Obj _35reg846 = primSub(n, makeNumber(1));
+pushCont(co, 3, clofun14, 1, _35reg845);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#gen-paramenters"));
+__arg1 = _35reg846;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun14) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35val847 = __arg1;
+Obj _35reg845= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg848 = primCons(_35reg845, _35val847);
+__nargs = 2;
+__arg1 = _35reg848;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun14) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
+{
+Obj rules = __arg1;
+pushCont(co, 5, clofun14, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#rules-patterns"));
+__arg1 = Nil;
+__arg2 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun14) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val833 = __arg1;
+Obj pats = _35val833;
+Obj len = makeNative(4, clofun15, 1, 0);
+pushCont(co, 0, clofun15, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("map"));
+__arg1 = len;
+__arg2 = pats;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun14) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun15(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val835 = __arg1;
+Obj counts = _35val835;
+Obj _35reg836 = primCar(counts);
+Obj n = _35reg836;
+Obj dif = makeNative(3, clofun15, 1, 1, n);
+Obj _35reg839 = primCdr(counts);
+pushCont(co, 1, clofun15, 1, n);
+__nargs = 3;
+__arg0 = globalRef(intern("filter"));
+__arg1 = dif;
+__arg2 = _35reg839;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val840 = __arg1;
+Obj n= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 2, clofun15, 1, n);
+__nargs = 2;
+__arg0 = globalRef(intern("null?"));
+__arg1 = _35val840;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val841 = __arg1;
+Obj n= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg842 = primNot(_35val841);
+if (True == _35reg842) {
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeCString("inconsistent func rule args count");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = n;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun15) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label3:
+{
+Obj x = __arg1;
+Obj _35reg837 = primEQ(closureRef(co, 0), x);
+Obj _35reg838 = primNot(_35reg837);
+__nargs = 2;
+__arg1 = _35reg838;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun15) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
+{
+Obj x = __arg1;
+Obj _35reg834 = primCdr(x);
+__nargs = 2;
+__arg0 = globalRef(intern("length"));
+__arg1 = _35reg834;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj l1 = __arg1;
+Obj l2 = __arg2;
+Obj _35reg827 = primEQ(l1, Nil);
+if (True == _35reg827) {
+__nargs = 2;
+__arg1 = l2;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun15) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg828 = primCar(l1);
+Obj _35reg829 = primCdr(l1);
+pushCont(co, 0, clofun16, 1, _35reg828);
+__nargs = 3;
+__arg0 = globalRef(intern("append"));
+__arg1 = _35reg829;
+__arg2 = l2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun16(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val830 = __arg1;
+Obj _35reg828= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg831 = primCons(_35reg828, _35val830);
+__nargs = 2;
+__arg1 = _35reg831;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun16) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label1:
 {
 Obj fn = __arg1;
 Obj l = __arg2;
@@ -3257,310 +3741,112 @@ __arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj res = __arg1;
+Obj fn = __arg2;
+Obj l = __arg3;
+Obj _35reg818 = primIsCons(l);
+if (True == _35reg818) {
+Obj _35reg819 = primCar(l);
+pushCont(co, 3, clofun16, 3, l, res, fn);
+__nargs = 2;
+__arg0 = fn;
+__arg1 = _35reg819;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("reverse"));
+__arg1 = res;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label3:
 {
-Obj _35val726 = __arg1;
-Obj _35reg724= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg727 = primCons(_35reg724, _35val726);
-__nargs = 2;
-__arg1 = _35reg727;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1361) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val820 = __arg1;
+Obj l= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj res= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val820) {
+Obj _35reg821 = primCar(l);
+Obj _35reg822 = primCons(_35reg821, res);
+Obj _35reg823 = primCdr(l);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/init#filter-h"));
+__arg1 = _35reg822;
+__arg2 = fn;
+__arg3 = _35reg823;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg824 = primCdr(l);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/init#filter-h"));
+__arg1 = res;
+__arg2 = fn;
+__arg3 = _35reg824;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label4:
 {
-Obj l1 = __arg1;
-Obj l2 = __arg2;
-Obj _35reg723 = primEQ(l1, Nil);
-if (True == _35reg723) {
-__nargs = 2;
-__arg1 = l2;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1361) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg724 = primCar(l1);
-Obj _35reg725 = primCdr(l1);
-pushCont(co, 3, _35clofun1361, 1, _35reg724);
+Obj l = __arg1;
 __nargs = 3;
-__arg0 = globalRef(intern("append"));
-__arg1 = _35reg725;
-__arg2 = l2;
+__arg0 = globalRef(intern("cora/init#length-h"));
+__arg1 = makeNumber(0);
+__arg2 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 
 label5:
 {
-Obj x = __arg1;
-Obj _35reg730 = primCdr(x);
+Obj i = __arg1;
+Obj l = __arg2;
+Obj _35reg813 = primEQ(l, Nil);
+if (True == _35reg813) {
 __nargs = 2;
-__arg0 = globalRef(intern("length"));
-__arg1 = _35reg730;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj x = __arg1;
-Obj _35reg733 = primEQ(closureRef(co, 0), x);
-Obj _35reg734 = primNot(_35reg733);
-__nargs = 2;
-__arg1 = _35reg734;
+__arg1 = i;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1361) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label7:
-{
-Obj _35val737 = __arg1;
-Obj n= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg738 = primNot(_35val737);
-if (True == _35reg738) {
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeCString("inconsistent func rule args count");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg1 = n;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1361) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label8:
-{
-Obj _35val736 = __arg1;
-Obj n= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 7, _35clofun1361, 1, n);
-__nargs = 2;
-__arg0 = globalRef(intern("null?"));
-__arg1 = _35val736;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val731 = __arg1;
-Obj counts = _35val731;
-Obj _35reg732 = primCar(counts);
-Obj n = _35reg732;
-Obj dif = makeNative(6, _35clofun1361, 1, 1, n);
-Obj _35reg735 = primCdr(counts);
-pushCont(co, 8, _35clofun1361, 1, n);
-__nargs = 3;
-__arg0 = globalRef(intern("filter"));
-__arg1 = dif;
-__arg2 = _35reg735;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35val729 = __arg1;
-Obj pats = _35val729;
-Obj len = makeNative(5, _35clofun1361, 1, 0);
-pushCont(co, 9, _35clofun1361, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("map"));
-__arg1 = len;
-__arg2 = pats;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj rules = __arg1;
-pushCont(co, 10, _35clofun1361, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#rules-patterns"));
-__arg1 = Nil;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35val743 = __arg1;
-Obj _35reg741= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg744 = primCons(_35reg741, _35val743);
-__nargs = 2;
-__arg1 = _35reg744;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1361) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label13:
-{
-Obj n = __arg1;
-Obj _35reg740 = primEQ(n, makeNumber(0));
-if (True == _35reg740) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1361) { goto fail; }
+if (co->ctx.pc.func != clofun16) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg741 = primGenSym(intern("p"));
-Obj _35reg742 = primSub(n, makeNumber(1));
-pushCont(co, 12, _35clofun1361, 1, _35reg741);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#gen-paramenters"));
-__arg1 = _35reg742;
+Obj _35reg814 = primAdd(i, makeNumber(1));
+Obj _35reg815 = primCdr(l);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#length-h"));
+__arg1 = _35reg814;
+__arg2 = _35reg815;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label14:
-{
-Obj _35val750 = __arg1;
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg751 = primCons(intern("list"), args);
-Obj _35reg752 = primCons(_35reg751, body);
-Obj _35reg753 = primCons(intern("match"), _35reg752);
-Obj _35reg754 = primCons(_35reg753, Nil);
-Obj _35reg755 = primCons(args, _35reg754);
-Obj _35reg756 = primCons(_35val750, _35reg755);
-Obj _35reg757 = primCons(intern("defun"), _35reg756);
-__nargs = 2;
-__arg1 = _35reg757;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1361) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label15:
-{
-Obj _35val749 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj args = _35val749;
-pushCont(co, 14, _35clofun1361, 2, body, args);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val748 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj nargs = _35val748;
-pushCont(co, 15, _35clofun1361, 2, exp, body);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#gen-paramenters"));
-__arg1 = nargs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val747 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body = _35val747;
-pushCont(co, 16, _35clofun1361, 2, exp, body);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#rules-arg-count"));
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val746 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 17, _35clofun1361, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#extract-rules"));
-__arg1 = _35val746;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj exp = __arg1;
-pushCont(co, 18, _35clofun1361, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cddr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1361) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 }
 
 fail:
@@ -3572,487 +3858,77 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1360(struct Cora* co){
+void clofun17(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val632 = __arg1;
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj val= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg633 = primCons(_35val632, Nil);
-Obj _35reg634 = primCons(value, _35reg633);
-Obj _35reg635 = primCons(val, _35reg634);
-Obj _35reg636 = primCons(intern("let"), _35reg635);
+Obj res = __arg1;
+Obj rules = __arg2;
+pushCont(co, 1, clofun17, 2, res, rules);
 __nargs = 2;
-__arg1 = _35reg636;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1360) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("null?"));
+__arg1 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val638 = __arg1;
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj val= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg639 = primCons(_35val638, Nil);
-Obj _35reg640 = primCons(value, _35reg639);
-Obj _35reg641 = primCons(val, _35reg640);
-Obj _35reg642 = primCons(intern("let"), _35reg641);
+Obj _35val808 = __arg1;
+Obj res= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val808) {
 __nargs = 2;
-__arg1 = _35reg642;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1360) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("reverse"));
+__arg1 = res;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg809 = primCar(rules);
+Obj _35reg810 = primCons(_35reg809, res);
+pushCont(co, 2, clofun17, 1, _35reg810);
+__nargs = 2;
+__arg0 = globalRef(intern("cddr"));
+__arg1 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label2:
 {
-Obj _35val644 = __arg1;
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj val= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg645 = primCons(_35val644, Nil);
-Obj _35reg646 = primCons(value, _35reg645);
-Obj _35reg647 = primCons(val, _35reg646);
-Obj _35reg648 = primCons(intern("let"), _35reg647);
-__nargs = 2;
-__arg1 = _35reg648;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1360) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val811 = __arg1;
+Obj _35reg810= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#rules-patterns"));
+__arg1 = _35reg810;
+__arg2 = _35val811;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label3:
-{
-Obj _35val626 = __arg1;
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj rules = _35val626;
-Obj _35reg627 = primIsCons(value);
-if (True == _35reg627) {
-Obj _35reg628 = primCar(value);
-Obj _35reg629 = primEQ(intern("cons"), _35reg628);
-Obj _35reg630 = primNot(_35reg629);
-if (True == _35reg630) {
-if (True == True) {
-Obj _35reg631 = primGenSym(intern("val"));
-Obj val = _35reg631;
-pushCont(co, 0, _35clofun1360, 2, value, val);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#match-helper"));
-__arg1 = val;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#match-helper"));
-__arg1 = value;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-Obj _35reg637 = primGenSym(intern("val"));
-Obj val = _35reg637;
-pushCont(co, 1, _35clofun1360, 2, value, val);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#match-helper"));
-__arg1 = val;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#match-helper"));
-__arg1 = value;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-if (True == False) {
-Obj _35reg643 = primGenSym(intern("val"));
-Obj val = _35reg643;
-pushCont(co, 2, _35clofun1360, 2, value, val);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#match-helper"));
-__arg1 = val;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#match-helper"));
-__arg1 = value;
-__arg2 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label4:
-{
-Obj _35val625 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj value = _35val625;
-pushCont(co, 3, _35clofun1360, 1, value);
-__nargs = 2;
-__arg0 = globalRef(intern("cddr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35val624 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 4, _35clofun1360, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("macroexpand"));
-__arg1 = _35val624;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj exp = __arg1;
-pushCont(co, 5, _35clofun1360, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj exp = __arg1;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#rewrite-match"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35cc224 = makeNative(8, _35clofun1360, 0, 0);
-Obj _35reg651 = primIsCons(closureRef(co, 0));
-if (True == _35reg651) {
-Obj _35reg652 = primCar(closureRef(co, 0));
-Obj x = _35reg652;
-Obj _35reg653 = primCdr(closureRef(co, 0));
-Obj y = _35reg653;
-Obj _35reg654 = primCons(x, closureRef(co, 1));
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#extract-rules1"));
-__arg1 = y;
-__arg2 = _35reg654;
-__arg3 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc224;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj _35val664 = __arg1;
-Obj act= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj remain= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg665 = primCons(intern("list"), _35val664);
-Obj pat = _35reg665;
-Obj _35reg666 = primCons(pat, closureRef(co, 2));
-Obj _35reg667 = primCons(act, _35reg666);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#extract-rules1"));
-__arg1 = remain;
-__arg2 = Nil;
-__arg3 = _35reg667;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35cc223 = makeNative(9, _35clofun1360, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj _35reg655 = primIsCons(closureRef(co, 0));
-if (True == _35reg655) {
-Obj _35reg656 = primCar(closureRef(co, 0));
-Obj _35reg657 = primEQ(intern("=>"), _35reg656);
-if (True == _35reg657) {
-Obj _35reg658 = primCdr(closureRef(co, 0));
-Obj _35reg659 = primIsCons(_35reg658);
-if (True == _35reg659) {
-Obj _35reg660 = primCdr(closureRef(co, 0));
-Obj _35reg661 = primCar(_35reg660);
-Obj act = _35reg661;
-Obj _35reg662 = primCdr(closureRef(co, 0));
-Obj _35reg663 = primCdr(_35reg662);
-Obj remain = _35reg663;
-pushCont(co, 10, _35clofun1360, 2, act, remain);
-__nargs = 2;
-__arg0 = globalRef(intern("reverse"));
-__arg1 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc223;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc223;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc223;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35val694 = __arg1;
-Obj act= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj pred= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj remain= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg695 = primCons(intern("list"), _35val694);
-Obj pat = _35reg695;
-Obj _35reg696 = primCons(act, Nil);
-Obj _35reg697 = primCons(pred, _35reg696);
-Obj _35reg698 = primCons(intern("where"), _35reg697);
-Obj _35reg699 = primCons(pat, closureRef(co, 2));
-Obj _35reg700 = primCons(_35reg698, _35reg699);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#extract-rules1"));
-__arg1 = remain;
-__arg2 = Nil;
-__arg3 = _35reg700;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35cc222 = makeNative(11, _35clofun1360, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj _35reg668 = primIsCons(closureRef(co, 0));
-if (True == _35reg668) {
-Obj _35reg669 = primCar(closureRef(co, 0));
-Obj _35reg670 = primEQ(intern("=>"), _35reg669);
-if (True == _35reg670) {
-Obj _35reg671 = primCdr(closureRef(co, 0));
-Obj _35reg672 = primIsCons(_35reg671);
-if (True == _35reg672) {
-Obj _35reg673 = primCdr(closureRef(co, 0));
-Obj _35reg674 = primCar(_35reg673);
-Obj act = _35reg674;
-Obj _35reg675 = primCdr(closureRef(co, 0));
-Obj _35reg676 = primCdr(_35reg675);
-Obj _35reg677 = primIsCons(_35reg676);
-if (True == _35reg677) {
-Obj _35reg678 = primCdr(closureRef(co, 0));
-Obj _35reg679 = primCdr(_35reg678);
-Obj _35reg680 = primCar(_35reg679);
-Obj _35reg681 = primEQ(intern("where"), _35reg680);
-if (True == _35reg681) {
-Obj _35reg682 = primCdr(closureRef(co, 0));
-Obj _35reg683 = primCdr(_35reg682);
-Obj _35reg684 = primCdr(_35reg683);
-Obj _35reg685 = primIsCons(_35reg684);
-if (True == _35reg685) {
-Obj _35reg686 = primCdr(closureRef(co, 0));
-Obj _35reg687 = primCdr(_35reg686);
-Obj _35reg688 = primCdr(_35reg687);
-Obj _35reg689 = primCar(_35reg688);
-Obj pred = _35reg689;
-Obj _35reg690 = primCdr(closureRef(co, 0));
-Obj _35reg691 = primCdr(_35reg690);
-Obj _35reg692 = primCdr(_35reg691);
-Obj _35reg693 = primCdr(_35reg692);
-Obj remain = _35reg693;
-pushCont(co, 12, _35clofun1360, 3, act, pred, remain);
-__nargs = 2;
-__arg0 = globalRef(intern("reverse"));
-__arg1 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc222;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc222;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc222;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc222;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc222;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc222;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label14:
-{
-Obj input = __arg1;
-Obj current = __arg2;
-Obj result = __arg3;
-Obj _35cc221 = makeNative(13, _35clofun1360, 0, 3, input, current, result);
-Obj _35reg701 = primEQ(Nil, input);
-if (True == _35reg701) {
-__nargs = 2;
-__arg0 = globalRef(intern("reverse"));
-__arg1 = result;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc221;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
 {
 Obj input = __arg1;
 __nargs = 4;
@@ -4063,106 +3939,314 @@ __arg3 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label4:
 {
-Obj _35val707 = __arg1;
-Obj _35reg706= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#rules-patterns"));
-__arg1 = _35reg706;
-__arg2 = _35val707;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val704 = __arg1;
-Obj res= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val704) {
+Obj input = __arg1;
+Obj current = __arg2;
+Obj result = __arg3;
+Obj _35cc325 = makeNative(5, clofun17, 0, 3, input, current, result);
+Obj _35reg805 = primEQ(Nil, input);
+if (True == _35reg805) {
 __nargs = 2;
 __arg0 = globalRef(intern("reverse"));
-__arg1 = res;
+__arg1 = result;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg705 = primCar(rules);
-Obj _35reg706 = primCons(_35reg705, res);
-pushCont(co, 16, _35clofun1360, 1, _35reg706);
-__nargs = 2;
-__arg0 = globalRef(intern("cddr"));
-__arg1 = rules;
+__nargs = 1;
+__arg0 = _35cc325;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label18:
+label5:
 {
-Obj res = __arg1;
-Obj rules = __arg2;
-pushCont(co, 17, _35clofun1360, 2, res, rules);
+Obj _35cc326 = makeNative(1, clofun18, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35reg772 = primIsCons(closureRef(co, 0));
+if (True == _35reg772) {
+Obj _35reg773 = primCar(closureRef(co, 0));
+Obj _35reg774 = primEQ(intern("=>"), _35reg773);
+if (True == _35reg774) {
+Obj _35reg775 = primCdr(closureRef(co, 0));
+Obj _35reg776 = primIsCons(_35reg775);
+if (True == _35reg776) {
+Obj _35reg777 = primCdr(closureRef(co, 0));
+Obj _35reg778 = primCar(_35reg777);
+Obj act = _35reg778;
+Obj _35reg779 = primCdr(closureRef(co, 0));
+Obj _35reg780 = primCdr(_35reg779);
+Obj _35reg781 = primIsCons(_35reg780);
+if (True == _35reg781) {
+Obj _35reg782 = primCdr(closureRef(co, 0));
+Obj _35reg783 = primCdr(_35reg782);
+Obj _35reg784 = primCar(_35reg783);
+Obj _35reg785 = primEQ(intern("where"), _35reg784);
+if (True == _35reg785) {
+Obj _35reg786 = primCdr(closureRef(co, 0));
+Obj _35reg787 = primCdr(_35reg786);
+Obj _35reg788 = primCdr(_35reg787);
+Obj _35reg789 = primIsCons(_35reg788);
+if (True == _35reg789) {
+Obj _35reg790 = primCdr(closureRef(co, 0));
+Obj _35reg791 = primCdr(_35reg790);
+Obj _35reg792 = primCdr(_35reg791);
+Obj _35reg793 = primCar(_35reg792);
+Obj pred = _35reg793;
+Obj _35reg794 = primCdr(closureRef(co, 0));
+Obj _35reg795 = primCdr(_35reg794);
+Obj _35reg796 = primCdr(_35reg795);
+Obj _35reg797 = primCdr(_35reg796);
+Obj remain = _35reg797;
+pushCont(co, 0, clofun18, 3, act, pred, remain);
 __nargs = 2;
-__arg0 = globalRef(intern("null?"));
-__arg1 = rules;
+__arg0 = globalRef(intern("reverse"));
+__arg1 = closureRef(co, 1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc326;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = _35cc326;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc326;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc326;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc326;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc326;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 
-label19:
-{
-Obj i = __arg1;
-Obj l = __arg2;
-Obj _35reg709 = primEQ(l, Nil);
-if (True == _35reg709) {
-__nargs = 2;
-__arg1 = i;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1360) { goto fail; }
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun18(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
 goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg710 = primAdd(i, makeNumber(1));
-Obj _35reg711 = primCdr(l);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#length-h"));
-__arg1 = _35reg710;
-__arg2 = _35reg711;
+
+label0:
+{
+Obj _35val798 = __arg1;
+Obj act= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj pred= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj remain= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg799 = primCons(intern("list"), _35val798);
+Obj pat = _35reg799;
+Obj _35reg800 = primCons(act, Nil);
+Obj _35reg801 = primCons(pred, _35reg800);
+Obj _35reg802 = primCons(intern("where"), _35reg801);
+Obj _35reg803 = primCons(pat, closureRef(co, 2));
+Obj _35reg804 = primCons(_35reg802, _35reg803);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/init#extract-rules1"));
+__arg1 = remain;
+__arg2 = Nil;
+__arg3 = _35reg804;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35cc327 = makeNative(3, clofun18, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj _35reg759 = primIsCons(closureRef(co, 0));
+if (True == _35reg759) {
+Obj _35reg760 = primCar(closureRef(co, 0));
+Obj _35reg761 = primEQ(intern("=>"), _35reg760);
+if (True == _35reg761) {
+Obj _35reg762 = primCdr(closureRef(co, 0));
+Obj _35reg763 = primIsCons(_35reg762);
+if (True == _35reg763) {
+Obj _35reg764 = primCdr(closureRef(co, 0));
+Obj _35reg765 = primCar(_35reg764);
+Obj act = _35reg765;
+Obj _35reg766 = primCdr(closureRef(co, 0));
+Obj _35reg767 = primCdr(_35reg766);
+Obj remain = _35reg767;
+pushCont(co, 2, clofun18, 2, act, remain);
+__nargs = 2;
+__arg0 = globalRef(intern("reverse"));
+__arg1 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc327;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc327;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc327;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label20:
+label2:
 {
-Obj l = __arg1;
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#length-h"));
-__arg1 = makeNumber(0);
-__arg2 = l;
+Obj _35val768 = __arg1;
+Obj act= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj remain= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg769 = primCons(intern("list"), _35val768);
+Obj pat = _35reg769;
+Obj _35reg770 = primCons(pat, closureRef(co, 2));
+Obj _35reg771 = primCons(act, _35reg770);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/init#extract-rules1"));
+__arg1 = remain;
+__arg2 = Nil;
+__arg3 = _35reg771;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1360) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35cc328 = makeNative(4, clofun18, 0, 0);
+Obj _35reg755 = primIsCons(closureRef(co, 0));
+if (True == _35reg755) {
+Obj _35reg756 = primCar(closureRef(co, 0));
+Obj x = _35reg756;
+Obj _35reg757 = primCdr(closureRef(co, 0));
+Obj y = _35reg757;
+Obj _35reg758 = primCons(x, closureRef(co, 1));
+__nargs = 4;
+__arg0 = globalRef(intern("cora/init#extract-rules1"));
+__arg1 = y;
+__arg2 = _35reg758;
+__arg3 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc328;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj exp = __arg1;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rewrite-match"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4175,536 +4259,342 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1359(struct Cora* co){
+void clofun19(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val557 = __arg1;
-Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 20, _35clofun1358, 2, cc, _35val557);
+Obj exp = __arg1;
+pushCont(co, 1, clofun19, 1, exp);
 __nargs = 2;
-__arg0 = globalRef(intern("caddr"));
-__arg1 = action;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val565 = __arg1;
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val564= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg566 = primCons(cc, Nil);
-Obj _35reg567 = primCons(_35reg566, Nil);
-Obj _35reg568 = primCons(_35val565, _35reg567);
-Obj _35reg569 = primCons(_35val564, _35reg568);
-Obj _35reg570 = primCons(intern("if"), _35reg569);
+Obj _35val728 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 2, clofun19, 1, exp);
 __nargs = 2;
-__arg1 = _35reg570;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1359) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("macroexpand"));
+__arg1 = _35val728;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val564 = __arg1;
-Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun1359, 2, cc, _35val564);
+Obj _35val729 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value = _35val729;
+pushCont(co, 3, clofun19, 1, value);
 __nargs = 2;
-__arg0 = globalRef(intern("caddr"));
-__arg1 = action;
+__arg0 = globalRef(intern("cddr"));
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val547 = __arg1;
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj action= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val547) {
-Obj _35reg548 = primCar(action);
-Obj _35reg549 = primEQ(_35reg548, intern("where"));
-if (True == _35reg549) {
+Obj _35val730 = __arg1;
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules = _35val730;
+Obj _35reg731 = primIsCons(value);
+if (True == _35reg731) {
+Obj _35reg732 = primCar(value);
+Obj _35reg733 = primEQ(intern("cons"), _35reg732);
+Obj _35reg734 = primNot(_35reg733);
+if (True == _35reg734) {
 if (True == True) {
-pushCont(co, 19, _35clofun1358, 2, action, cc);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = action;
+Obj _35reg735 = primGenSym(intern("val"));
+Obj val = _35reg735;
+pushCont(co, 0, clofun20, 2, value, val);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#match-helper"));
+__arg1 = val;
+__arg2 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 2;
-__arg1 = action;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1359) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#match-helper"));
+__arg1 = value;
+__arg2 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-pushCont(co, 0, _35clofun1359, 2, action, cc);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = action;
+Obj _35reg741 = primGenSym(intern("val"));
+Obj val = _35reg741;
+pushCont(co, 5, clofun19, 2, value, val);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#match-helper"));
+__arg1 = val;
+__arg2 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 2;
-__arg1 = action;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1359) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#match-helper"));
+__arg1 = value;
+__arg2 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 }
 } else {
 if (True == False) {
-pushCont(co, 2, _35clofun1359, 2, action, cc);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = action;
+Obj _35reg747 = primGenSym(intern("val"));
+Obj val = _35reg747;
+pushCont(co, 4, clofun19, 2, value, val);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#match-helper"));
+__arg1 = val;
+__arg2 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 2;
-__arg1 = action;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1359) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#match-helper"));
+__arg1 = value;
+__arg2 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 }
 }
 
 label4:
 {
-Obj rules = __arg1;
-Obj cc = __arg2;
-Obj _35reg545 = primCdr(rules);
-Obj _35reg546 = primCar(_35reg545);
-Obj action = _35reg546;
-pushCont(co, 3, _35clofun1359, 2, cc, action);
+Obj _35val748 = __arg1;
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg749 = primCons(_35val748, Nil);
+Obj _35reg750 = primCons(value, _35reg749);
+Obj _35reg751 = primCons(val, _35reg750);
+Obj _35reg752 = primCons(intern("let"), _35reg751);
 __nargs = 2;
-__arg0 = globalRef(intern("pair?"));
-__arg1 = action;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = _35reg752;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun19) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label5:
 {
-Obj _35val585 = __arg1;
-Obj curr= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj rest = _35val585;
-Obj _35reg586 = primCons(rest, Nil);
-Obj _35reg587 = primCons(Nil, _35reg586);
-Obj _35reg588 = primCons(intern("lambda"), _35reg587);
-Obj _35reg589 = primCons(curr, Nil);
-Obj _35reg590 = primCons(_35reg588, _35reg589);
-Obj _35reg591 = primCons(cc, _35reg590);
-Obj _35reg592 = primCons(intern("let"), _35reg591);
+Obj _35val742 = __arg1;
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg743 = primCons(_35val742, Nil);
+Obj _35reg744 = primCons(value, _35reg743);
+Obj _35reg745 = primCons(val, _35reg744);
+Obj _35reg746 = primCons(intern("let"), _35reg745);
 __nargs = 2;
-__arg1 = _35reg592;
+__arg1 = _35reg746;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1359) { goto fail; }
+if (co->ctx.pc.func != clofun19) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label6:
-{
-Obj _35val582 = __arg1;
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj curr = _35val582;
-Obj _35reg583 = primCdr(rules);
-Obj _35reg584 = primCdr(_35reg583);
-pushCont(co, 5, _35clofun1359, 2, curr, cc);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#match-helper"));
-__arg1 = value;
-__arg2 = _35reg584;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
 }
 
-label7:
-{
-Obj _35val581 = __arg1;
-Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 6, _35clofun1359, 3, rules, value, cc);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = _35val581;
-__arg2 = value;
-__arg3 = action;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+void clofun20(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
 
-label8:
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
 {
-Obj _35val580 = __arg1;
-Obj pat= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj action = _35val580;
-pushCont(co, 7, _35clofun1359, 4, action, rules, value, cc);
+Obj _35val736 = __arg1;
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg737 = primCons(_35val736, Nil);
+Obj _35reg738 = primCons(value, _35reg737);
+Obj _35reg739 = primCons(val, _35reg738);
+Obj _35reg740 = primCons(intern("let"), _35reg739);
 __nargs = 2;
-__arg0 = globalRef(intern("macroexpand"));
-__arg1 = pat;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val600 = __arg1;
-Obj curr= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj rest = _35val600;
-Obj _35reg601 = primCons(rest, Nil);
-Obj _35reg602 = primCons(Nil, _35reg601);
-Obj _35reg603 = primCons(intern("lambda"), _35reg602);
-Obj _35reg604 = primCons(curr, Nil);
-Obj _35reg605 = primCons(_35reg603, _35reg604);
-Obj _35reg606 = primCons(cc, _35reg605);
-Obj _35reg607 = primCons(intern("let"), _35reg606);
-__nargs = 2;
-__arg1 = _35reg607;
+__arg1 = _35reg740;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1359) { goto fail; }
+if (co->ctx.pc.func != clofun20) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label10:
-{
-Obj _35val597 = __arg1;
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj curr = _35val597;
-Obj _35reg598 = primCdr(rules);
-Obj _35reg599 = primCdr(_35reg598);
-pushCont(co, 9, _35clofun1359, 2, curr, cc);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#match-helper"));
-__arg1 = value;
-__arg2 = _35reg599;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val596 = __arg1;
-Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 10, _35clofun1359, 3, rules, value, cc);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = _35val596;
-__arg2 = value;
-__arg3 = action;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35val595 = __arg1;
-Obj pat= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj action = _35val595;
-pushCont(co, 11, _35clofun1359, 4, action, rules, value, cc);
-__nargs = 2;
-__arg0 = globalRef(intern("macroexpand"));
-__arg1 = pat;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35val577 = __arg1;
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val577) {
-if (True == True) {
-Obj _35reg578 = primCar(rules);
-Obj pat = _35reg578;
-Obj _35reg579 = primGenSym(intern("cc"));
-Obj cc = _35reg579;
-pushCont(co, 8, _35clofun1359, 4, pat, rules, value, cc);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#extract-rule-action"));
-__arg1 = rules;
-__arg2 = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-Obj _35reg593 = primCar(rules);
-Obj pat = _35reg593;
-Obj _35reg594 = primGenSym(intern("cc"));
-Obj cc = _35reg594;
-pushCont(co, 12, _35clofun1359, 4, pat, rules, value, cc);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#extract-rule-action"));
-__arg1 = rules;
-__arg2 = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label14:
-{
-Obj _35val615 = __arg1;
-Obj curr= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj rest = _35val615;
-Obj _35reg616 = primCons(rest, Nil);
-Obj _35reg617 = primCons(Nil, _35reg616);
-Obj _35reg618 = primCons(intern("lambda"), _35reg617);
-Obj _35reg619 = primCons(curr, Nil);
-Obj _35reg620 = primCons(_35reg618, _35reg619);
-Obj _35reg621 = primCons(cc, _35reg620);
-Obj _35reg622 = primCons(intern("let"), _35reg621);
-__nargs = 2;
-__arg1 = _35reg622;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1359) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label15:
-{
-Obj _35val612 = __arg1;
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj curr = _35val612;
-Obj _35reg613 = primCdr(rules);
-Obj _35reg614 = primCdr(_35reg613);
-pushCont(co, 14, _35clofun1359, 2, curr, cc);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#match-helper"));
-__arg1 = value;
-__arg2 = _35reg614;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val611 = __arg1;
-Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 15, _35clofun1359, 3, rules, value, cc);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = _35val611;
-__arg2 = value;
-__arg3 = action;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val610 = __arg1;
-Obj pat= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj action = _35val610;
-pushCont(co, 16, _35clofun1359, 4, action, rules, value, cc);
-__nargs = 2;
-__arg0 = globalRef(intern("macroexpand"));
-__arg1 = pat;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val575 = __arg1;
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val575) {
-Obj _35reg576 = primCdr(rules);
-pushCont(co, 13, _35clofun1359, 2, rules, value);
-__nargs = 2;
-__arg0 = globalRef(intern("pair?"));
-__arg1 = _35reg576;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-if (True == False) {
-Obj _35reg608 = primCar(rules);
-Obj pat = _35reg608;
-Obj _35reg609 = primGenSym(intern("cc"));
-Obj cc = _35reg609;
-pushCont(co, 17, _35clofun1359, 4, pat, rules, value, cc);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#extract-rule-action"));
-__arg1 = rules;
-__arg2 = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label19:
-{
-Obj _35val572 = __arg1;
-Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val572) {
-Obj _35reg573 = primCons(makeCString("no match-help found!"), Nil);
-Obj _35reg574 = primCons(intern("error"), _35reg573);
-__nargs = 2;
-__arg1 = _35reg574;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1359) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 18, _35clofun1359, 2, rules, value);
-__nargs = 2;
-__arg0 = globalRef(intern("pair?"));
-__arg1 = rules;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
+label1:
 {
 Obj value = __arg1;
 Obj rules = __arg2;
-pushCont(co, 19, _35clofun1359, 2, rules, value);
+pushCont(co, 2, clofun20, 2, rules, value);
 __nargs = 2;
 __arg0 = globalRef(intern("null?"));
 __arg1 = rules;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1359) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val676 = __arg1;
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val676) {
+Obj _35reg677 = primCons(makeCString("no match-help found!"), Nil);
+Obj _35reg678 = primCons(intern("error"), _35reg677);
+__nargs = 2;
+__arg1 = _35reg678;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun20) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 3, clofun20, 2, rules, value);
+__nargs = 2;
+__arg0 = globalRef(intern("pair?"));
+__arg1 = rules;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35val679 = __arg1;
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val679) {
+Obj _35reg680 = primCdr(rules);
+pushCont(co, 2, clofun21, 2, rules, value);
+__nargs = 2;
+__arg0 = globalRef(intern("pair?"));
+__arg1 = _35reg680;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+if (True == False) {
+Obj _35reg712 = primCar(rules);
+Obj pat = _35reg712;
+Obj _35reg713 = primGenSym(intern("cc"));
+Obj cc = _35reg713;
+pushCont(co, 4, clofun20, 4, pat, rules, value, cc);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#extract-rule-action"));
+__arg1 = rules;
+__arg2 = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label4:
+{
+Obj _35val714 = __arg1;
+Obj pat= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj action = _35val714;
+pushCont(co, 5, clofun20, 4, action, rules, value, cc);
+__nargs = 2;
+__arg0 = globalRef(intern("macroexpand"));
+__arg1 = pat;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val715 = __arg1;
+Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, clofun21, 3, rules, value, cc);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#match1"));
+__arg1 = _35val715;
+__arg2 = value;
+__arg3 = action;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4717,427 +4607,625 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1358(struct Cora* co){
+void clofun21(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val480 = __arg1;
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj e2 = _35val480;
-pushCont(co, 20, _35clofun1357, 3, x, e1, cc);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = y;
-__arg2 = e2;
-__arg3 = body;
-co->args[4] = cc;
+Obj _35val716 = __arg1;
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj curr = _35val716;
+Obj _35reg717 = primCdr(rules);
+Obj _35reg718 = primCdr(_35reg717);
+pushCont(co, 1, clofun21, 2, curr, cc);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#match-helper"));
+__arg1 = value;
+__arg2 = _35reg718;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val479 = __arg1;
-Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj e1 = _35val479;
-pushCont(co, 0, _35clofun1358, 5, y, body, x, e1, cc);
+Obj _35val719 = __arg1;
+Obj curr= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj rest = _35val719;
+Obj _35reg720 = primCons(rest, Nil);
+Obj _35reg721 = primCons(Nil, _35reg720);
+Obj _35reg722 = primCons(intern("lambda"), _35reg721);
+Obj _35reg723 = primCons(curr, Nil);
+Obj _35reg724 = primCons(_35reg722, _35reg723);
+Obj _35reg725 = primCons(cc, _35reg724);
+Obj _35reg726 = primCons(intern("let"), _35reg725);
 __nargs = 2;
-__arg0 = globalRef(intern("caddr"));
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = _35reg726;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun21) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val489 = __arg1;
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg483= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg490 = primCons(cc, Nil);
-Obj _35reg491 = primCons(_35reg490, Nil);
-Obj _35reg492 = primCons(_35val489, _35reg491);
-Obj _35reg493 = primCons(_35reg483, _35reg492);
-Obj _35reg494 = primCons(intern("if"), _35reg493);
+Obj _35val681 = __arg1;
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val681) {
+if (True == True) {
+Obj _35reg682 = primCar(rules);
+Obj pat = _35reg682;
+Obj _35reg683 = primGenSym(intern("cc"));
+Obj cc = _35reg683;
+pushCont(co, 1, clofun22, 4, pat, rules, value, cc);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#extract-rule-action"));
+__arg1 = rules;
+__arg2 = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
 __nargs = 2;
-__arg1 = _35reg494;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1358) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("error"));
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+Obj _35reg697 = primCar(rules);
+Obj pat = _35reg697;
+Obj _35reg698 = primGenSym(intern("cc"));
+Obj cc = _35reg698;
+pushCont(co, 3, clofun21, 4, pat, rules, value, cc);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#extract-rule-action"));
+__arg1 = rules;
+__arg2 = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("error"));
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 label3:
 {
-Obj _35val488 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg485= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg483= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 2, _35clofun1358, 2, cc, _35reg483);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = x;
-__arg2 = _35reg485;
-__arg3 = _35val488;
-co->args[4] = cc;
+Obj _35val699 = __arg1;
+Obj pat= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj action = _35val699;
+pushCont(co, 4, clofun21, 4, action, rules, value, cc);
+__nargs = 2;
+__arg0 = globalRef(intern("macroexpand"));
+__arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val497 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35val700 = __arg1;
+Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 5, clofun21, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = x;
-__arg2 = e1;
-__arg3 = _35val497;
+__arg1 = _35val700;
+__arg2 = value;
+__arg3 = action;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val496 = __arg1;
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj e2 = _35val496;
-pushCont(co, 4, _35clofun1358, 3, x, e1, cc);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = y;
-__arg2 = e2;
-__arg3 = body;
-co->args[4] = cc;
+Obj _35val701 = __arg1;
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj curr = _35val701;
+Obj _35reg702 = primCdr(rules);
+Obj _35reg703 = primCdr(_35reg702);
+pushCont(co, 0, clofun22, 2, curr, cc);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#match-helper"));
+__arg1 = value;
+__arg2 = _35reg703;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
-{
-Obj _35val495 = __arg1;
-Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj e1 = _35val495;
-pushCont(co, 5, _35clofun1358, 5, y, body, x, e1, cc);
-__nargs = 2;
-__arg0 = globalRef(intern("caddr"));
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
 }
 
-label7:
+void clofun22(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
 {
-Obj _35val505 = __arg1;
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg499= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg506 = primCons(cc, Nil);
-Obj _35reg507 = primCons(_35reg506, Nil);
-Obj _35reg508 = primCons(_35val505, _35reg507);
-Obj _35reg509 = primCons(_35reg499, _35reg508);
-Obj _35reg510 = primCons(intern("if"), _35reg509);
+Obj _35val704 = __arg1;
+Obj curr= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj rest = _35val704;
+Obj _35reg705 = primCons(rest, Nil);
+Obj _35reg706 = primCons(Nil, _35reg705);
+Obj _35reg707 = primCons(intern("lambda"), _35reg706);
+Obj _35reg708 = primCons(curr, Nil);
+Obj _35reg709 = primCons(_35reg707, _35reg708);
+Obj _35reg710 = primCons(cc, _35reg709);
+Obj _35reg711 = primCons(intern("let"), _35reg710);
 __nargs = 2;
-__arg1 = _35reg510;
+__arg1 = _35reg711;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1358) { goto fail; }
+if (co->ctx.pc.func != clofun22) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label8:
+label1:
 {
-Obj _35val504 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg501= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg499= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 7, _35clofun1358, 2, cc, _35reg499);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = x;
-__arg2 = _35reg501;
-__arg3 = _35val504;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val459 = __arg1;
-Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj y = _35val459;
-Obj _35reg460 = primIsCons(expr);
-if (True == _35reg460) {
-Obj _35reg461 = primCar(expr);
-Obj _35reg462 = primEQ(_35reg461, intern("cons"));
-if (True == _35reg462) {
-if (True == True) {
-pushCont(co, 17, _35clofun1357, 5, expr, y, body, x, cc);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg466 = primCons(expr, Nil);
-Obj _35reg467 = primCons(intern("cons?"), _35reg466);
-Obj _35reg468 = primCons(expr, Nil);
-Obj _35reg469 = primCons(intern("car"), _35reg468);
-Obj _35reg470 = primCons(expr, Nil);
-Obj _35reg471 = primCons(intern("cdr"), _35reg470);
-pushCont(co, 19, _35clofun1357, 4, x, _35reg469, cc, _35reg467);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = y;
-__arg2 = _35reg471;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-pushCont(co, 1, _35clofun1358, 5, expr, y, body, x, cc);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg482 = primCons(expr, Nil);
-Obj _35reg483 = primCons(intern("cons?"), _35reg482);
-Obj _35reg484 = primCons(expr, Nil);
-Obj _35reg485 = primCons(intern("car"), _35reg484);
-Obj _35reg486 = primCons(expr, Nil);
-Obj _35reg487 = primCons(intern("cdr"), _35reg486);
-pushCont(co, 3, _35clofun1358, 4, x, _35reg485, cc, _35reg483);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = y;
-__arg2 = _35reg487;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-if (True == False) {
-pushCont(co, 6, _35clofun1358, 5, expr, y, body, x, cc);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg498 = primCons(expr, Nil);
-Obj _35reg499 = primCons(intern("cons?"), _35reg498);
-Obj _35reg500 = primCons(expr, Nil);
-Obj _35reg501 = primCons(intern("car"), _35reg500);
-Obj _35reg502 = primCons(expr, Nil);
-Obj _35reg503 = primCons(intern("cdr"), _35reg502);
-pushCont(co, 8, _35clofun1358, 4, x, _35reg501, cc, _35reg499);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = y;
-__arg2 = _35reg503;
-__arg3 = body;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label10:
-{
-Obj _35val458 = __arg1;
+Obj _35val684 = __arg1;
 Obj pat= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj x = _35val458;
-pushCont(co, 9, _35clofun1358, 4, expr, body, x, cc);
+Obj action = _35val684;
+pushCont(co, 2, clofun22, 4, action, rules, value, cc);
 __nargs = 2;
-__arg0 = globalRef(intern("caddr"));
+__arg0 = globalRef(intern("macroexpand"));
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label2:
+{
+Obj _35val685 = __arg1;
+Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 3, clofun22, 3, rules, value, cc);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#match1"));
+__arg1 = _35val685;
+__arg2 = value;
+__arg3 = action;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val686 = __arg1;
+Obj rules= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj value= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj curr = _35val686;
+Obj _35reg687 = primCdr(rules);
+Obj _35reg688 = primCdr(_35reg687);
+pushCont(co, 4, clofun22, 2, curr, cc);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#match-helper"));
+__arg1 = value;
+__arg2 = _35reg688;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val689 = __arg1;
+Obj curr= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj rest = _35val689;
+Obj _35reg690 = primCons(rest, Nil);
+Obj _35reg691 = primCons(Nil, _35reg690);
+Obj _35reg692 = primCons(intern("lambda"), _35reg691);
+Obj _35reg693 = primCons(curr, Nil);
+Obj _35reg694 = primCons(_35reg692, _35reg693);
+Obj _35reg695 = primCons(cc, _35reg694);
+Obj _35reg696 = primCons(intern("let"), _35reg695);
+__nargs = 2;
+__arg1 = _35reg696;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun22) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label5:
+{
+Obj rules = __arg1;
+Obj cc = __arg2;
+Obj _35reg649 = primCdr(rules);
+Obj _35reg650 = primCar(_35reg649);
+Obj action = _35reg650;
+pushCont(co, 0, clofun23, 2, cc, action);
+__nargs = 2;
+__arg0 = globalRef(intern("pair?"));
+__arg1 = action;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun23(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val651 = __arg1;
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj action= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val651) {
+Obj _35reg652 = primCar(action);
+Obj _35reg653 = primEQ(_35reg652, intern("where"));
+if (True == _35reg653) {
+if (True == True) {
+pushCont(co, 5, clofun23, 2, action, cc);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = action;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun23) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = action;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun23) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+} else {
+if (True == False) {
+pushCont(co, 3, clofun23, 2, action, cc);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = action;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun23) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = action;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun23) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+} else {
+if (True == False) {
+pushCont(co, 1, clofun23, 2, action, cc);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = action;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun23) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = action;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun23) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+}
+
+label1:
+{
+Obj _35val668 = __arg1;
+Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 2, clofun23, 2, cc, _35val668);
+__nargs = 2;
+__arg0 = globalRef(intern("caddr"));
+__arg1 = action;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun23) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val669 = __arg1;
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val668= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg670 = primCons(cc, Nil);
+Obj _35reg671 = primCons(_35reg670, Nil);
+Obj _35reg672 = primCons(_35val669, _35reg671);
+Obj _35reg673 = primCons(_35val668, _35reg672);
+Obj _35reg674 = primCons(intern("if"), _35reg673);
+__nargs = 2;
+__arg1 = _35reg674;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun23) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label3:
+{
+Obj _35val661 = __arg1;
+Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 4, clofun23, 2, cc, _35val661);
+__nargs = 2;
+__arg0 = globalRef(intern("caddr"));
+__arg1 = action;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun23) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val662 = __arg1;
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val661= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg663 = primCons(cc, Nil);
+Obj _35reg664 = primCons(_35reg663, Nil);
+Obj _35reg665 = primCons(_35val662, _35reg664);
+Obj _35reg666 = primCons(_35val661, _35reg665);
+Obj _35reg667 = primCons(intern("if"), _35reg666);
+__nargs = 2;
+__arg1 = _35reg667;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun23) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label5:
+{
+Obj _35val654 = __arg1;
+Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, clofun24, 2, cc, _35val654);
+__nargs = 2;
+__arg0 = globalRef(intern("caddr"));
+__arg1 = action;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun23) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun24(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val655 = __arg1;
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val654= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg656 = primCons(cc, Nil);
+Obj _35reg657 = primCons(_35reg656, Nil);
+Obj _35reg658 = primCons(_35val655, _35reg657);
+Obj _35reg659 = primCons(_35val654, _35reg658);
+Obj _35reg660 = primCons(intern("if"), _35reg659);
+__nargs = 2;
+__arg1 = _35reg660;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun24) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label1:
 {
 Obj pat = __arg1;
 Obj expr = __arg2;
 Obj body = __arg3;
 Obj cc = co->args[4];
-pushCont(co, 10, _35clofun1358, 4, pat, expr, body, cc);
+Obj literal_63 = makeNative(5, clofun24, 1, 0);
+pushCont(co, 2, clofun24, 4, expr, body, cc, pat);
 __nargs = 2;
-__arg0 = globalRef(intern("cadr"));
+__arg0 = literal_63;
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label2:
 {
-Obj _35val512 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val512) {
-Obj _35reg513 = primIsSymbol(x);
-Obj _35reg514 = primNot(_35reg513);
-if (True == _35reg514) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1358) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1358) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-} else {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1358) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label13:
-{
-Obj x = __arg1;
-pushCont(co, 12, _35clofun1358, 1, x);
-__nargs = 2;
-__arg0 = globalRef(intern("atom?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35val543 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(intern("error"));
-__arg1 = _35val543;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35val530 = __arg1;
+Obj _35val619 = __arg1;
 Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj pat= co->ctx.stk.stack[co->ctx.stk.base + 3];
-if (True == _35val530) {
-Obj _35reg531 = primCar(pat);
-Obj _35reg532 = primEQ(_35reg531, intern("quote"));
-if (True == _35reg532) {
-Obj _35reg533 = primCons(expr, Nil);
-Obj _35reg534 = primCons(pat, _35reg533);
-Obj _35reg535 = primCons(intern("="), _35reg534);
-Obj _35reg536 = primCons(cc, Nil);
-Obj _35reg537 = primCons(_35reg536, Nil);
-Obj _35reg538 = primCons(body, _35reg537);
-Obj _35reg539 = primCons(_35reg535, _35reg538);
-Obj _35reg540 = primCons(intern("if"), _35reg539);
+if (True == _35val619) {
+Obj _35reg620 = primEQ(pat, expr);
+if (True == _35reg620) {
 __nargs = 2;
-__arg1 = _35reg540;
+__arg1 = body;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1358) { goto fail; }
+if (co->ctx.pc.func != clofun24) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg541 = primCar(pat);
-Obj _35reg542 = primEQ(_35reg541, intern("cons"));
-if (True == _35reg542) {
+Obj _35reg621 = primCons(expr, Nil);
+Obj _35reg622 = primCons(pat, _35reg621);
+Obj _35reg623 = primCons(intern("="), _35reg622);
+Obj _35reg624 = primCons(cc, Nil);
+Obj _35reg625 = primCons(_35reg624, Nil);
+Obj _35reg626 = primCons(body, _35reg625);
+Obj _35reg627 = primCons(_35reg623, _35reg626);
+Obj _35reg628 = primCons(intern("if"), _35reg627);
+__nargs = 2;
+__arg1 = _35reg628;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun24) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+} else {
+Obj _35reg629 = primIsSymbol(pat);
+if (True == _35reg629) {
+Obj _35reg630 = primCons(body, Nil);
+Obj _35reg631 = primCons(expr, _35reg630);
+Obj _35reg632 = primCons(pat, _35reg631);
+Obj _35reg633 = primCons(intern("let"), _35reg632);
+__nargs = 2;
+__arg1 = _35reg633;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun24) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 3, clofun24, 4, expr, body, cc, pat);
+__nargs = 2;
+__arg0 = globalRef(intern("pair?"));
+__arg1 = pat;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label3:
+{
+Obj _35val634 = __arg1;
+Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj pat= co->ctx.stk.stack[co->ctx.stk.base + 3];
+if (True == _35val634) {
+Obj _35reg635 = primCar(pat);
+Obj _35reg636 = primEQ(_35reg635, intern("quote"));
+if (True == _35reg636) {
+Obj _35reg637 = primCons(expr, Nil);
+Obj _35reg638 = primCons(pat, _35reg637);
+Obj _35reg639 = primCons(intern("="), _35reg638);
+Obj _35reg640 = primCons(cc, Nil);
+Obj _35reg641 = primCons(_35reg640, Nil);
+Obj _35reg642 = primCons(body, _35reg641);
+Obj _35reg643 = primCons(_35reg639, _35reg642);
+Obj _35reg644 = primCons(intern("if"), _35reg643);
+__nargs = 2;
+__arg1 = _35reg644;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun24) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg645 = primCar(pat);
+Obj _35reg646 = primEQ(_35reg645, intern("cons"));
+if (True == _35reg646) {
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init#match-cons-expander"));
 __arg1 = pat;
@@ -5147,7 +5235,7 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -5156,12 +5244,12 @@ __arg1 = makeCString("no cond match");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 } else {
-pushCont(co, 14, _35clofun1358, 0);
+pushCont(co, 4, clofun24, 0);
 __nargs = 3;
 __arg0 = globalRef(intern("str"));
 __arg1 = makeCString("match fail ");
@@ -5169,132 +5257,267 @@ __arg2 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label16:
+label4:
 {
-Obj _35val515 = __arg1;
-Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj pat= co->ctx.stk.stack[co->ctx.stk.base + 3];
-if (True == _35val515) {
-Obj _35reg516 = primEQ(pat, expr);
-if (True == _35reg516) {
+Obj _35val647 = __arg1;
 __nargs = 2;
-__arg1 = body;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1358) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg517 = primCons(expr, Nil);
-Obj _35reg518 = primCons(pat, _35reg517);
-Obj _35reg519 = primCons(intern("="), _35reg518);
-Obj _35reg520 = primCons(cc, Nil);
-Obj _35reg521 = primCons(_35reg520, Nil);
-Obj _35reg522 = primCons(body, _35reg521);
-Obj _35reg523 = primCons(_35reg519, _35reg522);
-Obj _35reg524 = primCons(intern("if"), _35reg523);
-__nargs = 2;
-__arg1 = _35reg524;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1358) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-} else {
-Obj _35reg525 = primIsSymbol(pat);
-if (True == _35reg525) {
-Obj _35reg526 = primCons(body, Nil);
-Obj _35reg527 = primCons(expr, _35reg526);
-Obj _35reg528 = primCons(pat, _35reg527);
-Obj _35reg529 = primCons(intern("let"), _35reg528);
-__nargs = 2;
-__arg1 = _35reg529;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1358) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 15, _35clofun1358, 4, expr, body, cc, pat);
-__nargs = 2;
-__arg0 = globalRef(intern("pair?"));
-__arg1 = pat;
+__arg0 = globalRef(intern("error"));
+__arg1 = _35val647;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+
+label5:
+{
+Obj x = __arg1;
+pushCont(co, 0, clofun25, 1, x);
+__nargs = 2;
+__arg0 = globalRef(intern("atom?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun25(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val616 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val616) {
+Obj _35reg617 = primIsSymbol(x);
+Obj _35reg618 = primNot(_35reg617);
+if (True == _35reg618) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun25) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun25) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+} else {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun25) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 }
 
-label17:
+label1:
 {
 Obj pat = __arg1;
 Obj expr = __arg2;
 Obj body = __arg3;
 Obj cc = co->args[4];
-Obj literal_63 = makeNative(13, _35clofun1358, 1, 0);
-pushCont(co, 16, _35clofun1358, 4, expr, body, cc, pat);
+pushCont(co, 2, clofun25, 4, pat, expr, body, cc);
 __nargs = 2;
-__arg0 = literal_63;
+__arg0 = globalRef(intern("cadr"));
 __arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label2:
 {
-Obj _35val551 = __arg1;
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val550= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg552 = primCons(cc, Nil);
-Obj _35reg553 = primCons(_35reg552, Nil);
-Obj _35reg554 = primCons(_35val551, _35reg553);
-Obj _35reg555 = primCons(_35val550, _35reg554);
-Obj _35reg556 = primCons(intern("if"), _35reg555);
-__nargs = 2;
-__arg1 = _35reg556;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1358) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label19:
-{
-Obj _35val550 = __arg1;
-Obj action= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 18, _35clofun1358, 2, cc, _35val550);
+Obj _35val562 = __arg1;
+Obj pat= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj x = _35val562;
+pushCont(co, 3, clofun25, 4, expr, body, x, cc);
 __nargs = 2;
 __arg0 = globalRef(intern("caddr"));
-__arg1 = action;
+__arg1 = pat;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1358) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label3:
 {
-Obj _35val558 = __arg1;
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val557= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg559 = primCons(cc, Nil);
-Obj _35reg560 = primCons(_35reg559, Nil);
-Obj _35reg561 = primCons(_35val558, _35reg560);
-Obj _35reg562 = primCons(_35val557, _35reg561);
-Obj _35reg563 = primCons(intern("if"), _35reg562);
+Obj _35val563 = __arg1;
+Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj y = _35val563;
+Obj _35reg564 = primIsCons(expr);
+if (True == _35reg564) {
+Obj _35reg565 = primCar(expr);
+Obj _35reg566 = primEQ(_35reg565, intern("cons"));
+if (True == _35reg566) {
+if (True == True) {
+pushCont(co, 4, clofun27, 5, expr, y, body, x, cc);
 __nargs = 2;
-__arg1 = _35reg563;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = expr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg570 = primCons(expr, Nil);
+Obj _35reg571 = primCons(intern("cons?"), _35reg570);
+Obj _35reg572 = primCons(expr, Nil);
+Obj _35reg573 = primCons(intern("car"), _35reg572);
+Obj _35reg574 = primCons(expr, Nil);
+Obj _35reg575 = primCons(intern("cdr"), _35reg574);
+pushCont(co, 2, clofun27, 4, x, _35reg573, cc, _35reg571);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#match1"));
+__arg1 = y;
+__arg2 = _35reg575;
+__arg3 = body;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+pushCont(co, 5, clofun26, 5, expr, y, body, x, cc);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = expr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg586 = primCons(expr, Nil);
+Obj _35reg587 = primCons(intern("cons?"), _35reg586);
+Obj _35reg588 = primCons(expr, Nil);
+Obj _35reg589 = primCons(intern("car"), _35reg588);
+Obj _35reg590 = primCons(expr, Nil);
+Obj _35reg591 = primCons(intern("cdr"), _35reg590);
+pushCont(co, 3, clofun26, 4, x, _35reg589, cc, _35reg587);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#match1"));
+__arg1 = y;
+__arg2 = _35reg591;
+__arg3 = body;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+if (True == False) {
+pushCont(co, 0, clofun26, 5, expr, y, body, x, cc);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = expr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg602 = primCons(expr, Nil);
+Obj _35reg603 = primCons(intern("cons?"), _35reg602);
+Obj _35reg604 = primCons(expr, Nil);
+Obj _35reg605 = primCons(intern("car"), _35reg604);
+Obj _35reg606 = primCons(expr, Nil);
+Obj _35reg607 = primCons(intern("cdr"), _35reg606);
+pushCont(co, 4, clofun25, 4, x, _35reg605, cc, _35reg603);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#match1"));
+__arg1 = y;
+__arg2 = _35reg607;
+__arg3 = body;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label4:
+{
+Obj _35val608 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg605= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg603= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 5, clofun25, 2, cc, _35reg603);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#match1"));
+__arg1 = x;
+__arg2 = _35reg605;
+__arg3 = _35val608;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val609 = __arg1;
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg603= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg610 = primCons(cc, Nil);
+Obj _35reg611 = primCons(_35reg610, Nil);
+Obj _35reg612 = primCons(_35val609, _35reg611);
+Obj _35reg613 = primCons(_35reg603, _35reg612);
+Obj _35reg614 = primCons(intern("if"), _35reg613);
+__nargs = 2;
+__arg1 = _35reg614;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1358) { goto fail; }
+if (co->ctx.pc.func != clofun25) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -5307,367 +5530,47 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1357(struct Cora* co){
+void clofun26(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val408 = __arg1;
-Obj _35val407= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg406= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg409 = primCons(intern("cond"), _35val408);
-Obj _35reg410 = primCons(_35reg409, Nil);
-Obj _35reg411 = primCons(_35val407, _35reg410);
-Obj _35reg412 = primCons(_35reg406, _35reg411);
-Obj _35reg413 = primCons(intern("if"), _35reg412);
+Obj _35val599 = __arg1;
+Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj e1 = _35val599;
+pushCont(co, 1, clofun26, 5, y, body, x, e1, cc);
 __nargs = 2;
-__arg1 = _35reg413;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("caddr"));
+__arg1 = expr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val407 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg406= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun1357, 2, _35val407, _35reg406);
-__nargs = 2;
-__arg0 = globalRef(intern("cddr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj _35val405 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj curr = _35val405;
-Obj _35reg406 = primCar(curr);
-pushCont(co, 1, _35clofun1357, 2, exp, _35reg406);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = curr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj exp = __arg1;
-Obj _35reg401 = primCdr(exp);
-Obj _35reg402 = primEQ(Nil, _35reg401);
-if (True == _35reg402) {
-Obj _35reg403 = primCons(makeCString("no cond match"), Nil);
-Obj _35reg404 = primCons(intern("error"), _35reg403);
-__nargs = 2;
-__arg1 = _35reg404;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 2, _35clofun1357, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label4:
-{
-Obj _35val419 = __arg1;
-Obj l= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj more = _35val419;
-Obj _35reg420 = primEQ(more, True);
-if (True == _35reg420) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg421 = primCar(l);
-Obj _35reg422 = primCons(more, Nil);
-Obj _35reg423 = primCons(True, _35reg422);
-Obj _35reg424 = primCons(_35reg421, _35reg423);
-Obj _35reg425 = primCons(intern("if"), _35reg424);
-__nargs = 2;
-__arg1 = _35reg425;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label5:
-{
-Obj l = __arg1;
-Obj _35reg415 = primEQ(l, Nil);
-if (True == _35reg415) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg416 = primCar(l);
-Obj _35reg417 = primEQ(_35reg416, True);
-if (True == _35reg417) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg418 = primCdr(l);
-pushCont(co, 4, _35clofun1357, 1, l);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#rewrite-or"));
-__arg1 = _35reg418;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label6:
-{
-Obj exp = __arg1;
-Obj _35reg427 = primCdr(exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#rewrite-or"));
-__arg1 = _35reg427;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val433 = __arg1;
-Obj l= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj more = _35val433;
-Obj _35reg434 = primEQ(more, False);
-if (True == _35reg434) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg435 = primCar(l);
-Obj _35reg436 = primCons(False, Nil);
-Obj _35reg437 = primCons(more, _35reg436);
-Obj _35reg438 = primCons(_35reg435, _35reg437);
-Obj _35reg439 = primCons(intern("if"), _35reg438);
-__nargs = 2;
-__arg1 = _35reg439;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label8:
-{
-Obj l = __arg1;
-Obj _35reg429 = primEQ(Nil, l);
-if (True == _35reg429) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg430 = primCar(l);
-Obj _35reg431 = primEQ(_35reg430, False);
-if (True == _35reg431) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg432 = primCdr(l);
-pushCont(co, 7, _35clofun1357, 1, l);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#rewrite-and"));
-__arg1 = _35reg432;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label9:
-{
-Obj exp = __arg1;
-Obj _35reg441 = primCdr(exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#rewrite-and"));
-__arg1 = _35reg441;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj x = __arg1;
-Obj _35reg443 = primEQ(x, True);
-if (True == _35reg443) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg444 = primEQ(x, False);
-if (True == _35reg444) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-}
-
-label11:
-{
-Obj _35val451 = __arg1;
-Obj _35reg449= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg452 = primCons(_35val451, Nil);
-Obj _35reg453 = primCons(_35reg449, _35reg452);
-Obj _35reg454 = primCons(intern("cons"), _35reg453);
-__nargs = 2;
-__arg1 = _35reg454;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label12:
-{
-Obj _35val447 = __arg1;
-Obj pat= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val447) {
-Obj _35reg448 = primCar(pat);
-__nargs = 2;
-__arg1 = _35reg448;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg449 = primCar(pat);
-Obj _35reg450 = primCdr(pat);
-pushCont(co, 11, _35clofun1357, 1, _35reg449);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#rcons1"));
-__arg1 = _35reg450;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
-{
-Obj pat = __arg1;
-Obj _35reg446 = primCdr(pat);
-pushCont(co, 12, _35clofun1357, 1, pat);
-__nargs = 2;
-__arg0 = globalRef(intern("null?"));
-__arg1 = _35reg446;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj exp = __arg1;
-Obj _35reg456 = primCdr(exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#rcons1"));
-__arg1 = _35reg456;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35val465 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = x;
-__arg2 = e1;
-__arg3 = _35val465;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val464 = __arg1;
+Obj _35val600 = __arg1;
 Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj e2 = _35val464;
-pushCont(co, 15, _35clofun1357, 3, x, e1, cc);
+Obj e2 = _35val600;
+pushCont(co, 2, clofun26, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/init#match1"));
 __arg1 = y;
@@ -5677,71 +5580,13 @@ co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label2:
 {
-Obj _35val463 = __arg1;
-Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj e1 = _35val463;
-pushCont(co, 16, _35clofun1357, 5, y, body, x, e1, cc);
-__nargs = 2;
-__arg0 = globalRef(intern("caddr"));
-__arg1 = expr;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val473 = __arg1;
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg467= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg474 = primCons(cc, Nil);
-Obj _35reg475 = primCons(_35reg474, Nil);
-Obj _35reg476 = primCons(_35val473, _35reg475);
-Obj _35reg477 = primCons(_35reg467, _35reg476);
-Obj _35reg478 = primCons(intern("if"), _35reg477);
-__nargs = 2;
-__arg1 = _35reg478;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1357) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label19:
-{
-Obj _35val472 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg469= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg467= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun1357, 2, cc, _35reg467);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/init#match1"));
-__arg1 = x;
-__arg2 = _35reg469;
-__arg3 = _35val472;
-co->args[4] = cc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val481 = __arg1;
+Obj _35val601 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -5749,12 +5594,70 @@ __nargs = 5;
 __arg0 = globalRef(intern("cora/init#match1"));
 __arg1 = x;
 __arg2 = e1;
-__arg3 = _35val481;
+__arg3 = _35val601;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1357) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val592 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg589= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg587= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 4, clofun26, 2, cc, _35reg587);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#match1"));
+__arg1 = x;
+__arg2 = _35reg589;
+__arg3 = _35val592;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val593 = __arg1;
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg587= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg594 = primCons(cc, Nil);
+Obj _35reg595 = primCons(_35reg594, Nil);
+Obj _35reg596 = primCons(_35val593, _35reg595);
+Obj _35reg597 = primCons(_35reg587, _35reg596);
+Obj _35reg598 = primCons(intern("if"), _35reg597);
+__nargs = 2;
+__arg1 = _35reg598;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun26) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label5:
+{
+Obj _35val583 = __arg1;
+Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj e1 = _35val583;
+pushCont(co, 0, clofun27, 5, y, body, x, e1, cc);
+__nargs = 2;
+__arg0 = globalRef(intern("caddr"));
+__arg1 = expr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5767,37 +5670,967 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1356(struct Cora* co){
+void clofun27(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val343 = __arg1;
+Obj _35val584 = __arg1;
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj e2 = _35val584;
+pushCont(co, 1, clofun27, 3, x, e1, cc);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#match1"));
+__arg1 = y;
+__arg2 = e2;
+__arg3 = body;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val585 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#match1"));
+__arg1 = x;
+__arg2 = e1;
+__arg3 = _35val585;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val576 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg573= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg571= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 3, clofun27, 2, cc, _35reg571);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#match1"));
+__arg1 = x;
+__arg2 = _35reg573;
+__arg3 = _35val576;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val577 = __arg1;
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg571= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg578 = primCons(cc, Nil);
+Obj _35reg579 = primCons(_35reg578, Nil);
+Obj _35reg580 = primCons(_35val577, _35reg579);
+Obj _35reg581 = primCons(_35reg571, _35reg580);
+Obj _35reg582 = primCons(intern("if"), _35reg581);
+__nargs = 2;
+__arg1 = _35reg582;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun27) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
+{
+Obj _35val567 = __arg1;
+Obj expr= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj e1 = _35val567;
+pushCont(co, 5, clofun27, 5, y, body, x, e1, cc);
+__nargs = 2;
+__arg0 = globalRef(intern("caddr"));
+__arg1 = expr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val568 = __arg1;
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj e2 = _35val568;
+pushCont(co, 0, clofun28, 3, x, e1, cc);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#match1"));
+__arg1 = y;
+__arg2 = e2;
+__arg3 = body;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun28(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val569 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cc= co->ctx.stk.stack[co->ctx.stk.base + 2];
+__nargs = 5;
+__arg0 = globalRef(intern("cora/init#match1"));
+__arg1 = x;
+__arg2 = e1;
+__arg3 = _35val569;
+co->args[4] = cc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj exp = __arg1;
+Obj _35reg560 = primCdr(exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rcons1"));
+__arg1 = _35reg560;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj pat = __arg1;
+Obj _35reg550 = primCdr(pat);
+pushCont(co, 3, clofun28, 1, pat);
+__nargs = 2;
+__arg0 = globalRef(intern("null?"));
+__arg1 = _35reg550;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val551 = __arg1;
+Obj pat= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val551) {
+Obj _35reg552 = primCar(pat);
+__nargs = 2;
+__arg1 = _35reg552;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun28) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg553 = primCar(pat);
+Obj _35reg554 = primCdr(pat);
+pushCont(co, 4, clofun28, 1, _35reg553);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rcons1"));
+__arg1 = _35reg554;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val555 = __arg1;
+Obj _35reg553= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg556 = primCons(_35val555, Nil);
+Obj _35reg557 = primCons(_35reg553, _35reg556);
+Obj _35reg558 = primCons(intern("cons"), _35reg557);
+__nargs = 2;
+__arg1 = _35reg558;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun28) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label5:
+{
+Obj x = __arg1;
+Obj _35reg547 = primEQ(x, True);
+if (True == _35reg547) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun28) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg548 = primEQ(x, False);
+if (True == _35reg548) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun28) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun28) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun29(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj exp = __arg1;
+Obj _35reg545 = primCdr(exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rewrite-and"));
+__arg1 = _35reg545;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun29) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj l = __arg1;
+Obj _35reg533 = primEQ(Nil, l);
+if (True == _35reg533) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun29) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg534 = primCar(l);
+Obj _35reg535 = primEQ(_35reg534, False);
+if (True == _35reg535) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun29) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg536 = primCdr(l);
+pushCont(co, 2, clofun29, 1, l);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rewrite-and"));
+__arg1 = _35reg536;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun29) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label2:
+{
+Obj _35val537 = __arg1;
+Obj l= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj more = _35val537;
+Obj _35reg538 = primEQ(more, False);
+if (True == _35reg538) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun29) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg539 = primCar(l);
+Obj _35reg540 = primCons(False, Nil);
+Obj _35reg541 = primCons(more, _35reg540);
+Obj _35reg542 = primCons(_35reg539, _35reg541);
+Obj _35reg543 = primCons(intern("if"), _35reg542);
+__nargs = 2;
+__arg1 = _35reg543;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun29) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label3:
+{
+Obj exp = __arg1;
+Obj _35reg531 = primCdr(exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rewrite-or"));
+__arg1 = _35reg531;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun29) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj l = __arg1;
+Obj _35reg519 = primEQ(l, Nil);
+if (True == _35reg519) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun29) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg520 = primCar(l);
+Obj _35reg521 = primEQ(_35reg520, True);
+if (True == _35reg521) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun29) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg522 = primCdr(l);
+pushCont(co, 5, clofun29, 1, l);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rewrite-or"));
+__arg1 = _35reg522;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun29) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label5:
+{
+Obj _35val523 = __arg1;
+Obj l= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj more = _35val523;
+Obj _35reg524 = primEQ(more, True);
+if (True == _35reg524) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun29) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg525 = primCar(l);
+Obj _35reg526 = primCons(more, Nil);
+Obj _35reg527 = primCons(True, _35reg526);
+Obj _35reg528 = primCons(_35reg525, _35reg527);
+Obj _35reg529 = primCons(intern("if"), _35reg528);
+__nargs = 2;
+__arg1 = _35reg529;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun29) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun30(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj exp = __arg1;
+Obj _35reg505 = primCdr(exp);
+Obj _35reg506 = primEQ(Nil, _35reg505);
+if (True == _35reg506) {
+Obj _35reg507 = primCons(makeCString("no cond match"), Nil);
+Obj _35reg508 = primCons(intern("error"), _35reg507);
+__nargs = 2;
+__arg1 = _35reg508;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun30) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 1, clofun30, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35val509 = __arg1;
 Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 20, _35clofun1355, 1, _35val343);
+Obj curr = _35val509;
+Obj _35reg510 = primCar(curr);
+pushCont(co, 2, clofun30, 2, exp, _35reg510);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = curr;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val511 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg510= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 3, clofun30, 2, _35val511, _35reg510);
+__nargs = 2;
+__arg0 = globalRef(intern("cddr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val512 = __arg1;
+Obj _35val511= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg510= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg513 = primCons(intern("cond"), _35val512);
+Obj _35reg514 = primCons(_35reg513, Nil);
+Obj _35reg515 = primCons(_35val511, _35reg514);
+Obj _35reg516 = primCons(_35reg510, _35reg515);
+Obj _35reg517 = primCons(intern("if"), _35reg516);
+__nargs = 2;
+__arg1 = _35reg517;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun30) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
+{
+Obj exp = __arg1;
+Obj _35reg503 = primCdr(exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rewrite-let"));
+__arg1 = _35reg503;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj exp = __arg1;
+Obj _35reg491 = primCdr(exp);
+pushCont(co, 0, clofun31, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("null?"));
+__arg1 = _35reg491;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun31(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val492 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val492) {
+Obj _35reg493 = primCar(exp);
+__nargs = 2;
+__arg1 = _35reg493;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun31) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg494 = primCar(exp);
+pushCont(co, 1, clofun31, 2, exp, _35reg494);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35val495 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg494= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 2, clofun31, 2, _35val495, _35reg494);
+__nargs = 2;
+__arg0 = globalRef(intern("cddr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val496 = __arg1;
+Obj _35val495= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg494= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 3, clofun31, 2, _35val495, _35reg494);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#rewrite-let"));
+__arg1 = _35val496;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val497 = __arg1;
+Obj _35val495= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg494= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg498 = primCons(_35val497, Nil);
+Obj _35reg499 = primCons(_35val495, _35reg498);
+Obj _35reg500 = primCons(_35reg494, _35reg499);
+Obj _35reg501 = primCons(intern("let"), _35reg500);
+__nargs = 2;
+__arg1 = _35reg501;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun31) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
+{
+Obj x = __arg1;
+Obj _35reg488 = primIsCons(x);
+Obj _35reg489 = primNot(_35reg488);
+__nargs = 2;
+__arg1 = _35reg489;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun31) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label5:
+{
+Obj x = __arg1;
+Obj l = __arg2;
+Obj _35reg483 = primIsCons(l);
+if (True == _35reg483) {
+Obj _35reg484 = primCar(l);
+Obj _35reg485 = primEQ(_35reg484, x);
+if (True == _35reg485) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun31) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg486 = primCdr(l);
+__nargs = 3;
+__arg0 = globalRef(intern("elem?"));
+__arg1 = x;
+__arg2 = _35reg486;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun31) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun32(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj exp = __arg1;
+pushCont(co, 1, clofun32, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val473 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 2, clofun32, 2, exp, _35val473);
 __nargs = 2;
 __arg0 = globalRef(intern("caddr"));
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val474 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val473= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 3, clofun32, 2, _35val474, _35val473);
+__nargs = 2;
+__arg0 = globalRef(intern("cadddr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val475 = __arg1;
+Obj _35val474= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val473= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg476 = primCons(_35val475, Nil);
+Obj _35reg477 = primCons(_35val474, _35reg476);
+Obj _35reg478 = primCons(intern("lambda"), _35reg477);
+Obj _35reg479 = primCons(_35reg478, Nil);
+Obj _35reg480 = primCons(_35val473, _35reg479);
+Obj _35reg481 = primCons(intern("def"), _35reg480);
+__nargs = 2;
+__arg1 = _35reg481;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun32) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
+{
+Obj exp = __arg1;
+Obj _35reg471 = primCdr(exp);
+__nargs = 2;
+__arg0 = globalRef(intern("rcons"));
+__arg1 = _35reg471;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj exp = __arg1;
+pushCont(co, 0, clofun33, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun33(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val459 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg460 = primCons(_35val459, Nil);
+Obj _35reg461 = primCons(intern("quote"), _35reg460);
+pushCont(co, 1, clofun33, 2, exp, _35reg461);
+__nargs = 2;
+__arg0 = globalRef(intern("caddr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
+Obj _35val462 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg461= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 2, clofun33, 2, _35val462, _35reg461);
+__nargs = 2;
+__arg0 = globalRef(intern("cdddr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val463 = __arg1;
+Obj _35val462= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg461= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg464 = primCons(_35val462, _35val463);
+Obj _35reg465 = primCons(intern("lambda"), _35reg464);
+Obj _35reg466 = primCons(_35reg465, Nil);
+Obj _35reg467 = primCons(_35reg461, _35reg466);
+Obj _35reg468 = primCons(intern("cora/init#add-to-*macros*"), _35reg467);
+__nargs = 2;
+__arg1 = _35reg468;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun33) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label3:
+{
+Obj exp = __arg1;
+Obj _35reg441 = primIsCons(exp);
+if (True == _35reg441) {
+Obj _35reg442 = primCar(exp);
+Obj _35reg443 = primEQ(_35reg442, globalRef(intern("*protect-symbol*")));
+if (True == _35reg443) {
+Obj _35reg444 = primCdr(exp);
+__nargs = 2;
+__arg1 = _35reg444;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun33) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg445 = primCar(exp);
+Obj _35reg446 = primEQ(_35reg445, intern("lambda"));
+if (True == _35reg446) {
+pushCont(co, 0, clofun34, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg453 = primCar(exp);
+Obj _35reg454 = primEQ(_35reg453, intern("quote"));
+if (True == _35reg454) {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun33) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 4, clofun33, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#macroexpand1"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+} else {
+__nargs = 2;
+__arg1 = exp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun33) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label4:
+{
+Obj _35val456 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 2;
+__arg0 = makeNative(5, clofun33, 1, 1, exp);
+__arg1 = _35val456;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
 Obj exp1 = __arg1;
-Obj _35reg351 = primEQ(exp1, closureRef(co, 0));
-if (True == _35reg351) {
+Obj _35reg455 = primEQ(exp1, closureRef(co, 0));
+if (True == _35reg455) {
 __nargs = 3;
 __arg0 = globalRef(intern("map"));
 __arg1 = globalRef(intern("cora/init#macroexpand-boot"));
@@ -5805,7 +6638,7 @@ __arg2 = exp1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 2;
@@ -5814,371 +6647,9 @@ __arg1 = exp1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label2:
-{
-Obj _35val352 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 2;
-__arg0 = makeNative(1, _35clofun1356, 1, 1, exp);
-__arg1 = _35val352;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj exp = __arg1;
-Obj _35reg337 = primIsCons(exp);
-if (True == _35reg337) {
-Obj _35reg338 = primCar(exp);
-Obj _35reg339 = primEQ(_35reg338, globalRef(intern("*protect-symbol*")));
-if (True == _35reg339) {
-Obj _35reg340 = primCdr(exp);
-__nargs = 2;
-__arg1 = _35reg340;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1356) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg341 = primCar(exp);
-Obj _35reg342 = primEQ(_35reg341, intern("lambda"));
-if (True == _35reg342) {
-pushCont(co, 0, _35clofun1356, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg349 = primCar(exp);
-Obj _35reg350 = primEQ(_35reg349, intern("quote"));
-if (True == _35reg350) {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1356) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 2, _35clofun1356, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#macroexpand1"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-} else {
-__nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1356) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label4:
-{
-Obj _35val359 = __arg1;
-Obj _35val358= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg357= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg360 = primCons(_35val358, _35val359);
-Obj _35reg361 = primCons(intern("lambda"), _35reg360);
-Obj _35reg362 = primCons(_35reg361, Nil);
-Obj _35reg363 = primCons(_35reg357, _35reg362);
-Obj _35reg364 = primCons(intern("cora/init#add-to-*macros*"), _35reg363);
-__nargs = 2;
-__arg1 = _35reg364;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1356) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label5:
-{
-Obj _35val358 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg357= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun1356, 2, _35val358, _35reg357);
-__nargs = 2;
-__arg0 = globalRef(intern("cdddr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val355 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg356 = primCons(_35val355, Nil);
-Obj _35reg357 = primCons(intern("quote"), _35reg356);
-pushCont(co, 5, _35clofun1356, 2, exp, _35reg357);
-__nargs = 2;
-__arg0 = globalRef(intern("caddr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj exp = __arg1;
-pushCont(co, 6, _35clofun1356, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj exp = __arg1;
-Obj _35reg367 = primCdr(exp);
-__nargs = 2;
-__arg0 = globalRef(intern("rcons"));
-__arg1 = _35reg367;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val371 = __arg1;
-Obj _35val370= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val369= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg372 = primCons(_35val371, Nil);
-Obj _35reg373 = primCons(_35val370, _35reg372);
-Obj _35reg374 = primCons(intern("lambda"), _35reg373);
-Obj _35reg375 = primCons(_35reg374, Nil);
-Obj _35reg376 = primCons(_35val369, _35reg375);
-Obj _35reg377 = primCons(intern("def"), _35reg376);
-__nargs = 2;
-__arg1 = _35reg377;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1356) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label10:
-{
-Obj _35val370 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val369= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun1356, 2, _35val370, _35val369);
-__nargs = 2;
-__arg0 = globalRef(intern("cadddr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val369 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 10, _35clofun1356, 2, exp, _35val369);
-__nargs = 2;
-__arg0 = globalRef(intern("caddr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj exp = __arg1;
-pushCont(co, 11, _35clofun1356, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj x = __arg1;
-Obj l = __arg2;
-Obj _35reg379 = primIsCons(l);
-if (True == _35reg379) {
-Obj _35reg380 = primCar(l);
-Obj _35reg381 = primEQ(_35reg380, x);
-if (True == _35reg381) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1356) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg382 = primCdr(l);
-__nargs = 3;
-__arg0 = globalRef(intern("elem?"));
-__arg1 = x;
-__arg2 = _35reg382;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1356) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label14:
-{
-Obj x = __arg1;
-Obj _35reg384 = primIsCons(x);
-Obj _35reg385 = primNot(_35reg384);
-__nargs = 2;
-__arg1 = _35reg385;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1356) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label15:
-{
-Obj _35val393 = __arg1;
-Obj _35val391= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg390= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg394 = primCons(_35val393, Nil);
-Obj _35reg395 = primCons(_35val391, _35reg394);
-Obj _35reg396 = primCons(_35reg390, _35reg395);
-Obj _35reg397 = primCons(intern("let"), _35reg396);
-__nargs = 2;
-__arg1 = _35reg397;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1356) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label16:
-{
-Obj _35val392 = __arg1;
-Obj _35val391= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg390= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 15, _35clofun1356, 2, _35val391, _35reg390);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#rewrite-let"));
-__arg1 = _35val392;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val391 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg390= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 16, _35clofun1356, 2, _35val391, _35reg390);
-__nargs = 2;
-__arg0 = globalRef(intern("cddr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val388 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val388) {
-Obj _35reg389 = primCar(exp);
-__nargs = 2;
-__arg1 = _35reg389;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1356) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg390 = primCar(exp);
-pushCont(co, 17, _35clofun1356, 2, exp, _35reg390);
-__nargs = 2;
-__arg0 = globalRef(intern("cadr"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label19:
-{
-Obj exp = __arg1;
-Obj _35reg387 = primCdr(exp);
-pushCont(co, 18, _35clofun1356, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("null?"));
-__arg1 = _35reg387;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj exp = __arg1;
-Obj _35reg399 = primCdr(exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#rewrite-let"));
-__arg1 = _35reg399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1356) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 }
 
 fail:
@@ -6190,243 +6661,215 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun1355(struct Cora* co){
+void clofun34(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj x = __arg1;
-Obj _35reg265 = primEQ(x, Nil);
+Obj _35val447 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 1, clofun34, 1, _35val447);
 __nargs = 2;
-__arg1 = _35reg265;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("caddr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj x = __arg1;
-Obj _35reg267 = primCdr(x);
-Obj _35reg268 = primCar(_35reg267);
+Obj _35val448 = __arg1;
+Obj _35val447= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 2, clofun34, 1, _35val447);
 __nargs = 2;
-__arg1 = _35reg268;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("cora/init#macroexpand-boot"));
+__arg1 = _35val448;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj x = __arg1;
-Obj _35reg270 = primCar(x);
-Obj _35reg271 = primCar(_35reg270);
+Obj _35val449 = __arg1;
+Obj _35val447= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg450 = primCons(_35val449, Nil);
+Obj _35reg451 = primCons(_35val447, _35reg450);
+Obj _35reg452 = primCons(intern("lambda"), _35reg451);
 __nargs = 2;
-__arg1 = _35reg271;
+__arg1 = _35reg452;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
+if (co->ctx.pc.func != clofun34) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label3:
 {
-Obj x = __arg1;
-Obj _35reg273 = primCar(x);
-Obj _35reg274 = primCdr(_35reg273);
-__nargs = 2;
-__arg1 = _35reg274;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj exp = __arg1;
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#macroexpand1-h"));
+__arg1 = exp;
+__arg2 = globalRef(intern("*macros*"));
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj x = __arg1;
-Obj _35reg276 = primCdr(x);
-Obj _35reg277 = primCdr(_35reg276);
+Obj exp = __arg1;
+Obj macros = __arg2;
+Obj _35reg427 = primEQ(Nil, macros);
+if (True == _35reg427) {
 __nargs = 2;
-__arg1 = _35reg277;
+__arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
+if (co->ctx.pc.func != clofun34) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg438 = primCar(macros);
+__nargs = 2;
+__arg0 = makeNative(5, clofun34, 1, 2, exp, macros);
+__arg1 = _35reg438;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label5:
 {
-Obj x = __arg1;
-Obj _35reg279 = primCdr(x);
-Obj _35reg280 = primCdr(_35reg279);
-Obj _35reg281 = primCar(_35reg280);
+Obj item = __arg1;
+Obj _35reg428 = primIsCons(closureRef(co, 0));
+if (True == _35reg428) {
+Obj _35reg429 = primCar(closureRef(co, 0));
+Obj _35reg430 = primCar(item);
+Obj _35reg431 = primEQ(_35reg429, _35reg430);
+if (True == _35reg431) {
+if (True == True) {
+Obj _35reg432 = primCdr(item);
 __nargs = 2;
-__arg1 = _35reg281;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label6:
-{
-Obj x = __arg1;
-Obj _35reg283 = primCdr(x);
-Obj _35reg284 = primCdr(_35reg283);
-Obj _35reg285 = primCdr(_35reg284);
-Obj _35reg286 = primCar(_35reg285);
-__nargs = 2;
-__arg1 = _35reg286;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label7:
-{
-Obj x = __arg1;
-Obj _35reg288 = primCdr(x);
-Obj _35reg289 = primCdr(_35reg288);
-Obj _35reg290 = primCdr(_35reg289);
-__nargs = 2;
-__arg1 = _35reg290;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label8:
-{
-Obj _35val295 = __arg1;
-Obj _35reg293= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg296 = primCons(_35val295, Nil);
-Obj _35reg297 = primCons(_35reg293, _35reg296);
-Obj _35reg298 = primCons(intern("cons"), _35reg297);
-__nargs = 2;
-__arg1 = _35reg298;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label9:
-{
-Obj exp = __arg1;
-Obj _35reg292 = primIsCons(exp);
-if (True == _35reg292) {
-Obj _35reg293 = primCar(exp);
-Obj _35reg294 = primCdr(exp);
-pushCont(co, 8, _35clofun1355, 1, _35reg293);
-__nargs = 2;
-__arg0 = globalRef(intern("rcons"));
-__arg1 = _35reg294;
+__arg0 = _35reg432;
+__arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label10:
-{
-Obj x = __arg1;
-Obj _35reg300 = primIsCons(x);
-__nargs = 2;
-__arg1 = _35reg300;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label11:
-{
-Obj res = __arg1;
-Obj l = __arg2;
-Obj _35reg302 = primIsCons(l);
-if (True == _35reg302) {
-Obj _35reg303 = primCar(l);
-Obj _35reg304 = primCons(_35reg303, res);
-Obj _35reg305 = primCdr(l);
+Obj _35reg433 = primCdr(closureRef(co, 1));
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#reverse-h"));
-__arg1 = _35reg304;
-__arg2 = _35reg305;
+__arg0 = globalRef(intern("cora/init#macroexpand1-h"));
+__arg1 = closureRef(co, 0);
+__arg2 = _35reg433;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+Obj _35reg434 = primCdr(item);
+__nargs = 2;
+__arg0 = _35reg434;
+__arg1 = closureRef(co, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
+Obj _35reg435 = primCdr(closureRef(co, 1));
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#macroexpand1-h"));
+__arg1 = closureRef(co, 0);
+__arg2 = _35reg435;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+if (True == False) {
+Obj _35reg436 = primCdr(item);
 __nargs = 2;
-__arg1 = res;
+__arg0 = _35reg436;
+__arg1 = closureRef(co, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg437 = primCdr(closureRef(co, 1));
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#macroexpand1-h"));
+__arg1 = closureRef(co, 0);
+__arg2 = _35reg437;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun35(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj n = __arg1;
+Obj v = __arg2;
+Obj _35reg423 = primCons(n, v);
+Obj _35reg424 = primCons(_35reg423, globalRef(intern("*macros*")));
+Obj _35reg425 = primSet(co, intern("*macros*"), _35reg424);
+__nargs = 2;
+__arg1 = _35reg425;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
+if (co->ctx.pc.func != clofun35) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
-}
 
-label12:
-{
-Obj _35val311 = __arg1;
-Obj res= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj l= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg312 = primCons(_35val311, res);
-Obj _35reg313 = primCdr(l);
-__nargs = 4;
-__arg0 = globalRef(intern("map-h"));
-__arg1 = _35reg312;
-__arg2 = f;
-__arg3 = _35reg313;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj res = __arg1;
-Obj f = __arg2;
-Obj l = __arg3;
-Obj _35reg309 = primIsCons(l);
-if (True == _35reg309) {
-Obj _35reg310 = primCar(l);
-pushCont(co, 12, _35clofun1355, 3, res, l, f);
-__nargs = 2;
-__arg0 = f;
-__arg1 = _35reg310;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("reverse"));
-__arg1 = res;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label14:
+label1:
 {
 Obj f = __arg1;
 Obj l = __arg2;
@@ -6438,170 +6881,273 @@ __arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label2:
 {
-Obj n = __arg1;
-Obj v = __arg2;
-Obj _35reg319 = primCons(n, v);
-Obj _35reg320 = primCons(_35reg319, globalRef(intern("*macros*")));
-Obj _35reg321 = primSet(co, intern("*macros*"), _35reg320);
+Obj res = __arg1;
+Obj f = __arg2;
+Obj l = __arg3;
+Obj _35reg413 = primIsCons(l);
+if (True == _35reg413) {
+Obj _35reg414 = primCar(l);
+pushCont(co, 3, clofun35, 3, res, l, f);
 __nargs = 2;
-__arg1 = _35reg321;
+__arg0 = f;
+__arg1 = _35reg414;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("reverse"));
+__arg1 = res;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35val415 = __arg1;
+Obj res= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj l= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg416 = primCons(_35val415, res);
+Obj _35reg417 = primCdr(l);
+__nargs = 4;
+__arg0 = globalRef(intern("map-h"));
+__arg1 = _35reg416;
+__arg2 = f;
+__arg3 = _35reg417;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj res = __arg1;
+Obj l = __arg2;
+Obj _35reg406 = primIsCons(l);
+if (True == _35reg406) {
+Obj _35reg407 = primCar(l);
+Obj _35reg408 = primCons(_35reg407, res);
+Obj _35reg409 = primCdr(l);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#reverse-h"));
+__arg1 = _35reg408;
+__arg2 = _35reg409;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = res;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
+if (co->ctx.pc.func != clofun35) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label5:
+{
+Obj x = __arg1;
+Obj _35reg404 = primIsCons(x);
+__nargs = 2;
+__arg1 = _35reg404;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun35) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label16:
-{
-Obj item = __arg1;
-Obj _35reg324 = primIsCons(closureRef(co, 0));
-if (True == _35reg324) {
-Obj _35reg325 = primCar(closureRef(co, 0));
-Obj _35reg326 = primCar(item);
-Obj _35reg327 = primEQ(_35reg325, _35reg326);
-if (True == _35reg327) {
-if (True == True) {
-Obj _35reg328 = primCdr(item);
-__nargs = 2;
-__arg0 = _35reg328;
-__arg1 = closureRef(co, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg329 = primCdr(closureRef(co, 1));
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#macroexpand1-h"));
-__arg1 = closureRef(co, 0);
-__arg2 = _35reg329;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-Obj _35reg330 = primCdr(item);
-__nargs = 2;
-__arg0 = _35reg330;
-__arg1 = closureRef(co, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg331 = primCdr(closureRef(co, 1));
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#macroexpand1-h"));
-__arg1 = closureRef(co, 0);
-__arg2 = _35reg331;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-if (True == False) {
-Obj _35reg332 = primCdr(item);
-__nargs = 2;
-__arg0 = _35reg332;
-__arg1 = closureRef(co, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg333 = primCdr(closureRef(co, 1));
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#macroexpand1-h"));
-__arg1 = closureRef(co, 0);
-__arg2 = _35reg333;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
 }
 
-label17:
+void clofun36(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
 {
 Obj exp = __arg1;
-Obj macros = __arg2;
-Obj _35reg323 = primEQ(Nil, macros);
-if (True == _35reg323) {
+Obj _35reg396 = primIsCons(exp);
+if (True == _35reg396) {
+Obj _35reg397 = primCar(exp);
+Obj _35reg398 = primCdr(exp);
+pushCont(co, 1, clofun36, 1, _35reg397);
 __nargs = 2;
-__arg1 = exp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("rcons"));
+__arg1 = _35reg398;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun36) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 } else {
-Obj _35reg334 = primCar(macros);
 __nargs = 2;
-__arg0 = makeNative(16, _35clofun1355, 1, 2, exp, macros);
-__arg1 = _35reg334;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label18:
-{
-Obj exp = __arg1;
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#macroexpand1-h"));
-__arg1 = exp;
-__arg2 = globalRef(intern("*macros*"));
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35val345 = __arg1;
-Obj _35val343= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg346 = primCons(_35val345, Nil);
-Obj _35reg347 = primCons(_35val343, _35reg346);
-Obj _35reg348 = primCons(intern("lambda"), _35reg347);
-__nargs = 2;
-__arg1 = _35reg348;
+__arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun1355) { goto fail; }
+if (co->ctx.pc.func != clofun36) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label1:
+{
+Obj _35val399 = __arg1;
+Obj _35reg397= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg400 = primCons(_35val399, Nil);
+Obj _35reg401 = primCons(_35reg397, _35reg400);
+Obj _35reg402 = primCons(intern("cons"), _35reg401);
+__nargs = 2;
+__arg1 = _35reg402;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun36) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label20:
+label2:
 {
-Obj _35val344 = __arg1;
-Obj _35val343= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 19, _35clofun1355, 1, _35val343);
+Obj x = __arg1;
+Obj _35reg392 = primCdr(x);
+Obj _35reg393 = primCdr(_35reg392);
+Obj _35reg394 = primCdr(_35reg393);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/init#macroexpand-boot"));
-__arg1 = _35val344;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun1355) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = _35reg394;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun36) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label3:
+{
+Obj x = __arg1;
+Obj _35reg387 = primCdr(x);
+Obj _35reg388 = primCdr(_35reg387);
+Obj _35reg389 = primCdr(_35reg388);
+Obj _35reg390 = primCar(_35reg389);
+__nargs = 2;
+__arg1 = _35reg390;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun36) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
+{
+Obj x = __arg1;
+Obj _35reg383 = primCdr(x);
+Obj _35reg384 = primCdr(_35reg383);
+Obj _35reg385 = primCar(_35reg384);
+__nargs = 2;
+__arg1 = _35reg385;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun36) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label5:
+{
+Obj x = __arg1;
+Obj _35reg380 = primCdr(x);
+Obj _35reg381 = primCdr(_35reg380);
+__nargs = 2;
+__arg1 = _35reg381;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun36) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun37(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj x = __arg1;
+Obj _35reg377 = primCar(x);
+Obj _35reg378 = primCdr(_35reg377);
+__nargs = 2;
+__arg1 = _35reg378;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun37) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label1:
+{
+Obj x = __arg1;
+Obj _35reg374 = primCar(x);
+Obj _35reg375 = primCar(_35reg374);
+__nargs = 2;
+__arg1 = _35reg375;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun37) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label2:
+{
+Obj x = __arg1;
+Obj _35reg371 = primCdr(x);
+Obj _35reg372 = primCar(_35reg371);
+__nargs = 2;
+__arg1 = _35reg372;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun37) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label3:
+{
+Obj x = __arg1;
+Obj _35reg369 = primEQ(x, Nil);
+__nargs = 2;
+__arg1 = _35reg369;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun37) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 fail:

--- a/lib/toc.c
+++ b/lib/toc.c
@@ -2,29 +2,82 @@
 #include "runtime.h"
 
 void entry(struct Cora* co);
-void _35clofun3261(struct Cora* co);
-void _35clofun3260(struct Cora* co);
-void _35clofun3259(struct Cora* co);
-void _35clofun3258(struct Cora* co);
-void _35clofun3257(struct Cora* co);
-void _35clofun3256(struct Cora* co);
-void _35clofun3255(struct Cora* co);
-void _35clofun3254(struct Cora* co);
-void _35clofun3253(struct Cora* co);
-void _35clofun3252(struct Cora* co);
-void _35clofun3251(struct Cora* co);
-void _35clofun3250(struct Cora* co);
-void _35clofun3249(struct Cora* co);
-void _35clofun3248(struct Cora* co);
-void _35clofun3247(struct Cora* co);
-void _35clofun3246(struct Cora* co);
-void _35clofun3245(struct Cora* co);
-void _35clofun3244(struct Cora* co);
-void _35clofun3243(struct Cora* co);
-void _35clofun3242(struct Cora* co);
-void _35clofun3241(struct Cora* co);
-void _35clofun3240(struct Cora* co);
-void _35clofun3239(struct Cora* co);
+void clofun1(struct Cora* co);
+void clofun2(struct Cora* co);
+void clofun3(struct Cora* co);
+void clofun4(struct Cora* co);
+void clofun5(struct Cora* co);
+void clofun6(struct Cora* co);
+void clofun7(struct Cora* co);
+void clofun8(struct Cora* co);
+void clofun9(struct Cora* co);
+void clofun10(struct Cora* co);
+void clofun11(struct Cora* co);
+void clofun12(struct Cora* co);
+void clofun13(struct Cora* co);
+void clofun14(struct Cora* co);
+void clofun15(struct Cora* co);
+void clofun16(struct Cora* co);
+void clofun17(struct Cora* co);
+void clofun18(struct Cora* co);
+void clofun19(struct Cora* co);
+void clofun20(struct Cora* co);
+void clofun21(struct Cora* co);
+void clofun22(struct Cora* co);
+void clofun23(struct Cora* co);
+void clofun24(struct Cora* co);
+void clofun25(struct Cora* co);
+void clofun26(struct Cora* co);
+void clofun27(struct Cora* co);
+void clofun28(struct Cora* co);
+void clofun29(struct Cora* co);
+void clofun30(struct Cora* co);
+void clofun31(struct Cora* co);
+void clofun32(struct Cora* co);
+void clofun33(struct Cora* co);
+void clofun34(struct Cora* co);
+void clofun35(struct Cora* co);
+void clofun36(struct Cora* co);
+void clofun37(struct Cora* co);
+void clofun38(struct Cora* co);
+void clofun39(struct Cora* co);
+void clofun40(struct Cora* co);
+void clofun41(struct Cora* co);
+void clofun42(struct Cora* co);
+void clofun43(struct Cora* co);
+void clofun44(struct Cora* co);
+void clofun45(struct Cora* co);
+void clofun46(struct Cora* co);
+void clofun47(struct Cora* co);
+void clofun48(struct Cora* co);
+void clofun49(struct Cora* co);
+void clofun50(struct Cora* co);
+void clofun51(struct Cora* co);
+void clofun52(struct Cora* co);
+void clofun53(struct Cora* co);
+void clofun54(struct Cora* co);
+void clofun55(struct Cora* co);
+void clofun56(struct Cora* co);
+void clofun57(struct Cora* co);
+void clofun58(struct Cora* co);
+void clofun59(struct Cora* co);
+void clofun60(struct Cora* co);
+void clofun61(struct Cora* co);
+void clofun62(struct Cora* co);
+void clofun63(struct Cora* co);
+void clofun64(struct Cora* co);
+void clofun65(struct Cora* co);
+void clofun66(struct Cora* co);
+void clofun67(struct Cora* co);
+void clofun68(struct Cora* co);
+void clofun69(struct Cora* co);
+void clofun70(struct Cora* co);
+void clofun71(struct Cora* co);
+void clofun72(struct Cora* co);
+void clofun73(struct Cora* co);
+void clofun74(struct Cora* co);
+void clofun75(struct Cora* co);
+void clofun76(struct Cora* co);
 
 
 void entry(struct Cora* co){
@@ -34,16 +87,207 @@ Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-pushCont(co, 5, _35clofun3261, 0);
+pushCont(co, 1, entry, 0);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#import"));
 __arg1 = makeCString("cora/lib/toc/internal");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != entry) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val1640 = __arg1;
+pushCont(co, 2, entry, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#import"));
+__arg1 = makeCString("cora/lib/io");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != entry) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val1641 = __arg1;
+pushCont(co, 3, entry, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#import"));
+__arg1 = makeCString("cora/lib/hash-h");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != entry) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val1642 = __arg1;
+Obj _35reg1643 = primSet(co, intern("cora/lib/toc#*ns-export*"), Nil);
+Obj _35reg1658 = primSet(co, intern("cora/lib/toc#assq"), makeNative(1, clofun76, 2, 0));
+Obj _35reg1664 = primSet(co, intern("cora/lib/toc#foldl"), makeNative(3, clofun75, 3, 0));
+Obj _35reg1674 = primSet(co, intern("cora/lib/toc#pos-in-list0"), makeNative(5, clofun74, 3, 0));
+Obj _35reg1675 = primSet(co, intern("cora/lib/toc#index"), makeNative(4, clofun74, 2, 0));
+Obj _35reg1682 = primSet(co, intern("cora/lib/toc#exist-in-env"), makeNative(0, clofun74, 2, 0));
+Obj _35reg1683 = primCons(intern("primSet"), Nil);
+Obj _35reg1684 = primCons(makeNumber(2), _35reg1683);
+Obj _35reg1685 = primCons(intern("set"), _35reg1684);
+Obj _35reg1686 = primCons(intern("primCar"), Nil);
+Obj _35reg1687 = primCons(makeNumber(1), _35reg1686);
+Obj _35reg1688 = primCons(intern("car"), _35reg1687);
+Obj _35reg1689 = primCons(intern("primCdr"), Nil);
+Obj _35reg1690 = primCons(makeNumber(1), _35reg1689);
+Obj _35reg1691 = primCons(intern("cdr"), _35reg1690);
+Obj _35reg1692 = primCons(intern("primCons"), Nil);
+Obj _35reg1693 = primCons(makeNumber(2), _35reg1692);
+Obj _35reg1694 = primCons(intern("cons"), _35reg1693);
+Obj _35reg1695 = primCons(intern("primIsCons"), Nil);
+Obj _35reg1696 = primCons(makeNumber(1), _35reg1695);
+Obj _35reg1697 = primCons(intern("cons?"), _35reg1696);
+Obj _35reg1698 = primCons(intern("primAdd"), Nil);
+Obj _35reg1699 = primCons(makeNumber(2), _35reg1698);
+Obj _35reg1700 = primCons(intern("+"), _35reg1699);
+Obj _35reg1701 = primCons(intern("primSub"), Nil);
+Obj _35reg1702 = primCons(makeNumber(2), _35reg1701);
+Obj _35reg1703 = primCons(intern("-"), _35reg1702);
+Obj _35reg1704 = primCons(intern("primMul"), Nil);
+Obj _35reg1705 = primCons(makeNumber(2), _35reg1704);
+Obj _35reg1706 = primCons(intern("*"), _35reg1705);
+Obj _35reg1707 = primCons(intern("primDiv"), Nil);
+Obj _35reg1708 = primCons(makeNumber(2), _35reg1707);
+Obj _35reg1709 = primCons(intern("/"), _35reg1708);
+Obj _35reg1710 = primCons(intern("primEQ"), Nil);
+Obj _35reg1711 = primCons(makeNumber(2), _35reg1710);
+Obj _35reg1712 = primCons(intern("="), _35reg1711);
+Obj _35reg1713 = primCons(intern("primGT"), Nil);
+Obj _35reg1714 = primCons(makeNumber(2), _35reg1713);
+Obj _35reg1715 = primCons(intern(">"), _35reg1714);
+Obj _35reg1716 = primCons(intern("primLT"), Nil);
+Obj _35reg1717 = primCons(makeNumber(2), _35reg1716);
+Obj _35reg1718 = primCons(intern("<"), _35reg1717);
+Obj _35reg1719 = primCons(intern("primGenSym"), Nil);
+Obj _35reg1720 = primCons(makeNumber(1), _35reg1719);
+Obj _35reg1721 = primCons(intern("gensym"), _35reg1720);
+Obj _35reg1722 = primCons(intern("primIsSymbol"), Nil);
+Obj _35reg1723 = primCons(makeNumber(1), _35reg1722);
+Obj _35reg1724 = primCons(intern("symbol?"), _35reg1723);
+Obj _35reg1725 = primCons(intern("primNot"), Nil);
+Obj _35reg1726 = primCons(makeNumber(1), _35reg1725);
+Obj _35reg1727 = primCons(intern("not"), _35reg1726);
+Obj _35reg1728 = primCons(intern("primIsNumber"), Nil);
+Obj _35reg1729 = primCons(makeNumber(1), _35reg1728);
+Obj _35reg1730 = primCons(intern("integer?"), _35reg1729);
+Obj _35reg1731 = primCons(intern("primIsString"), Nil);
+Obj _35reg1732 = primCons(makeNumber(1), _35reg1731);
+Obj _35reg1733 = primCons(intern("string?"), _35reg1732);
+Obj _35reg1734 = primCons(_35reg1733, Nil);
+Obj _35reg1735 = primCons(_35reg1730, _35reg1734);
+Obj _35reg1736 = primCons(_35reg1727, _35reg1735);
+Obj _35reg1737 = primCons(_35reg1724, _35reg1736);
+Obj _35reg1738 = primCons(_35reg1721, _35reg1737);
+Obj _35reg1739 = primCons(_35reg1718, _35reg1738);
+Obj _35reg1740 = primCons(_35reg1715, _35reg1739);
+Obj _35reg1741 = primCons(_35reg1712, _35reg1740);
+Obj _35reg1742 = primCons(_35reg1709, _35reg1741);
+Obj _35reg1743 = primCons(_35reg1706, _35reg1742);
+Obj _35reg1744 = primCons(_35reg1703, _35reg1743);
+Obj _35reg1745 = primCons(_35reg1700, _35reg1744);
+Obj _35reg1746 = primCons(_35reg1697, _35reg1745);
+Obj _35reg1747 = primCons(_35reg1694, _35reg1746);
+Obj _35reg1748 = primCons(_35reg1691, _35reg1747);
+Obj _35reg1749 = primCons(_35reg1688, _35reg1748);
+Obj _35reg1750 = primCons(_35reg1685, _35reg1749);
+Obj _35reg1751 = primSet(co, intern("cora/lib/toc#*builtin-prims*"), _35reg1750);
+Obj _35reg1755 = primSet(co, intern("cora/lib/toc#builtin?"), makeNative(3, clofun73, 1, 0));
+Obj _35reg1758 = primSet(co, intern("cora/lib/toc#builtin->name"), makeNative(0, clofun73, 1, 0));
+Obj _35reg1761 = primSet(co, intern("cora/lib/toc#builtin->args"), makeNative(3, clofun72, 1, 0));
+Obj _35reg1766 = primSet(co, intern("cora/lib/toc#temp-list"), makeNative(0, clofun72, 2, 0));
+Obj _35reg1772 = primSet(co, intern("cora/lib/toc#var-with-ns"), makeNative(1, clofun71, 2, 0));
+Obj _35reg1784 = primSet(co, intern("cora/lib/toc#lookup-var"), makeNative(3, clofun69, 3, 0));
+Obj _35reg1973 = primSet(co, intern("cora/lib/toc#parse"), makeNative(4, clofun63, 4, 0));
+Obj _35reg1984 = primSet(co, intern("cora/lib/toc#union"), makeNative(4, clofun62, 2, 0));
+Obj _35reg1995 = primSet(co, intern("cora/lib/toc#diff"), makeNative(4, clofun61, 2, 0));
+Obj _35reg2046 = primSet(co, intern("cora/lib/toc#convert-protect?"), makeNative(3, clofun60, 1, 0));
+Obj _35reg2221 = primSet(co, intern("cora/lib/toc#free-vars"), makeNative(4, clofun56, 1, 0));
+Obj _35reg2294 = primSet(co, intern("cora/lib/toc#closure-convert"), makeNative(1, clofun54, 2, 0));
+Obj _35reg2297 = primSet(co, intern("cora/lib/toc#id"), makeNative(0, clofun54, 1, 0));
+Obj _35reg2434 = primSet(co, intern("cora/lib/toc#tailify"), makeNative(0, clofun51, 2, 0));
+Obj _35reg2481 = primSet(co, intern("cora/lib/toc#tailify-list"), makeNative(2, clofun49, 3, 0));
+Obj _35reg2560 = primSet(co, intern("cora/lib/toc#explicit-stack"), makeNative(2, clofun46, 2, 0));
+Obj _35reg2658 = primSet(co, intern("cora/lib/toc#collect-lambda"), makeNative(0, clofun43, 2, 0));
+Obj _35reg2666 = primSet(co, intern("cora/lib/toc#append-result"), makeNative(2, clofun42, 2, 0));
+Obj _35reg2673 = primSet(co, intern("cora/lib/toc#wrap-var"), makeNative(0, clofun42, 2, 0));
+Obj _35reg2693 = primSet(co, intern("cora/lib/toc#generate-call-list"), makeNative(4, clofun39, 4, 0));
+Obj _35reg2969 = primSet(co, intern("cora/lib/toc#generate-inst"), makeNative(0, clofun25, 4, 0));
+Obj _35reg2994 = primSet(co, intern("cora/lib/toc#generate-cont"), makeNative(4, clofun22, 3, 0));
+Obj _35reg3003 = primSet(co, intern("cora/lib/toc#generate-inst-list-h"), makeNative(4, clofun21, 5, 0));
+Obj _35reg3004 = primSet(co, intern("cora/lib/toc#generate-inst-list"), makeNative(3, clofun21, 4, 0));
+Obj _35reg3005 = primSet(co, intern("cora/lib/toc#*mod-num*"), makeNumber(6));
+Obj _35reg3010 = primSet(co, intern("cora/lib/toc#generate-group-name"), makeNative(1, clofun21, 3, 0));
+Obj _35reg3014 = primSet(co, intern("cora/lib/toc#code-gen-func-declare"), makeNative(3, clofun20, 3, 0));
+Obj _35reg3022 = primSet(co, intern("cora/lib/toc#local-from-params"), makeNative(2, clofun19, 3, 0));
+Obj _35reg3027 = primSet(co, intern("cora/lib/toc#local-from-cont"), makeNative(3, clofun18, 3, 0));
+Obj _35reg3034 = primSet(co, intern("cora/lib/toc#generate-call-args-reverse"), makeNative(5, clofun17, 4, 0));
+Obj _35reg3097 = primSet(co, intern("cora/lib/toc#code-gen-toplevel"), makeNative(5, clofun15, 3, 0));
+Obj _35reg3098 = primSet(co, intern("cora/lib/toc#parse-pass"), makeNative(4, clofun15, 1, 0));
+Obj _35reg3099 = primSet(co, intern("cora/lib/toc#closure-convert-pass"), makeNative(3, clofun15, 1, 0));
+Obj _35reg3100 = primSet(co, intern("cora/lib/toc#tailify-pass"), makeNative(2, clofun15, 1, 0));
+Obj _35reg3101 = primSet(co, intern("cora/lib/toc#explicit-stack-pass"), makeNative(1, clofun15, 1, 0));
+Obj _35reg3111 = primSet(co, intern("cora/lib/toc#collect-lambda-pass"), makeNative(1, clofun14, 1, 0));
+Obj _35reg3118 = primSet(co, intern("cora/lib/toc#rewrite-->macro"), makeNative(4, clofun13, 2, 0));
+pushCont(co, 4, entry, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
+__arg1 = intern("->");
+__arg2 = makeNative(1, clofun13, 1, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != entry) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val3121 = __arg1;
+Obj _35reg3126 = primSet(co, intern("cora/lib/toc#compile"), makeNative(2, clofun12, 1, 0));
+Obj _35reg3132 = primSet(co, intern("cora/lib/toc#for-each"), makeNative(4, clofun11, 2, 0));
+Obj _35reg3139 = primSet(co, intern("cora/lib/toc#generate-jumptable"), makeNative(0, clofun11, 3, 0));
+Obj _35reg3160 = primSet(co, intern("cora/lib/toc#generate-toplevel-group"), makeNative(2, clofun7, 3, 0));
+Obj _35reg3175 = primSet(co, intern("cora/lib/toc#group-by-mod-h"), makeNative(2, clofun6, 4, 0));
+Obj _35reg3184 = primSet(co, intern("cora/lib/toc#generate-c"), makeNative(3, clofun4, 2, 0));
+Obj _35reg3216 = primSet(co, intern("cora/lib/toc#handle-import-eagerly"), makeNative(3, clofun3, 1, 0));
+Obj _35reg3257 = primSet(co, intern("cora/lib/toc#split-type-and-code"), makeNative(2, clofun2, 4, 0));
+Obj _35reg3258 = primSet(co, intern("cora/lib/infer#*typecheck*"), False);
+Obj _35reg3261 = primSet(co, intern("cora/lib/toc#preprocess"), makeNative(5, clofun1, 1, 0));
+Obj _35reg3267 = primSet(co, intern("cora/lib/toc#compile-to-c"), makeNative(5, entry, 2, 0));
+__nargs = 2;
+__arg1 = _35reg3267;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != entry) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label5:
+{
+Obj from = __arg1;
+Obj to = __arg2;
+pushCont(co, 0, clofun1, 1, to);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#preprocess"));
+__arg1 = from;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -60,7 +304,7 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3261(struct Cora* co){
+void clofun1(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
@@ -73,780 +317,56 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val3234 = __arg1;
+Obj _35val3262 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 20, _35clofun3260, 1, to);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#compile"));
-__arg1 = _35val3234;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3261) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35val3233 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun3261, 1, to);
+pushCont(co, 1, clofun1, 1, to);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#macroexpand"));
-__arg1 = _35val3233;
+__arg1 = _35val3262;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3261) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj from = __arg1;
-Obj to = __arg2;
-pushCont(co, 1, _35clofun3261, 1, to);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#preprocess"));
-__arg1 = from;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3261) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj _35val3109 = __arg1;
-Obj _35reg3114 = primSet(co, intern("cora/lib/toc#compile"), makeNative(4, _35clofun3258, 1, 0));
-Obj _35reg3120 = primSet(co, intern("cora/lib/toc#for-each"), makeNative(8, _35clofun3258, 2, 0));
-Obj _35reg3127 = primSet(co, intern("cora/lib/toc#generate-jumptable"), makeNative(12, _35clofun3258, 3, 0));
-Obj _35reg3148 = primSet(co, intern("cora/lib/toc#generate-toplevel-group"), makeNative(13, _35clofun3259, 2, 0));
-Obj _35reg3155 = primSet(co, intern("cora/lib/toc#generate-c"), makeNative(1, _35clofun3260, 2, 0));
-Obj _35reg3187 = primSet(co, intern("cora/lib/toc#handle-import-eagerly"), makeNative(7, _35clofun3260, 1, 0));
-Obj _35reg3228 = primSet(co, intern("cora/lib/toc#split-type-and-code"), makeNative(14, _35clofun3260, 4, 0));
-Obj _35reg3229 = primSet(co, intern("cora/lib/infer#*typecheck*"), False);
-Obj _35reg3232 = primSet(co, intern("cora/lib/toc#preprocess"), makeNative(17, _35clofun3260, 1, 0));
-Obj _35reg3238 = primSet(co, intern("cora/lib/toc#compile-to-c"), makeNative(2, _35clofun3261, 2, 0));
-__nargs = 2;
-__arg1 = _35reg3238;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3261) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label4:
-{
-Obj _35val1541 = __arg1;
-Obj _35reg1542 = primSet(co, intern("cora/lib/toc#*ns-export*"), Nil);
-Obj _35reg1557 = primSet(co, intern("cora/lib/toc#assq"), makeNative(3, _35clofun3239, 2, 0));
-Obj _35reg1563 = primSet(co, intern("cora/lib/toc#foldl"), makeNative(7, _35clofun3239, 3, 0));
-Obj _35reg1573 = primSet(co, intern("cora/lib/toc#pos-in-list0"), makeNative(11, _35clofun3239, 3, 0));
-Obj _35reg1574 = primSet(co, intern("cora/lib/toc#index"), makeNative(12, _35clofun3239, 2, 0));
-Obj _35reg1581 = primSet(co, intern("cora/lib/toc#exist-in-env"), makeNative(16, _35clofun3239, 2, 0));
-Obj _35reg1582 = primCons(intern("primSet"), Nil);
-Obj _35reg1583 = primCons(makeNumber(2), _35reg1582);
-Obj _35reg1584 = primCons(intern("set"), _35reg1583);
-Obj _35reg1585 = primCons(intern("primCar"), Nil);
-Obj _35reg1586 = primCons(makeNumber(1), _35reg1585);
-Obj _35reg1587 = primCons(intern("car"), _35reg1586);
-Obj _35reg1588 = primCons(intern("primCdr"), Nil);
-Obj _35reg1589 = primCons(makeNumber(1), _35reg1588);
-Obj _35reg1590 = primCons(intern("cdr"), _35reg1589);
-Obj _35reg1591 = primCons(intern("primCons"), Nil);
-Obj _35reg1592 = primCons(makeNumber(2), _35reg1591);
-Obj _35reg1593 = primCons(intern("cons"), _35reg1592);
-Obj _35reg1594 = primCons(intern("primIsCons"), Nil);
-Obj _35reg1595 = primCons(makeNumber(1), _35reg1594);
-Obj _35reg1596 = primCons(intern("cons?"), _35reg1595);
-Obj _35reg1597 = primCons(intern("primAdd"), Nil);
-Obj _35reg1598 = primCons(makeNumber(2), _35reg1597);
-Obj _35reg1599 = primCons(intern("+"), _35reg1598);
-Obj _35reg1600 = primCons(intern("primSub"), Nil);
-Obj _35reg1601 = primCons(makeNumber(2), _35reg1600);
-Obj _35reg1602 = primCons(intern("-"), _35reg1601);
-Obj _35reg1603 = primCons(intern("primMul"), Nil);
-Obj _35reg1604 = primCons(makeNumber(2), _35reg1603);
-Obj _35reg1605 = primCons(intern("*"), _35reg1604);
-Obj _35reg1606 = primCons(intern("primDiv"), Nil);
-Obj _35reg1607 = primCons(makeNumber(2), _35reg1606);
-Obj _35reg1608 = primCons(intern("/"), _35reg1607);
-Obj _35reg1609 = primCons(intern("primEQ"), Nil);
-Obj _35reg1610 = primCons(makeNumber(2), _35reg1609);
-Obj _35reg1611 = primCons(intern("="), _35reg1610);
-Obj _35reg1612 = primCons(intern("primGT"), Nil);
-Obj _35reg1613 = primCons(makeNumber(2), _35reg1612);
-Obj _35reg1614 = primCons(intern(">"), _35reg1613);
-Obj _35reg1615 = primCons(intern("primLT"), Nil);
-Obj _35reg1616 = primCons(makeNumber(2), _35reg1615);
-Obj _35reg1617 = primCons(intern("<"), _35reg1616);
-Obj _35reg1618 = primCons(intern("primGenSym"), Nil);
-Obj _35reg1619 = primCons(makeNumber(1), _35reg1618);
-Obj _35reg1620 = primCons(intern("gensym"), _35reg1619);
-Obj _35reg1621 = primCons(intern("primIsSymbol"), Nil);
-Obj _35reg1622 = primCons(makeNumber(1), _35reg1621);
-Obj _35reg1623 = primCons(intern("symbol?"), _35reg1622);
-Obj _35reg1624 = primCons(intern("primNot"), Nil);
-Obj _35reg1625 = primCons(makeNumber(1), _35reg1624);
-Obj _35reg1626 = primCons(intern("not"), _35reg1625);
-Obj _35reg1627 = primCons(intern("primIsNumber"), Nil);
-Obj _35reg1628 = primCons(makeNumber(1), _35reg1627);
-Obj _35reg1629 = primCons(intern("integer?"), _35reg1628);
-Obj _35reg1630 = primCons(intern("primIsString"), Nil);
-Obj _35reg1631 = primCons(makeNumber(1), _35reg1630);
-Obj _35reg1632 = primCons(intern("string?"), _35reg1631);
-Obj _35reg1633 = primCons(_35reg1632, Nil);
-Obj _35reg1634 = primCons(_35reg1629, _35reg1633);
-Obj _35reg1635 = primCons(_35reg1626, _35reg1634);
-Obj _35reg1636 = primCons(_35reg1623, _35reg1635);
-Obj _35reg1637 = primCons(_35reg1620, _35reg1636);
-Obj _35reg1638 = primCons(_35reg1617, _35reg1637);
-Obj _35reg1639 = primCons(_35reg1614, _35reg1638);
-Obj _35reg1640 = primCons(_35reg1611, _35reg1639);
-Obj _35reg1641 = primCons(_35reg1608, _35reg1640);
-Obj _35reg1642 = primCons(_35reg1605, _35reg1641);
-Obj _35reg1643 = primCons(_35reg1602, _35reg1642);
-Obj _35reg1644 = primCons(_35reg1599, _35reg1643);
-Obj _35reg1645 = primCons(_35reg1596, _35reg1644);
-Obj _35reg1646 = primCons(_35reg1593, _35reg1645);
-Obj _35reg1647 = primCons(_35reg1590, _35reg1646);
-Obj _35reg1648 = primCons(_35reg1587, _35reg1647);
-Obj _35reg1649 = primCons(_35reg1584, _35reg1648);
-Obj _35reg1650 = primSet(co, intern("cora/lib/toc#*builtin-prims*"), _35reg1649);
-Obj _35reg1654 = primSet(co, intern("cora/lib/toc#builtin?"), makeNative(19, _35clofun3239, 1, 0));
-Obj _35reg1657 = primSet(co, intern("cora/lib/toc#builtin->name"), makeNative(1, _35clofun3240, 1, 0));
-Obj _35reg1660 = primSet(co, intern("cora/lib/toc#builtin->args"), makeNative(4, _35clofun3240, 1, 0));
-Obj _35reg1665 = primSet(co, intern("cora/lib/toc#temp-list"), makeNative(7, _35clofun3240, 2, 0));
-Obj _35reg1671 = primSet(co, intern("cora/lib/toc#var-with-ns"), makeNative(12, _35clofun3240, 2, 0));
-Obj _35reg1683 = primSet(co, intern("cora/lib/toc#lookup-var"), makeNative(1, _35clofun3241, 3, 0));
-Obj _35reg1872 = primSet(co, intern("cora/lib/toc#parse"), makeNative(15, _35clofun3242, 4, 0));
-Obj _35reg1883 = primSet(co, intern("cora/lib/toc#union"), makeNative(0, _35clofun3243, 2, 0));
-Obj _35reg1894 = primSet(co, intern("cora/lib/toc#diff"), makeNative(6, _35clofun3243, 2, 0));
-Obj _35reg1945 = primSet(co, intern("cora/lib/toc#convert-protect?"), makeNative(13, _35clofun3243, 1, 0));
-Obj _35reg2120 = primSet(co, intern("cora/lib/toc#free-vars"), makeNative(15, _35clofun3244, 1, 0));
-Obj _35reg2193 = primSet(co, intern("cora/lib/toc#closure-convert"), makeNative(9, _35clofun3245, 2, 0));
-Obj _35reg2196 = primSet(co, intern("cora/lib/toc#id"), makeNative(10, _35clofun3245, 1, 0));
-Obj _35reg2333 = primSet(co, intern("cora/lib/toc#tailify"), makeNative(7, _35clofun3246, 2, 0));
-Obj _35reg2380 = primSet(co, intern("cora/lib/toc#tailify-list"), makeNative(17, _35clofun3246, 3, 0));
-Obj _35reg2459 = primSet(co, intern("cora/lib/toc#explicit-stack"), makeNative(14, _35clofun3247, 2, 0));
-Obj _35reg2635 = primSet(co, intern("cora/lib/toc#collect-lambda"), makeNative(7, _35clofun3249, 2, 0));
-Obj _35reg2648 = primSet(co, intern("cora/lib/toc#append-result"), makeNative(13, _35clofun3249, 5, 0));
-Obj _35reg2655 = primSet(co, intern("cora/lib/toc#wrap-var"), makeNative(15, _35clofun3249, 2, 0));
-Obj _35reg2675 = primSet(co, intern("cora/lib/toc#generate-call-list"), makeNative(8, _35clofun3250, 4, 0));
-Obj _35reg2945 = primSet(co, intern("cora/lib/toc#generate-inst"), makeNative(11, _35clofun3254, 4, 0));
-Obj _35reg2968 = primSet(co, intern("cora/lib/toc#generate-cont"), makeNative(3, _35clofun3255, 3, 0));
-Obj _35reg2977 = primSet(co, intern("cora/lib/toc#generate-inst-list-h"), makeNative(9, _35clofun3255, 5, 0));
-Obj _35reg2978 = primSet(co, intern("cora/lib/toc#generate-inst-list"), makeNative(10, _35clofun3255, 4, 0));
-Obj _35reg2983 = primSet(co, intern("cora/lib/toc#code-gen-func-declare"), makeNative(14, _35clofun3255, 2, 0));
-Obj _35reg2991 = primSet(co, intern("cora/lib/toc#local-from-params"), makeNative(0, _35clofun3256, 3, 0));
-Obj _35reg2996 = primSet(co, intern("cora/lib/toc#local-from-cont"), makeNative(5, _35clofun3256, 3, 0));
-Obj _35reg3003 = primSet(co, intern("cora/lib/toc#generate-call-args-reverse"), makeNative(9, _35clofun3256, 4, 0));
-Obj _35reg3065 = primSet(co, intern("cora/lib/toc#code-gen-toplevel"), makeNative(20, _35clofun3256, 2, 0));
-Obj _35reg3066 = primSet(co, intern("cora/lib/toc#parse-pass"), makeNative(0, _35clofun3257, 1, 0));
-Obj _35reg3067 = primSet(co, intern("cora/lib/toc#closure-convert-pass"), makeNative(1, _35clofun3257, 1, 0));
-Obj _35reg3068 = primSet(co, intern("cora/lib/toc#tailify-pass"), makeNative(2, _35clofun3257, 1, 0));
-Obj _35reg3069 = primSet(co, intern("cora/lib/toc#explicit-stack-pass"), makeNative(3, _35clofun3257, 1, 0));
-Obj _35reg3099 = primSet(co, intern("cora/lib/toc#collect-lambda-pass"), makeNative(14, _35clofun3257, 1, 0));
-Obj _35reg3106 = primSet(co, intern("cora/lib/toc#rewrite-->macro"), makeNative(17, _35clofun3257, 2, 0));
-pushCont(co, 3, _35clofun3261, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#add-to-*macros*"));
-__arg1 = intern("->");
-__arg2 = makeNative(20, _35clofun3257, 1, 0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3261) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35val1540 = __arg1;
-pushCont(co, 4, _35clofun3261, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#import"));
-__arg1 = makeCString("cora/lib/io");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3261) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-fail:
-co->nargs = __nargs;
-co->args[0] = __arg0;
-co->args[1] = __arg1;
-co->args[2] = __arg2;
-co->args[3] = __arg3;
-
-}
-
-void _35clofun3260(struct Cora* co){
-int __nargs = co->nargs;
-Obj __arg0 = co->args[0];
-Obj __arg1 = co->args[1];
-Obj __arg2 = co->args[2];
-Obj __arg3 = co->args[3];
-
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
-
-goto *jumpTable[co->ctx.pc.label];
-
-label0:
-{
-Obj _35val3149 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 20, _35clofun3259, 2, to, bc);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("#include \"runtime.h\"\n\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj to = __arg1;
-Obj bc = __arg2;
-pushCont(co, 0, _35clofun3260, 2, to, bc);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("#include \"types.h\"\n");
+Obj _35val3263 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 2, clofun1, 1, to);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#compile"));
+__arg1 = _35val3263;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
+Obj _35val3264 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj bc = _35val3264;
+pushCont(co, 3, clofun1, 1, bc);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
+__arg0 = globalRef(intern("cora/lib/io#open-output-file"));
+__arg1 = to;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc1531 = makeNative(2, _35clofun3260, 0, 0);
-Obj __ = closureRef(co, 0);
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3260) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label4:
-{
-Obj _35val3173 = __arg1;
-Obj remain= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
-__arg1 = remain;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35cc1530 = makeNative(3, _35clofun3260, 0, 1, closureRef(co, 0));
-Obj _35reg3156 = primIsCons(closureRef(co, 0));
-if (True == _35reg3156) {
-Obj _35reg3157 = primCar(closureRef(co, 0));
-Obj _35reg3158 = primIsCons(_35reg3157);
-if (True == _35reg3158) {
-Obj _35reg3159 = primCar(closureRef(co, 0));
-Obj _35reg3160 = primCar(_35reg3159);
-Obj _35reg3161 = primEQ(intern("import"), _35reg3160);
-if (True == _35reg3161) {
-Obj _35reg3162 = primCar(closureRef(co, 0));
-Obj _35reg3163 = primCdr(_35reg3162);
-Obj _35reg3164 = primIsCons(_35reg3163);
-if (True == _35reg3164) {
-Obj _35reg3165 = primCar(closureRef(co, 0));
-Obj _35reg3166 = primCdr(_35reg3165);
-Obj _35reg3167 = primCar(_35reg3166);
-Obj pkg = _35reg3167;
-Obj _35reg3168 = primCar(closureRef(co, 0));
-Obj _35reg3169 = primCdr(_35reg3168);
-Obj _35reg3170 = primCdr(_35reg3169);
-Obj _35reg3171 = primEQ(Nil, _35reg3170);
-if (True == _35reg3171) {
-Obj _35reg3172 = primCdr(closureRef(co, 0));
-Obj remain = _35reg3172;
-pushCont(co, 4, _35clofun3260, 1, remain);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#import"));
-__arg1 = pkg;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1530;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1530;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1530;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1530;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1530;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label6:
-{
-Obj _35cc1529 = makeNative(5, _35clofun3260, 0, 1, closureRef(co, 0));
-Obj _35reg3174 = primIsCons(closureRef(co, 0));
-if (True == _35reg3174) {
-Obj _35reg3175 = primCar(closureRef(co, 0));
-Obj _35reg3176 = primEQ(intern("begin"), _35reg3175);
-if (True == _35reg3176) {
-Obj _35reg3177 = primCdr(closureRef(co, 0));
-Obj remain = _35reg3177;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
-__arg1 = remain;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1529;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1529;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label7:
-{
-Obj _35p1527 = __arg1;
-Obj _35cc1528 = makeNative(6, _35clofun3260, 0, 1, _35p1527);
-Obj _35reg3178 = primIsCons(_35p1527);
-if (True == _35reg3178) {
-Obj _35reg3179 = primCar(_35p1527);
-Obj _35reg3180 = primEQ(intern("define-library"), _35reg3179);
-if (True == _35reg3180) {
-Obj _35reg3181 = primCdr(_35p1527);
-Obj _35reg3182 = primIsCons(_35reg3181);
-if (True == _35reg3182) {
-Obj _35reg3183 = primCdr(_35p1527);
-Obj _35reg3184 = primCar(_35reg3183);
-Obj __ = _35reg3184;
-Obj _35reg3185 = primCdr(_35p1527);
-Obj _35reg3186 = primCdr(_35reg3185);
-Obj remain = _35reg3186;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
-__arg1 = remain;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1528;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1528;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1528;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35cc1539 = makeNative(8, _35clofun3260, 0, 0);
-Obj _35reg3188 = primIsCons(closureRef(co, 0));
-if (True == _35reg3188) {
-Obj _35reg3189 = primCar(closureRef(co, 0));
-Obj exp = _35reg3189;
-Obj _35reg3190 = primCdr(closureRef(co, 0));
-Obj more = _35reg3190;
-Obj type = closureRef(co, 1);
-Obj code = closureRef(co, 2);
-Obj k = closureRef(co, 3);
-Obj _35reg3191 = primCons(exp, Nil);
-Obj _35reg3192 = primCons(intern("backquote"), _35reg3191);
-Obj _35reg3193 = primCons(_35reg3192, Nil);
-Obj _35reg3194 = primCons(intern("macroexpand"), _35reg3193);
-Obj _35reg3195 = primCons(intern("tvar"), Nil);
-Obj _35reg3196 = primCons(Nil, Nil);
-Obj _35reg3197 = primCons(Nil, _35reg3196);
-Obj _35reg3198 = primCons(_35reg3195, _35reg3197);
-Obj _35reg3199 = primCons(_35reg3194, _35reg3198);
-Obj _35reg3200 = primCons(intern("cora/lib/infer#check-type"), _35reg3199);
-Obj _35reg3201 = primCons(_35reg3200, type);
-Obj _35reg3202 = primCons(exp, code);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
-__arg1 = more;
-__arg2 = _35reg3201;
-__arg3 = _35reg3202;
-co->args[4] = k;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1539;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj _35cc1538 = makeNative(9, _35clofun3260, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg3203 = primIsCons(closureRef(co, 0));
-if (True == _35reg3203) {
-Obj _35reg3204 = primCar(closureRef(co, 0));
-Obj _35reg3205 = primIsCons(_35reg3204);
-if (True == _35reg3205) {
-Obj _35reg3206 = primCar(closureRef(co, 0));
-Obj _35reg3207 = primCar(_35reg3206);
-Obj _35reg3208 = primEQ(intern(":declare"), _35reg3207);
-if (True == _35reg3208) {
-Obj _35reg3209 = primCar(closureRef(co, 0));
-Obj _35reg3210 = primCdr(_35reg3209);
-Obj exp = _35reg3210;
-Obj _35reg3211 = primCdr(closureRef(co, 0));
-Obj more = _35reg3211;
-Obj type = closureRef(co, 1);
-Obj code = closureRef(co, 2);
-Obj k = closureRef(co, 3);
-Obj _35reg3212 = primCons(intern("declare"), exp);
-Obj _35reg3213 = primCons(_35reg3212, type);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
-__arg1 = more;
-__arg2 = _35reg3213;
-__arg3 = code;
-co->args[4] = k;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1538;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1538;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1538;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label11:
-{
-Obj _35cc1537 = makeNative(10, _35clofun3260, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg3214 = primIsCons(closureRef(co, 0));
-if (True == _35reg3214) {
-Obj _35reg3215 = primCar(closureRef(co, 0));
-Obj _35reg3216 = primIsCons(_35reg3215);
-if (True == _35reg3216) {
-Obj _35reg3217 = primCar(closureRef(co, 0));
-Obj _35reg3218 = primCar(_35reg3217);
-Obj _35reg3219 = primEQ(intern(":type"), _35reg3218);
-if (True == _35reg3219) {
-Obj _35reg3220 = primCar(closureRef(co, 0));
-Obj _35reg3221 = primCdr(_35reg3220);
-Obj exp = _35reg3221;
-Obj _35reg3222 = primCdr(closureRef(co, 0));
-Obj more = _35reg3222;
-Obj type = closureRef(co, 1);
-Obj code = closureRef(co, 2);
-Obj k = closureRef(co, 3);
-Obj _35reg3223 = primCons(intern("begin"), exp);
-Obj _35reg3224 = primCons(_35reg3223, type);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
-__arg1 = more;
-__arg2 = _35reg3224;
-__arg3 = code;
-co->args[4] = k;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1537;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1537;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1537;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35val3227 = __arg1;
-Obj k= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val3226= co->ctx.stk.stack[co->ctx.stk.base + 1];
-__nargs = 3;
-__arg0 = k;
-__arg1 = _35val3226;
-__arg2 = _35val3227;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35val3226 = __arg1;
-Obj code= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj k= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun3260, 2, k, _35val3226);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#reverse"));
-__arg1 = code;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35p1532 = __arg1;
-Obj _35p1533 = __arg2;
-Obj _35p1534 = __arg3;
-Obj _35p1535 = co->args[4];
-Obj _35cc1536 = makeNative(11, _35clofun3260, 0, 4, _35p1532, _35p1533, _35p1534, _35p1535);
-Obj _35reg3225 = primEQ(Nil, _35p1532);
-if (True == _35reg3225) {
-Obj type = _35p1533;
-Obj code = _35p1534;
-Obj k = _35p1535;
-pushCont(co, 13, _35clofun3260, 2, code, k);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#reverse"));
-__arg1 = type;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1536;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj _35val3231 = __arg1;
-Obj sexp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 2;
-__arg1 = sexp;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3260) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label16:
-{
-Obj _35val3230 = __arg1;
-Obj sexp = _35val3230;
-pushCont(co, 15, _35clofun3260, 1, sexp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
-__arg1 = sexp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj file_45path = __arg1;
-pushCont(co, 16, _35clofun3260, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#read-file-as-sexp"));
-__arg1 = file_45path;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val3237 = __arg1;
-Obj stream= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/io#close-output-file"));
-__arg1 = stream;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35val3236 = __arg1;
+Obj _35val3265 = __arg1;
 Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stream = _35val3236;
-pushCont(co, 18, _35clofun3260, 1, stream);
+Obj stream = _35val3265;
+pushCont(co, 4, clofun1, 1, stream);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#generate-c"));
 __arg1 = stream;
@@ -854,23 +374,35 @@ __arg2 = bc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label4:
 {
-Obj _35val3235 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc = _35val3235;
-pushCont(co, 19, _35clofun3260, 1, bc);
+Obj _35val3266 = __arg1;
+Obj stream= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/io#open-output-file"));
-__arg1 = to;
+__arg0 = globalRef(intern("cora/lib/io#close-output-file"));
+__arg1 = stream;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3260) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj file_45path = __arg1;
+pushCont(co, 0, clofun2, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#read-file-as-sexp"));
+__arg1 = file_45path;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -883,358 +415,167 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3259(struct Cora* co){
+void clofun2(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val3140 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 20, _35clofun3258, 1, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(13, _35clofun3258, 1, 1, to);
-__arg2 = group;
+Obj _35val3259 = __arg1;
+Obj sexp = _35val3259;
+pushCont(co, 1, clofun2, 1, sexp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
+__arg1 = sexp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val3139 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3259, 2, group, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj _35val3260 = __arg1;
+Obj sexp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 2;
+__arg1 = sexp;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun2) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val3138 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun3259, 2, group, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("};\n\n");
+Obj _35p1632 = __arg1;
+Obj _35p1633 = __arg2;
+Obj _35p1634 = __arg3;
+Obj _35p1635 = co->args[4];
+Obj _35cc1636 = makeNative(5, clofun2, 0, 4, _35p1632, _35p1633, _35p1634, _35p1635);
+Obj _35reg3254 = primEQ(Nil, _35p1632);
+if (True == _35reg3254) {
+Obj type = _35p1633;
+Obj code = _35p1634;
+Obj k = _35p1635;
+pushCont(co, 3, clofun2, 2, code, k);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#reverse"));
+__arg1 = type;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1636;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label3:
 {
-Obj _35val3137 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun3259, 2, group, to);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#generate-jumptable"));
-__arg1 = to;
-__arg2 = makeNumber(0);
-__arg3 = _35val3137;
+Obj _35val3255 = __arg1;
+Obj code= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj k= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 4, clofun2, 2, k, _35val3255);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#reverse"));
+__arg1 = code;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val3136 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 3, _35clofun3259, 2, group, to);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = group;
+Obj _35val3256 = __arg1;
+Obj k= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val3255= co->ctx.stk.stack[co->ctx.stk.base + 1];
+__nargs = 3;
+__arg0 = k;
+__arg1 = _35val3255;
+__arg2 = _35val3256;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val3135 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun3259, 2, group, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("static void* jumpTable[] = {");
+Obj _35cc1637 = makeNative(0, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35reg3243 = primIsCons(closureRef(co, 0));
+if (True == _35reg3243) {
+Obj _35reg3244 = primCar(closureRef(co, 0));
+Obj _35reg3245 = primIsCons(_35reg3244);
+if (True == _35reg3245) {
+Obj _35reg3246 = primCar(closureRef(co, 0));
+Obj _35reg3247 = primCar(_35reg3246);
+Obj _35reg3248 = primEQ(intern(":type"), _35reg3247);
+if (True == _35reg3248) {
+Obj _35reg3249 = primCar(closureRef(co, 0));
+Obj _35reg3250 = primCdr(_35reg3249);
+Obj exp = _35reg3250;
+Obj _35reg3251 = primCdr(closureRef(co, 0));
+Obj more = _35reg3251;
+Obj type = closureRef(co, 1);
+Obj code = closureRef(co, 2);
+Obj k = closureRef(co, 3);
+Obj _35reg3252 = primCons(intern("begin"), exp);
+Obj _35reg3253 = primCons(_35reg3252, type);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
+__arg1 = more;
+__arg2 = _35reg3253;
+__arg3 = code;
+co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1637;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-
-label6:
-{
-Obj _35val3134 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun3259, 2, group, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("Obj __arg3 = co->args[3];\n\n");
+} else {
+__nargs = 1;
+__arg0 = _35cc1637;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-
-label7:
-{
-Obj _35val3133 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 6, _35clofun3259, 2, group, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("Obj __arg2 = co->args[2];\n");
+} else {
+__nargs = 1;
+__arg0 = _35cc1637;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-
-label8:
-{
-Obj _35val3132 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun3259, 2, group, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("Obj __arg1 = co->args[1];\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val3131 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun3259, 2, group, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("Obj __arg0 = co->args[0];\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35val3130 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun3259, 2, group, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("int __nargs = co->nargs;\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val3129 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun3259, 2, group, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("{\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35val3128 = __arg1;
-Obj group= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun3259, 2, group, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#code-gen-func-declare"));
-__arg1 = to;
-__arg2 = _35val3128;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj to = __arg1;
-Obj group = __arg2;
-pushCont(co, 12, _35clofun3259, 2, group, to);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#caar"));
-__arg1 = group;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35val3152 = __arg1;
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = closureRef(co, 0);
-__arg2 = makeCString(";\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35val3151 = __arg1;
-pushCont(co, 14, _35clofun3259, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#code-gen-func-declare"));
-__arg1 = closureRef(co, 0);
-__arg2 = _35val3151;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj group = __arg1;
-pushCont(co, 15, _35clofun3259, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#caar"));
-__arg1 = group;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj group = __arg1;
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#generate-toplevel-group"));
-__arg1 = closureRef(co, 0);
-__arg2 = group;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val3154 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(17, _35clofun3259, 1, 1, to);
-__arg2 = bc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35val3153 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 18, _35clofun3259, 2, to, bc);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("\n\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val3150 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 19, _35clofun3259, 2, to, bc);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(16, _35clofun3259, 1, 1, to);
-__arg2 = bc;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3259) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 }
 
 fail:
@@ -1246,87 +587,126 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3258(struct Cora* co){
+void clofun3(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val3113 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#collect-lambda-pass"));
-__arg1 = _35val3113;
+Obj _35cc1638 = makeNative(1, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35reg3232 = primIsCons(closureRef(co, 0));
+if (True == _35reg3232) {
+Obj _35reg3233 = primCar(closureRef(co, 0));
+Obj _35reg3234 = primIsCons(_35reg3233);
+if (True == _35reg3234) {
+Obj _35reg3235 = primCar(closureRef(co, 0));
+Obj _35reg3236 = primCar(_35reg3235);
+Obj _35reg3237 = primEQ(intern(":declare"), _35reg3236);
+if (True == _35reg3237) {
+Obj _35reg3238 = primCar(closureRef(co, 0));
+Obj _35reg3239 = primCdr(_35reg3238);
+Obj exp = _35reg3239;
+Obj _35reg3240 = primCdr(closureRef(co, 0));
+Obj more = _35reg3240;
+Obj type = closureRef(co, 1);
+Obj code = closureRef(co, 2);
+Obj k = closureRef(co, 3);
+Obj _35reg3241 = primCons(intern("declare"), exp);
+Obj _35reg3242 = primCons(_35reg3241, type);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
+__arg1 = more;
+__arg2 = _35reg3242;
+__arg3 = code;
+co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1638;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1638;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1638;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label1:
 {
-Obj _35val3112 = __arg1;
-pushCont(co, 0, _35clofun3258, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#explicit-stack-pass"));
-__arg1 = _35val3112;
+Obj _35cc1639 = makeNative(2, clofun3, 0, 0);
+Obj _35reg3217 = primIsCons(closureRef(co, 0));
+if (True == _35reg3217) {
+Obj _35reg3218 = primCar(closureRef(co, 0));
+Obj exp = _35reg3218;
+Obj _35reg3219 = primCdr(closureRef(co, 0));
+Obj more = _35reg3219;
+Obj type = closureRef(co, 1);
+Obj code = closureRef(co, 2);
+Obj k = closureRef(co, 3);
+Obj _35reg3220 = primCons(exp, Nil);
+Obj _35reg3221 = primCons(intern("backquote"), _35reg3220);
+Obj _35reg3222 = primCons(_35reg3221, Nil);
+Obj _35reg3223 = primCons(intern("macroexpand"), _35reg3222);
+Obj _35reg3224 = primCons(intern("tvar"), Nil);
+Obj _35reg3225 = primCons(Nil, Nil);
+Obj _35reg3226 = primCons(Nil, _35reg3225);
+Obj _35reg3227 = primCons(_35reg3224, _35reg3226);
+Obj _35reg3228 = primCons(_35reg3223, _35reg3227);
+Obj _35reg3229 = primCons(intern("cora/lib/infer#check-type"), _35reg3228);
+Obj _35reg3230 = primCons(_35reg3229, type);
+Obj _35reg3231 = primCons(exp, code);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#split-type-and-code"));
+__arg1 = more;
+__arg2 = _35reg3230;
+__arg3 = _35reg3231;
+co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1639;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label2:
-{
-Obj _35val3111 = __arg1;
-pushCont(co, 1, _35clofun3258, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#tailify-pass"));
-__arg1 = _35val3111;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj _35val3110 = __arg1;
-pushCont(co, 2, _35clofun3258, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#closure-convert-pass"));
-__arg1 = _35val3110;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj exp = __arg1;
-pushCont(co, 3, _35clofun3258, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#parse-pass"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -1334,83 +714,1180 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label3:
 {
-Obj _35val3118 = __arg1;
-Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = fn;
-__arg2 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35cc1526 = makeNative(5, _35clofun3258, 0, 0);
-Obj fn = closureRef(co, 0);
-Obj _35reg3115 = primIsCons(closureRef(co, 1));
-if (True == _35reg3115) {
-Obj _35reg3116 = primCar(closureRef(co, 1));
-Obj x = _35reg3116;
-Obj _35reg3117 = primCdr(closureRef(co, 1));
-Obj y = _35reg3117;
-pushCont(co, 6, _35clofun3258, 2, fn, y);
+Obj _35p1627 = __arg1;
+Obj _35cc1628 = makeNative(4, clofun3, 0, 1, _35p1627);
+Obj _35reg3207 = primIsCons(_35p1627);
+if (True == _35reg3207) {
+Obj _35reg3208 = primCar(_35p1627);
+Obj _35reg3209 = primEQ(intern("define-library"), _35reg3208);
+if (True == _35reg3209) {
+Obj _35reg3210 = primCdr(_35p1627);
+Obj _35reg3211 = primIsCons(_35reg3210);
+if (True == _35reg3211) {
+Obj _35reg3212 = primCdr(_35p1627);
+Obj _35reg3213 = primCar(_35reg3212);
+Obj __ = _35reg3213;
+Obj _35reg3214 = primCdr(_35p1627);
+Obj _35reg3215 = primCdr(_35reg3214);
+Obj remain = _35reg3215;
 __nargs = 2;
-__arg0 = fn;
-__arg1 = x;
+__arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
+__arg1 = remain;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1526;
+__arg0 = _35cc1628;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1628;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1628;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label8:
+label4:
 {
-Obj _35p1523 = __arg1;
-Obj _35p1524 = __arg2;
-Obj _35cc1525 = makeNative(7, _35clofun3258, 0, 2, _35p1523, _35p1524);
-Obj fn = _35p1523;
-Obj _35reg3119 = primEQ(Nil, _35p1524);
-if (True == _35reg3119) {
+Obj _35cc1629 = makeNative(5, clofun3, 0, 1, closureRef(co, 0));
+Obj _35reg3203 = primIsCons(closureRef(co, 0));
+if (True == _35reg3203) {
+Obj _35reg3204 = primCar(closureRef(co, 0));
+Obj _35reg3205 = primEQ(intern("begin"), _35reg3204);
+if (True == _35reg3205) {
+Obj _35reg3206 = primCdr(closureRef(co, 0));
+Obj remain = _35reg3206;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
+__arg1 = remain;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1629;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1629;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35cc1630 = makeNative(1, clofun4, 0, 1, closureRef(co, 0));
+Obj _35reg3185 = primIsCons(closureRef(co, 0));
+if (True == _35reg3185) {
+Obj _35reg3186 = primCar(closureRef(co, 0));
+Obj _35reg3187 = primIsCons(_35reg3186);
+if (True == _35reg3187) {
+Obj _35reg3188 = primCar(closureRef(co, 0));
+Obj _35reg3189 = primCar(_35reg3188);
+Obj _35reg3190 = primEQ(intern("import"), _35reg3189);
+if (True == _35reg3190) {
+Obj _35reg3191 = primCar(closureRef(co, 0));
+Obj _35reg3192 = primCdr(_35reg3191);
+Obj _35reg3193 = primIsCons(_35reg3192);
+if (True == _35reg3193) {
+Obj _35reg3194 = primCar(closureRef(co, 0));
+Obj _35reg3195 = primCdr(_35reg3194);
+Obj _35reg3196 = primCar(_35reg3195);
+Obj pkg = _35reg3196;
+Obj _35reg3197 = primCar(closureRef(co, 0));
+Obj _35reg3198 = primCdr(_35reg3197);
+Obj _35reg3199 = primCdr(_35reg3198);
+Obj _35reg3200 = primEQ(Nil, _35reg3199);
+if (True == _35reg3200) {
+Obj _35reg3201 = primCdr(closureRef(co, 0));
+Obj remain = _35reg3201;
+pushCont(co, 0, clofun4, 1, remain);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#import"));
+__arg1 = pkg;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1630;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1630;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1630;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1630;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1630;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun4(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val3202 = __arg1;
+Obj remain= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#handle-import-eagerly"));
+__arg1 = remain;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35cc1631 = makeNative(2, clofun4, 0, 0);
+Obj __ = closureRef(co, 0);
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3258) { goto fail; }
+if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1525;
+}
+
+label2:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj to = __arg1;
+Obj bc = __arg2;
+pushCont(co, 4, clofun4, 2, bc, to);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#group-by-mod-h"));
+__arg1 = Nil;
+__arg2 = makeNumber(0);
+__arg3 = Nil;
+co->args[4] = bc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val3176 = __arg1;
+Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj groups = _35val3176;
+pushCont(co, 5, clofun4, 2, to, groups);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#caar"));
+__arg1 = bc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val3177 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj groups= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj maxid = _35val3177;
+pushCont(co, 0, clofun5, 3, to, maxid, groups);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("#include \"types.h\"\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun5(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val3178 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj groups= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 1, clofun5, 3, to, maxid, groups);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("#include \"runtime.h\"\n\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val3179 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj groups= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 2, clofun5, 3, to, maxid, groups);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#for-each"));
+__arg1 = makeNative(5, clofun5, 1, 2, maxid, to);
+__arg2 = groups;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val3182 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj groups= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 3, clofun5, 3, to, maxid, groups);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("\n\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val3183 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj groups= co->ctx.stk.stack[co->ctx.stk.base + 2];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#for-each"));
+__arg1 = makeNative(4, clofun5, 1, 2, to, maxid);
+__arg2 = groups;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj group = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#generate-toplevel-group"));
+__arg1 = closureRef(co, 0);
+__arg2 = group;
+__arg3 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj group = __arg1;
+pushCont(co, 0, clofun6, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#caar"));
+__arg1 = group;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun6(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val3180 = __arg1;
+pushCont(co, 1, clofun6, 0);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#code-gen-func-declare"));
+__arg1 = closureRef(co, 1);
+__arg2 = _35val3180;
+__arg3 = closureRef(co, 0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val3181 = __arg1;
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = closureRef(co, 1);
+__arg2 = makeCString(";\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35p1621 = __arg1;
+Obj _35p1622 = __arg2;
+Obj _35p1623 = __arg3;
+Obj _35p1624 = co->args[4];
+Obj _35cc1625 = makeNative(5, clofun6, 0, 4, _35p1621, _35p1622, _35p1623, _35p1624);
+Obj res = _35p1621;
+Obj idx = _35p1622;
+Obj acc = _35p1623;
+Obj _35reg3170 = primEQ(Nil, _35p1624);
+if (True == _35reg3170) {
+pushCont(co, 3, clofun6, 2, acc, res);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#null?"));
+__arg1 = acc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1625;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label9:
+label3:
 {
-Obj _35val3122 = __arg1;
+Obj _35val3171 = __arg1;
+Obj acc= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj res= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg3172 = primNot(_35val3171);
+if (True == _35reg3172) {
+pushCont(co, 4, clofun6, 1, res);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#reverse"));
+__arg1 = acc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#reverse"));
+__arg1 = res;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val3173 = __arg1;
+Obj res= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg3174 = primCons(_35val3173, res);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#reverse"));
+__arg1 = _35reg3174;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35cc1626 = makeNative(1, clofun7, 0, 0);
+Obj res = closureRef(co, 0);
+Obj idx = closureRef(co, 1);
+Obj acc = closureRef(co, 2);
+Obj _35reg3161 = primIsCons(closureRef(co, 3));
+if (True == _35reg3161) {
+Obj _35reg3162 = primCar(closureRef(co, 3));
+Obj bc = _35reg3162;
+Obj _35reg3163 = primCdr(closureRef(co, 3));
+Obj more = _35reg3163;
+Obj _35reg3164 = primEQ(idx, globalRef(intern("cora/lib/toc#*mod-num*")));
+if (True == _35reg3164) {
+pushCont(co, 0, clofun7, 3, res, bc, more);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#reverse"));
+__arg1 = acc;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg3168 = primAdd(idx, makeNumber(1));
+Obj _35reg3169 = primCons(bc, acc);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#group-by-mod-h"));
+__arg1 = res;
+__arg2 = _35reg3168;
+__arg3 = _35reg3169;
+co->args[4] = more;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1626;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun7(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val3165 = __arg1;
+Obj res= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj bc= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg3166 = primCons(_35val3165, res);
+Obj _35reg3167 = primCons(bc, more);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#group-by-mod-h"));
+__arg1 = _35reg3166;
+__arg2 = makeNumber(0);
+__arg3 = Nil;
+co->args[4] = _35reg3167;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj to = __arg1;
+Obj group = __arg2;
+Obj maxid = __arg3;
+pushCont(co, 3, clofun7, 3, maxid, group, to);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#caar"));
+__arg1 = group;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val3140 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 4, clofun7, 3, maxid, group, to);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#code-gen-func-declare"));
+__arg1 = to;
+__arg2 = _35val3140;
+__arg3 = maxid;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val3141 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 5, clofun7, 3, maxid, group, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("{\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val3142 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, clofun8, 3, maxid, group, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("int __nargs = co->nargs;\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun8(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val3143 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 1, clofun8, 3, maxid, group, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("Obj __arg0 = co->args[0];\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val3144 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 2, clofun8, 3, maxid, group, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("Obj __arg1 = co->args[1];\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val3145 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 3, clofun8, 3, maxid, group, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("Obj __arg2 = co->args[2];\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val3146 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 4, clofun8, 3, maxid, group, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("Obj __arg3 = co->args[3];\n\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val3147 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 5, clofun8, 3, maxid, group, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("static void* jumpTable[] = {");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val3148 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, clofun9, 3, maxid, group, to);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#length"));
+__arg1 = group;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun9(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val3149 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 1, clofun9, 3, maxid, group, to);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#generate-jumptable"));
+__arg1 = to;
+__arg2 = makeNumber(0);
+__arg3 = _35val3149;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val3150 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 2, clofun9, 3, maxid, group, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("};\n\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val3151 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 3, clofun9, 3, maxid, group, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val3152 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj group= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 4, clofun9, 1, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#for-each"));
+__arg1 = makeNative(5, clofun10, 1, 2, to, maxid);
+__arg2 = group;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val3153 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 5, clofun9, 1, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("fail:\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val3154 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 0, clofun10, 1, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("co->nargs = __nargs;\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun10(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val3155 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 1, clofun10, 1, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("co->args[0] = __arg0;\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val3156 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 2, clofun10, 1, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("co->args[1] = __arg1;\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val3157 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 3, clofun10, 1, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("co->args[2] = __arg2;\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val3158 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 4, clofun10, 1, to);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("co->args[3] = __arg3;\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val3159 = __arg1;
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("\n}\n\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj x = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#code-gen-toplevel"));
+__arg1 = closureRef(co, 0);
+__arg2 = x;
+__arg3 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun10) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun11(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj to = __arg1;
+Obj i = __arg2;
+Obj n = __arg3;
+Obj _35reg3133 = primEQ(i, makeNumber(0));
+if (True == _35reg3133) {
+pushCont(co, 3, clofun11, 2, to, n);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString("&&label0");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg3135 = primLT(i, n);
+if (True == _35reg3135) {
+pushCont(co, 1, clofun11, 3, i, to, n);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = to;
+__arg2 = makeCString(", &&label");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun11) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+}
+
+label1:
+{
+Obj _35val3136 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj n= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 2, clofun11, 3, i, to, n);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = to;
+__arg2 = i;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val3137 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj n= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg3138 = primAdd(i, makeNumber(1));
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#generate-jumptable"));
+__arg1 = to;
+__arg2 = _35reg3138;
+__arg3 = n;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val3134 = __arg1;
 Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj n= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -1421,209 +1898,165 @@ __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label10:
+label4:
 {
-Obj _35val3125 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj n= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg3126 = primAdd(i, makeNumber(1));
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#generate-jumptable"));
-__arg1 = to;
-__arg2 = _35reg3126;
-__arg3 = n;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val3124 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj n= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 10, _35clofun3258, 3, i, to, n);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = to;
-__arg2 = i;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj to = __arg1;
-Obj i = __arg2;
-Obj n = __arg3;
-Obj _35reg3121 = primEQ(i, makeNumber(0));
-if (True == _35reg3121) {
-pushCont(co, 9, _35clofun3258, 2, to, n);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("&&label0");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg3123 = primLT(i, n);
-if (True == _35reg3123) {
-pushCont(co, 11, _35clofun3258, 3, i, to, n);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString(", &&label");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
+Obj _35p1617 = __arg1;
+Obj _35p1618 = __arg2;
+Obj _35cc1619 = makeNative(5, clofun11, 0, 2, _35p1617, _35p1618);
+Obj fn = _35p1617;
+Obj _35reg3131 = primEQ(Nil, _35p1618);
+if (True == _35reg3131) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3258) { goto fail; }
+if (co->ctx.pc.func != clofun11) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-}
-}
-}
-
-label13:
-{
-Obj x = __arg1;
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#code-gen-toplevel"));
-__arg1 = closureRef(co, 0);
-__arg2 = x;
+} else {
+__nargs = 1;
+__arg0 = _35cc1619;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35cc1620 = makeNative(1, clofun12, 0, 0);
+Obj fn = closureRef(co, 0);
+Obj _35reg3127 = primIsCons(closureRef(co, 1));
+if (True == _35reg3127) {
+Obj _35reg3128 = primCar(closureRef(co, 1));
+Obj x = _35reg3128;
+Obj _35reg3129 = primCdr(closureRef(co, 1));
+Obj y = _35reg3129;
+pushCont(co, 0, clofun12, 2, fn, y);
+__nargs = 2;
+__arg0 = fn;
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1620;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun11) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun12(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val3130 = __arg1;
+Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#for-each"));
+__arg1 = fn;
+__arg2 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label1:
 {
-Obj _35val3147 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("\n}\n\n");
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label2:
 {
-Obj _35val3146 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 14, _35clofun3258, 1, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("co->args[3] = __arg3;\n");
+Obj exp = __arg1;
+pushCont(co, 3, clofun12, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#parse-pass"));
+__arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label3:
 {
-Obj _35val3145 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 15, _35clofun3258, 1, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("co->args[2] = __arg2;\n");
+Obj _35val3122 = __arg1;
+pushCont(co, 4, clofun12, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#closure-convert-pass"));
+__arg1 = _35val3122;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label4:
 {
-Obj _35val3144 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 16, _35clofun3258, 1, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("co->args[1] = __arg1;\n");
+Obj _35val3123 = __arg1;
+pushCont(co, 5, clofun12, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#tailify-pass"));
+__arg1 = _35val3123;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label5:
 {
-Obj _35val3143 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 17, _35clofun3258, 1, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("co->args[0] = __arg0;\n");
+Obj _35val3124 = __arg1;
+pushCont(co, 0, clofun13, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#explicit-stack-pass"));
+__arg1 = _35val3124;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35val3142 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 18, _35clofun3258, 1, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("co->nargs = __nargs;\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val3141 = __arg1;
-Obj to= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 19, _35clofun3258, 1, to);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = to;
-__arg2 = makeCString("fail:\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3258) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun12) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1636,30 +2069,284 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3257(struct Cora* co){
+void clofun13(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj exp = __arg1;
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = Nil;
-__arg2 = makeCString("");
-__arg3 = Nil;
-co->args[4] = exp;
+Obj _35val3125 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#collect-lambda-pass"));
+__arg1 = _35val3125;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun13) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj exp = __arg1;
+pushCont(co, 2, clofun13, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun13) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val3119 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj obj = _35val3119;
+pushCont(co, 3, clofun13, 1, obj);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cddr"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun13) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val3120 = __arg1;
+Obj obj= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fns = _35val3120;
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#rewrite-->macro"));
+__arg1 = obj;
+__arg2 = fns;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun13) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35p1613 = __arg1;
+Obj _35p1614 = __arg2;
+Obj _35cc1615 = makeNative(5, clofun13, 0, 2, _35p1613, _35p1614);
+Obj obj = _35p1613;
+Obj _35reg3117 = primEQ(Nil, _35p1614);
+if (True == _35reg3117) {
+__nargs = 2;
+__arg1 = obj;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun13) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1615;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun13) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35cc1616 = makeNative(0, clofun14, 0, 0);
+Obj obj = closureRef(co, 0);
+Obj _35reg3112 = primIsCons(closureRef(co, 1));
+if (True == _35reg3112) {
+Obj _35reg3113 = primCar(closureRef(co, 1));
+Obj hd = _35reg3113;
+Obj _35reg3114 = primCdr(closureRef(co, 1));
+Obj more = _35reg3114;
+Obj _35reg3115 = primCons(obj, Nil);
+Obj _35reg3116 = primCons(hd, _35reg3115);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#rewrite-->macro"));
+__arg1 = _35reg3116;
+__arg2 = more;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun13) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1616;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun13) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun14(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun14) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj exp = __arg1;
+pushCont(co, 2, clofun14, 1, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#vector"));
+__arg1 = makeNumber(2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun14) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val3102 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj v = _35val3102;
+pushCont(co, 3, clofun14, 2, exp, v);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/init#vector-set!"));
+__arg1 = v;
+__arg2 = makeNumber(0);
+__arg3 = makeNumber(0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun14) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val3103 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 4, clofun14, 2, exp, v);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/init#vector-set!"));
+__arg1 = v;
+__arg2 = makeNumber(1);
+__arg3 = Nil;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun14) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val3104 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 5, clofun14, 1, v);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
+__arg1 = v;
+__arg2 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun14) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val3105 = __arg1;
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj e1 = _35val3105;
+Obj _35reg3106 = primCons(e1, Nil);
+Obj _35reg3107 = primCons(Nil, _35reg3106);
+Obj _35reg3108 = primCons(Nil, _35reg3107);
+Obj _35reg3109 = primCons(intern("lambda"), _35reg3108);
+pushCont(co, 0, clofun15, 1, v);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#append-result"));
+__arg1 = v;
+__arg2 = _35reg3109;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun14) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun15(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val3110 = __arg1;
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#vector-ref"));
+__arg1 = v;
+__arg2 = makeNumber(1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1667,13 +2354,13 @@ label1:
 {
 Obj exp = __arg1;
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
+__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
 __arg1 = Nil;
 __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1687,7 +2374,7 @@ __arg2 = globalRef(intern("cora/lib/toc#id"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -1695,338 +2382,195 @@ label3:
 {
 Obj exp = __arg1;
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
+__arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = Nil;
 __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val3077 = __arg1;
-Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj res = _35val3077;
-Obj _35reg3078 = primCons(intern("entry"), makeNumber(0));
-Obj _35reg3079 = primCons(e1, Nil);
-Obj _35reg3080 = primCons(Nil, _35reg3079);
-Obj _35reg3081 = primCons(Nil, _35reg3080);
-Obj _35reg3082 = primCons(intern("lambda"), _35reg3081);
-Obj _35reg3083 = primCons(_35reg3082, Nil);
-Obj _35reg3084 = primCons(_35reg3078, _35reg3083);
-Obj _35reg3085 = primCons(_35reg3084, Nil);
-Obj _35reg3086 = primCons(_35reg3085, res);
-__nargs = 2;
-__arg1 = _35reg3086;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3257) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj exp = __arg1;
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#parse"));
+__arg1 = Nil;
+__arg2 = makeCString("");
+__arg3 = Nil;
+co->args[4] = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val3088 = __arg1;
-Obj _35val3087= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg3089 = primCons(_35val3087, _35val3088);
-Obj res = _35reg3089;
-Obj _35reg3090 = primCons(intern("entry"), makeNumber(0));
-Obj _35reg3091 = primCons(e1, Nil);
-Obj _35reg3092 = primCons(Nil, _35reg3091);
-Obj _35reg3093 = primCons(Nil, _35reg3092);
-Obj _35reg3094 = primCons(intern("lambda"), _35reg3093);
-Obj _35reg3095 = primCons(_35reg3094, Nil);
-Obj _35reg3096 = primCons(_35reg3090, _35reg3095);
-Obj _35reg3097 = primCons(_35reg3096, Nil);
-Obj _35reg3098 = primCons(_35reg3097, res);
-__nargs = 2;
-__arg1 = _35reg3098;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3257) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label6:
-{
-Obj _35val3087 = __arg1;
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun3257, 2, _35val3087, e1);
+Obj _35p1608 = __arg1;
+Obj _35p1609 = __arg2;
+Obj _35p1610 = __arg3;
+Obj _35cc1611 = makeNative(1, clofun17, 0, 3, _35p1608, _35p1609, _35p1610);
+Obj w = _35p1608;
+Obj _35reg3037 = primIsCons(_35p1609);
+if (True == _35reg3037) {
+Obj _35reg3038 = primCar(_35p1609);
+Obj label = _35reg3038;
+Obj _35reg3039 = primCdr(_35p1609);
+Obj _35reg3040 = primIsCons(_35reg3039);
+if (True == _35reg3040) {
+Obj _35reg3041 = primCdr(_35p1609);
+Obj _35reg3042 = primCar(_35reg3041);
+Obj _35reg3043 = primIsCons(_35reg3042);
+if (True == _35reg3043) {
+Obj _35reg3044 = primCdr(_35p1609);
+Obj _35reg3045 = primCar(_35reg3044);
+Obj _35reg3046 = primCar(_35reg3045);
+Obj _35reg3047 = primEQ(intern("lambda"), _35reg3046);
+if (True == _35reg3047) {
+Obj _35reg3048 = primCdr(_35p1609);
+Obj _35reg3049 = primCar(_35reg3048);
+Obj _35reg3050 = primCdr(_35reg3049);
+Obj _35reg3051 = primIsCons(_35reg3050);
+if (True == _35reg3051) {
+Obj _35reg3052 = primCdr(_35p1609);
+Obj _35reg3053 = primCar(_35reg3052);
+Obj _35reg3054 = primCdr(_35reg3053);
+Obj _35reg3055 = primCar(_35reg3054);
+Obj params = _35reg3055;
+Obj _35reg3056 = primCdr(_35p1609);
+Obj _35reg3057 = primCar(_35reg3056);
+Obj _35reg3058 = primCdr(_35reg3057);
+Obj _35reg3059 = primCdr(_35reg3058);
+Obj _35reg3060 = primIsCons(_35reg3059);
+if (True == _35reg3060) {
+Obj _35reg3061 = primCdr(_35p1609);
+Obj _35reg3062 = primCar(_35reg3061);
+Obj _35reg3063 = primCdr(_35reg3062);
+Obj _35reg3064 = primCdr(_35reg3063);
+Obj _35reg3065 = primCar(_35reg3064);
+Obj actives = _35reg3065;
+Obj _35reg3066 = primCdr(_35p1609);
+Obj _35reg3067 = primCar(_35reg3066);
+Obj _35reg3068 = primCdr(_35reg3067);
+Obj _35reg3069 = primCdr(_35reg3068);
+Obj _35reg3070 = primCdr(_35reg3069);
+Obj _35reg3071 = primIsCons(_35reg3070);
+if (True == _35reg3071) {
+Obj _35reg3072 = primCdr(_35p1609);
+Obj _35reg3073 = primCar(_35reg3072);
+Obj _35reg3074 = primCdr(_35reg3073);
+Obj _35reg3075 = primCdr(_35reg3074);
+Obj _35reg3076 = primCdr(_35reg3075);
+Obj _35reg3077 = primCar(_35reg3076);
+Obj body = _35reg3077;
+Obj _35reg3078 = primCdr(_35p1609);
+Obj _35reg3079 = primCar(_35reg3078);
+Obj _35reg3080 = primCdr(_35reg3079);
+Obj _35reg3081 = primCdr(_35reg3080);
+Obj _35reg3082 = primCdr(_35reg3081);
+Obj _35reg3083 = primCdr(_35reg3082);
+Obj _35reg3084 = primEQ(Nil, _35reg3083);
+if (True == _35reg3084) {
+Obj _35reg3085 = primCdr(_35p1609);
+Obj _35reg3086 = primCdr(_35reg3085);
+Obj _35reg3087 = primEQ(Nil, _35reg3086);
+if (True == _35reg3087) {
+Obj maxid = _35p1610;
+pushCont(co, 0, clofun16, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#vector-ref"));
-__arg1 = v;
-__arg2 = makeNumber(2);
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("label");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val3076 = __arg1;
-Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val3076) {
-pushCont(co, 4, _35clofun3257, 1, e1);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#vector-ref"));
-__arg1 = v;
-__arg2 = makeNumber(2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 6, _35clofun3257, 2, v, e1);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#reverse"));
-__arg1 = cur;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-Obj _35val3075 = __arg1;
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj e1= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cur = _35val3075;
-pushCont(co, 7, _35clofun3257, 3, cur, v, e1);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#null?"));
-__arg1 = cur;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val3074 = __arg1;
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj e1 = _35val3074;
-pushCont(co, 8, _35clofun3257, 2, v, e1);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#vector-ref"));
-__arg1 = v;
-__arg2 = makeNumber(1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35val3073 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 9, _35clofun3257, 1, v);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
-__arg1 = v;
-__arg2 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val3072 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun3257, 2, exp, v);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#vector-set!"));
-__arg1 = v;
-__arg2 = makeNumber(2);
-__arg3 = Nil;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35val3071 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun3257, 2, exp, v);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#vector-set!"));
-__arg1 = v;
-__arg2 = makeNumber(1);
-__arg3 = Nil;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35val3070 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v = _35val3070;
-pushCont(co, 12, _35clofun3257, 2, exp, v);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#vector-set!"));
-__arg1 = v;
-__arg2 = makeNumber(0);
-__arg3 = makeNumber(0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj exp = __arg1;
-pushCont(co, 13, _35clofun3257, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#vector"));
-__arg1 = makeNumber(3);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35cc1522 = makeNative(15, _35clofun3257, 0, 0);
-Obj obj = closureRef(co, 0);
-Obj _35reg3100 = primIsCons(closureRef(co, 1));
-if (True == _35reg3100) {
-Obj _35reg3101 = primCar(closureRef(co, 1));
-Obj hd = _35reg3101;
-Obj _35reg3102 = primCdr(closureRef(co, 1));
-Obj more = _35reg3102;
-Obj _35reg3103 = primCons(obj, Nil);
-Obj _35reg3104 = primCons(hd, _35reg3103);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#rewrite-->macro"));
-__arg1 = _35reg3104;
-__arg2 = more;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1522;
+__arg0 = _35cc1611;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label17:
-{
-Obj _35p1519 = __arg1;
-Obj _35p1520 = __arg2;
-Obj _35cc1521 = makeNative(16, _35clofun3257, 0, 2, _35p1519, _35p1520);
-Obj obj = _35p1519;
-Obj _35reg3105 = primEQ(Nil, _35p1520);
-if (True == _35reg3105) {
-__nargs = 2;
-__arg1 = obj;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3257) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1521;
+__arg0 = _35cc1611;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label18:
-{
-Obj _35val3108 = __arg1;
-Obj obj= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fns = _35val3108;
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#rewrite-->macro"));
-__arg1 = obj;
-__arg2 = fns;
+} else {
+__nargs = 1;
+__arg0 = _35cc1611;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-
-label19:
-{
-Obj _35val3107 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj obj = _35val3107;
-pushCont(co, 18, _35clofun3257, 1, obj);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cddr"));
-__arg1 = exp;
+} else {
+__nargs = 1;
+__arg0 = _35cc1611;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-
-label20:
-{
-Obj exp = __arg1;
-pushCont(co, 19, _35clofun3257, 1, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = exp;
+} else {
+__nargs = 1;
+__arg0 = _35cc1611;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3257) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1611;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1611;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1611;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1611;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun15) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 fail:
@@ -2038,339 +2582,91 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3256(struct Cora* co){
+void clofun16(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj w = __arg1;
-Obj i = __arg2;
-Obj var = __arg3;
-pushCont(co, 20, _35clofun3255, 3, var, i, w);
+Obj _35val3088 = __arg1;
+Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
+Obj _35reg3089 = primSub(maxid, label);
+pushCont(co, 1, clofun16, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("Obj ");
+__arg0 = globalRef(intern("cora/lib/hash-h#mod"));
+__arg1 = _35reg3089;
+__arg2 = globalRef(intern("cora/lib/toc#*mod-num*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2995 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val3090 = __arg1;
+Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 2, clofun16, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = makeCString("];\n");
+__arg2 = _35val3090;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val2994 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun3256, 1, w);
+Obj _35val3091 = __arg1;
+Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 3, clofun16, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = i;
+__arg2 = makeCString(":\n{\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2993 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 2, _35clofun3256, 2, i, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("= co->ctx.stk.stack[co->ctx.stk.base + ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj _35val2992 = __arg1;
-Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 3, _35clofun3256, 2, i, w);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = intern("ignore");
-__arg2 = Nil;
-__arg3 = w;
-co->args[4] = var;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj w = __arg1;
-Obj i = __arg2;
-Obj var = __arg3;
-pushCont(co, 4, _35clofun3256, 3, var, i, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("Obj ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val3000 = __arg1;
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg3001 = primAdd(idx, makeNumber(1));
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
-__arg1 = fn;
-__arg2 = w;
-__arg3 = _35reg3001;
-co->args[4] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35cc1514 = makeNative(6, _35clofun3256, 0, 0);
-Obj fn = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj idx = closureRef(co, 2);
-Obj _35reg2997 = primIsCons(closureRef(co, 3));
-if (True == _35reg2997) {
-Obj _35reg2998 = primCar(closureRef(co, 3));
-Obj a = _35reg2998;
-Obj _35reg2999 = primCdr(closureRef(co, 3));
-Obj b = _35reg2999;
-pushCont(co, 7, _35clofun3256, 4, idx, fn, w, b);
-__nargs = 4;
-__arg0 = fn;
-__arg1 = w;
-__arg2 = idx;
-__arg3 = a;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1514;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label9:
-{
-Obj _35p1509 = __arg1;
-Obj _35p1510 = __arg2;
-Obj _35p1511 = __arg3;
-Obj _35p1512 = co->args[4];
-Obj _35cc1513 = makeNative(8, _35clofun3256, 0, 4, _35p1509, _35p1510, _35p1511, _35p1512);
-Obj fn = _35p1509;
-Obj w = _35p1510;
-Obj idx = _35p1511;
-Obj _35reg3002 = primEQ(Nil, _35p1512);
-if (True == _35reg3002) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3256) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1513;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val3005 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/io#display"));
-__arg1 = makeCString("\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35val3004 = __arg1;
-Obj other= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 11, _35clofun3256, 0);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/io#display"));
-__arg1 = other;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35cc1518 = makeNative(10, _35clofun3256, 0, 0);
-Obj w = closureRef(co, 0);
-Obj other = closureRef(co, 1);
-pushCont(co, 12, _35clofun3256, 1, other);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/io#display"));
-__arg1 = makeCString("wrong format of toplevel\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35val3064 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("}\n\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35val3062 = __arg1;
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg3063 = primCar(label);
-pushCont(co, 14, _35clofun3256, 1, w);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = _35reg3063;
-__arg2 = params;
-__arg3 = w;
-co->args[4] = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val3061 = __arg1;
+Obj _35val3092 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 15, _35clofun3256, 4, label, params, body, w);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
-__arg1 = globalRef(intern("cora/lib/toc#local-from-cont"));
-__arg2 = w;
-__arg3 = makeNumber(0);
-co->args[4] = actives;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val3060 = __arg1;
-Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 16, _35clofun3256, 5, actives, label, params, body, w);
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 4, clofun16, 6, actives, maxid, label, params, body, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
 __arg1 = globalRef(intern("cora/lib/toc#local-from-params"));
@@ -2380,210 +2676,172 @@ co->args[4] = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label4:
 {
-Obj _35val3059 = __arg1;
+Obj _35val3093 = __arg1;
 Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 5, clofun16, 5, maxid, label, params, body, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
+__arg1 = globalRef(intern("cora/lib/toc#local-from-cont"));
+__arg2 = w;
+__arg3 = makeNumber(0);
+co->args[4] = actives;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val3094 = __arg1;
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 17, _35clofun3256, 5, actives, label, params, body, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(":\n{\n");
+Obj _35reg3095 = primCons(maxid, label);
+pushCont(co, 0, clofun17, 1, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = _35reg3095;
+__arg2 = params;
+__arg3 = w;
+co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun16) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
-{
-Obj _35val3057 = __arg1;
-Obj actives= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg3058 = primCdr(label);
-pushCont(co, 18, _35clofun3256, 5, actives, label, params, body, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = _35reg3058;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
 }
 
-label20:
+void clofun17(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
 {
-Obj _35p1515 = __arg1;
-Obj _35p1516 = __arg2;
-Obj _35cc1517 = makeNative(13, _35clofun3256, 0, 2, _35p1515, _35p1516);
-Obj w = _35p1515;
-Obj _35reg3006 = primIsCons(_35p1516);
-if (True == _35reg3006) {
-Obj _35reg3007 = primCar(_35p1516);
-Obj label = _35reg3007;
-Obj _35reg3008 = primCdr(_35p1516);
-Obj _35reg3009 = primIsCons(_35reg3008);
-if (True == _35reg3009) {
-Obj _35reg3010 = primCdr(_35p1516);
-Obj _35reg3011 = primCar(_35reg3010);
-Obj _35reg3012 = primIsCons(_35reg3011);
-if (True == _35reg3012) {
-Obj _35reg3013 = primCdr(_35p1516);
-Obj _35reg3014 = primCar(_35reg3013);
-Obj _35reg3015 = primCar(_35reg3014);
-Obj _35reg3016 = primEQ(intern("lambda"), _35reg3015);
-if (True == _35reg3016) {
-Obj _35reg3017 = primCdr(_35p1516);
-Obj _35reg3018 = primCar(_35reg3017);
-Obj _35reg3019 = primCdr(_35reg3018);
-Obj _35reg3020 = primIsCons(_35reg3019);
-if (True == _35reg3020) {
-Obj _35reg3021 = primCdr(_35p1516);
-Obj _35reg3022 = primCar(_35reg3021);
-Obj _35reg3023 = primCdr(_35reg3022);
-Obj _35reg3024 = primCar(_35reg3023);
-Obj params = _35reg3024;
-Obj _35reg3025 = primCdr(_35p1516);
-Obj _35reg3026 = primCar(_35reg3025);
-Obj _35reg3027 = primCdr(_35reg3026);
-Obj _35reg3028 = primCdr(_35reg3027);
-Obj _35reg3029 = primIsCons(_35reg3028);
-if (True == _35reg3029) {
-Obj _35reg3030 = primCdr(_35p1516);
-Obj _35reg3031 = primCar(_35reg3030);
-Obj _35reg3032 = primCdr(_35reg3031);
-Obj _35reg3033 = primCdr(_35reg3032);
-Obj _35reg3034 = primCar(_35reg3033);
-Obj actives = _35reg3034;
-Obj _35reg3035 = primCdr(_35p1516);
-Obj _35reg3036 = primCar(_35reg3035);
-Obj _35reg3037 = primCdr(_35reg3036);
-Obj _35reg3038 = primCdr(_35reg3037);
-Obj _35reg3039 = primCdr(_35reg3038);
-Obj _35reg3040 = primIsCons(_35reg3039);
-if (True == _35reg3040) {
-Obj _35reg3041 = primCdr(_35p1516);
-Obj _35reg3042 = primCar(_35reg3041);
-Obj _35reg3043 = primCdr(_35reg3042);
-Obj _35reg3044 = primCdr(_35reg3043);
-Obj _35reg3045 = primCdr(_35reg3044);
-Obj _35reg3046 = primCar(_35reg3045);
-Obj body = _35reg3046;
-Obj _35reg3047 = primCdr(_35p1516);
-Obj _35reg3048 = primCar(_35reg3047);
-Obj _35reg3049 = primCdr(_35reg3048);
-Obj _35reg3050 = primCdr(_35reg3049);
-Obj _35reg3051 = primCdr(_35reg3050);
-Obj _35reg3052 = primCdr(_35reg3051);
-Obj _35reg3053 = primEQ(Nil, _35reg3052);
-if (True == _35reg3053) {
-Obj _35reg3054 = primCdr(_35p1516);
-Obj _35reg3055 = primCdr(_35reg3054);
-Obj _35reg3056 = primEQ(Nil, _35reg3055);
-if (True == _35reg3056) {
-pushCont(co, 19, _35clofun3256, 5, actives, label, params, body, w);
+Obj _35val3096 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString("label");
+__arg2 = makeCString("}\n\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1517;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-} else {
-__nargs = 1;
-__arg0 = _35cc1517;
+
+label1:
+{
+Obj _35cc1612 = makeNative(4, clofun17, 0, 0);
+Obj w = closureRef(co, 0);
+Obj other = closureRef(co, 1);
+Obj maxid = closureRef(co, 2);
+pushCont(co, 2, clofun17, 1, other);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/io#display"));
+__arg1 = makeCString("wrong format of toplevel\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-} else {
-__nargs = 1;
-__arg0 = _35cc1517;
+
+label2:
+{
+Obj _35val3035 = __arg1;
+Obj other= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 3, clofun17, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/io#display"));
+__arg1 = other;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-} else {
-__nargs = 1;
-__arg0 = _35cc1517;
+
+label3:
+{
+Obj _35val3036 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/io#display"));
+__arg1 = makeCString("\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-} else {
-__nargs = 1;
-__arg0 = _35cc1517;
+
+label4:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+
+label5:
+{
+Obj _35p1602 = __arg1;
+Obj _35p1603 = __arg2;
+Obj _35p1604 = __arg3;
+Obj _35p1605 = co->args[4];
+Obj _35cc1606 = makeNative(0, clofun18, 0, 4, _35p1602, _35p1603, _35p1604, _35p1605);
+Obj fn = _35p1602;
+Obj w = _35p1603;
+Obj idx = _35p1604;
+Obj _35reg3033 = primEQ(Nil, _35p1605);
+if (True == _35reg3033) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun17) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1517;
+__arg0 = _35cc1606;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1517;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1517;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1517;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3256) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun17) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -2597,138 +2855,73 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3255(struct Cora* co){
+void clofun18(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2958 = __arg1;
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2959 = primCar(label);
-pushCont(co, 20, _35clofun3254, 3, self, stacks, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
+Obj _35cc1607 = makeNative(2, clofun18, 0, 0);
+Obj fn = closureRef(co, 0);
+Obj w = closureRef(co, 1);
+Obj idx = closureRef(co, 2);
+Obj _35reg3028 = primIsCons(closureRef(co, 3));
+if (True == _35reg3028) {
+Obj _35reg3029 = primCar(closureRef(co, 3));
+Obj a = _35reg3029;
+Obj _35reg3030 = primCdr(closureRef(co, 3));
+Obj b = _35reg3030;
+pushCont(co, 1, clofun18, 4, idx, fn, w, b);
+__nargs = 4;
+__arg0 = fn;
 __arg1 = w;
-__arg2 = _35reg2959;
+__arg2 = idx;
+__arg3 = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1607;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label1:
 {
-Obj _35val2957 = __arg1;
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3255, 4, label, self, stacks, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(", ");
+Obj _35val3031 = __arg1;
+Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg3032 = primAdd(idx, makeNumber(1));
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-call-args-reverse"));
+__arg1 = fn;
+__arg2 = w;
+__arg3 = _35reg3032;
+co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
-{
-Obj _35val2955 = __arg1;
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2956 = primCdr(label);
-pushCont(co, 1, _35clofun3255, 4, label, self, stacks, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = _35reg2956;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj _35p1498 = __arg1;
-Obj _35p1499 = __arg2;
-Obj _35p1500 = __arg3;
-Obj _35cc1501 = makeNative(12, _35clofun3254, 0, 0);
-Obj self = _35p1498;
-Obj w = _35p1499;
-Obj _35reg2946 = primIsCons(_35p1500);
-if (True == _35reg2946) {
-Obj _35reg2947 = primCar(_35p1500);
-Obj _35reg2948 = primEQ(intern("%continuation"), _35reg2947);
-if (True == _35reg2948) {
-Obj _35reg2949 = primCdr(_35p1500);
-Obj _35reg2950 = primIsCons(_35reg2949);
-if (True == _35reg2950) {
-Obj _35reg2951 = primCdr(_35p1500);
-Obj _35reg2952 = primCar(_35reg2951);
-Obj label = _35reg2952;
-Obj _35reg2953 = primCdr(_35p1500);
-Obj _35reg2954 = primCdr(_35reg2953);
-Obj stacks = _35reg2954;
-pushCont(co, 2, _35clofun3255, 4, label, self, stacks, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("pushCont(co, ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1501;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1501;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1501;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label4:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -2736,155 +2929,405 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj w = __arg1;
+Obj i = __arg2;
+Obj var = __arg3;
+pushCont(co, 4, clofun18, 3, var, i, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("Obj ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val3023 = __arg1;
+Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 5, clofun18, 2, i, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = intern("ignore");
+__arg2 = Nil;
+__arg3 = w;
+co->args[4] = var;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val2975 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst-list-h"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = fn;
-co->args[4] = w;
-co->args[5] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val2973 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2974 = primNot(_35val2973);
-if (True == _35reg2974) {
-pushCont(co, 5, _35clofun3255, 5, self, env, fn, w, b);
+Obj _35val3024 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, clofun19, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString(", ");
+__arg2 = makeCString("= co->ctx.stk.stack[co->ctx.stk.base + ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Nil;
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst-list-h"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = fn;
-co->args[4] = w;
-co->args[5] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label7:
-{
-Obj _35val2972 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 6, _35clofun3255, 5, self, env, fn, w, b);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#null?"));
-__arg1 = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun18) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
-{
-Obj _35cc1508 = makeNative(4, _35clofun3255, 0, 0);
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj fn = closureRef(co, 2);
-Obj w = closureRef(co, 3);
-Obj _35reg2969 = primIsCons(closureRef(co, 4));
-if (True == _35reg2969) {
-Obj _35reg2970 = primCar(closureRef(co, 4));
-Obj a = _35reg2970;
-Obj _35reg2971 = primCdr(closureRef(co, 4));
-Obj b = _35reg2971;
-pushCont(co, 7, _35clofun3255, 5, self, env, fn, w, b);
-__nargs = 5;
-__arg0 = fn;
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = a;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1508;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
 }
 
-label9:
-{
-Obj _35p1502 = __arg1;
-Obj _35p1503 = __arg2;
-Obj _35p1504 = __arg3;
-Obj _35p1505 = co->args[4];
-Obj _35p1506 = co->args[5];
-Obj _35cc1507 = makeNative(8, _35clofun3255, 0, 5, _35p1502, _35p1503, _35p1504, _35p1505, _35p1506);
-Obj self = _35p1502;
-Obj env = _35p1503;
-Obj fn = _35p1504;
-Obj w = _35p1505;
-Obj _35reg2976 = primEQ(Nil, _35p1506);
-if (True == _35reg2976) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3255) { goto fail; }
+void clofun19(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1507;
+
+label0:
+{
+Obj _35val3025 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 1, clofun19, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = i;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val3026 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("];\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj w = __arg1;
+Obj i = __arg2;
+Obj var = __arg3;
+pushCont(co, 3, clofun19, 3, var, i, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("Obj ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val3015 = __arg1;
+Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 4, clofun19, 2, i, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = intern("ignore");
+__arg2 = Nil;
+__arg3 = w;
+co->args[4] = var;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val3016 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg3017 = primLT(i, makeNumber(4));
+if (True == _35reg3017) {
+pushCont(co, 1, clofun20, 2, i, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(" = __arg");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 5, clofun19, 2, i, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(" = co->args[");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label10:
+label5:
+{
+Obj _35val3020 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, clofun20, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = i;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun19) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun20(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val3021 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("];\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val3018 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 2, clofun20, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = i;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val3019 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(";\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj w = __arg1;
+Obj label = __arg2;
+Obj maxid = __arg3;
+pushCont(co, 4, clofun20, 3, label, maxid, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("void ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val3011 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj maxid= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 5, clofun20, 1, w);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#generate-group-name"));
+__arg1 = w;
+__arg2 = label;
+__arg3 = maxid;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val3012 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 0, clofun21, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("(struct Cora* co");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun20) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun21(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val3013 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj w = __arg1;
+Obj label = __arg2;
+Obj maxid = __arg3;
+Obj _35reg3006 = primSub(maxid, label);
+Obj _35reg3007 = primDiv(_35reg3006, globalRef(intern("cora/lib/toc#*mod-num*")));
+Obj gid = _35reg3007;
+Obj _35reg3008 = primEQ(gid, makeNumber(0));
+if (True == _35reg3008) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("entry");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 2, clofun21, 2, w, gid);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("clofun");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35val3009 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj gid= co->ctx.stk.stack[co->ctx.stk.base + 1];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = gid;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
 {
 Obj self = __arg1;
 Obj env = __arg2;
@@ -2900,187 +3343,265 @@ co->args[5] = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label4:
 {
-Obj _35val2982 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(")");
+Obj _35p1595 = __arg1;
+Obj _35p1596 = __arg2;
+Obj _35p1597 = __arg3;
+Obj _35p1598 = co->args[4];
+Obj _35p1599 = co->args[5];
+Obj _35cc1600 = makeNative(5, clofun21, 0, 5, _35p1595, _35p1596, _35p1597, _35p1598, _35p1599);
+Obj self = _35p1595;
+Obj env = _35p1596;
+Obj fn = _35p1597;
+Obj w = _35p1598;
+Obj _35reg3002 = primEQ(Nil, _35p1599);
+if (True == _35reg3002) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun21) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1600;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
-label12:
+label5:
 {
-Obj _35val2981 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 11, _35clofun3255, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("(struct Cora* co");
+Obj _35cc1601 = makeNative(3, clofun22, 0, 0);
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj fn = closureRef(co, 2);
+Obj w = closureRef(co, 3);
+Obj _35reg2995 = primIsCons(closureRef(co, 4));
+if (True == _35reg2995) {
+Obj _35reg2996 = primCar(closureRef(co, 4));
+Obj a = _35reg2996;
+Obj _35reg2997 = primCdr(closureRef(co, 4));
+Obj b = _35reg2997;
+pushCont(co, 0, clofun22, 5, self, env, fn, w, b);
+__nargs = 5;
+__arg0 = fn;
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1601;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun21) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun22(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2998 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 1, clofun22, 5, self, env, fn, w, b);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#null?"));
+__arg1 = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label1:
+{
+Obj _35val2999 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj _35reg3000 = primNot(_35val2999);
+if (True == _35reg3000) {
+pushCont(co, 2, clofun22, 5, self, env, fn, w, b);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Nil;
+__nargs = 6;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst-list-h"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = fn;
+co->args[4] = w;
+co->args[5] = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35val3001 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fn= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 4];
+__nargs = 6;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst-list-h"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = fn;
+co->args[4] = w;
+co->args[5] = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35p1591 = __arg1;
+Obj _35p1592 = __arg2;
+Obj _35p1593 = __arg3;
+Obj _35cc1594 = makeNative(5, clofun24, 0, 0);
+Obj self = _35p1591;
+Obj w = _35p1592;
+Obj _35reg2970 = primIsCons(_35p1593);
+if (True == _35reg2970) {
+Obj _35reg2971 = primCar(_35p1593);
+Obj _35reg2972 = primEQ(intern("%continuation"), _35reg2971);
+if (True == _35reg2972) {
+Obj _35reg2973 = primCdr(_35p1593);
+Obj _35reg2974 = primIsCons(_35reg2973);
+if (True == _35reg2974) {
+Obj _35reg2975 = primCdr(_35p1593);
+Obj _35reg2976 = primCar(_35reg2975);
+Obj label = _35reg2976;
+Obj _35reg2977 = primCdr(_35p1593);
+Obj _35reg2978 = primCdr(_35reg2977);
+Obj stacks = _35reg2978;
+pushCont(co, 5, clofun22, 4, label, self, stacks, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("pushCont(co, ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1594;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1594;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1594;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
 {
 Obj _35val2979 = __arg1;
 Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2980 = primCar(label);
-pushCont(co, 12, _35clofun3255, 1, w);
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg2980 = primCar(self);
+Obj _35reg2981 = primSub(_35reg2980, label);
+pushCont(co, 0, clofun23, 4, label, self, stacks, w);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
-__arg1 = w;
-__arg2 = _35reg2980;
+__arg0 = globalRef(intern("cora/lib/hash-h#mod"));
+__arg1 = _35reg2981;
+__arg2 = globalRef(intern("cora/lib/toc#*mod-num*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj w = __arg1;
-Obj label = __arg2;
-pushCont(co, 13, _35clofun3255, 2, label, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("void ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35val2988 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(";\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val2987 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 15, _35clofun3255, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = i;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val2990 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("];\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val2989 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 17, _35clofun3255, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = i;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35val2985 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2986 = primLT(i, makeNumber(4));
-if (True == _35reg2986) {
-pushCont(co, 16, _35clofun3255, 2, i, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(" = __arg");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 18, _35clofun3255, 2, i, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(" = co->args[");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
-{
-Obj _35val2984 = __arg1;
-Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 19, _35clofun3255, 2, i, w);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = intern("ignore");
-__arg2 = Nil;
-__arg3 = w;
-co->args[4] = var;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3255) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun22) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3093,465 +3614,231 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3254(struct Cora* co){
+void clofun23(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1488 = makeNative(11, _35clofun3253, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj w = closureRef(co, 2);
-Obj _35reg2883 = primIsCons(closureRef(co, 3));
-if (True == _35reg2883) {
-Obj _35reg2884 = primCar(closureRef(co, 3));
-Obj _35reg2885 = primEQ(intern("%const"), _35reg2884);
-if (True == _35reg2885) {
-Obj _35reg2886 = primCdr(closureRef(co, 3));
-Obj _35reg2887 = primIsCons(_35reg2886);
-if (True == _35reg2887) {
-Obj _35reg2888 = primCdr(closureRef(co, 3));
-Obj _35reg2889 = primCar(_35reg2888);
-Obj x = _35reg2889;
-Obj _35reg2890 = primCdr(closureRef(co, 3));
-Obj _35reg2891 = primCdr(_35reg2890);
-Obj _35reg2892 = primEQ(Nil, _35reg2891);
-if (True == _35reg2892) {
-Obj _35reg2893 = primIsSymbol(x);
-if (True == _35reg2893) {
-pushCont(co, 14, _35clofun3253, 2, x, w);
+Obj _35val2982 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 1, clofun23, 4, label, self, stacks, w);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = makeCString("intern(\"");
+__arg2 = _35val2982;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun23) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-pushCont(co, 20, _35clofun3253, 2, x, w);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#number?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1488;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1488;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1488;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1488;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label1:
 {
-Obj _35val2918 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2983 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 2, clofun23, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString(")");
+__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun23) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val2917 = __arg1;
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun3254, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+Obj _35val2984 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg2985 = primCar(self);
+pushCont(co, 3, clofun23, 3, self, stacks, w);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#generate-group-name"));
 __arg1 = w;
-__arg2 = idx;
+__arg2 = label;
+__arg3 = _35reg2985;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun23) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc1487 = makeNative(0, _35clofun3254, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj w = closureRef(co, 2);
-Obj _35reg2907 = primIsCons(closureRef(co, 3));
-if (True == _35reg2907) {
-Obj _35reg2908 = primCar(closureRef(co, 3));
-Obj _35reg2909 = primEQ(intern("%stack-ref"), _35reg2908);
-if (True == _35reg2909) {
-Obj _35reg2910 = primCdr(closureRef(co, 3));
-Obj _35reg2911 = primIsCons(_35reg2910);
-if (True == _35reg2911) {
-Obj _35reg2912 = primCdr(closureRef(co, 3));
-Obj _35reg2913 = primCar(_35reg2912);
-Obj idx = _35reg2913;
-Obj _35reg2914 = primCdr(closureRef(co, 3));
-Obj _35reg2915 = primCdr(_35reg2914);
-Obj _35reg2916 = primEQ(Nil, _35reg2915);
-if (True == _35reg2916) {
-pushCont(co, 2, _35clofun3254, 2, idx, w);
+Obj _35val2986 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 4, clofun23, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString("stackRef(co, ");
+__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun23) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1487;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1487;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1487;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1487;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label4:
 {
-Obj _35val2930 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(")");
+Obj _35val2987 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 5, clofun23, 3, self, stacks, w);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#length"));
+__arg1 = stacks;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun23) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val2929 = __arg1;
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun3254, 1, w);
+Obj _35val2988 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 0, clofun24, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = idx;
+__arg2 = _35val2988;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun23) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun24(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
 {
-Obj _35cc1486 = makeNative(3, _35clofun3254, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj w = closureRef(co, 2);
-Obj _35reg2919 = primIsCons(closureRef(co, 3));
-if (True == _35reg2919) {
-Obj _35reg2920 = primCar(closureRef(co, 3));
-Obj _35reg2921 = primEQ(intern("%closure-ref"), _35reg2920);
-if (True == _35reg2921) {
-Obj _35reg2922 = primCdr(closureRef(co, 3));
-Obj _35reg2923 = primIsCons(_35reg2922);
-if (True == _35reg2923) {
-Obj _35reg2924 = primCdr(closureRef(co, 3));
-Obj _35reg2925 = primCar(_35reg2924);
-Obj idx = _35reg2925;
-Obj _35reg2926 = primCdr(closureRef(co, 3));
-Obj _35reg2927 = primCdr(_35reg2926);
-Obj _35reg2928 = primEQ(Nil, _35reg2927);
-if (True == _35reg2928) {
-pushCont(co, 5, _35clofun3254, 2, idx, w);
+Obj _35val2989 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 1, clofun24, 3, self, stacks, w);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#null?"));
+__arg1 = stacks;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2990 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg2991 = primNot(_35val2990);
+if (True == _35reg2991) {
+pushCont(co, 2, clofun24, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#for-each"));
+__arg1 = makeNative(3, clofun24, 1, 2, self, w);
+__arg2 = stacks;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Nil;
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString("closureRef(co, ");
+__arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1486;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1486;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1486;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1486;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label7:
+label2:
 {
-Obj _35val2943 = __arg1;
+Obj _35val2993 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString("\"))");
+__arg2 = makeCString(");\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label8:
+label3:
 {
-Obj _35val2942 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 7, _35clofun3254, 1, w);
+Obj x = __arg1;
+pushCont(co, 4, clofun24, 1, x);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = _35val2942;
+__arg1 = closureRef(co, 1);
+__arg2 = makeCString(", ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label9:
+label4:
 {
-Obj _35val2941 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun3254, 1, w);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#symbol->string"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35cc1485 = makeNative(6, _35clofun3254, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj w = closureRef(co, 2);
-Obj _35reg2931 = primIsCons(closureRef(co, 3));
-if (True == _35reg2931) {
-Obj _35reg2932 = primCar(closureRef(co, 3));
-Obj _35reg2933 = primEQ(intern("%global"), _35reg2932);
-if (True == _35reg2933) {
-Obj _35reg2934 = primCdr(closureRef(co, 3));
-Obj _35reg2935 = primIsCons(_35reg2934);
-if (True == _35reg2935) {
-Obj _35reg2936 = primCdr(closureRef(co, 3));
-Obj _35reg2937 = primCar(_35reg2936);
-Obj x = _35reg2937;
-Obj _35reg2938 = primCdr(closureRef(co, 3));
-Obj _35reg2939 = primCdr(_35reg2938);
-Obj _35reg2940 = primEQ(Nil, _35reg2939);
-if (True == _35reg2940) {
-pushCont(co, 9, _35clofun3254, 2, x, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("globalRef(intern(\"");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1485;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1485;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1485;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1485;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label11:
-{
-Obj _35p1480 = __arg1;
-Obj _35p1481 = __arg2;
-Obj _35p1482 = __arg3;
-Obj _35p1483 = co->args[4];
-Obj _35cc1484 = makeNative(10, _35clofun3254, 0, 4, _35p1480, _35p1481, _35p1482, _35p1483);
-Obj self = _35p1480;
-Obj env = _35p1481;
-Obj w = _35p1482;
-Obj x = _35p1483;
-Obj _35reg2944 = primIsSymbol(x);
-if (True == _35reg2944) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
-__arg1 = w;
-__arg2 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1484;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35val2966 = __arg1;
+Obj _35val2992 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
@@ -3562,139 +3849,19 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label5:
 {
-Obj x = __arg1;
-pushCont(co, 13, _35clofun3254, 1, x);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = closureRef(co, 1);
-__arg2 = makeCString(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35val2967 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(");\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val2964 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2965 = primNot(_35val2964);
-if (True == _35reg2965) {
-pushCont(co, 15, _35clofun3254, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#for-each"));
-__arg1 = makeNative(14, _35clofun3254, 1, 2, self, w);
-__arg2 = stacks;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Nil;
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(");\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label17:
-{
-Obj _35val2963 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 16, _35clofun3254, 3, self, stacks, w);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/init#null?"));
-__arg1 = stacks;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val2962 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 17, _35clofun3254, 3, self, stacks, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = _35val2962;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35val2961 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 18, _35clofun3254, 3, self, stacks, w);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = stacks;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val2960 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj stacks= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 19, _35clofun3254, 3, self, stacks, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3254) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun24) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -3707,490 +3874,275 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3253(struct Cora* co){
+void clofun25(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1490 = makeNative(14, _35clofun3252, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj w = closureRef(co, 2);
-Obj _35reg2820 = primIsCons(closureRef(co, 3));
-if (True == _35reg2820) {
-Obj _35reg2821 = primCar(closureRef(co, 3));
-Obj _35reg2822 = primIsCons(_35reg2821);
-if (True == _35reg2822) {
-Obj _35reg2823 = primCar(closureRef(co, 3));
-Obj _35reg2824 = primCar(_35reg2823);
-Obj _35reg2825 = primEQ(intern("%builtin"), _35reg2824);
-if (True == _35reg2825) {
-Obj _35reg2826 = primCar(closureRef(co, 3));
-Obj _35reg2827 = primCdr(_35reg2826);
-Obj _35reg2828 = primIsCons(_35reg2827);
-if (True == _35reg2828) {
-Obj _35reg2829 = primCar(closureRef(co, 3));
-Obj _35reg2830 = primCdr(_35reg2829);
-Obj _35reg2831 = primCar(_35reg2830);
-Obj f = _35reg2831;
-Obj _35reg2832 = primCar(closureRef(co, 3));
-Obj _35reg2833 = primCdr(_35reg2832);
-Obj _35reg2834 = primCdr(_35reg2833);
-Obj _35reg2835 = primEQ(Nil, _35reg2834);
-if (True == _35reg2835) {
-Obj _35reg2836 = primCdr(closureRef(co, 3));
-Obj args = _35reg2836;
-pushCont(co, 20, _35clofun3252, 5, f, self, env, args, w);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#builtin->name"));
-__arg1 = f;
+Obj _35p1573 = __arg1;
+Obj _35p1574 = __arg2;
+Obj _35p1575 = __arg3;
+Obj _35p1576 = co->args[4];
+Obj _35cc1577 = makeNative(1, clofun25, 0, 4, _35p1573, _35p1574, _35p1575, _35p1576);
+Obj self = _35p1573;
+Obj env = _35p1574;
+Obj w = _35p1575;
+Obj x = _35p1576;
+Obj _35reg2968 = primIsSymbol(x);
+if (True == _35reg2968) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
+__arg1 = w;
+__arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1490;
+__arg0 = _35cc1577;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1490;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1490;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1490;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1490;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35val2876 = __arg1;
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2877 = primCons(a, env);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = self;
-__arg2 = _35reg2877;
-__arg3 = w;
-co->args[4] = c;
+Obj _35cc1578 = makeNative(5, clofun25, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj w = closureRef(co, 2);
+Obj _35reg2955 = primIsCons(closureRef(co, 3));
+if (True == _35reg2955) {
+Obj _35reg2956 = primCar(closureRef(co, 3));
+Obj _35reg2957 = primEQ(intern("%global"), _35reg2956);
+if (True == _35reg2957) {
+Obj _35reg2958 = primCdr(closureRef(co, 3));
+Obj _35reg2959 = primIsCons(_35reg2958);
+if (True == _35reg2959) {
+Obj _35reg2960 = primCdr(closureRef(co, 3));
+Obj _35reg2961 = primCar(_35reg2960);
+Obj x = _35reg2961;
+Obj _35reg2962 = primCdr(closureRef(co, 3));
+Obj _35reg2963 = primCdr(_35reg2962);
+Obj _35reg2964 = primEQ(Nil, _35reg2963);
+if (True == _35reg2964) {
+pushCont(co, 2, clofun25, 2, x, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("globalRef(intern(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1578;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1578;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1578;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1578;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label2:
 {
-Obj _35val2875 = __arg1;
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 1, _35clofun3253, 5, a, env, self, w, c);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(";\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj _35val2874 = __arg1;
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 2, _35clofun3253, 5, a, env, self, w, c);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj _35val2873 = __arg1;
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 3, _35clofun3253, 6, b, a, env, self, w, c);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(" = ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35val2872 = __arg1;
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 4, _35clofun3253, 6, b, a, env, self, w, c);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
-__arg1 = w;
-__arg2 = a;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val2881 = __arg1;
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2882 = primCons(a, env);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = self;
-__arg2 = _35reg2882;
-__arg3 = w;
-co->args[4] = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val2880 = __arg1;
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 6, _35clofun3253, 5, a, env, self, w, c);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(";\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35val2879 = __arg1;
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 7, _35clofun3253, 5, a, env, self, w, c);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val2878 = __arg1;
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 8, _35clofun3253, 6, b, a, env, self, w, c);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(" = ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35val2870 = __arg1;
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj idx = _35val2870;
-Obj _35reg2871 = primLT(idx, makeNumber(0));
-if (True == _35reg2871) {
-pushCont(co, 5, _35clofun3253, 6, b, a, env, self, w, c);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("Obj ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Nil;
-pushCont(co, 9, _35clofun3253, 6, b, a, env, self, w, c);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
-__arg1 = w;
-__arg2 = a;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label11:
-{
-Obj _35cc1489 = makeNative(0, _35clofun3253, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj w = closureRef(co, 2);
-Obj _35reg2844 = primIsCons(closureRef(co, 3));
-if (True == _35reg2844) {
-Obj _35reg2845 = primCar(closureRef(co, 3));
-Obj _35reg2846 = primEQ(intern("let"), _35reg2845);
-if (True == _35reg2846) {
-Obj _35reg2847 = primCdr(closureRef(co, 3));
-Obj _35reg2848 = primIsCons(_35reg2847);
-if (True == _35reg2848) {
-Obj _35reg2849 = primCdr(closureRef(co, 3));
-Obj _35reg2850 = primCar(_35reg2849);
-Obj a = _35reg2850;
-Obj _35reg2851 = primCdr(closureRef(co, 3));
-Obj _35reg2852 = primCdr(_35reg2851);
-Obj _35reg2853 = primIsCons(_35reg2852);
-if (True == _35reg2853) {
-Obj _35reg2854 = primCdr(closureRef(co, 3));
-Obj _35reg2855 = primCdr(_35reg2854);
-Obj _35reg2856 = primCar(_35reg2855);
-Obj b = _35reg2856;
-Obj _35reg2857 = primCdr(closureRef(co, 3));
-Obj _35reg2858 = primCdr(_35reg2857);
-Obj _35reg2859 = primCdr(_35reg2858);
-Obj _35reg2860 = primIsCons(_35reg2859);
-if (True == _35reg2860) {
-Obj _35reg2861 = primCdr(closureRef(co, 3));
-Obj _35reg2862 = primCdr(_35reg2861);
-Obj _35reg2863 = primCdr(_35reg2862);
-Obj _35reg2864 = primCar(_35reg2863);
-Obj c = _35reg2864;
-Obj _35reg2865 = primCdr(closureRef(co, 3));
-Obj _35reg2866 = primCdr(_35reg2865);
-Obj _35reg2867 = primCdr(_35reg2866);
-Obj _35reg2868 = primCdr(_35reg2867);
-Obj _35reg2869 = primEQ(Nil, _35reg2868);
-if (True == _35reg2869) {
-pushCont(co, 10, _35clofun3253, 6, b, a, env, self, w, c);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#index"));
-__arg1 = a;
-__arg2 = env;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1489;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1489;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1489;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1489;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1489;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1489;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35val2896 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("\")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35val2895 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 12, _35clofun3253, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = _35val2895;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35val2894 = __arg1;
+Obj _35val2965 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 13, _35clofun3253, 1, w);
+pushCont(co, 3, clofun25, 1, w);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label15:
+label3:
 {
-Obj _35val2899 = __arg1;
+Obj _35val2966 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 4, clofun25, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = _35val2966;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val2967 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("\"))");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35cc1579 = makeNative(2, clofun26, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj w = closureRef(co, 2);
+Obj _35reg2943 = primIsCons(closureRef(co, 3));
+if (True == _35reg2943) {
+Obj _35reg2944 = primCar(closureRef(co, 3));
+Obj _35reg2945 = primEQ(intern("%closure-ref"), _35reg2944);
+if (True == _35reg2945) {
+Obj _35reg2946 = primCdr(closureRef(co, 3));
+Obj _35reg2947 = primIsCons(_35reg2946);
+if (True == _35reg2947) {
+Obj _35reg2948 = primCdr(closureRef(co, 3));
+Obj _35reg2949 = primCar(_35reg2948);
+Obj idx = _35reg2949;
+Obj _35reg2950 = primCdr(closureRef(co, 3));
+Obj _35reg2951 = primCdr(_35reg2950);
+Obj _35reg2952 = primEQ(Nil, _35reg2951);
+if (True == _35reg2952) {
+pushCont(co, 0, clofun26, 2, idx, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("closureRef(co, ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1579;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1579;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1579;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1579;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun25) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun26(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2953 = __arg1;
+Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 1, clofun26, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = idx;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2954 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
@@ -4199,152 +4151,190 @@ __arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label16:
+label2:
 {
-Obj _35val2898 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1580 = makeNative(5, clofun26, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj w = closureRef(co, 2);
+Obj _35reg2931 = primIsCons(closureRef(co, 3));
+if (True == _35reg2931) {
+Obj _35reg2932 = primCar(closureRef(co, 3));
+Obj _35reg2933 = primEQ(intern("%stack-ref"), _35reg2932);
+if (True == _35reg2933) {
+Obj _35reg2934 = primCdr(closureRef(co, 3));
+Obj _35reg2935 = primIsCons(_35reg2934);
+if (True == _35reg2935) {
+Obj _35reg2936 = primCdr(closureRef(co, 3));
+Obj _35reg2937 = primCar(_35reg2936);
+Obj idx = _35reg2937;
+Obj _35reg2938 = primCdr(closureRef(co, 3));
+Obj _35reg2939 = primCdr(_35reg2938);
+Obj _35reg2940 = primEQ(Nil, _35reg2939);
+if (True == _35reg2940) {
+pushCont(co, 3, clofun26, 2, idx, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("stackRef(co, ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1580;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1580;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1580;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1580;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35val2941 = __arg1;
+Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 15, _35clofun3253, 1, w);
+pushCont(co, 4, clofun26, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = x;
+__arg2 = idx;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label4:
 {
-Obj _35val2903 = __arg1;
+Obj _35val2942 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString("\")");
+__arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label18:
+label5:
 {
-Obj _35val2902 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 17, _35clofun3253, 1, w);
+Obj _35cc1581 = makeNative(3, clofun28, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj w = closureRef(co, 2);
+Obj _35reg2907 = primIsCons(closureRef(co, 3));
+if (True == _35reg2907) {
+Obj _35reg2908 = primCar(closureRef(co, 3));
+Obj _35reg2909 = primEQ(intern("%const"), _35reg2908);
+if (True == _35reg2909) {
+Obj _35reg2910 = primCdr(closureRef(co, 3));
+Obj _35reg2911 = primIsCons(_35reg2910);
+if (True == _35reg2911) {
+Obj _35reg2912 = primCdr(closureRef(co, 3));
+Obj _35reg2913 = primCar(_35reg2912);
+Obj x = _35reg2913;
+Obj _35reg2914 = primCdr(closureRef(co, 3));
+Obj _35reg2915 = primCdr(_35reg2914);
+Obj _35reg2916 = primEQ(Nil, _35reg2915);
+if (True == _35reg2916) {
+Obj _35reg2917 = primIsSymbol(x);
+if (True == _35reg2917) {
+pushCont(co, 0, clofun28, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = _35val2902;
+__arg2 = makeCString("intern(\"");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35val2901 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 18, _35clofun3253, 1, w);
+} else {
+pushCont(co, 0, clofun27, 2, x, w);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc/internal#escape-str"));
+__arg0 = globalRef(intern("cora/init#number?"));
 __arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-
-label20:
-{
-Obj _35val2897 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2897) {
-pushCont(co, 16, _35clofun3253, 2, x, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("makeNumber(");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 } else {
-Obj _35reg2900 = primIsString(x);
-if (True == _35reg2900) {
-pushCont(co, 19, _35clofun3253, 2, x, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("makeCString(\"");
+__nargs = 1;
+__arg0 = _35cc1581;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2904 = primEQ(x, Nil);
-if (True == _35reg2904) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("Nil");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2905 = primEQ(x, True);
-if (True == _35reg2905) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("True");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2906 = primEQ(x, False);
-if (True == _35reg2906) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("False");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no cond match");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3253) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = _35cc1581;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
+} else {
+__nargs = 1;
+__arg0 = _35cc1581;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
-}
+} else {
+__nargs = 1;
+__arg0 = _35cc1581;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun26) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 }
 
@@ -4357,300 +4347,439 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3252(struct Cora* co){
+void clofun27(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2781 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 20, _35clofun3251, 4, self, env, frees, w);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = frees;
+Obj _35val2921 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val2921) {
+pushCont(co, 4, clofun27, 2, x, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("makeNumber(");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+Obj _35reg2924 = primIsString(x);
+if (True == _35reg2924) {
+pushCont(co, 1, clofun27, 2, x, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("makeCString(\"");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2928 = primEQ(x, Nil);
+if (True == _35reg2928) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("Nil");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2929 = primEQ(x, True);
+if (True == _35reg2929) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("True");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2930 = primEQ(x, False);
+if (True == _35reg2930) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("False");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no cond match");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+}
+}
 }
 
 label1:
 {
-Obj _35val2780 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 0, _35clofun3252, 4, self, env, frees, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(", ");
+Obj _35val2925 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 2, clofun27, 1, w);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc/internal#escape-str"));
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val2779 = __arg1;
-Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 1, _35clofun3252, 4, self, env, frees, w);
+Obj _35val2926 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 3, clofun27, 1, w);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = nargs;
+__arg2 = _35val2926;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2778 = __arg1;
-Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 2, _35clofun3252, 5, nargs, self, env, frees, w);
+Obj _35val2927 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString(", ");
+__arg2 = makeCString("\")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val2776 = __arg1;
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj _35reg2777 = primCar(label);
-pushCont(co, 3, _35clofun3252, 5, nargs, self, env, frees, w);
+Obj _35val2922 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 5, clofun27, 1, w);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = _35reg2777;
+__arg2 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val2775 = __arg1;
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 4, _35clofun3252, 6, label, nargs, self, env, frees, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val2773 = __arg1;
-Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj _35reg2774 = primCdr(label);
-pushCont(co, 5, _35clofun3252, 6, label, nargs, self, env, frees, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = _35reg2774;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35cc1492 = makeNative(15, _35clofun3251, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj w = closureRef(co, 2);
-Obj _35reg2757 = primIsCons(closureRef(co, 3));
-if (True == _35reg2757) {
-Obj _35reg2758 = primCar(closureRef(co, 3));
-Obj _35reg2759 = primEQ(intern("%closure"), _35reg2758);
-if (True == _35reg2759) {
-Obj _35reg2760 = primCdr(closureRef(co, 3));
-Obj _35reg2761 = primIsCons(_35reg2760);
-if (True == _35reg2761) {
-Obj _35reg2762 = primCdr(closureRef(co, 3));
-Obj _35reg2763 = primCar(_35reg2762);
-Obj label = _35reg2763;
-Obj _35reg2764 = primCdr(closureRef(co, 3));
-Obj _35reg2765 = primCdr(_35reg2764);
-Obj _35reg2766 = primIsCons(_35reg2765);
-if (True == _35reg2766) {
-Obj _35reg2767 = primCdr(closureRef(co, 3));
-Obj _35reg2768 = primCdr(_35reg2767);
-Obj _35reg2769 = primCar(_35reg2768);
-Obj nargs = _35reg2769;
-Obj _35reg2770 = primCdr(closureRef(co, 3));
-Obj _35reg2771 = primCdr(_35reg2770);
-Obj _35reg2772 = primCdr(_35reg2771);
-Obj frees = _35reg2772;
-pushCont(co, 6, _35clofun3252, 6, label, nargs, self, env, frees, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("makeNative(");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1492;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1492;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1492;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1492;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-Obj _35val2819 = __arg1;
+Obj _35val2923 = __arg1;
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString("}\n");
+__arg2 = makeCString(")");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun27) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label9:
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun28(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
 {
-Obj _35val2818 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 8, _35clofun3252, 1, w);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = c;
+Obj _35val2918 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 1, clofun28, 1, w);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#symbol->string"));
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label10:
+label1:
 {
-Obj _35val2817 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 9, _35clofun3252, 4, self, env, c, w);
+Obj _35val2919 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 2, clofun28, 1, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString("} else {\n");
+__arg2 = _35val2919;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label2:
 {
-Obj _35val2816 = __arg1;
+Obj _35val2920 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("\")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35cc1582 = makeNative(2, clofun30, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj w = closureRef(co, 2);
+Obj _35reg2868 = primIsCons(closureRef(co, 3));
+if (True == _35reg2868) {
+Obj _35reg2869 = primCar(closureRef(co, 3));
+Obj _35reg2870 = primEQ(intern("let"), _35reg2869);
+if (True == _35reg2870) {
+Obj _35reg2871 = primCdr(closureRef(co, 3));
+Obj _35reg2872 = primIsCons(_35reg2871);
+if (True == _35reg2872) {
+Obj _35reg2873 = primCdr(closureRef(co, 3));
+Obj _35reg2874 = primCar(_35reg2873);
+Obj a = _35reg2874;
+Obj _35reg2875 = primCdr(closureRef(co, 3));
+Obj _35reg2876 = primCdr(_35reg2875);
+Obj _35reg2877 = primIsCons(_35reg2876);
+if (True == _35reg2877) {
+Obj _35reg2878 = primCdr(closureRef(co, 3));
+Obj _35reg2879 = primCdr(_35reg2878);
+Obj _35reg2880 = primCar(_35reg2879);
+Obj b = _35reg2880;
+Obj _35reg2881 = primCdr(closureRef(co, 3));
+Obj _35reg2882 = primCdr(_35reg2881);
+Obj _35reg2883 = primCdr(_35reg2882);
+Obj _35reg2884 = primIsCons(_35reg2883);
+if (True == _35reg2884) {
+Obj _35reg2885 = primCdr(closureRef(co, 3));
+Obj _35reg2886 = primCdr(_35reg2885);
+Obj _35reg2887 = primCdr(_35reg2886);
+Obj _35reg2888 = primCar(_35reg2887);
+Obj c = _35reg2888;
+Obj _35reg2889 = primCdr(closureRef(co, 3));
+Obj _35reg2890 = primCdr(_35reg2889);
+Obj _35reg2891 = primCdr(_35reg2890);
+Obj _35reg2892 = primCdr(_35reg2891);
+Obj _35reg2893 = primEQ(Nil, _35reg2892);
+if (True == _35reg2893) {
+pushCont(co, 4, clofun28, 6, b, a, env, self, w, c);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#index"));
+__arg1 = a;
+__arg2 = env;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1582;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1582;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1582;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1582;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1582;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1582;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val2894 = __arg1;
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 10, _35clofun3252, 4, self, env, c, w);
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
+Obj idx = _35val2894;
+Obj _35reg2895 = primLT(idx, makeNumber(0));
+if (True == _35reg2895) {
+pushCont(co, 3, clofun29, 6, b, a, env, self, w, c);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("Obj ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Nil;
+pushCont(co, 5, clofun28, 6, b, a, env, self, w, c);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
+__arg1 = w;
+__arg2 = a;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35val2902 = __arg1;
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 0, clofun29, 6, b, a, env, self, w, c);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(" = ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun28) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun29(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2903 = __arg1;
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 1, clofun29, 5, a, env, self, w, c);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -4660,40 +4789,528 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun29) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label12:
+label1:
 {
-Obj _35val2815 = __arg1;
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 11, _35clofun3252, 5, b, self, env, c, w);
+Obj _35val2904 = __arg1;
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 2, clofun29, 5, a, env, self, w, c);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString(") {\n");
+__arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun29) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label2:
 {
-Obj _35val2814 = __arg1;
+Obj _35val2905 = __arg1;
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj _35reg2906 = primCons(a, env);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = self;
+__arg2 = _35reg2906;
+__arg3 = w;
+co->args[4] = c;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun29) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2896 = __arg1;
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 4, clofun29, 6, b, a, env, self, w, c);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
+__arg1 = w;
+__arg2 = a;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun29) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val2897 = __arg1;
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 5, clofun29, 6, b, a, env, self, w, c);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(" = ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun29) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val2898 = __arg1;
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 0, clofun30, 5, a, env, self, w, c);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun29) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun30(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2899 = __arg1;
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 1, clofun30, 5, a, env, self, w, c);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(";\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2900 = __arg1;
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj _35reg2901 = primCons(a, env);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = self;
+__arg2 = _35reg2901;
+__arg3 = w;
+co->args[4] = c;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35cc1583 = makeNative(3, clofun31, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj w = closureRef(co, 2);
+Obj _35reg2844 = primIsCons(closureRef(co, 3));
+if (True == _35reg2844) {
+Obj _35reg2845 = primCar(closureRef(co, 3));
+Obj _35reg2846 = primIsCons(_35reg2845);
+if (True == _35reg2846) {
+Obj _35reg2847 = primCar(closureRef(co, 3));
+Obj _35reg2848 = primCar(_35reg2847);
+Obj _35reg2849 = primEQ(intern("%builtin"), _35reg2848);
+if (True == _35reg2849) {
+Obj _35reg2850 = primCar(closureRef(co, 3));
+Obj _35reg2851 = primCdr(_35reg2850);
+Obj _35reg2852 = primIsCons(_35reg2851);
+if (True == _35reg2852) {
+Obj _35reg2853 = primCar(closureRef(co, 3));
+Obj _35reg2854 = primCdr(_35reg2853);
+Obj _35reg2855 = primCar(_35reg2854);
+Obj f = _35reg2855;
+Obj _35reg2856 = primCar(closureRef(co, 3));
+Obj _35reg2857 = primCdr(_35reg2856);
+Obj _35reg2858 = primCdr(_35reg2857);
+Obj _35reg2859 = primEQ(Nil, _35reg2858);
+if (True == _35reg2859) {
+Obj _35reg2860 = primCdr(closureRef(co, 3));
+Obj args = _35reg2860;
+pushCont(co, 3, clofun30, 5, f, self, env, args, w);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#builtin->name"));
+__arg1 = f;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1583;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1583;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1583;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1583;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1583;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35val2861 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 4, clofun30, 5, f, self, env, args, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
+__arg1 = w;
+__arg2 = _35val2861;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val2862 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj _35reg2863 = primEQ(f, intern("set"));
+if (True == _35reg2863) {
+pushCont(co, 1, clofun31, 4, self, env, args, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("(co, ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 5, clofun30, 4, self, env, args, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("(");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35val2866 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, clofun31, 1, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun30) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun31(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2867 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2864 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 2, clofun31, 1, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val2865 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35cc1584 = makeNative(4, clofun32, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj w = closureRef(co, 2);
+Obj _35reg2812 = primIsCons(closureRef(co, 3));
+if (True == _35reg2812) {
+Obj _35reg2813 = primCar(closureRef(co, 3));
+Obj _35reg2814 = primEQ(intern("if"), _35reg2813);
+if (True == _35reg2814) {
+Obj _35reg2815 = primCdr(closureRef(co, 3));
+Obj _35reg2816 = primIsCons(_35reg2815);
+if (True == _35reg2816) {
+Obj _35reg2817 = primCdr(closureRef(co, 3));
+Obj _35reg2818 = primCar(_35reg2817);
+Obj a = _35reg2818;
+Obj _35reg2819 = primCdr(closureRef(co, 3));
+Obj _35reg2820 = primCdr(_35reg2819);
+Obj _35reg2821 = primIsCons(_35reg2820);
+if (True == _35reg2821) {
+Obj _35reg2822 = primCdr(closureRef(co, 3));
+Obj _35reg2823 = primCdr(_35reg2822);
+Obj _35reg2824 = primCar(_35reg2823);
+Obj b = _35reg2824;
+Obj _35reg2825 = primCdr(closureRef(co, 3));
+Obj _35reg2826 = primCdr(_35reg2825);
+Obj _35reg2827 = primCdr(_35reg2826);
+Obj _35reg2828 = primIsCons(_35reg2827);
+if (True == _35reg2828) {
+Obj _35reg2829 = primCdr(closureRef(co, 3));
+Obj _35reg2830 = primCdr(_35reg2829);
+Obj _35reg2831 = primCdr(_35reg2830);
+Obj _35reg2832 = primCar(_35reg2831);
+Obj c = _35reg2832;
+Obj _35reg2833 = primCdr(closureRef(co, 3));
+Obj _35reg2834 = primCdr(_35reg2833);
+Obj _35reg2835 = primCdr(_35reg2834);
+Obj _35reg2836 = primCdr(_35reg2835);
+Obj _35reg2837 = primEQ(Nil, _35reg2836);
+if (True == _35reg2837) {
+pushCont(co, 4, clofun31, 6, a, b, self, env, c, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("if (True == ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1584;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1584;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1584;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1584;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1584;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1584;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val2838 = __arg1;
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj b= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 4];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
-pushCont(co, 12, _35clofun3252, 5, b, self, env, c, w);
+pushCont(co, 5, clofun31, 5, b, self, env, c, w);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -4703,240 +5320,27 @@ co->args[4] = a;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label5:
 {
-Obj _35cc1491 = makeNative(7, _35clofun3252, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj w = closureRef(co, 2);
-Obj _35reg2788 = primIsCons(closureRef(co, 3));
-if (True == _35reg2788) {
-Obj _35reg2789 = primCar(closureRef(co, 3));
-Obj _35reg2790 = primEQ(intern("if"), _35reg2789);
-if (True == _35reg2790) {
-Obj _35reg2791 = primCdr(closureRef(co, 3));
-Obj _35reg2792 = primIsCons(_35reg2791);
-if (True == _35reg2792) {
-Obj _35reg2793 = primCdr(closureRef(co, 3));
-Obj _35reg2794 = primCar(_35reg2793);
-Obj a = _35reg2794;
-Obj _35reg2795 = primCdr(closureRef(co, 3));
-Obj _35reg2796 = primCdr(_35reg2795);
-Obj _35reg2797 = primIsCons(_35reg2796);
-if (True == _35reg2797) {
-Obj _35reg2798 = primCdr(closureRef(co, 3));
-Obj _35reg2799 = primCdr(_35reg2798);
-Obj _35reg2800 = primCar(_35reg2799);
-Obj b = _35reg2800;
-Obj _35reg2801 = primCdr(closureRef(co, 3));
-Obj _35reg2802 = primCdr(_35reg2801);
-Obj _35reg2803 = primCdr(_35reg2802);
-Obj _35reg2804 = primIsCons(_35reg2803);
-if (True == _35reg2804) {
-Obj _35reg2805 = primCdr(closureRef(co, 3));
-Obj _35reg2806 = primCdr(_35reg2805);
-Obj _35reg2807 = primCdr(_35reg2806);
-Obj _35reg2808 = primCar(_35reg2807);
-Obj c = _35reg2808;
-Obj _35reg2809 = primCdr(closureRef(co, 3));
-Obj _35reg2810 = primCdr(_35reg2809);
-Obj _35reg2811 = primCdr(_35reg2810);
-Obj _35reg2812 = primCdr(_35reg2811);
-Obj _35reg2813 = primEQ(Nil, _35reg2812);
-if (True == _35reg2813) {
-pushCont(co, 13, _35clofun3252, 6, a, b, self, env, c, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("if (True == ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1491;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1491;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1491;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1491;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1491;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1491;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj _35val2841 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val2840 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 15, _35clofun3252, 1, w);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val2843 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val2842 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 17, _35clofun3252, 1, w);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35val2838 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2839 = __arg1;
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2839 = primEQ(f, intern("set"));
-if (True == _35reg2839) {
-pushCont(co, 16, _35clofun3252, 4, self, env, args, w);
+pushCont(co, 0, clofun32, 5, b, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString("(co, ");
+__arg2 = makeCString(") {\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 18, _35clofun3252, 4, self, env, args, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("(");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
-{
-Obj _35val2837 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 19, _35clofun3252, 5, f, self, env, args, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
-__arg1 = w;
-__arg2 = _35val2837;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3252) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun31) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -4949,53 +5353,1042 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3251(struct Cora* co){
+void clofun32(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1497 = makeNative(9, _35clofun3250, 0, 0);
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj w = closureRef(co, 2);
-Obj _35reg2676 = primIsCons(closureRef(co, 3));
-if (True == _35reg2676) {
-Obj _35reg2677 = primCar(closureRef(co, 3));
-Obj f = _35reg2677;
-Obj _35reg2678 = primCdr(closureRef(co, 3));
-Obj args = _35reg2678;
-pushCont(co, 20, _35clofun3250, 4, f, args, self, w);
+Obj _35val2840 = __arg1;
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 1, clofun32, 4, self, env, c, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2841 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 2, clofun32, 4, self, env, c, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
-__arg2 = makeCString("__nargs = ");
+__arg2 = makeCString("} else {\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val2842 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 3, clofun32, 1, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = c;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2843 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("}\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35cc1585 = makeNative(0, clofun35, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj w = closureRef(co, 2);
+Obj _35reg2779 = primIsCons(closureRef(co, 3));
+if (True == _35reg2779) {
+Obj _35reg2780 = primCar(closureRef(co, 3));
+Obj _35reg2781 = primEQ(intern("%closure"), _35reg2780);
+if (True == _35reg2781) {
+Obj _35reg2782 = primCdr(closureRef(co, 3));
+Obj _35reg2783 = primIsCons(_35reg2782);
+if (True == _35reg2783) {
+Obj _35reg2784 = primCdr(closureRef(co, 3));
+Obj _35reg2785 = primCar(_35reg2784);
+Obj label = _35reg2785;
+Obj _35reg2786 = primCdr(closureRef(co, 3));
+Obj _35reg2787 = primCdr(_35reg2786);
+Obj _35reg2788 = primIsCons(_35reg2787);
+if (True == _35reg2788) {
+Obj _35reg2789 = primCdr(closureRef(co, 3));
+Obj _35reg2790 = primCdr(_35reg2789);
+Obj _35reg2791 = primCar(_35reg2790);
+Obj nargs = _35reg2791;
+Obj _35reg2792 = primCdr(closureRef(co, 3));
+Obj _35reg2793 = primCdr(_35reg2792);
+Obj _35reg2794 = primCdr(_35reg2793);
+Obj frees = _35reg2794;
+pushCont(co, 5, clofun32, 6, label, nargs, self, env, frees, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("makeNative(");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1497;
+__arg0 = _35cc1585;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1585;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1585;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1585;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35val2795 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
+Obj _35reg2796 = primCar(self);
+Obj _35reg2797 = primSub(_35reg2796, label);
+pushCont(co, 0, clofun33, 6, label, nargs, self, env, frees, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/hash-h#mod"));
+__arg1 = _35reg2797;
+__arg2 = globalRef(intern("cora/lib/toc#*mod-num*"));
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun32) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun33(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2798 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 1, clofun33, 6, label, nargs, self, env, frees, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = _35val2798;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2799 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
+pushCont(co, 2, clofun33, 6, label, nargs, self, env, frees, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val2800 = __arg1;
+Obj label= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 5];
+Obj _35reg2801 = primCar(self);
+pushCont(co, 3, clofun33, 5, nargs, self, env, frees, w);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#generate-group-name"));
+__arg1 = w;
+__arg2 = label;
+__arg3 = _35reg2801;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2802 = __arg1;
+Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 4, clofun33, 5, nargs, self, env, frees, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val2803 = __arg1;
+Obj nargs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 5, clofun33, 4, self, env, frees, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = nargs;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val2804 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, clofun34, 4, self, env, frees, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun33) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun34(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2805 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 1, clofun34, 4, self, env, frees, w);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#length"));
+__arg1 = frees;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2806 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 2, clofun34, 4, self, env, frees, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = _35val2806;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val2807 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 3, clofun34, 4, self, env, frees, w);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#null?"));
+__arg1 = frees;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2808 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg2809 = primNot(_35val2808);
+if (True == _35reg2809) {
+pushCont(co, 4, clofun34, 4, self, env, frees, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(", ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Nil;
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val2810 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 5, clofun34, 1, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = frees;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val2811 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(")");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun34) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun35(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc1586 = makeNative(3, clofun35, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj w = closureRef(co, 2);
+Obj _35reg2760 = primIsCons(closureRef(co, 3));
+if (True == _35reg2760) {
+Obj _35reg2761 = primCar(closureRef(co, 3));
+Obj _35reg2762 = primEQ(intern("do"), _35reg2761);
+if (True == _35reg2762) {
+Obj _35reg2763 = primCdr(closureRef(co, 3));
+Obj _35reg2764 = primIsCons(_35reg2763);
+if (True == _35reg2764) {
+Obj _35reg2765 = primCdr(closureRef(co, 3));
+Obj _35reg2766 = primCar(_35reg2765);
+Obj a = _35reg2766;
+Obj _35reg2767 = primCdr(closureRef(co, 3));
+Obj _35reg2768 = primCdr(_35reg2767);
+Obj _35reg2769 = primIsCons(_35reg2768);
+if (True == _35reg2769) {
+Obj _35reg2770 = primCdr(closureRef(co, 3));
+Obj _35reg2771 = primCdr(_35reg2770);
+Obj _35reg2772 = primCar(_35reg2771);
+Obj b = _35reg2772;
+Obj _35reg2773 = primCdr(closureRef(co, 3));
+Obj _35reg2774 = primCdr(_35reg2773);
+Obj _35reg2775 = primCdr(_35reg2774);
+Obj _35reg2776 = primEQ(Nil, _35reg2775);
+if (True == _35reg2776) {
+pushCont(co, 1, clofun35, 4, self, env, w, b);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = a;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1586;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1586;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1586;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1586;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1586;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35val2709 = __arg1;
+Obj _35val2777 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 2, clofun35, 4, self, env, w, b);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(";\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val2778 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35cc1587 = makeNative(0, clofun37, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj w = closureRef(co, 2);
+Obj _35reg2740 = primIsCons(closureRef(co, 3));
+if (True == _35reg2740) {
+Obj _35reg2741 = primCar(closureRef(co, 3));
+Obj _35reg2742 = primEQ(intern("return"), _35reg2741);
+if (True == _35reg2742) {
+Obj _35reg2743 = primCdr(closureRef(co, 3));
+Obj _35reg2744 = primIsCons(_35reg2743);
+if (True == _35reg2744) {
+Obj _35reg2745 = primCdr(closureRef(co, 3));
+Obj _35reg2746 = primCar(_35reg2745);
+Obj x = _35reg2746;
+Obj _35reg2747 = primCdr(closureRef(co, 3));
+Obj _35reg2748 = primCdr(_35reg2747);
+Obj _35reg2749 = primEQ(Nil, _35reg2748);
+if (True == _35reg2749) {
+pushCont(co, 4, clofun35, 4, env, x, self, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("__nargs = 2;\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1587;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1587;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1587;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1587;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val2750 = __arg1;
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 5, clofun35, 4, env, x, self, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("__arg1 = ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val2751 = __arg1;
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 0, clofun36, 2, self, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun35) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun36(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2752 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 1, clofun36, 2, self, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(";\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun36) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2753 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 2, clofun36, 2, self, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("co->ctx = co->callstack.data[--co->callstack.len];\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun36) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val2754 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 3, clofun36, 2, self, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("if (co->ctx.pc.func != ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun36) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2755 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2756 = primCdr(self);
+Obj _35reg2757 = primCar(self);
+pushCont(co, 4, clofun36, 1, w);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#generate-group-name"));
+__arg1 = w;
+__arg2 = _35reg2756;
+__arg3 = _35reg2757;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun36) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val2758 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 5, clofun36, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(") { goto fail; }\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun36) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val2759 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun36) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun37(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc1588 = makeNative(1, clofun37, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj w = closureRef(co, 2);
+Obj _35reg2730 = primIsCons(closureRef(co, 3));
+if (True == _35reg2730) {
+Obj _35reg2731 = primCar(closureRef(co, 3));
+Obj _35reg2732 = primEQ(intern("tailcall"), _35reg2731);
+if (True == _35reg2732) {
+Obj _35reg2733 = primCdr(closureRef(co, 3));
+Obj _35reg2734 = primIsCons(_35reg2733);
+if (True == _35reg2734) {
+Obj _35reg2735 = primCdr(closureRef(co, 3));
+Obj _35reg2736 = primCar(_35reg2735);
+Obj exp = _35reg2736;
+Obj _35reg2737 = primCdr(closureRef(co, 3));
+Obj _35reg2738 = primCdr(_35reg2737);
+Obj _35reg2739 = primEQ(Nil, _35reg2738);
+if (True == _35reg2739) {
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = self;
+__arg2 = env;
+__arg3 = w;
+co->args[4] = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1588;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1588;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1588;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1588;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35cc1589 = makeNative(3, clofun37, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj self = closureRef(co, 0);
+Obj env = closureRef(co, 1);
+Obj w = closureRef(co, 2);
+Obj _35reg2712 = primIsCons(closureRef(co, 3));
+if (True == _35reg2712) {
+Obj _35reg2713 = primCar(closureRef(co, 3));
+Obj _35reg2714 = primEQ(intern("call"), _35reg2713);
+if (True == _35reg2714) {
+Obj _35reg2715 = primCdr(closureRef(co, 3));
+Obj _35reg2716 = primIsCons(_35reg2715);
+if (True == _35reg2716) {
+Obj _35reg2717 = primCdr(closureRef(co, 3));
+Obj _35reg2718 = primCar(_35reg2717);
+Obj exp = _35reg2718;
+Obj _35reg2719 = primCdr(closureRef(co, 3));
+Obj _35reg2720 = primCdr(_35reg2719);
+Obj _35reg2721 = primIsCons(_35reg2720);
+if (True == _35reg2721) {
+Obj _35reg2722 = primCdr(closureRef(co, 3));
+Obj _35reg2723 = primCdr(_35reg2722);
+Obj _35reg2724 = primCar(_35reg2723);
+Obj cont = _35reg2724;
+Obj _35reg2725 = primCdr(closureRef(co, 3));
+Obj _35reg2726 = primCdr(_35reg2725);
+Obj _35reg2727 = primCdr(_35reg2726);
+Obj _35reg2728 = primEQ(Nil, _35reg2727);
+if (True == _35reg2728) {
+pushCont(co, 2, clofun37, 4, self, env, w, exp);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#generate-cont"));
+__arg1 = self;
+__arg2 = w;
+__arg3 = cont;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1589;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1589;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1589;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1589;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1589;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35val2729 = __arg1;
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
@@ -5009,607 +6402,78 @@ co->args[4] = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj _35cc1496 = makeNative(0, _35clofun3251, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj w = closureRef(co, 2);
-Obj _35reg2692 = primIsCons(closureRef(co, 3));
-if (True == _35reg2692) {
-Obj _35reg2693 = primCar(closureRef(co, 3));
-Obj _35reg2694 = primEQ(intern("call"), _35reg2693);
-if (True == _35reg2694) {
-Obj _35reg2695 = primCdr(closureRef(co, 3));
-Obj _35reg2696 = primIsCons(_35reg2695);
-if (True == _35reg2696) {
-Obj _35reg2697 = primCdr(closureRef(co, 3));
-Obj _35reg2698 = primCar(_35reg2697);
-Obj exp = _35reg2698;
-Obj _35reg2699 = primCdr(closureRef(co, 3));
-Obj _35reg2700 = primCdr(_35reg2699);
-Obj _35reg2701 = primIsCons(_35reg2700);
-if (True == _35reg2701) {
-Obj _35reg2702 = primCdr(closureRef(co, 3));
-Obj _35reg2703 = primCdr(_35reg2702);
-Obj _35reg2704 = primCar(_35reg2703);
-Obj cont = _35reg2704;
-Obj _35reg2705 = primCdr(closureRef(co, 3));
-Obj _35reg2706 = primCdr(_35reg2705);
-Obj _35reg2707 = primCdr(_35reg2706);
-Obj _35reg2708 = primEQ(Nil, _35reg2707);
-if (True == _35reg2708) {
-pushCont(co, 1, _35clofun3251, 4, self, env, w, exp);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#generate-cont"));
-__arg1 = self;
-__arg2 = w;
-__arg3 = cont;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1496;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1496;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1496;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1496;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1496;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label3:
 {
-Obj _35cc1495 = makeNative(2, _35clofun3251, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1590 = makeNative(3, clofun39, 0, 0);
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj w = closureRef(co, 2);
-Obj _35reg2710 = primIsCons(closureRef(co, 3));
-if (True == _35reg2710) {
-Obj _35reg2711 = primCar(closureRef(co, 3));
-Obj _35reg2712 = primEQ(intern("tailcall"), _35reg2711);
-if (True == _35reg2712) {
-Obj _35reg2713 = primCdr(closureRef(co, 3));
-Obj _35reg2714 = primIsCons(_35reg2713);
-if (True == _35reg2714) {
-Obj _35reg2715 = primCdr(closureRef(co, 3));
-Obj _35reg2716 = primCar(_35reg2715);
-Obj exp = _35reg2716;
-Obj _35reg2717 = primCdr(closureRef(co, 3));
-Obj _35reg2718 = primCdr(_35reg2717);
-Obj _35reg2719 = primEQ(Nil, _35reg2718);
-if (True == _35reg2719) {
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = exp;
+Obj _35reg2694 = primIsCons(closureRef(co, 3));
+if (True == _35reg2694) {
+Obj _35reg2695 = primCar(closureRef(co, 3));
+Obj f = _35reg2695;
+Obj _35reg2696 = primCdr(closureRef(co, 3));
+Obj args = _35reg2696;
+pushCont(co, 4, clofun37, 4, f, args, self, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("__nargs = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1495;
+__arg0 = _35cc1590;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1495;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1495;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1495;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35val2737 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("goto *jumpTable[co->ctx.pc.label];\n");
+Obj _35val2697 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 5, clofun37, 4, f, args, self, w);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#length"));
+__arg1 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val2736 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 4, _35clofun3251, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(") { goto fail; }\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val2735 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun3251, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
-__arg1 = w;
-__arg2 = self;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val2734 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 6, _35clofun3251, 2, self, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("if (co->ctx.pc.func != ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35val2733 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 7, _35clofun3251, 2, self, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("co->ctx = co->callstack.data[--co->callstack.len];\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val2732 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 8, _35clofun3251, 2, self, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(";\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35val2731 = __arg1;
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35val2698 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 9, _35clofun3251, 2, self, w);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val2730 = __arg1;
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 10, _35clofun3251, 4, env, x, self, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("__arg1 = ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35cc1494 = makeNative(3, _35clofun3251, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj w = closureRef(co, 2);
-Obj _35reg2720 = primIsCons(closureRef(co, 3));
-if (True == _35reg2720) {
-Obj _35reg2721 = primCar(closureRef(co, 3));
-Obj _35reg2722 = primEQ(intern("return"), _35reg2721);
-if (True == _35reg2722) {
-Obj _35reg2723 = primCdr(closureRef(co, 3));
-Obj _35reg2724 = primIsCons(_35reg2723);
-if (True == _35reg2724) {
-Obj _35reg2725 = primCdr(closureRef(co, 3));
-Obj _35reg2726 = primCar(_35reg2725);
-Obj x = _35reg2726;
-Obj _35reg2727 = primCdr(closureRef(co, 3));
-Obj _35reg2728 = primCdr(_35reg2727);
-Obj _35reg2729 = primEQ(Nil, _35reg2728);
-if (True == _35reg2729) {
-pushCont(co, 11, _35clofun3251, 4, env, x, self, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("__nargs = 2;\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1494;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1494;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1494;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1494;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
-{
-Obj _35val2756 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35val2755 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj b= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 13, _35clofun3251, 4, self, env, w, b);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(";\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35cc1493 = makeNative(12, _35clofun3251, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj self = closureRef(co, 0);
-Obj env = closureRef(co, 1);
-Obj w = closureRef(co, 2);
-Obj _35reg2738 = primIsCons(closureRef(co, 3));
-if (True == _35reg2738) {
-Obj _35reg2739 = primCar(closureRef(co, 3));
-Obj _35reg2740 = primEQ(intern("do"), _35reg2739);
-if (True == _35reg2740) {
-Obj _35reg2741 = primCdr(closureRef(co, 3));
-Obj _35reg2742 = primIsCons(_35reg2741);
-if (True == _35reg2742) {
-Obj _35reg2743 = primCdr(closureRef(co, 3));
-Obj _35reg2744 = primCar(_35reg2743);
-Obj a = _35reg2744;
-Obj _35reg2745 = primCdr(closureRef(co, 3));
-Obj _35reg2746 = primCdr(_35reg2745);
-Obj _35reg2747 = primIsCons(_35reg2746);
-if (True == _35reg2747) {
-Obj _35reg2748 = primCdr(closureRef(co, 3));
-Obj _35reg2749 = primCdr(_35reg2748);
-Obj _35reg2750 = primCar(_35reg2749);
-Obj b = _35reg2750;
-Obj _35reg2751 = primCdr(closureRef(co, 3));
-Obj _35reg2752 = primCdr(_35reg2751);
-Obj _35reg2753 = primCdr(_35reg2752);
-Obj _35reg2754 = primEQ(Nil, _35reg2753);
-if (True == _35reg2754) {
-pushCont(co, 14, _35clofun3251, 4, self, env, w, b);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = a;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1493;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1493;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1493;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1493;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1493;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label16:
-{
-Obj _35val2787 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val2786 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 16, _35clofun3251, 1, w);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst-list"));
-__arg1 = self;
-__arg2 = env;
-__arg3 = w;
-co->args[4] = frees;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val2784 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2785 = primNot(_35val2784);
-if (True == _35reg2785) {
-pushCont(co, 17, _35clofun3251, 4, self, env, frees, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(", ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Nil;
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(")");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label19:
-{
-Obj _35val2783 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun3251, 4, self, env, frees, w);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#null?"));
-__arg1 = frees;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val2782 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun3251, 4, self, env, frees, w);
+Obj _35reg2699 = primAdd(makeNumber(1), _35val2698);
+pushCont(co, 0, clofun38, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
 __arg1 = w;
-__arg2 = _35val2782;
+__arg2 = _35reg2699;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3251) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun37) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -5622,66 +6486,25 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3250(struct Cora* co){
+void clofun38(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2661 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35val2700 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 20, _35clofun3249, 5, x, i, self, w, more);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = i;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label1:
-{
-Obj _35val2672 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2673 = primAdd(i, makeNumber(1));
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
-__arg1 = self;
-__arg2 = w;
-__arg3 = _35reg2673;
-co->args[4] = more;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label2:
-{
-Obj _35val2671 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 1, _35clofun3250, 4, i, self, w, more);
+pushCont(co, 1, clofun38, 4, f, args, self, w);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -5689,19 +6512,348 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun38) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2701 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg2702 = primCons(f, args);
+pushCont(co, 2, clofun38, 2, self, w);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
+__arg1 = self;
+__arg2 = w;
+__arg3 = makeNumber(0);
+co->args[4] = _35reg2702;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun38) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val2703 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 3, clofun38, 2, self, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("co->ctx.frees = __arg0;\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun38) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2670 = __arg1;
+Obj _35val2704 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 4, clofun38, 2, self, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun38) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val2705 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 5, clofun38, 2, self, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun38) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val2706 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 0, clofun39, 2, self, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("if (ps.func != ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun38) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun39(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2707 = __arg1;
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2708 = primCdr(self);
+Obj _35reg2709 = primCar(self);
+pushCont(co, 1, clofun39, 1, w);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#generate-group-name"));
+__arg1 = w;
+__arg2 = _35reg2708;
+__arg3 = _35reg2709;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun39) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2710 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 2, clofun39, 1, w);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(") { co->ctx.pc = ps; goto fail; };\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun39) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val2711 = __arg1;
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("goto *jumpTable[ps.label];\n");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun39) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun39) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35p1567 = __arg1;
+Obj _35p1568 = __arg2;
+Obj _35p1569 = __arg3;
+Obj _35p1570 = co->args[4];
+Obj _35cc1571 = makeNative(5, clofun39, 0, 4, _35p1567, _35p1568, _35p1569, _35p1570);
+Obj self = _35p1567;
+Obj w = _35p1568;
+Obj i = _35p1569;
+Obj _35reg2692 = primEQ(Nil, _35p1570);
+if (True == _35reg2692) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun39) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1571;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun39) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35cc1572 = makeNative(5, clofun41, 0, 0);
+Obj self = closureRef(co, 0);
+Obj w = closureRef(co, 1);
+Obj i = closureRef(co, 2);
+Obj _35reg2674 = primIsCons(closureRef(co, 3));
+if (True == _35reg2674) {
+Obj _35reg2675 = primCar(closureRef(co, 3));
+Obj x = _35reg2675;
+Obj _35reg2676 = primCdr(closureRef(co, 3));
+Obj more = _35reg2676;
+Obj _35reg2677 = primGT(i, makeNumber(3));
+Obj _35reg2678 = primNot(_35reg2677);
+if (True == _35reg2678) {
+pushCont(co, 0, clofun41, 5, x, i, self, w, more);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("__arg");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun39) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 0, clofun40, 5, x, i, self, w, more);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("co->args[");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun39) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1572;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun39) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun40(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2685 = __arg1;
 Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 2, _35clofun3250, 4, i, self, w, more);
+pushCont(co, 1, clofun40, 5, x, i, self, w, more);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = i;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun40) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2686 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 2, clofun40, 5, x, i, self, w, more);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString("]");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun40) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val2687 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 3, clofun40, 5, x, i, self, w, more);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(" = ");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun40) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2688 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 4, clofun40, 4, i, self, w, more);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
 __arg1 = self;
@@ -5711,304 +6863,18 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun40) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val2669 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 3, _35clofun3250, 5, x, i, self, w, more);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(" = ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35val2668 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 4, _35clofun3250, 5, x, i, self, w, more);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("]");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val2667 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 5, _35clofun3250, 5, x, i, self, w, more);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = i;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35cc1479 = makeNative(16, _35clofun3249, 0, 0);
-Obj self = closureRef(co, 0);
-Obj w = closureRef(co, 1);
-Obj i = closureRef(co, 2);
-Obj _35reg2656 = primIsCons(closureRef(co, 3));
-if (True == _35reg2656) {
-Obj _35reg2657 = primCar(closureRef(co, 3));
-Obj x = _35reg2657;
-Obj _35reg2658 = primCdr(closureRef(co, 3));
-Obj more = _35reg2658;
-Obj _35reg2659 = primGT(i, makeNumber(3));
-Obj _35reg2660 = primNot(_35reg2659);
-if (True == _35reg2660) {
-pushCont(co, 0, _35clofun3250, 5, x, i, self, w, more);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("__arg");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 6, _35clofun3250, 5, x, i, self, w, more);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("co->args[");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1479;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-Obj _35p1474 = __arg1;
-Obj _35p1475 = __arg2;
-Obj _35p1476 = __arg3;
-Obj _35p1477 = co->args[4];
-Obj _35cc1478 = makeNative(7, _35clofun3250, 0, 4, _35p1474, _35p1475, _35p1476, _35p1477);
-Obj self = _35p1474;
-Obj w = _35p1475;
-Obj i = _35p1476;
-Obj _35reg2674 = primEQ(Nil, _35p1477);
-if (True == _35reg2674) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3250) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1478;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label9:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35val2691 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("goto *jumpTable[ps.label];\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val2690 = __arg1;
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 10, _35clofun3250, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(") { co->ctx.pc = ps; goto fail; };\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
 Obj _35val2689 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun3250, 1, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-sym"));
-__arg1 = w;
-__arg2 = self;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35val2688 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 12, _35clofun3250, 2, self, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("if (ps.func != ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35val2687 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 13, _35clofun3250, 2, self, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35val2686 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 14, _35clofun3250, 2, self, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val2685 = __arg1;
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 15, _35clofun3250, 2, self, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString("co->ctx.frees = __arg0;\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val2683 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2684 = primCons(f, args);
-pushCont(co, 16, _35clofun3250, 2, self, w);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
-__arg1 = self;
-__arg2 = w;
-__arg3 = makeNumber(0);
-co->args[4] = _35reg2684;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val2682 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 17, _35clofun3250, 4, f, args, self, w);
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 5, clofun40, 4, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
 __arg1 = w;
@@ -6016,45 +6882,28 @@ __arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun40) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label5:
 {
-Obj _35val2680 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2681 = primAdd(makeNumber(1), _35val2680);
-pushCont(co, 18, _35clofun3250, 4, f, args, self, w);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
-__arg1 = w;
-__arg2 = _35reg2681;
+Obj _35val2690 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg2691 = primAdd(i, makeNumber(1));
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
+__arg1 = self;
+__arg2 = w;
+__arg3 = _35reg2691;
+co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val2679 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun3250, 4, f, args, self, w);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3250) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun40) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -6067,217 +6916,189 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3249(struct Cora* co){
+void clofun41(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2623 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2622= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2624 = primCons(_35val2623, fvs);
-Obj _35reg2625 = primCons(_35reg2622, _35reg2624);
-Obj _35reg2626 = primCons(clo_45or_45cont, _35reg2625);
-__nargs = 2;
-__arg1 = _35reg2626;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3249) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val2679 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 1, clofun41, 5, x, i, self, w, more);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-num"));
+__arg1 = w;
+__arg2 = i;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun41) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2621 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2622 = primCons(name, idx);
-pushCont(co, 0, _35clofun3249, 3, fvs, _35reg2622, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = params;
+Obj _35val2680 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 2, clofun41, 5, x, i, self, w, more);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(" = ");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun41) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label2:
 {
-Obj _35val2631 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2632 = primCons(name, idx);
-Obj _35reg2633 = primCons(_35reg2632, fvs);
-Obj _35reg2634 = primCons(clo_45or_45cont, _35reg2633);
-__nargs = 2;
-__arg1 = _35reg2634;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3249) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val2681 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
+pushCont(co, 3, clofun41, 4, i, self, w, more);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
+__arg1 = self;
+__arg2 = Nil;
+__arg3 = w;
+co->args[4] = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun41) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35val2614 = __arg1;
-Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 6];
-Obj _35reg2615 = primCar(_35val2614);
-Obj name = _35reg2615;
-Obj _35reg2616 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2616) {
-Obj _35reg2617 = primCons(body1, Nil);
-Obj _35reg2618 = primCons(Nil, _35reg2617);
-Obj _35reg2619 = primCons(params, _35reg2618);
-Obj _35reg2620 = primCons(intern("lambda"), _35reg2619);
-pushCont(co, 1, _35clofun3249, 5, name, idx, params, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2620;
+Obj _35val2682 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 4, clofun41, 4, i, self, w, more);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
+__arg1 = w;
+__arg2 = makeCString(";\n");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun41) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj _35reg2627 = primCons(body1, Nil);
-Obj _35reg2628 = primCons(fvs, _35reg2627);
-Obj _35reg2629 = primCons(params, _35reg2628);
-Obj _35reg2630 = primCons(intern("lambda"), _35reg2629);
-pushCont(co, 2, _35clofun3249, 4, name, idx, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2630;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label4:
 {
-Obj _35val2592 = __arg1;
-Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj cur = _35val2592;
-Obj _35reg2593 = primEQ(idx, makeNumber(0));
-if (True == _35reg2593) {
-Obj _35reg2594 = primGenSym(intern("clofun"));
-Obj name = _35reg2594;
-Obj _35reg2595 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2595) {
-Obj _35reg2596 = primCons(body1, Nil);
-Obj _35reg2597 = primCons(Nil, _35reg2596);
-Obj _35reg2598 = primCons(params, _35reg2597);
-Obj _35reg2599 = primCons(intern("lambda"), _35reg2598);
-pushCont(co, 19, _35clofun3248, 5, name, idx, params, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2599;
+Obj _35val2683 = __arg1;
+Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg2684 = primAdd(i, makeNumber(1));
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
+__arg1 = self;
+__arg2 = w;
+__arg3 = _35reg2684;
+co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun41) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-Obj _35reg2606 = primCons(body1, Nil);
-Obj _35reg2607 = primCons(fvs, _35reg2606);
-Obj _35reg2608 = primCons(params, _35reg2607);
-Obj _35reg2609 = primCons(intern("lambda"), _35reg2608);
-pushCont(co, 20, _35clofun3248, 4, name, idx, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2609;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 3, _35clofun3249, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#caar"));
-__arg1 = cur;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label5:
 {
-Obj _35val2591 = __arg1;
-Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val2591;
-pushCont(co, 4, _35clofun3249, 6, body1, params, v, idx, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#vector-ref"));
-__arg1 = v;
-__arg2 = makeNumber(1);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun41) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun42(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
 {
-Obj _35val2590 = __arg1;
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj body1 = _35val2590;
-pushCont(co, 5, _35clofun3249, 5, body1, params, v, fvs, clo_45or_45cont);
+Obj x = __arg1;
+Obj k = __arg2;
+Obj _35reg2667 = primGenSym(intern("reg"));
+Obj tmp = _35reg2667;
+pushCont(co, 1, clofun42, 2, x, tmp);
+__nargs = 2;
+__arg0 = k;
+__arg1 = tmp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun42) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2668 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj tmp= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2669 = primCons(_35val2668, Nil);
+Obj _35reg2670 = primCons(x, _35reg2669);
+Obj _35reg2671 = primCons(tmp, _35reg2670);
+Obj _35reg2672 = primCons(intern("let"), _35reg2671);
+__nargs = 2;
+__arg1 = _35reg2672;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun42) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label2:
+{
+Obj v = __arg1;
+Obj val = __arg2;
+pushCont(co, 3, clofun42, 2, val, v);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
@@ -6285,200 +7106,56 @@ __arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun42) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label7:
+label3:
 {
-Obj _35p1469 = __arg1;
-Obj _35p1470 = __arg2;
-Obj _35cc1471 = makeNative(18, _35clofun3247, 0, 2, _35p1469, _35p1470);
-Obj v = _35p1469;
-Obj _35reg2461 = primIsCons(_35p1470);
-if (True == _35reg2461) {
-Obj _35reg2462 = primCar(_35p1470);
-Obj clo_45or_45cont = _35reg2462;
-Obj _35reg2463 = primCdr(_35p1470);
-Obj _35reg2464 = primIsCons(_35reg2463);
-if (True == _35reg2464) {
-Obj _35reg2465 = primCdr(_35p1470);
-Obj _35reg2466 = primCar(_35reg2465);
-Obj _35reg2467 = primIsCons(_35reg2466);
-if (True == _35reg2467) {
-Obj _35reg2468 = primCdr(_35p1470);
-Obj _35reg2469 = primCar(_35reg2468);
-Obj _35reg2470 = primCar(_35reg2469);
-Obj _35reg2471 = primEQ(intern("lambda"), _35reg2470);
-if (True == _35reg2471) {
-Obj _35reg2472 = primCdr(_35p1470);
-Obj _35reg2473 = primCar(_35reg2472);
-Obj _35reg2474 = primCdr(_35reg2473);
-Obj _35reg2475 = primIsCons(_35reg2474);
-if (True == _35reg2475) {
-Obj _35reg2476 = primCdr(_35p1470);
-Obj _35reg2477 = primCar(_35reg2476);
-Obj _35reg2478 = primCdr(_35reg2477);
-Obj _35reg2479 = primCar(_35reg2478);
-Obj params = _35reg2479;
-Obj _35reg2480 = primCdr(_35p1470);
-Obj _35reg2481 = primCar(_35reg2480);
-Obj _35reg2482 = primCdr(_35reg2481);
-Obj _35reg2483 = primCdr(_35reg2482);
-Obj _35reg2484 = primIsCons(_35reg2483);
-if (True == _35reg2484) {
-Obj _35reg2485 = primCdr(_35p1470);
-Obj _35reg2486 = primCar(_35reg2485);
-Obj _35reg2487 = primCdr(_35reg2486);
-Obj _35reg2488 = primCdr(_35reg2487);
-Obj _35reg2489 = primCar(_35reg2488);
-Obj body = _35reg2489;
-Obj _35reg2490 = primCdr(_35p1470);
-Obj _35reg2491 = primCar(_35reg2490);
-Obj _35reg2492 = primCdr(_35reg2491);
-Obj _35reg2493 = primCdr(_35reg2492);
-Obj _35reg2494 = primCdr(_35reg2493);
-Obj _35reg2495 = primEQ(Nil, _35reg2494);
-if (True == _35reg2495) {
-Obj _35reg2496 = primCdr(_35p1470);
-Obj _35reg2497 = primCdr(_35reg2496);
-Obj fvs = _35reg2497;
-Obj _35reg2498 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2498) {
-if (True == True) {
-pushCont(co, 7, _35clofun3248, 4, params, v, fvs, clo_45or_45cont);
+Obj _35val2659 = __arg1;
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj idx = _35val2659;
+pushCont(co, 4, clofun42, 3, val, idx, v);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
+__arg0 = globalRef(intern("cora/init#vector-ref"));
 __arg1 = v;
-__arg2 = body;
+__arg2 = makeNumber(1);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun42) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1471;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-Obj _35reg2544 = primEQ(clo_45or_45cont, intern("%continuation"));
-if (True == _35reg2544) {
-if (True == True) {
-pushCont(co, 17, _35clofun3248, 4, params, v, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
-__arg1 = v;
-__arg2 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1471;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-pushCont(co, 6, _35clofun3249, 4, params, v, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
-__arg1 = v;
-__arg2 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1471;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1471;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1471;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1471;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1471;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1471;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1471;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1471;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
-label8:
+label4:
 {
-Obj _35val2642 = __arg1;
+Obj _35val2660 = __arg1;
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj cur = _35val2660;
+Obj _35reg2661 = primCons(val, Nil);
+Obj _35reg2662 = primCons(idx, _35reg2661);
+Obj _35reg2663 = primCons(_35reg2662, cur);
+Obj cur1 = _35reg2663;
+Obj _35reg2664 = primAdd(idx, makeNumber(1));
+pushCont(co, 5, clofun42, 2, v, cur1);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/init#vector-set!"));
+__arg1 = v;
+__arg2 = makeNumber(0);
+__arg3 = _35reg2664;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun42) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val2665 = __arg1;
 Obj v= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -6489,246 +7166,327 @@ __arg3 = cur1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun42) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label9:
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun43(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35p1562 = __arg1;
+Obj _35p1563 = __arg2;
+Obj _35cc1564 = makeNative(4, clofun45, 0, 2, _35p1562, _35p1563);
+Obj v = _35p1562;
+Obj _35reg2562 = primIsCons(_35p1563);
+if (True == _35reg2562) {
+Obj _35reg2563 = primCar(_35p1563);
+Obj clo_45or_45cont = _35reg2563;
+Obj _35reg2564 = primCdr(_35p1563);
+Obj _35reg2565 = primIsCons(_35reg2564);
+if (True == _35reg2565) {
+Obj _35reg2566 = primCdr(_35p1563);
+Obj _35reg2567 = primCar(_35reg2566);
+Obj _35reg2568 = primIsCons(_35reg2567);
+if (True == _35reg2568) {
+Obj _35reg2569 = primCdr(_35p1563);
+Obj _35reg2570 = primCar(_35reg2569);
+Obj _35reg2571 = primCar(_35reg2570);
+Obj _35reg2572 = primEQ(intern("lambda"), _35reg2571);
+if (True == _35reg2572) {
+Obj _35reg2573 = primCdr(_35p1563);
+Obj _35reg2574 = primCar(_35reg2573);
+Obj _35reg2575 = primCdr(_35reg2574);
+Obj _35reg2576 = primIsCons(_35reg2575);
+if (True == _35reg2576) {
+Obj _35reg2577 = primCdr(_35p1563);
+Obj _35reg2578 = primCar(_35reg2577);
+Obj _35reg2579 = primCdr(_35reg2578);
+Obj _35reg2580 = primCar(_35reg2579);
+Obj params = _35reg2580;
+Obj _35reg2581 = primCdr(_35p1563);
+Obj _35reg2582 = primCar(_35reg2581);
+Obj _35reg2583 = primCdr(_35reg2582);
+Obj _35reg2584 = primCdr(_35reg2583);
+Obj _35reg2585 = primIsCons(_35reg2584);
+if (True == _35reg2585) {
+Obj _35reg2586 = primCdr(_35p1563);
+Obj _35reg2587 = primCar(_35reg2586);
+Obj _35reg2588 = primCdr(_35reg2587);
+Obj _35reg2589 = primCdr(_35reg2588);
+Obj _35reg2590 = primCar(_35reg2589);
+Obj body = _35reg2590;
+Obj _35reg2591 = primCdr(_35p1563);
+Obj _35reg2592 = primCar(_35reg2591);
+Obj _35reg2593 = primCdr(_35reg2592);
+Obj _35reg2594 = primCdr(_35reg2593);
+Obj _35reg2595 = primCdr(_35reg2594);
+Obj _35reg2596 = primEQ(Nil, _35reg2595);
+if (True == _35reg2596) {
+Obj _35reg2597 = primCdr(_35p1563);
+Obj _35reg2598 = primCdr(_35reg2597);
+Obj fvs = _35reg2598;
+Obj _35reg2599 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2599) {
+if (True == True) {
+pushCont(co, 5, clofun44, 4, params, v, fvs, clo_45or_45cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
+__arg1 = v;
+__arg2 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1564;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+Obj _35reg2619 = primEQ(clo_45or_45cont, intern("%continuation"));
+if (True == _35reg2619) {
+if (True == True) {
+pushCont(co, 0, clofun44, 4, params, v, fvs, clo_45or_45cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
+__arg1 = v;
+__arg2 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1564;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+pushCont(co, 1, clofun43, 4, params, v, fvs, clo_45or_45cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#collect-lambda"));
+__arg1 = v;
+__arg2 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1564;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1564;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1564;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1564;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1564;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1564;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1564;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1564;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35val2639 = __arg1;
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj body1 = _35val2639;
+pushCont(co, 2, clofun43, 5, body1, params, v, fvs, clo_45or_45cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#vector-ref"));
+__arg1 = v;
+__arg2 = makeNumber(0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val2640 = __arg1;
+Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj cur = _35val2640;
+Obj _35reg2641 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2641) {
+Obj _35reg2642 = primCons(body1, Nil);
+Obj _35reg2643 = primCons(Nil, _35reg2642);
+Obj _35reg2644 = primCons(params, _35reg2643);
+Obj _35reg2645 = primCons(intern("lambda"), _35reg2644);
+pushCont(co, 4, clofun43, 4, params, fvs, cur, clo_45or_45cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#append-result"));
+__arg1 = v;
+__arg2 = _35reg2645;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2651 = primCons(body1, Nil);
+Obj _35reg2652 = primCons(fvs, _35reg2651);
+Obj _35reg2653 = primCons(params, _35reg2652);
+Obj _35reg2654 = primCons(intern("lambda"), _35reg2653);
+pushCont(co, 3, clofun43, 3, cur, fvs, clo_45or_45cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#append-result"));
+__arg1 = v;
+__arg2 = _35reg2654;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35val2655 = __arg1;
+Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg2656 = primCons(cur, fvs);
+Obj _35reg2657 = primCons(clo_45or_45cont, _35reg2656);
+__nargs = 2;
+__arg1 = _35reg2657;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun43) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
 {
 Obj _35val2646 = __arg1;
-Obj res= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2647 = primCons(_35val2646, res);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#vector-set!"));
-__arg1 = v;
-__arg2 = makeNumber(2);
-__arg3 = _35reg2647;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35val2645 = __arg1;
-Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj res = _35val2645;
-pushCont(co, 9, _35clofun3249, 2, res, v);
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 5, clofun43, 3, fvs, cur, clo_45or_45cont);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/init#reverse"));
-__arg1 = cur1;
+__arg0 = globalRef(intern("cora/init#length"));
+__arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun43) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label11:
+label5:
 {
-Obj _35val2644 = __arg1;
-Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 10, _35clofun3249, 2, cur1, v);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#vector-ref"));
-__arg1 = v;
-__arg2 = makeNumber(2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35val2643 = __arg1;
-Obj cur1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 11, _35clofun3249, 2, cur1, v);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#vector-set!"));
-__arg1 = v;
-__arg2 = makeNumber(1);
-__arg3 = Nil;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj v = __arg1;
-Obj idx = __arg2;
-Obj cur = __arg3;
-Obj name = co->args[4];
-Obj val = co->args[5];
-Obj _35reg2636 = primCons(name, idx);
-Obj _35reg2637 = primCons(val, Nil);
-Obj _35reg2638 = primCons(_35reg2636, _35reg2637);
-Obj _35reg2639 = primCons(_35reg2638, cur);
-Obj cur1 = _35reg2639;
-Obj _35reg2640 = primLT(idx, makeNumber(20));
-if (True == _35reg2640) {
-Obj _35reg2641 = primAdd(idx, makeNumber(1));
-pushCont(co, 8, _35clofun3249, 2, v, cur1);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#vector-set!"));
-__arg1 = v;
-__arg2 = makeNumber(0);
-__arg3 = _35reg2641;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 12, _35clofun3249, 2, cur1, v);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/init#vector-set!"));
-__arg1 = v;
-__arg2 = makeNumber(0);
-__arg3 = makeNumber(0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label14:
-{
-Obj _35val2650 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj tmp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2651 = primCons(_35val2650, Nil);
-Obj _35reg2652 = primCons(x, _35reg2651);
-Obj _35reg2653 = primCons(tmp, _35reg2652);
-Obj _35reg2654 = primCons(intern("let"), _35reg2653);
+Obj _35val2647 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg2648 = primCons(_35val2647, fvs);
+Obj _35reg2649 = primCons(cur, _35reg2648);
+Obj _35reg2650 = primCons(clo_45or_45cont, _35reg2649);
 __nargs = 2;
-__arg1 = _35reg2654;
+__arg1 = _35reg2650;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3249) { goto fail; }
+if (co->ctx.pc.func != clofun43) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-}
-
-label15:
-{
-Obj x = __arg1;
-Obj k = __arg2;
-Obj _35reg2649 = primGenSym(intern("reg"));
-Obj tmp = _35reg2649;
-pushCont(co, 14, _35clofun3249, 2, x, tmp);
-__nargs = 2;
-__arg0 = k;
-__arg1 = tmp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val2665 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2666 = primAdd(i, makeNumber(1));
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-call-list"));
-__arg1 = self;
-__arg2 = w;
-__arg3 = _35reg2666;
-co->args[4] = more;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val2664 = __arg1;
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 17, _35clofun3249, 4, i, self, w, more);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(";\n");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35val2663 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 18, _35clofun3249, 4, i, self, w, more);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#generate-inst"));
-__arg1 = self;
-__arg2 = Nil;
-__arg3 = w;
-co->args[4] = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val2662 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj i= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj self= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj w= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 4];
-pushCont(co, 19, _35clofun3249, 5, x, i, self, w, more);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc/internal#generate-str"));
-__arg1 = w;
-__arg2 = makeCString(" = ");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3249) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 }
 
 fail:
@@ -6740,560 +7498,147 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3248(struct Cora* co){
+void clofun44(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2519 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35val2620 = __arg1;
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2520 = primCons(name, idx);
-Obj _35reg2521 = primCons(_35reg2520, fvs);
-Obj _35reg2522 = primCons(clo_45or_45cont, _35reg2521);
-__nargs = 2;
-__arg1 = _35reg2522;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3248) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj body1 = _35val2620;
+pushCont(co, 1, clofun44, 5, body1, params, v, fvs, clo_45or_45cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#vector-ref"));
+__arg1 = v;
+__arg2 = makeNumber(0);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun44) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35val2532 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2531= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2533 = primCons(_35val2532, fvs);
-Obj _35reg2534 = primCons(_35reg2531, _35reg2533);
-Obj _35reg2535 = primCons(clo_45or_45cont, _35reg2534);
-__nargs = 2;
-__arg1 = _35reg2535;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3248) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val2621 = __arg1;
+Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj cur = _35val2621;
+Obj _35reg2622 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2622) {
+Obj _35reg2623 = primCons(body1, Nil);
+Obj _35reg2624 = primCons(Nil, _35reg2623);
+Obj _35reg2625 = primCons(params, _35reg2624);
+Obj _35reg2626 = primCons(intern("lambda"), _35reg2625);
+pushCont(co, 3, clofun44, 4, params, fvs, cur, clo_45or_45cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#append-result"));
+__arg1 = v;
+__arg2 = _35reg2626;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun44) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2632 = primCons(body1, Nil);
+Obj _35reg2633 = primCons(fvs, _35reg2632);
+Obj _35reg2634 = primCons(params, _35reg2633);
+Obj _35reg2635 = primCons(intern("lambda"), _35reg2634);
+pushCont(co, 2, clofun44, 3, cur, fvs, clo_45or_45cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#append-result"));
+__arg1 = v;
+__arg2 = _35reg2635;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun44) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label2:
 {
-Obj _35val2530 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2531 = primCons(name, idx);
-pushCont(co, 1, _35clofun3248, 3, fvs, _35reg2531, clo_45or_45cont);
+Obj _35val2636 = __arg1;
+Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg2637 = primCons(cur, fvs);
+Obj _35reg2638 = primCons(clo_45or_45cont, _35reg2637);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = params;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = _35reg2638;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun44) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label3:
 {
-Obj _35val2540 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35val2627 = __arg1;
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2541 = primCons(name, idx);
-Obj _35reg2542 = primCons(_35reg2541, fvs);
-Obj _35reg2543 = primCons(clo_45or_45cont, _35reg2542);
+pushCont(co, 4, clofun44, 3, fvs, cur, clo_45or_45cont);
 __nargs = 2;
-__arg1 = _35reg2543;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3248) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+__arg0 = globalRef(intern("cora/init#length"));
+__arg1 = params;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun44) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj _35val2523 = __arg1;
-Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 6];
-Obj _35reg2524 = primCar(_35val2523);
-Obj name = _35reg2524;
-Obj _35reg2525 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2525) {
-Obj _35reg2526 = primCons(body1, Nil);
-Obj _35reg2527 = primCons(Nil, _35reg2526);
-Obj _35reg2528 = primCons(params, _35reg2527);
-Obj _35reg2529 = primCons(intern("lambda"), _35reg2528);
-pushCont(co, 2, _35clofun3248, 5, name, idx, params, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2529;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2536 = primCons(body1, Nil);
-Obj _35reg2537 = primCons(fvs, _35reg2536);
-Obj _35reg2538 = primCons(params, _35reg2537);
-Obj _35reg2539 = primCons(intern("lambda"), _35reg2538);
-pushCont(co, 3, _35clofun3248, 4, name, idx, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2539;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+Obj _35val2628 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg2629 = primCons(_35val2628, fvs);
+Obj _35reg2630 = primCons(cur, _35reg2629);
+Obj _35reg2631 = primCons(clo_45or_45cont, _35reg2630);
+__nargs = 2;
+__arg1 = _35reg2631;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun44) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label5:
-{
-Obj _35val2501 = __arg1;
-Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj cur = _35val2501;
-Obj _35reg2502 = primEQ(idx, makeNumber(0));
-if (True == _35reg2502) {
-Obj _35reg2503 = primGenSym(intern("clofun"));
-Obj name = _35reg2503;
-Obj _35reg2504 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2504) {
-Obj _35reg2505 = primCons(body1, Nil);
-Obj _35reg2506 = primCons(Nil, _35reg2505);
-Obj _35reg2507 = primCons(params, _35reg2506);
-Obj _35reg2508 = primCons(intern("lambda"), _35reg2507);
-pushCont(co, 20, _35clofun3247, 5, name, idx, params, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2508;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2515 = primCons(body1, Nil);
-Obj _35reg2516 = primCons(fvs, _35reg2515);
-Obj _35reg2517 = primCons(params, _35reg2516);
-Obj _35reg2518 = primCons(intern("lambda"), _35reg2517);
-pushCont(co, 0, _35clofun3248, 4, name, idx, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2518;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 4, _35clofun3248, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#caar"));
-__arg1 = cur;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label6:
-{
-Obj _35val2500 = __arg1;
-Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val2500;
-pushCont(co, 5, _35clofun3248, 6, body1, params, v, idx, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#vector-ref"));
-__arg1 = v;
-__arg2 = makeNumber(1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val2499 = __arg1;
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj body1 = _35val2499;
-pushCont(co, 6, _35clofun3248, 5, body1, params, v, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#vector-ref"));
-__arg1 = v;
-__arg2 = makeNumber(0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35val2557 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2556= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2558 = primCons(_35val2557, fvs);
-Obj _35reg2559 = primCons(_35reg2556, _35reg2558);
-Obj _35reg2560 = primCons(clo_45or_45cont, _35reg2559);
-__nargs = 2;
-__arg1 = _35reg2560;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3248) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label9:
-{
-Obj _35val2555 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2556 = primCons(name, idx);
-pushCont(co, 8, _35clofun3248, 3, fvs, _35reg2556, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = params;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35val2565 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2566 = primCons(name, idx);
-Obj _35reg2567 = primCons(_35reg2566, fvs);
-Obj _35reg2568 = primCons(clo_45or_45cont, _35reg2567);
-__nargs = 2;
-__arg1 = _35reg2568;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3248) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label11:
-{
-Obj _35val2578 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2577= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2579 = primCons(_35val2578, fvs);
-Obj _35reg2580 = primCons(_35reg2577, _35reg2579);
-Obj _35reg2581 = primCons(clo_45or_45cont, _35reg2580);
-__nargs = 2;
-__arg1 = _35reg2581;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3248) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label12:
-{
-Obj _35val2576 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2577 = primCons(name, idx);
-pushCont(co, 11, _35clofun3248, 3, fvs, _35reg2577, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = params;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label13:
-{
-Obj _35val2586 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2587 = primCons(name, idx);
-Obj _35reg2588 = primCons(_35reg2587, fvs);
-Obj _35reg2589 = primCons(clo_45or_45cont, _35reg2588);
-__nargs = 2;
-__arg1 = _35reg2589;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3248) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label14:
-{
-Obj _35val2569 = __arg1;
-Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 6];
-Obj _35reg2570 = primCar(_35val2569);
-Obj name = _35reg2570;
-Obj _35reg2571 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2571) {
-Obj _35reg2572 = primCons(body1, Nil);
-Obj _35reg2573 = primCons(Nil, _35reg2572);
-Obj _35reg2574 = primCons(params, _35reg2573);
-Obj _35reg2575 = primCons(intern("lambda"), _35reg2574);
-pushCont(co, 12, _35clofun3248, 5, name, idx, params, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2575;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2582 = primCons(body1, Nil);
-Obj _35reg2583 = primCons(fvs, _35reg2582);
-Obj _35reg2584 = primCons(params, _35reg2583);
-Obj _35reg2585 = primCons(intern("lambda"), _35reg2584);
-pushCont(co, 13, _35clofun3248, 4, name, idx, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2585;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj _35val2547 = __arg1;
-Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj cur = _35val2547;
-Obj _35reg2548 = primEQ(idx, makeNumber(0));
-if (True == _35reg2548) {
-Obj _35reg2549 = primGenSym(intern("clofun"));
-Obj name = _35reg2549;
-Obj _35reg2550 = primEQ(clo_45or_45cont, intern("%closure"));
-if (True == _35reg2550) {
-Obj _35reg2551 = primCons(body1, Nil);
-Obj _35reg2552 = primCons(Nil, _35reg2551);
-Obj _35reg2553 = primCons(params, _35reg2552);
-Obj _35reg2554 = primCons(intern("lambda"), _35reg2553);
-pushCont(co, 9, _35clofun3248, 5, name, idx, params, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2554;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2561 = primCons(body1, Nil);
-Obj _35reg2562 = primCons(fvs, _35reg2561);
-Obj _35reg2563 = primCons(params, _35reg2562);
-Obj _35reg2564 = primCons(intern("lambda"), _35reg2563);
-pushCont(co, 10, _35clofun3248, 4, name, idx, fvs, clo_45or_45cont);
-__nargs = 6;
-__arg0 = globalRef(intern("cora/lib/toc#append-result"));
-__arg1 = v;
-__arg2 = idx;
-__arg3 = cur;
-co->args[4] = name;
-co->args[5] = _35reg2564;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 14, _35clofun3248, 7, body1, params, v, cur, idx, fvs, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#caar"));
-__arg1 = cur;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label16:
-{
-Obj _35val2546 = __arg1;
-Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj idx = _35val2546;
-pushCont(co, 15, _35clofun3248, 6, body1, params, v, idx, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#vector-ref"));
-__arg1 = v;
-__arg2 = makeNumber(1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val2545 = __arg1;
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj body1 = _35val2545;
-pushCont(co, 16, _35clofun3248, 5, body1, params, v, fvs, clo_45or_45cont);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#vector-ref"));
-__arg1 = v;
-__arg2 = makeNumber(0);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35val2602 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2601= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2603 = primCons(_35val2602, fvs);
-Obj _35reg2604 = primCons(_35reg2601, _35reg2603);
-Obj _35reg2605 = primCons(clo_45or_45cont, _35reg2604);
-__nargs = 2;
-__arg1 = _35reg2605;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3248) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label19:
 {
 Obj _35val2600 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2601 = primCons(name, idx);
-pushCont(co, 18, _35clofun3248, 3, fvs, _35reg2601, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = params;
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj body1 = _35val2600;
+pushCont(co, 0, clofun45, 5, body1, params, v, fvs, clo_45or_45cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#vector-ref"));
+__arg1 = v;
+__arg2 = makeNumber(0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3248) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun44) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35val2610 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg2611 = primCons(name, idx);
-Obj _35reg2612 = primCons(_35reg2611, fvs);
-Obj _35reg2613 = primCons(clo_45or_45cont, _35reg2612);
-__nargs = 2;
-__arg1 = _35reg2613;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3248) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
 }
 
 fail:
@@ -7305,511 +7650,137 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3247(struct Cora* co){
+void clofun45(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2405 = __arg1;
-Obj _35val2404= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2406 = primCons(_35val2405, Nil);
-Obj _35reg2407 = primCons(_35val2404, _35reg2406);
-Obj _35reg2408 = primCons(intern("call"), _35reg2407);
-__nargs = 2;
-__arg1 = _35reg2408;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3247) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val2601 = __arg1;
+Obj body1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj v= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj cur = _35val2601;
+Obj _35reg2602 = primEQ(clo_45or_45cont, intern("%closure"));
+if (True == _35reg2602) {
+Obj _35reg2603 = primCons(body1, Nil);
+Obj _35reg2604 = primCons(Nil, _35reg2603);
+Obj _35reg2605 = primCons(params, _35reg2604);
+Obj _35reg2606 = primCons(intern("lambda"), _35reg2605);
+pushCont(co, 2, clofun45, 4, params, fvs, cur, clo_45or_45cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#append-result"));
+__arg1 = v;
+__arg2 = _35reg2606;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun45) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2612 = primCons(body1, Nil);
+Obj _35reg2613 = primCons(fvs, _35reg2612);
+Obj _35reg2614 = primCons(params, _35reg2613);
+Obj _35reg2615 = primCons(intern("lambda"), _35reg2614);
+pushCont(co, 1, clofun45, 3, cur, fvs, clo_45or_45cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#append-result"));
+__arg1 = v;
+__arg2 = _35reg2615;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun45) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label1:
 {
-Obj _35val2404 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 0, _35clofun3247, 1, _35val2404);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
-__arg1 = fvs;
-__arg2 = cont;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+Obj _35val2616 = __arg1;
+Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg2617 = primCons(cur, fvs);
+Obj _35reg2618 = primCons(clo_45or_45cont, _35reg2617);
+__nargs = 2;
+__arg1 = _35reg2618;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun45) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val2403 = __arg1;
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2607 = __arg1;
+Obj params= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 1, _35clofun3247, 2, fvs, cont);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val2403;
-__arg2 = exp;
+Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 3, clofun45, 3, fvs, cur, clo_45or_45cont);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#length"));
+__arg1 = params;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun45) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc1467 = makeNative(20, _35clofun3246, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg2386 = primIsCons(closureRef(co, 1));
-if (True == _35reg2386) {
-Obj _35reg2387 = primCar(closureRef(co, 1));
-Obj _35reg2388 = primEQ(intern("call"), _35reg2387);
-if (True == _35reg2388) {
-Obj _35reg2389 = primCdr(closureRef(co, 1));
-Obj _35reg2390 = primIsCons(_35reg2389);
-if (True == _35reg2390) {
-Obj _35reg2391 = primCdr(closureRef(co, 1));
-Obj _35reg2392 = primCar(_35reg2391);
-Obj exp = _35reg2392;
-Obj _35reg2393 = primCdr(closureRef(co, 1));
-Obj _35reg2394 = primCdr(_35reg2393);
-Obj _35reg2395 = primIsCons(_35reg2394);
-if (True == _35reg2395) {
-Obj _35reg2396 = primCdr(closureRef(co, 1));
-Obj _35reg2397 = primCdr(_35reg2396);
-Obj _35reg2398 = primCar(_35reg2397);
-Obj cont = _35reg2398;
-Obj _35reg2399 = primCdr(closureRef(co, 1));
-Obj _35reg2400 = primCdr(_35reg2399);
-Obj _35reg2401 = primCdr(_35reg2400);
-Obj _35reg2402 = primEQ(Nil, _35reg2401);
-if (True == _35reg2402) {
-pushCont(co, 2, _35clofun3247, 3, exp, fvs, cont);
+Obj _35val2608 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cur= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg2609 = primCons(_35val2608, fvs);
+Obj _35reg2610 = primCons(cur, _35reg2609);
+Obj _35reg2611 = primCons(clo_45or_45cont, _35reg2610);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
-__arg1 = fvs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1467;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1467;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1467;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1467;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1467;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
+__arg1 = _35reg2611;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun45) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label4:
 {
-Obj _35val2430 = __arg1;
-Obj val= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fvs2= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2431 = primCons(_35val2430, Nil);
-Obj _35reg2432 = primCons(val, _35reg2431);
-Obj _35reg2433 = primCons(intern("lambda"), _35reg2432);
-Obj _35reg2434 = primCons(_35reg2433, fvs2);
-Obj _35reg2435 = primCons(intern("%continuation"), _35reg2434);
-__nargs = 2;
-__arg1 = _35reg2435;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3247) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35cc1565 = makeNative(0, clofun46, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v = closureRef(co, 0);
+Obj f_45args = closureRef(co, 1);
+Obj _35reg2561 = primIsCons(f_45args);
+if (True == _35reg2561) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = makeNative(5, clofun45, 1, 1, v);
+__arg2 = f_45args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun45) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1565;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun45) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label5:
-{
-Obj _35val2429 = __arg1;
-Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs2 = _35val2429;
-pushCont(co, 4, _35clofun3247, 2, val, fvs2);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
-__arg1 = fvs1;
-__arg2 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val2428 = __arg1;
-Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 5, _35clofun3247, 3, fvs1, body, val);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val2428;
-__arg2 = fvs1;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val2427 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs1 = _35val2427;
-pushCont(co, 6, _35clofun3247, 3, fvs1, body, val);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
-__arg1 = fvs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35val2426 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 7, _35clofun3247, 3, fvs, body, val);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = _35val2426;
-__arg2 = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35cc1466 = makeNative(3, _35clofun3247, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg2409 = primIsCons(closureRef(co, 1));
-if (True == _35reg2409) {
-Obj _35reg2410 = primCar(closureRef(co, 1));
-Obj _35reg2411 = primEQ(intern("continuation"), _35reg2410);
-if (True == _35reg2411) {
-Obj _35reg2412 = primCdr(closureRef(co, 1));
-Obj _35reg2413 = primIsCons(_35reg2412);
-if (True == _35reg2413) {
-Obj _35reg2414 = primCdr(closureRef(co, 1));
-Obj _35reg2415 = primCar(_35reg2414);
-Obj val = _35reg2415;
-Obj _35reg2416 = primCdr(closureRef(co, 1));
-Obj _35reg2417 = primCdr(_35reg2416);
-Obj _35reg2418 = primIsCons(_35reg2417);
-if (True == _35reg2418) {
-Obj _35reg2419 = primCdr(closureRef(co, 1));
-Obj _35reg2420 = primCdr(_35reg2419);
-Obj _35reg2421 = primCar(_35reg2420);
-Obj body = _35reg2421;
-Obj _35reg2422 = primCdr(closureRef(co, 1));
-Obj _35reg2423 = primCdr(_35reg2422);
-Obj _35reg2424 = primCdr(_35reg2423);
-Obj _35reg2425 = primEQ(Nil, _35reg2424);
-if (True == _35reg2425) {
-pushCont(co, 8, _35clofun3247, 3, fvs, body, val);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1466;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1466;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1466;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1466;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1466;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj _35val2453 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2454 = primCons(_35val2453, Nil);
-Obj _35reg2455 = primCons(args, _35reg2454);
-Obj _35reg2456 = primCons(intern("lambda"), _35reg2455);
-__nargs = 2;
-__arg1 = _35reg2456;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3247) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label11:
-{
-Obj _35cc1465 = makeNative(9, _35clofun3247, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg2436 = primIsCons(closureRef(co, 1));
-if (True == _35reg2436) {
-Obj _35reg2437 = primCar(closureRef(co, 1));
-Obj _35reg2438 = primEQ(intern("lambda"), _35reg2437);
-if (True == _35reg2438) {
-Obj _35reg2439 = primCdr(closureRef(co, 1));
-Obj _35reg2440 = primIsCons(_35reg2439);
-if (True == _35reg2440) {
-Obj _35reg2441 = primCdr(closureRef(co, 1));
-Obj _35reg2442 = primCar(_35reg2441);
-Obj args = _35reg2442;
-Obj _35reg2443 = primCdr(closureRef(co, 1));
-Obj _35reg2444 = primCdr(_35reg2443);
-Obj _35reg2445 = primIsCons(_35reg2444);
-if (True == _35reg2445) {
-Obj _35reg2446 = primCdr(closureRef(co, 1));
-Obj _35reg2447 = primCdr(_35reg2446);
-Obj _35reg2448 = primCar(_35reg2447);
-Obj body = _35reg2448;
-Obj _35reg2449 = primCdr(closureRef(co, 1));
-Obj _35reg2450 = primCdr(_35reg2449);
-Obj _35reg2451 = primCdr(_35reg2450);
-Obj _35reg2452 = primEQ(Nil, _35reg2451);
-if (True == _35reg2452) {
-pushCont(co, 10, _35clofun3247, 1, args);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
-__arg1 = fvs;
-__arg2 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1465;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1465;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1465;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1465;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1465;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35cc1464 = makeNative(11, _35clofun3247, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj var = closureRef(co, 1);
-Obj _35reg2457 = primIsSymbol(var);
-if (True == _35reg2457) {
-__nargs = 2;
-__arg1 = var;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3247) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1464;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
-{
-Obj _35val2458 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1463= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2458) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3247) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1463;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label14:
-{
-Obj _35p1461 = __arg1;
-Obj _35p1462 = __arg2;
-Obj _35cc1463 = makeNative(12, _35clofun3247, 0, 2, _35p1461, _35p1462);
-Obj __ = _35p1461;
-Obj x = _35p1462;
-pushCont(co, 13, _35clofun3247, 2, x, _35cc1463);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35cc1473 = makeNative(15, _35clofun3247, 0, 0);
-Obj v = closureRef(co, 0);
-Obj x = closureRef(co, 1);
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3247) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label17:
 {
 Obj e = __arg1;
 __nargs = 3;
@@ -7819,70 +7790,7 @@ __arg2 = e;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35cc1472 = makeNative(16, _35clofun3247, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj v = closureRef(co, 0);
-Obj f_45args = closureRef(co, 1);
-Obj _35reg2460 = primIsCons(f_45args);
-if (True == _35reg2460) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = makeNative(17, _35clofun3247, 1, 1, v);
-__arg2 = f_45args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1472;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label19:
-{
-Obj _35val2511 = __arg1;
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2510= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2512 = primCons(_35val2511, fvs);
-Obj _35reg2513 = primCons(_35reg2510, _35reg2512);
-Obj _35reg2514 = primCons(clo_45or_45cont, _35reg2513);
-__nargs = 2;
-__arg1 = _35reg2514;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3247) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label20:
-{
-Obj _35val2509 = __arg1;
-Obj name= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj idx= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj params= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj clo_45or_45cont= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg2510 = primCons(name, idx);
-pushCont(co, 19, _35clofun3247, 3, fvs, _35reg2510, clo_45or_45cont);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = params;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3247) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun45) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -7895,38 +7803,1233 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3246(struct Cora* co){
+void clofun46(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2325 = __arg1;
-Obj _35val2324= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2326 = primCons(_35val2325, Nil);
-Obj _35reg2327 = primCons(_35val2324, _35reg2326);
-Obj _35reg2328 = primCons(ra, _35reg2327);
-Obj _35reg2329 = primCons(intern("if"), _35reg2328);
+Obj _35cc1566 = makeNative(1, clofun46, 0, 0);
+Obj v = closureRef(co, 0);
+Obj x = closureRef(co, 1);
 __nargs = 2;
-__arg1 = _35reg2329;
+__arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3246) { goto fail; }
+if (co->ctx.pc.func != clofun46) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label1:
 {
-Obj _35val2324 = __arg1;
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun46) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35p1554 = __arg1;
+Obj _35p1555 = __arg2;
+Obj _35cc1556 = makeNative(4, clofun46, 0, 2, _35p1554, _35p1555);
+Obj __ = _35p1554;
+Obj x = _35p1555;
+pushCont(co, 3, clofun46, 2, x, _35cc1556);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun46) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2559 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1556= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val2559) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun46) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1556;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun46) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35cc1557 = makeNative(5, clofun46, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj var = closureRef(co, 1);
+Obj _35reg2558 = primIsSymbol(var);
+if (True == _35reg2558) {
+__nargs = 2;
+__arg1 = var;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun46) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1557;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun46) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35cc1558 = makeNative(1, clofun47, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj _35reg2537 = primIsCons(closureRef(co, 1));
+if (True == _35reg2537) {
+Obj _35reg2538 = primCar(closureRef(co, 1));
+Obj _35reg2539 = primEQ(intern("lambda"), _35reg2538);
+if (True == _35reg2539) {
+Obj _35reg2540 = primCdr(closureRef(co, 1));
+Obj _35reg2541 = primIsCons(_35reg2540);
+if (True == _35reg2541) {
+Obj _35reg2542 = primCdr(closureRef(co, 1));
+Obj _35reg2543 = primCar(_35reg2542);
+Obj args = _35reg2543;
+Obj _35reg2544 = primCdr(closureRef(co, 1));
+Obj _35reg2545 = primCdr(_35reg2544);
+Obj _35reg2546 = primIsCons(_35reg2545);
+if (True == _35reg2546) {
+Obj _35reg2547 = primCdr(closureRef(co, 1));
+Obj _35reg2548 = primCdr(_35reg2547);
+Obj _35reg2549 = primCar(_35reg2548);
+Obj body = _35reg2549;
+Obj _35reg2550 = primCdr(closureRef(co, 1));
+Obj _35reg2551 = primCdr(_35reg2550);
+Obj _35reg2552 = primCdr(_35reg2551);
+Obj _35reg2553 = primEQ(Nil, _35reg2552);
+if (True == _35reg2553) {
+pushCont(co, 0, clofun47, 1, args);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
+__arg1 = fvs;
+__arg2 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun46) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1558;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun46) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1558;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun46) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1558;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun46) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1558;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun46) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1558;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun46) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun47(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2554 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2555 = primCons(_35val2554, Nil);
+Obj _35reg2556 = primCons(args, _35reg2555);
+Obj _35reg2557 = primCons(intern("lambda"), _35reg2556);
+__nargs = 2;
+__arg1 = _35reg2557;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun47) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label1:
+{
+Obj _35cc1559 = makeNative(1, clofun48, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj _35reg2510 = primIsCons(closureRef(co, 1));
+if (True == _35reg2510) {
+Obj _35reg2511 = primCar(closureRef(co, 1));
+Obj _35reg2512 = primEQ(intern("continuation"), _35reg2511);
+if (True == _35reg2512) {
+Obj _35reg2513 = primCdr(closureRef(co, 1));
+Obj _35reg2514 = primIsCons(_35reg2513);
+if (True == _35reg2514) {
+Obj _35reg2515 = primCdr(closureRef(co, 1));
+Obj _35reg2516 = primCar(_35reg2515);
+Obj val = _35reg2516;
+Obj _35reg2517 = primCdr(closureRef(co, 1));
+Obj _35reg2518 = primCdr(_35reg2517);
+Obj _35reg2519 = primIsCons(_35reg2518);
+if (True == _35reg2519) {
+Obj _35reg2520 = primCdr(closureRef(co, 1));
+Obj _35reg2521 = primCdr(_35reg2520);
+Obj _35reg2522 = primCar(_35reg2521);
+Obj body = _35reg2522;
+Obj _35reg2523 = primCdr(closureRef(co, 1));
+Obj _35reg2524 = primCdr(_35reg2523);
+Obj _35reg2525 = primCdr(_35reg2524);
+Obj _35reg2526 = primEQ(Nil, _35reg2525);
+if (True == _35reg2526) {
+pushCont(co, 2, clofun47, 3, fvs, body, val);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun47) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1559;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun47) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1559;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun47) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1559;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun47) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1559;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun47) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1559;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun47) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35val2527 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 3, clofun47, 3, fvs, body, val);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#diff"));
+__arg1 = _35val2527;
+__arg2 = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun47) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2528 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj fvs1 = _35val2528;
+pushCont(co, 4, clofun47, 3, fvs1, body, val);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
+__arg1 = fvs;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun47) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val2529 = __arg1;
+Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 5, clofun47, 3, fvs1, body, val);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = _35val2529;
+__arg2 = fvs1;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun47) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val2530 = __arg1;
+Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj fvs2 = _35val2530;
+pushCont(co, 0, clofun48, 2, val, fvs2);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
+__arg1 = fvs1;
+__arg2 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun47) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun48(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2531 = __arg1;
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs2= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2532 = primCons(_35val2531, Nil);
+Obj _35reg2533 = primCons(val, _35reg2532);
+Obj _35reg2534 = primCons(intern("lambda"), _35reg2533);
+Obj _35reg2535 = primCons(_35reg2534, fvs2);
+Obj _35reg2536 = primCons(intern("%continuation"), _35reg2535);
+__nargs = 2;
+__arg1 = _35reg2536;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun48) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label1:
+{
+Obj _35cc1560 = makeNative(5, clofun48, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj _35reg2487 = primIsCons(closureRef(co, 1));
+if (True == _35reg2487) {
+Obj _35reg2488 = primCar(closureRef(co, 1));
+Obj _35reg2489 = primEQ(intern("call"), _35reg2488);
+if (True == _35reg2489) {
+Obj _35reg2490 = primCdr(closureRef(co, 1));
+Obj _35reg2491 = primIsCons(_35reg2490);
+if (True == _35reg2491) {
+Obj _35reg2492 = primCdr(closureRef(co, 1));
+Obj _35reg2493 = primCar(_35reg2492);
+Obj exp = _35reg2493;
+Obj _35reg2494 = primCdr(closureRef(co, 1));
+Obj _35reg2495 = primCdr(_35reg2494);
+Obj _35reg2496 = primIsCons(_35reg2495);
+if (True == _35reg2496) {
+Obj _35reg2497 = primCdr(closureRef(co, 1));
+Obj _35reg2498 = primCdr(_35reg2497);
+Obj _35reg2499 = primCar(_35reg2498);
+Obj cont = _35reg2499;
+Obj _35reg2500 = primCdr(closureRef(co, 1));
+Obj _35reg2501 = primCdr(_35reg2500);
+Obj _35reg2502 = primCdr(_35reg2501);
+Obj _35reg2503 = primEQ(Nil, _35reg2502);
+if (True == _35reg2503) {
+pushCont(co, 2, clofun48, 3, exp, fvs, cont);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
+__arg1 = fvs;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun48) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1560;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun48) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1560;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun48) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1560;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun48) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1560;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun48) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1560;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun48) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35val2504 = __arg1;
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 2];
+pushCont(co, 3, clofun48, 2, fvs, cont);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = _35val2504;
+__arg2 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun48) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2505 = __arg1;
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj cont= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 4, clofun48, 1, _35val2505);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
+__arg1 = fvs;
+__arg2 = cont;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun48) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val2506 = __arg1;
+Obj _35val2505= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2507 = primCons(_35val2506, Nil);
+Obj _35reg2508 = primCons(_35val2505, _35reg2507);
+Obj _35reg2509 = primCons(intern("call"), _35reg2508);
+__nargs = 2;
+__arg1 = _35reg2509;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun48) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label5:
+{
+Obj _35cc1561 = makeNative(1, clofun49, 0, 0);
+Obj fvs = closureRef(co, 0);
+Obj _35reg2482 = primIsCons(closureRef(co, 1));
+if (True == _35reg2482) {
+Obj _35reg2483 = primCar(closureRef(co, 1));
+Obj f = _35reg2483;
+Obj _35reg2484 = primCdr(closureRef(co, 1));
+Obj args = _35reg2484;
+pushCont(co, 0, clofun49, 2, f, args);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
+__arg1 = fvs;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun48) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1561;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun48) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun49(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2485 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2486 = primCons(f, args);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = _35val2485;
+__arg2 = _35reg2486;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun49) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun49) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35p1549 = __arg1;
+Obj _35p1550 = __arg2;
+Obj _35p1551 = __arg3;
+Obj _35cc1552 = makeNative(3, clofun50, 0, 3, _35p1549, _35p1550, _35p1551);
+Obj _35reg2439 = primEQ(Nil, _35p1549);
+if (True == _35reg2439) {
+Obj ls = _35p1550;
+Obj next = _35p1551;
+pushCont(co, 3, clofun49, 1, next);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#reverse"));
+__arg1 = ls;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun49) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1552;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun49) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35val2440 = __arg1;
+Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp = _35val2440;
+Obj _35reg2441 = primCar(exp);
+pushCont(co, 4, clofun49, 2, next, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#pair?"));
+__arg1 = _35reg2441;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun49) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val2442 = __arg1;
+Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val2442) {
+pushCont(co, 0, clofun50, 2, next, exp);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#caar"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun49) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+if (True == False) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#wrap-var"));
+__arg1 = exp;
+__arg2 = next;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun49) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2469 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
+if (True == _35reg2469) {
+Obj _35reg2470 = primCons(exp, Nil);
+Obj _35reg2471 = primCons(intern("tailcall"), _35reg2470);
+__nargs = 2;
+__arg1 = _35reg2471;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun49) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg2472 = primGenSym(intern("val"));
+Obj val = _35reg2472;
+Obj _35reg2473 = primCons(val, Nil);
+pushCont(co, 5, clofun49, 2, _35reg2473, exp);
+__nargs = 2;
+__arg0 = next;
+__arg1 = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun49) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+}
+
+label5:
+{
+Obj _35val2474 = __arg1;
+Obj _35reg2473= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2475 = primCons(_35val2474, Nil);
+Obj _35reg2476 = primCons(_35reg2473, _35reg2475);
+Obj _35reg2477 = primCons(intern("continuation"), _35reg2476);
+Obj _35reg2478 = primCons(_35reg2477, Nil);
+Obj _35reg2479 = primCons(exp, _35reg2478);
+Obj _35reg2480 = primCons(intern("call"), _35reg2479);
+__nargs = 2;
+__arg1 = _35reg2480;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun49) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun50(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2443 = __arg1;
+Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2444 = primEQ(_35val2443, intern("%builtin"));
+if (True == _35reg2444) {
+if (True == True) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#wrap-var"));
+__arg1 = exp;
+__arg2 = next;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun50) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2445 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
+if (True == _35reg2445) {
+Obj _35reg2446 = primCons(exp, Nil);
+Obj _35reg2447 = primCons(intern("tailcall"), _35reg2446);
+__nargs = 2;
+__arg1 = _35reg2447;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun50) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg2448 = primGenSym(intern("val"));
+Obj val = _35reg2448;
+Obj _35reg2449 = primCons(val, Nil);
+pushCont(co, 2, clofun50, 2, _35reg2449, exp);
+__nargs = 2;
+__arg0 = next;
+__arg1 = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun50) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+} else {
+if (True == False) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#wrap-var"));
+__arg1 = exp;
+__arg2 = next;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun50) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+Obj _35reg2457 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
+if (True == _35reg2457) {
+Obj _35reg2458 = primCons(exp, Nil);
+Obj _35reg2459 = primCons(intern("tailcall"), _35reg2458);
+__nargs = 2;
+__arg1 = _35reg2459;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun50) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg2460 = primGenSym(intern("val"));
+Obj val = _35reg2460;
+Obj _35reg2461 = primCons(val, Nil);
+pushCont(co, 1, clofun50, 2, _35reg2461, exp);
+__nargs = 2;
+__arg0 = next;
+__arg1 = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun50) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+}
+
+label1:
+{
+Obj _35val2462 = __arg1;
+Obj _35reg2461= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2463 = primCons(_35val2462, Nil);
+Obj _35reg2464 = primCons(_35reg2461, _35reg2463);
+Obj _35reg2465 = primCons(intern("continuation"), _35reg2464);
+Obj _35reg2466 = primCons(_35reg2465, Nil);
+Obj _35reg2467 = primCons(exp, _35reg2466);
+Obj _35reg2468 = primCons(intern("call"), _35reg2467);
+__nargs = 2;
+__arg1 = _35reg2468;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun50) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label2:
+{
+Obj _35val2450 = __arg1;
+Obj _35reg2449= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2451 = primCons(_35val2450, Nil);
+Obj _35reg2452 = primCons(_35reg2449, _35reg2451);
+Obj _35reg2453 = primCons(intern("continuation"), _35reg2452);
+Obj _35reg2454 = primCons(_35reg2453, Nil);
+Obj _35reg2455 = primCons(exp, _35reg2454);
+Obj _35reg2456 = primCons(intern("call"), _35reg2455);
+__nargs = 2;
+__arg1 = _35reg2456;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun50) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label3:
+{
+Obj _35cc1553 = makeNative(5, clofun50, 0, 0);
+Obj _35reg2435 = primIsCons(closureRef(co, 0));
+if (True == _35reg2435) {
+Obj _35reg2436 = primCar(closureRef(co, 0));
+Obj hd = _35reg2436;
+Obj _35reg2437 = primCdr(closureRef(co, 0));
+Obj tl = _35reg2437;
+Obj ls = closureRef(co, 1);
+Obj next = closureRef(co, 2);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#tailify"));
+__arg1 = hd;
+__arg2 = makeNative(4, clofun50, 1, 3, tl, ls, next);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun50) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1553;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun50) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj hd1 = __arg1;
+Obj _35reg2438 = primCons(hd1, closureRef(co, 1));
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#tailify-list"));
+__arg1 = closureRef(co, 0);
+__arg2 = _35reg2438;
+__arg3 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun50) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun50) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun51(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35p1540 = __arg1;
+Obj _35p1541 = __arg2;
+Obj _35cc1542 = makeNative(2, clofun51, 0, 2, _35p1540, _35p1541);
+Obj x = _35p1540;
+Obj next = _35p1541;
+Obj _35reg2432 = primIsSymbol(x);
+if (True == _35reg2432) {
+if (True == True) {
+__nargs = 2;
+__arg0 = next;
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1542;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+pushCont(co, 1, clofun51, 3, next, x, _35cc1542);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35val2433 = __arg1;
+Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc1542= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val2433) {
+if (True == True) {
+__nargs = 2;
+__arg0 = next;
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1542;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+__nargs = 2;
+__arg0 = next;
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1542;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label2:
+{
+Obj _35cc1543 = makeNative(4, clofun51, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj x = closureRef(co, 0);
+Obj __ = closureRef(co, 1);
+pushCont(co, 3, clofun51, 2, x, _35cc1543);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2431 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1543= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val2431) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun51) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1543;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35cc1544 = makeNative(2, clofun52, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2399 = primIsCons(closureRef(co, 0));
+if (True == _35reg2399) {
+Obj _35reg2400 = primCar(closureRef(co, 0));
+Obj _35reg2401 = primEQ(intern("if"), _35reg2400);
+if (True == _35reg2401) {
+Obj _35reg2402 = primCdr(closureRef(co, 0));
+Obj _35reg2403 = primIsCons(_35reg2402);
+if (True == _35reg2403) {
+Obj _35reg2404 = primCdr(closureRef(co, 0));
+Obj _35reg2405 = primCar(_35reg2404);
+Obj a = _35reg2405;
+Obj _35reg2406 = primCdr(closureRef(co, 0));
+Obj _35reg2407 = primCdr(_35reg2406);
+Obj _35reg2408 = primIsCons(_35reg2407);
+if (True == _35reg2408) {
+Obj _35reg2409 = primCdr(closureRef(co, 0));
+Obj _35reg2410 = primCdr(_35reg2409);
+Obj _35reg2411 = primCar(_35reg2410);
+Obj b = _35reg2411;
+Obj _35reg2412 = primCdr(closureRef(co, 0));
+Obj _35reg2413 = primCdr(_35reg2412);
+Obj _35reg2414 = primCdr(_35reg2413);
+Obj _35reg2415 = primIsCons(_35reg2414);
+if (True == _35reg2415) {
+Obj _35reg2416 = primCdr(closureRef(co, 0));
+Obj _35reg2417 = primCdr(_35reg2416);
+Obj _35reg2418 = primCdr(_35reg2417);
+Obj _35reg2419 = primCar(_35reg2418);
+Obj c = _35reg2419;
+Obj _35reg2420 = primCdr(closureRef(co, 0));
+Obj _35reg2421 = primCdr(_35reg2420);
+Obj _35reg2422 = primCdr(_35reg2421);
+Obj _35reg2423 = primCdr(_35reg2422);
+Obj _35reg2424 = primEQ(Nil, _35reg2423);
+if (True == _35reg2424) {
+Obj next = closureRef(co, 1);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#tailify"));
+__arg1 = a;
+__arg2 = makeNative(5, clofun51, 1, 3, b, c, next);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1544;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1544;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1544;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1544;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1544;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1544;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj ra = __arg1;
+pushCont(co, 0, clofun52, 1, ra);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#tailify"));
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 2);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun51) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun52(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2425 = __arg1;
 Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 0, _35clofun3246, 2, _35val2324, ra);
+pushCont(co, 1, clofun52, 2, _35val2425, ra);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = closureRef(co, 1);
@@ -7934,604 +9037,252 @@ __arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val2426 = __arg1;
+Obj _35val2425= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2427 = primCons(_35val2426, Nil);
+Obj _35reg2428 = primCons(_35val2425, _35reg2427);
+Obj _35reg2429 = primCons(ra, _35reg2428);
+Obj _35reg2430 = primCons(intern("if"), _35reg2429);
+__nargs = 2;
+__arg1 = _35reg2430;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun52) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj ra = __arg1;
-pushCont(co, 1, _35clofun3246, 1, ra);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#tailify"));
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj _35cc1451 = makeNative(20, _35clofun3245, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2298 = primIsCons(closureRef(co, 0));
-if (True == _35reg2298) {
-Obj _35reg2299 = primCar(closureRef(co, 0));
-Obj _35reg2300 = primEQ(intern("if"), _35reg2299);
-if (True == _35reg2300) {
-Obj _35reg2301 = primCdr(closureRef(co, 0));
-Obj _35reg2302 = primIsCons(_35reg2301);
-if (True == _35reg2302) {
-Obj _35reg2303 = primCdr(closureRef(co, 0));
-Obj _35reg2304 = primCar(_35reg2303);
-Obj a = _35reg2304;
-Obj _35reg2305 = primCdr(closureRef(co, 0));
-Obj _35reg2306 = primCdr(_35reg2305);
-Obj _35reg2307 = primIsCons(_35reg2306);
-if (True == _35reg2307) {
-Obj _35reg2308 = primCdr(closureRef(co, 0));
-Obj _35reg2309 = primCdr(_35reg2308);
-Obj _35reg2310 = primCar(_35reg2309);
-Obj b = _35reg2310;
-Obj _35reg2311 = primCdr(closureRef(co, 0));
-Obj _35reg2312 = primCdr(_35reg2311);
-Obj _35reg2313 = primCdr(_35reg2312);
-Obj _35reg2314 = primIsCons(_35reg2313);
-if (True == _35reg2314) {
-Obj _35reg2315 = primCdr(closureRef(co, 0));
-Obj _35reg2316 = primCdr(_35reg2315);
-Obj _35reg2317 = primCdr(_35reg2316);
-Obj _35reg2318 = primCar(_35reg2317);
-Obj c = _35reg2318;
-Obj _35reg2319 = primCdr(closureRef(co, 0));
-Obj _35reg2320 = primCdr(_35reg2319);
-Obj _35reg2321 = primCdr(_35reg2320);
-Obj _35reg2322 = primCdr(_35reg2321);
-Obj _35reg2323 = primEQ(Nil, _35reg2322);
-if (True == _35reg2323) {
+Obj _35cc1545 = makeNative(5, clofun52, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2377 = primIsCons(closureRef(co, 0));
+if (True == _35reg2377) {
+Obj _35reg2378 = primCar(closureRef(co, 0));
+Obj _35reg2379 = primEQ(intern("do"), _35reg2378);
+if (True == _35reg2379) {
+Obj _35reg2380 = primCdr(closureRef(co, 0));
+Obj _35reg2381 = primIsCons(_35reg2380);
+if (True == _35reg2381) {
+Obj _35reg2382 = primCdr(closureRef(co, 0));
+Obj _35reg2383 = primCar(_35reg2382);
+Obj a = _35reg2383;
+Obj _35reg2384 = primCdr(closureRef(co, 0));
+Obj _35reg2385 = primCdr(_35reg2384);
+Obj _35reg2386 = primIsCons(_35reg2385);
+if (True == _35reg2386) {
+Obj _35reg2387 = primCdr(closureRef(co, 0));
+Obj _35reg2388 = primCdr(_35reg2387);
+Obj _35reg2389 = primCar(_35reg2388);
+Obj b = _35reg2389;
+Obj _35reg2390 = primCdr(closureRef(co, 0));
+Obj _35reg2391 = primCdr(_35reg2390);
+Obj _35reg2392 = primCdr(_35reg2391);
+Obj _35reg2393 = primEQ(Nil, _35reg2392);
+if (True == _35reg2393) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = a;
-__arg2 = makeNative(2, _35clofun3246, 1, 3, b, c, next);
+__arg2 = makeNative(3, clofun52, 1, 2, b, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1451;
+__arg0 = _35cc1545;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1451;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1451;
+__arg0 = _35cc1545;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1451;
+__arg0 = _35cc1545;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1451;
+__arg0 = _35cc1545;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1451;
+__arg0 = _35cc1545;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj ra = __arg1;
+Obj _35reg2394 = primIsSymbol(ra);
+if (True == _35reg2394) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#tailify"));
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+pushCont(co, 4, clofun52, 1, ra);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#tailify"));
+__arg1 = closureRef(co, 0);
+__arg2 = closureRef(co, 1);
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35val2330 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1450= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2330) {
+Obj _35val2395 = __arg1;
+Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2396 = primCons(_35val2395, Nil);
+Obj _35reg2397 = primCons(ra, _35reg2396);
+Obj _35reg2398 = primCons(intern("do"), _35reg2397);
 __nargs = 2;
-__arg1 = x;
+__arg1 = _35reg2398;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3246) { goto fail; }
+if (co->ctx.pc.func != clofun52) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1450;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label5:
 {
-Obj _35cc1450 = makeNative(3, _35clofun3246, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj x = closureRef(co, 0);
-Obj __ = closureRef(co, 1);
-pushCont(co, 4, _35clofun3246, 2, x, _35cc1450);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35val2332 = __arg1;
-Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc1449= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val2332) {
-if (True == True) {
-__nargs = 2;
-__arg0 = next;
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1449;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-__nargs = 2;
-__arg0 = next;
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1449;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label7:
-{
-Obj _35p1447 = __arg1;
-Obj _35p1448 = __arg2;
-Obj _35cc1449 = makeNative(5, _35clofun3246, 0, 2, _35p1447, _35p1448);
-Obj x = _35p1447;
-Obj next = _35p1448;
-Obj _35reg2331 = primIsSymbol(x);
-if (True == _35reg2331) {
-if (True == True) {
-__nargs = 2;
-__arg0 = next;
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1449;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 6, _35clofun3246, 3, next, x, _35cc1449);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj hd1 = __arg1;
-Obj _35reg2337 = primCons(hd1, closureRef(co, 1));
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#tailify-list"));
-__arg1 = closureRef(co, 0);
-__arg2 = _35reg2337;
-__arg3 = closureRef(co, 2);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35cc1460 = makeNative(8, _35clofun3246, 0, 0);
-Obj _35reg2334 = primIsCons(closureRef(co, 0));
-if (True == _35reg2334) {
-Obj _35reg2335 = primCar(closureRef(co, 0));
-Obj hd = _35reg2335;
-Obj _35reg2336 = primCdr(closureRef(co, 0));
-Obj tl = _35reg2336;
-Obj ls = closureRef(co, 1);
-Obj next = closureRef(co, 2);
+Obj _35cc1546 = makeNative(2, clofun53, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2346 = primIsCons(closureRef(co, 0));
+if (True == _35reg2346) {
+Obj _35reg2347 = primCar(closureRef(co, 0));
+Obj _35reg2348 = primEQ(intern("let"), _35reg2347);
+if (True == _35reg2348) {
+Obj _35reg2349 = primCdr(closureRef(co, 0));
+Obj _35reg2350 = primIsCons(_35reg2349);
+if (True == _35reg2350) {
+Obj _35reg2351 = primCdr(closureRef(co, 0));
+Obj _35reg2352 = primCar(_35reg2351);
+Obj a = _35reg2352;
+Obj _35reg2353 = primCdr(closureRef(co, 0));
+Obj _35reg2354 = primCdr(_35reg2353);
+Obj _35reg2355 = primIsCons(_35reg2354);
+if (True == _35reg2355) {
+Obj _35reg2356 = primCdr(closureRef(co, 0));
+Obj _35reg2357 = primCdr(_35reg2356);
+Obj _35reg2358 = primCar(_35reg2357);
+Obj b = _35reg2358;
+Obj _35reg2359 = primCdr(closureRef(co, 0));
+Obj _35reg2360 = primCdr(_35reg2359);
+Obj _35reg2361 = primCdr(_35reg2360);
+Obj _35reg2362 = primIsCons(_35reg2361);
+if (True == _35reg2362) {
+Obj _35reg2363 = primCdr(closureRef(co, 0));
+Obj _35reg2364 = primCdr(_35reg2363);
+Obj _35reg2365 = primCdr(_35reg2364);
+Obj _35reg2366 = primCar(_35reg2365);
+Obj c = _35reg2366;
+Obj _35reg2367 = primCdr(closureRef(co, 0));
+Obj _35reg2368 = primCdr(_35reg2367);
+Obj _35reg2369 = primCdr(_35reg2368);
+Obj _35reg2370 = primCdr(_35reg2369);
+Obj _35reg2371 = primEQ(Nil, _35reg2370);
+if (True == _35reg2371) {
+Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
-__arg1 = hd;
-__arg2 = makeNative(9, _35clofun3246, 1, 3, tl, ls, next);
+__arg1 = b;
+__arg2 = makeNative(0, clofun53, 1, 3, a, c, next);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1460;
+__arg0 = _35cc1546;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label11:
-{
-Obj _35val2349 = __arg1;
-Obj _35reg2348= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2350 = primCons(_35val2349, Nil);
-Obj _35reg2351 = primCons(_35reg2348, _35reg2350);
-Obj _35reg2352 = primCons(intern("continuation"), _35reg2351);
-Obj _35reg2353 = primCons(_35reg2352, Nil);
-Obj _35reg2354 = primCons(exp, _35reg2353);
-Obj _35reg2355 = primCons(intern("call"), _35reg2354);
-__nargs = 2;
-__arg1 = _35reg2355;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3246) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label12:
-{
-Obj _35val2361 = __arg1;
-Obj _35reg2360= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2362 = primCons(_35val2361, Nil);
-Obj _35reg2363 = primCons(_35reg2360, _35reg2362);
-Obj _35reg2364 = primCons(intern("continuation"), _35reg2363);
-Obj _35reg2365 = primCons(_35reg2364, Nil);
-Obj _35reg2366 = primCons(exp, _35reg2365);
-Obj _35reg2367 = primCons(intern("call"), _35reg2366);
-__nargs = 2;
-__arg1 = _35reg2367;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3246) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label13:
-{
-Obj _35val2342 = __arg1;
-Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2343 = primEQ(_35val2342, intern("%builtin"));
-if (True == _35reg2343) {
-if (True == True) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#wrap-var"));
-__arg1 = exp;
-__arg2 = next;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2344 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
-if (True == _35reg2344) {
-Obj _35reg2345 = primCons(exp, Nil);
-Obj _35reg2346 = primCons(intern("tailcall"), _35reg2345);
-__nargs = 2;
-__arg1 = _35reg2346;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3246) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg2347 = primGenSym(intern("val"));
-Obj val = _35reg2347;
-Obj _35reg2348 = primCons(val, Nil);
-pushCont(co, 11, _35clofun3246, 2, _35reg2348, exp);
-__nargs = 2;
-__arg0 = next;
-__arg1 = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-} else {
-if (True == False) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#wrap-var"));
-__arg1 = exp;
-__arg2 = next;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2356 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
-if (True == _35reg2356) {
-Obj _35reg2357 = primCons(exp, Nil);
-Obj _35reg2358 = primCons(intern("tailcall"), _35reg2357);
-__nargs = 2;
-__arg1 = _35reg2358;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3246) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg2359 = primGenSym(intern("val"));
-Obj val = _35reg2359;
-Obj _35reg2360 = primCons(val, Nil);
-pushCont(co, 12, _35clofun3246, 2, _35reg2360, exp);
-__nargs = 2;
-__arg0 = next;
-__arg1 = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-}
-
-label14:
-{
-Obj _35val2373 = __arg1;
-Obj _35reg2372= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2374 = primCons(_35val2373, Nil);
-Obj _35reg2375 = primCons(_35reg2372, _35reg2374);
-Obj _35reg2376 = primCons(intern("continuation"), _35reg2375);
-Obj _35reg2377 = primCons(_35reg2376, Nil);
-Obj _35reg2378 = primCons(exp, _35reg2377);
-Obj _35reg2379 = primCons(intern("call"), _35reg2378);
-__nargs = 2;
-__arg1 = _35reg2379;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3246) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label15:
-{
-Obj _35val2341 = __arg1;
-Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2341) {
-pushCont(co, 13, _35clofun3246, 2, next, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#caar"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-if (True == False) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#wrap-var"));
-__arg1 = exp;
-__arg2 = next;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg2368 = primEQ(next, globalRef(intern("cora/lib/toc#id")));
-if (True == _35reg2368) {
-Obj _35reg2369 = primCons(exp, Nil);
-Obj _35reg2370 = primCons(intern("tailcall"), _35reg2369);
-__nargs = 2;
-__arg1 = _35reg2370;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3246) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg2371 = primGenSym(intern("val"));
-Obj val = _35reg2371;
-Obj _35reg2372 = primCons(val, Nil);
-pushCont(co, 14, _35clofun3246, 2, _35reg2372, exp);
-__nargs = 2;
-__arg0 = next;
-__arg1 = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-}
-
-label16:
-{
-Obj _35val2339 = __arg1;
-Obj next= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj exp = _35val2339;
-Obj _35reg2340 = primCar(exp);
-pushCont(co, 15, _35clofun3246, 2, next, exp);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#pair?"));
-__arg1 = _35reg2340;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35p1456 = __arg1;
-Obj _35p1457 = __arg2;
-Obj _35p1458 = __arg3;
-Obj _35cc1459 = makeNative(10, _35clofun3246, 0, 3, _35p1456, _35p1457, _35p1458);
-Obj _35reg2338 = primEQ(Nil, _35p1456);
-if (True == _35reg2338) {
-Obj ls = _35p1457;
-Obj next = _35p1458;
-pushCont(co, 16, _35clofun3246, 1, next);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#reverse"));
-__arg1 = ls;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1459;
+__arg0 = _35cc1546;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label18:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35val2384 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2385 = primCons(f, args);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val2384;
-__arg2 = _35reg2385;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label20:
-{
-Obj _35cc1468 = makeNative(18, _35clofun3246, 0, 0);
-Obj fvs = closureRef(co, 0);
-Obj _35reg2381 = primIsCons(closureRef(co, 1));
-if (True == _35reg2381) {
-Obj _35reg2382 = primCar(closureRef(co, 1));
-Obj f = _35reg2382;
-Obj _35reg2383 = primCdr(closureRef(co, 1));
-Obj args = _35reg2383;
-pushCont(co, 19, _35clofun3246, 2, f, args);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#explicit-stack"));
-__arg1 = fvs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1468;
+__arg0 = _35cc1546;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3246) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1546;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1546;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1546;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun52) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -8545,500 +9296,101 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3245(struct Cora* co){
+void clofun53(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1445 = makeNative(18, _35clofun3244, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg2126 = primIsCons(closureRef(co, 1));
-if (True == _35reg2126) {
-Obj _35reg2127 = primCar(closureRef(co, 1));
-Obj _35reg2128 = primEQ(intern("let"), _35reg2127);
-if (True == _35reg2128) {
-Obj _35reg2129 = primCdr(closureRef(co, 1));
-Obj _35reg2130 = primIsCons(_35reg2129);
-if (True == _35reg2130) {
-Obj _35reg2131 = primCdr(closureRef(co, 1));
-Obj _35reg2132 = primCar(_35reg2131);
-Obj a = _35reg2132;
-Obj _35reg2133 = primCdr(closureRef(co, 1));
-Obj _35reg2134 = primCdr(_35reg2133);
-Obj _35reg2135 = primIsCons(_35reg2134);
-if (True == _35reg2135) {
-Obj _35reg2136 = primCdr(closureRef(co, 1));
-Obj _35reg2137 = primCdr(_35reg2136);
-Obj _35reg2138 = primCar(_35reg2137);
-Obj b = _35reg2138;
-Obj _35reg2139 = primCdr(closureRef(co, 1));
-Obj _35reg2140 = primCdr(_35reg2139);
-Obj _35reg2141 = primCdr(_35reg2140);
-Obj _35reg2142 = primIsCons(_35reg2141);
-if (True == _35reg2142) {
-Obj _35reg2143 = primCdr(closureRef(co, 1));
-Obj _35reg2144 = primCdr(_35reg2143);
-Obj _35reg2145 = primCdr(_35reg2144);
-Obj _35reg2146 = primCar(_35reg2145);
-Obj c = _35reg2146;
-Obj _35reg2147 = primCdr(closureRef(co, 1));
-Obj _35reg2148 = primCdr(_35reg2147);
-Obj _35reg2149 = primCdr(_35reg2148);
-Obj _35reg2150 = primCdr(_35reg2149);
-Obj _35reg2151 = primEQ(Nil, _35reg2150);
-if (True == _35reg2151) {
-pushCont(co, 20, _35clofun3244, 3, fvs, c, a);
+Obj rb = __arg1;
+pushCont(co, 1, clofun53, 1, rb);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
-__arg1 = fvs;
-__arg2 = b;
+__arg0 = globalRef(intern("cora/lib/toc#tailify"));
+__arg1 = closureRef(co, 1);
+__arg2 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1445;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1445;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1445;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1445;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1445;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1445;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label1:
 {
-Obj _35val2184 = __arg1;
-Obj _35reg2182= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2185 = primCons(_35reg2182, _35val2184);
-Obj _35reg2186 = primCons(intern("%closure"), _35reg2185);
+Obj _35val2372 = __arg1;
+Obj rb= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2373 = primCons(_35val2372, Nil);
+Obj _35reg2374 = primCons(rb, _35reg2373);
+Obj _35reg2375 = primCons(closureRef(co, 0), _35reg2374);
+Obj _35reg2376 = primCons(intern("let"), _35reg2375);
 __nargs = 2;
-__arg1 = _35reg2186;
+__arg1 = _35reg2376;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3245) { goto fail; }
+if (co->ctx.pc.func != clofun53) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
 label2:
 {
-Obj _35val2183 = __arg1;
-Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2182= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 1, _35clofun3245, 1, _35reg2182);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val2183;
-__arg2 = fvs1;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label3:
-{
-Obj _35val2179 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2180 = primCons(_35val2179, Nil);
-Obj _35reg2181 = primCons(args, _35reg2180);
-Obj _35reg2182 = primCons(intern("lambda"), _35reg2181);
-pushCont(co, 2, _35clofun3245, 2, fvs1, _35reg2182);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
-__arg1 = fvs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj _35val2178 = __arg1;
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj fvs1 = _35val2178;
-pushCont(co, 3, _35clofun3245, 3, args, fvs, fvs1);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
-__arg1 = fvs1;
-__arg2 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35cc1444 = makeNative(0, _35clofun3245, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj _35reg2158 = primIsCons(closureRef(co, 1));
-if (True == _35reg2158) {
-Obj _35reg2159 = primCar(closureRef(co, 1));
-Obj _35reg2160 = primEQ(intern("lambda"), _35reg2159);
-if (True == _35reg2160) {
-Obj _35reg2161 = primCdr(closureRef(co, 1));
-Obj _35reg2162 = primIsCons(_35reg2161);
-if (True == _35reg2162) {
-Obj _35reg2163 = primCdr(closureRef(co, 1));
-Obj _35reg2164 = primCar(_35reg2163);
-Obj args = _35reg2164;
-Obj _35reg2165 = primCdr(closureRef(co, 1));
-Obj _35reg2166 = primCdr(_35reg2165);
-Obj _35reg2167 = primIsCons(_35reg2166);
-if (True == _35reg2167) {
-Obj _35reg2168 = primCdr(closureRef(co, 1));
-Obj _35reg2169 = primCdr(_35reg2168);
-Obj _35reg2170 = primCar(_35reg2169);
-Obj body = _35reg2170;
-Obj _35reg2171 = primCdr(closureRef(co, 1));
-Obj _35reg2172 = primCdr(_35reg2171);
-Obj _35reg2173 = primCdr(_35reg2172);
-Obj _35reg2174 = primEQ(Nil, _35reg2173);
-if (True == _35reg2174) {
-Obj _35reg2175 = primCons(body, Nil);
-Obj _35reg2176 = primCons(args, _35reg2175);
-Obj _35reg2177 = primCons(intern("lambda"), _35reg2176);
-pushCont(co, 4, _35clofun3245, 3, body, args, fvs);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = _35reg2177;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1444;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1444;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1444;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1444;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1444;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label6:
-{
-Obj _35val2188 = __arg1;
-Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj pos = _35val2188;
-Obj _35reg2189 = primEQ(makeNumber(-1), pos);
-if (True == _35reg2189) {
-__nargs = 2;
-__arg1 = var;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3245) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-Obj _35reg2190 = primCons(pos, Nil);
-Obj _35reg2191 = primCons(intern("%closure-ref"), _35reg2190);
-__nargs = 2;
-__arg1 = _35reg2191;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3245) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label7:
-{
-Obj _35cc1443 = makeNative(5, _35clofun3245, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj fvs = closureRef(co, 0);
-Obj var = closureRef(co, 1);
-Obj _35reg2187 = primIsSymbol(var);
-if (True == _35reg2187) {
-pushCont(co, 6, _35clofun3245, 1, var);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#index"));
-__arg1 = var;
-__arg2 = fvs;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1443;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-Obj _35val2192 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1442= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val2192) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3245) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1442;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label9:
-{
-Obj _35p1440 = __arg1;
-Obj _35p1441 = __arg2;
-Obj _35cc1442 = makeNative(7, _35clofun3245, 0, 2, _35p1440, _35p1441);
-Obj __ = _35p1440;
-Obj x = _35p1441;
-pushCont(co, 8, _35clofun3245, 2, x, _35cc1442);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj x = __arg1;
-Obj _35reg2194 = primCons(x, Nil);
-Obj _35reg2195 = primCons(intern("return"), _35reg2194);
-__nargs = 2;
-__arg1 = _35reg2195;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3245) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label11:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35cc1455 = makeNative(11, _35clofun3245, 0, 0);
-Obj _35reg2197 = primIsCons(closureRef(co, 0));
-if (True == _35reg2197) {
-Obj _35reg2198 = primCar(closureRef(co, 0));
-Obj f = _35reg2198;
-Obj _35reg2199 = primCdr(closureRef(co, 0));
-Obj args = _35reg2199;
+Obj _35cc1547 = makeNative(4, clofun53, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg2302 = primIsCons(closureRef(co, 0));
+if (True == _35reg2302) {
+Obj _35reg2303 = primCar(closureRef(co, 0));
+Obj _35reg2304 = primEQ(intern("%closure"), _35reg2303);
+if (True == _35reg2304) {
+Obj _35reg2305 = primCdr(closureRef(co, 0));
+Obj _35reg2306 = primIsCons(_35reg2305);
+if (True == _35reg2306) {
+Obj _35reg2307 = primCdr(closureRef(co, 0));
+Obj _35reg2308 = primCar(_35reg2307);
+Obj _35reg2309 = primIsCons(_35reg2308);
+if (True == _35reg2309) {
+Obj _35reg2310 = primCdr(closureRef(co, 0));
+Obj _35reg2311 = primCar(_35reg2310);
+Obj _35reg2312 = primCar(_35reg2311);
+Obj _35reg2313 = primEQ(intern("lambda"), _35reg2312);
+if (True == _35reg2313) {
+Obj _35reg2314 = primCdr(closureRef(co, 0));
+Obj _35reg2315 = primCar(_35reg2314);
+Obj _35reg2316 = primCdr(_35reg2315);
+Obj _35reg2317 = primIsCons(_35reg2316);
+if (True == _35reg2317) {
+Obj _35reg2318 = primCdr(closureRef(co, 0));
+Obj _35reg2319 = primCar(_35reg2318);
+Obj _35reg2320 = primCdr(_35reg2319);
+Obj _35reg2321 = primCar(_35reg2320);
+Obj args = _35reg2321;
+Obj _35reg2322 = primCdr(closureRef(co, 0));
+Obj _35reg2323 = primCar(_35reg2322);
+Obj _35reg2324 = primCdr(_35reg2323);
+Obj _35reg2325 = primCdr(_35reg2324);
+Obj _35reg2326 = primIsCons(_35reg2325);
+if (True == _35reg2326) {
+Obj _35reg2327 = primCdr(closureRef(co, 0));
+Obj _35reg2328 = primCar(_35reg2327);
+Obj _35reg2329 = primCdr(_35reg2328);
+Obj _35reg2330 = primCdr(_35reg2329);
+Obj _35reg2331 = primCar(_35reg2330);
+Obj body = _35reg2331;
+Obj _35reg2332 = primCdr(closureRef(co, 0));
+Obj _35reg2333 = primCar(_35reg2332);
+Obj _35reg2334 = primCdr(_35reg2333);
+Obj _35reg2335 = primCdr(_35reg2334);
+Obj _35reg2336 = primCdr(_35reg2335);
+Obj _35reg2337 = primEQ(Nil, _35reg2336);
+if (True == _35reg2337) {
+Obj _35reg2338 = primCdr(closureRef(co, 0));
+Obj _35reg2339 = primCdr(_35reg2338);
+Obj frees = _35reg2339;
 Obj next = closureRef(co, 1);
-Obj _35reg2200 = primCons(f, args);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#tailify-list"));
-__arg1 = _35reg2200;
-__arg2 = Nil;
-__arg3 = next;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1455;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
-{
-Obj _35val2239 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj next= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj _35reg2240 = primCons(_35val2239, Nil);
-Obj _35reg2241 = primCons(args, _35reg2240);
-Obj _35reg2242 = primCons(intern("lambda"), _35reg2241);
-Obj _35reg2243 = primCons(_35reg2242, frees);
-Obj _35reg2244 = primCons(intern("%closure"), _35reg2243);
-__nargs = 2;
-__arg0 = next;
-__arg1 = _35reg2244;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35cc1454 = makeNative(12, _35clofun3245, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2201 = primIsCons(closureRef(co, 0));
-if (True == _35reg2201) {
-Obj _35reg2202 = primCar(closureRef(co, 0));
-Obj _35reg2203 = primEQ(intern("%closure"), _35reg2202);
-if (True == _35reg2203) {
-Obj _35reg2204 = primCdr(closureRef(co, 0));
-Obj _35reg2205 = primIsCons(_35reg2204);
-if (True == _35reg2205) {
-Obj _35reg2206 = primCdr(closureRef(co, 0));
-Obj _35reg2207 = primCar(_35reg2206);
-Obj _35reg2208 = primIsCons(_35reg2207);
-if (True == _35reg2208) {
-Obj _35reg2209 = primCdr(closureRef(co, 0));
-Obj _35reg2210 = primCar(_35reg2209);
-Obj _35reg2211 = primCar(_35reg2210);
-Obj _35reg2212 = primEQ(intern("lambda"), _35reg2211);
-if (True == _35reg2212) {
-Obj _35reg2213 = primCdr(closureRef(co, 0));
-Obj _35reg2214 = primCar(_35reg2213);
-Obj _35reg2215 = primCdr(_35reg2214);
-Obj _35reg2216 = primIsCons(_35reg2215);
-if (True == _35reg2216) {
-Obj _35reg2217 = primCdr(closureRef(co, 0));
-Obj _35reg2218 = primCar(_35reg2217);
-Obj _35reg2219 = primCdr(_35reg2218);
-Obj _35reg2220 = primCar(_35reg2219);
-Obj args = _35reg2220;
-Obj _35reg2221 = primCdr(closureRef(co, 0));
-Obj _35reg2222 = primCar(_35reg2221);
-Obj _35reg2223 = primCdr(_35reg2222);
-Obj _35reg2224 = primCdr(_35reg2223);
-Obj _35reg2225 = primIsCons(_35reg2224);
-if (True == _35reg2225) {
-Obj _35reg2226 = primCdr(closureRef(co, 0));
-Obj _35reg2227 = primCar(_35reg2226);
-Obj _35reg2228 = primCdr(_35reg2227);
-Obj _35reg2229 = primCdr(_35reg2228);
-Obj _35reg2230 = primCar(_35reg2229);
-Obj body = _35reg2230;
-Obj _35reg2231 = primCdr(closureRef(co, 0));
-Obj _35reg2232 = primCar(_35reg2231);
-Obj _35reg2233 = primCdr(_35reg2232);
-Obj _35reg2234 = primCdr(_35reg2233);
-Obj _35reg2235 = primCdr(_35reg2234);
-Obj _35reg2236 = primEQ(Nil, _35reg2235);
-if (True == _35reg2236) {
-Obj _35reg2237 = primCdr(closureRef(co, 0));
-Obj _35reg2238 = primCdr(_35reg2237);
-Obj frees = _35reg2238;
-Obj next = closureRef(co, 1);
-pushCont(co, 13, _35clofun3245, 3, args, frees, next);
+pushCont(co, 3, clofun53, 3, args, frees, next);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#tailify"));
 __arg1 = body;
@@ -9046,338 +9398,353 @@ __arg2 = globalRef(intern("cora/lib/toc#id"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1454;
+__arg0 = _35cc1547;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1454;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1454;
+__arg0 = _35cc1547;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1454;
+__arg0 = _35cc1547;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1454;
+__arg0 = _35cc1547;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1454;
+__arg0 = _35cc1547;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1454;
+__arg0 = _35cc1547;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1454;
+__arg0 = _35cc1547;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1547;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label15:
+label3:
 {
-Obj _35val2271 = __arg1;
-Obj rb= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2272 = primCons(_35val2271, Nil);
-Obj _35reg2273 = primCons(rb, _35reg2272);
-Obj _35reg2274 = primCons(closureRef(co, 0), _35reg2273);
-Obj _35reg2275 = primCons(intern("let"), _35reg2274);
+Obj _35val2340 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj frees= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj next= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg2341 = primCons(_35val2340, Nil);
+Obj _35reg2342 = primCons(args, _35reg2341);
+Obj _35reg2343 = primCons(intern("lambda"), _35reg2342);
+Obj _35reg2344 = primCons(_35reg2343, frees);
+Obj _35reg2345 = primCons(intern("%closure"), _35reg2344);
 __nargs = 2;
-__arg1 = _35reg2275;
+__arg0 = next;
+__arg1 = _35reg2345;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35cc1548 = makeNative(5, clofun53, 0, 0);
+Obj _35reg2298 = primIsCons(closureRef(co, 0));
+if (True == _35reg2298) {
+Obj _35reg2299 = primCar(closureRef(co, 0));
+Obj f = _35reg2299;
+Obj _35reg2300 = primCdr(closureRef(co, 0));
+Obj args = _35reg2300;
+Obj next = closureRef(co, 1);
+Obj _35reg2301 = primCons(f, args);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#tailify-list"));
+__arg1 = _35reg2301;
+__arg2 = Nil;
+__arg3 = next;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1548;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun53) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun54(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj x = __arg1;
+Obj _35reg2295 = primCons(x, Nil);
+Obj _35reg2296 = primCons(intern("return"), _35reg2295);
+__nargs = 2;
+__arg1 = _35reg2296;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3245) { goto fail; }
+if (co->ctx.pc.func != clofun54) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
-label16:
+label1:
 {
-Obj rb = __arg1;
-pushCont(co, 15, _35clofun3245, 1, rb);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#tailify"));
-__arg1 = closureRef(co, 1);
-__arg2 = closureRef(co, 2);
+Obj _35p1533 = __arg1;
+Obj _35p1534 = __arg2;
+Obj _35cc1535 = makeNative(3, clofun54, 0, 2, _35p1533, _35p1534);
+Obj __ = _35p1533;
+Obj x = _35p1534;
+pushCont(co, 2, clofun54, 2, x, _35cc1535);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
+__arg1 = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun54) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label17:
+label2:
 {
-Obj _35cc1453 = makeNative(14, _35clofun3245, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2245 = primIsCons(closureRef(co, 0));
-if (True == _35reg2245) {
-Obj _35reg2246 = primCar(closureRef(co, 0));
-Obj _35reg2247 = primEQ(intern("let"), _35reg2246);
-if (True == _35reg2247) {
-Obj _35reg2248 = primCdr(closureRef(co, 0));
-Obj _35reg2249 = primIsCons(_35reg2248);
-if (True == _35reg2249) {
-Obj _35reg2250 = primCdr(closureRef(co, 0));
-Obj _35reg2251 = primCar(_35reg2250);
-Obj a = _35reg2251;
-Obj _35reg2252 = primCdr(closureRef(co, 0));
-Obj _35reg2253 = primCdr(_35reg2252);
-Obj _35reg2254 = primIsCons(_35reg2253);
-if (True == _35reg2254) {
-Obj _35reg2255 = primCdr(closureRef(co, 0));
-Obj _35reg2256 = primCdr(_35reg2255);
-Obj _35reg2257 = primCar(_35reg2256);
-Obj b = _35reg2257;
-Obj _35reg2258 = primCdr(closureRef(co, 0));
-Obj _35reg2259 = primCdr(_35reg2258);
-Obj _35reg2260 = primCdr(_35reg2259);
-Obj _35reg2261 = primIsCons(_35reg2260);
+Obj _35val2293 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1535= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val2293) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun54) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1535;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun54) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35cc1536 = makeNative(5, clofun54, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj var = closureRef(co, 1);
+Obj _35reg2288 = primIsSymbol(var);
+if (True == _35reg2288) {
+pushCont(co, 4, clofun54, 1, var);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#index"));
+__arg1 = var;
+__arg2 = fvs;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun54) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1536;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun54) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val2289 = __arg1;
+Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj pos = _35val2289;
+Obj _35reg2290 = primEQ(makeNumber(-1), pos);
+if (True == _35reg2290) {
+__nargs = 2;
+__arg1 = var;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun54) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+Obj _35reg2291 = primCons(pos, Nil);
+Obj _35reg2292 = primCons(intern("%closure-ref"), _35reg2291);
+__nargs = 2;
+__arg1 = _35reg2292;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun54) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label5:
+{
+Obj _35cc1537 = makeNative(4, clofun55, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj _35reg2259 = primIsCons(closureRef(co, 1));
+if (True == _35reg2259) {
+Obj _35reg2260 = primCar(closureRef(co, 1));
+Obj _35reg2261 = primEQ(intern("lambda"), _35reg2260);
 if (True == _35reg2261) {
-Obj _35reg2262 = primCdr(closureRef(co, 0));
-Obj _35reg2263 = primCdr(_35reg2262);
-Obj _35reg2264 = primCdr(_35reg2263);
+Obj _35reg2262 = primCdr(closureRef(co, 1));
+Obj _35reg2263 = primIsCons(_35reg2262);
+if (True == _35reg2263) {
+Obj _35reg2264 = primCdr(closureRef(co, 1));
 Obj _35reg2265 = primCar(_35reg2264);
-Obj c = _35reg2265;
-Obj _35reg2266 = primCdr(closureRef(co, 0));
+Obj args = _35reg2265;
+Obj _35reg2266 = primCdr(closureRef(co, 1));
 Obj _35reg2267 = primCdr(_35reg2266);
-Obj _35reg2268 = primCdr(_35reg2267);
-Obj _35reg2269 = primCdr(_35reg2268);
-Obj _35reg2270 = primEQ(Nil, _35reg2269);
-if (True == _35reg2270) {
-Obj next = closureRef(co, 1);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#tailify"));
-__arg1 = b;
-__arg2 = makeNative(16, _35clofun3245, 1, 3, a, c, next);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1453;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1453;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1453;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1453;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1453;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1453;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label18:
-{
-Obj _35val2294 = __arg1;
-Obj ra= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg2295 = primCons(_35val2294, Nil);
-Obj _35reg2296 = primCons(ra, _35reg2295);
-Obj _35reg2297 = primCons(intern("do"), _35reg2296);
+Obj _35reg2268 = primIsCons(_35reg2267);
+if (True == _35reg2268) {
+Obj _35reg2269 = primCdr(closureRef(co, 1));
+Obj _35reg2270 = primCdr(_35reg2269);
+Obj _35reg2271 = primCar(_35reg2270);
+Obj body = _35reg2271;
+Obj _35reg2272 = primCdr(closureRef(co, 1));
+Obj _35reg2273 = primCdr(_35reg2272);
+Obj _35reg2274 = primCdr(_35reg2273);
+Obj _35reg2275 = primEQ(Nil, _35reg2274);
+if (True == _35reg2275) {
+Obj _35reg2276 = primCons(body, Nil);
+Obj _35reg2277 = primCons(args, _35reg2276);
+Obj _35reg2278 = primCons(intern("lambda"), _35reg2277);
+pushCont(co, 0, clofun55, 3, body, args, fvs);
 __nargs = 2;
-__arg1 = _35reg2297;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3245) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label19:
-{
-Obj ra = __arg1;
-Obj _35reg2293 = primIsSymbol(ra);
-if (True == _35reg2293) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#tailify"));
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 1);
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = _35reg2278;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-pushCont(co, 18, _35clofun3245, 1, ra);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#tailify"));
-__arg1 = closureRef(co, 0);
-__arg2 = closureRef(co, 1);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
-{
-Obj _35cc1452 = makeNative(17, _35clofun3245, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2276 = primIsCons(closureRef(co, 0));
-if (True == _35reg2276) {
-Obj _35reg2277 = primCar(closureRef(co, 0));
-Obj _35reg2278 = primEQ(intern("do"), _35reg2277);
-if (True == _35reg2278) {
-Obj _35reg2279 = primCdr(closureRef(co, 0));
-Obj _35reg2280 = primIsCons(_35reg2279);
-if (True == _35reg2280) {
-Obj _35reg2281 = primCdr(closureRef(co, 0));
-Obj _35reg2282 = primCar(_35reg2281);
-Obj a = _35reg2282;
-Obj _35reg2283 = primCdr(closureRef(co, 0));
-Obj _35reg2284 = primCdr(_35reg2283);
-Obj _35reg2285 = primIsCons(_35reg2284);
-if (True == _35reg2285) {
-Obj _35reg2286 = primCdr(closureRef(co, 0));
-Obj _35reg2287 = primCdr(_35reg2286);
-Obj _35reg2288 = primCar(_35reg2287);
-Obj b = _35reg2288;
-Obj _35reg2289 = primCdr(closureRef(co, 0));
-Obj _35reg2290 = primCdr(_35reg2289);
-Obj _35reg2291 = primCdr(_35reg2290);
-Obj _35reg2292 = primEQ(Nil, _35reg2291);
-if (True == _35reg2292) {
-Obj next = closureRef(co, 1);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#tailify"));
-__arg1 = a;
-__arg2 = makeNative(19, _35clofun3245, 1, 2, b, next);
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun54) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1452;
+__arg0 = _35cc1537;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun54) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1452;
+__arg0 = _35cc1537;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun54) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1452;
+__arg0 = _35cc1537;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun54) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1452;
+__arg0 = _35cc1537;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun54) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1452;
+__arg0 = _35cc1537;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3245) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun54) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
@@ -9391,837 +9758,198 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3244(struct Cora* co){
+void clofun55(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1436 = makeNative(19, _35clofun3243, 0, 1, closureRef(co, 0));
-Obj _35reg1979 = primIsCons(closureRef(co, 0));
-if (True == _35reg1979) {
-Obj _35reg1980 = primCar(closureRef(co, 0));
-Obj _35reg1981 = primEQ(intern("call"), _35reg1980);
-if (True == _35reg1981) {
-Obj _35reg1982 = primCdr(closureRef(co, 0));
-Obj _35reg1983 = primIsCons(_35reg1982);
-if (True == _35reg1983) {
-Obj _35reg1984 = primCdr(closureRef(co, 0));
-Obj _35reg1985 = primCar(_35reg1984);
-Obj exp = _35reg1985;
-Obj _35reg1986 = primCdr(closureRef(co, 0));
-Obj _35reg1987 = primCdr(_35reg1986);
-Obj _35reg1988 = primIsCons(_35reg1987);
-if (True == _35reg1988) {
-Obj _35reg1989 = primCdr(closureRef(co, 0));
-Obj _35reg1990 = primCdr(_35reg1989);
-Obj _35reg1991 = primCar(_35reg1990);
-Obj cont = _35reg1991;
-Obj _35reg1992 = primCdr(closureRef(co, 0));
-Obj _35reg1993 = primCdr(_35reg1992);
-Obj _35reg1994 = primCdr(_35reg1993);
-Obj _35reg1995 = primEQ(Nil, _35reg1994);
-if (True == _35reg1995) {
-Obj _35reg1996 = primCons(cont, Nil);
-Obj _35reg1997 = primCons(exp, _35reg1996);
-pushCont(co, 20, _35clofun3243, 0);
+Obj _35val2279 = __arg1;
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj fvs1 = _35val2279;
+pushCont(co, 1, clofun55, 3, args, fvs, fvs1);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg2 = _35reg1997;
+__arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
+__arg1 = fvs1;
+__arg2 = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun55) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1436;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1436;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1436;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1436;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1436;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label1:
 {
-Obj _35cc1435 = makeNative(0, _35clofun3244, 0, 1, closureRef(co, 0));
-Obj _35reg1999 = primIsCons(closureRef(co, 0));
-if (True == _35reg1999) {
-Obj _35reg2000 = primCar(closureRef(co, 0));
-Obj _35reg2001 = primEQ(intern("return"), _35reg2000);
-if (True == _35reg2001) {
-Obj _35reg2002 = primCdr(closureRef(co, 0));
-Obj _35reg2003 = primIsCons(_35reg2002);
-if (True == _35reg2003) {
-Obj _35reg2004 = primCdr(closureRef(co, 0));
-Obj _35reg2005 = primCar(_35reg2004);
-Obj x = _35reg2005;
-Obj _35reg2006 = primCdr(closureRef(co, 0));
-Obj _35reg2007 = primCdr(_35reg2006);
-Obj _35reg2008 = primEQ(Nil, _35reg2007);
-if (True == _35reg2008) {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1435;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1435;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1435;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1435;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label2:
-{
-Obj _35cc1434 = makeNative(1, _35clofun3244, 0, 1, closureRef(co, 0));
-Obj _35reg2009 = primIsCons(closureRef(co, 0));
-if (True == _35reg2009) {
-Obj _35reg2010 = primCar(closureRef(co, 0));
-Obj _35reg2011 = primEQ(intern("%closure"), _35reg2010);
-if (True == _35reg2011) {
-Obj _35reg2012 = primCdr(closureRef(co, 0));
-Obj _35reg2013 = primIsCons(_35reg2012);
-if (True == _35reg2013) {
-Obj _35reg2014 = primCdr(closureRef(co, 0));
-Obj _35reg2015 = primCar(_35reg2014);
-Obj lam = _35reg2015;
-Obj _35reg2016 = primCdr(closureRef(co, 0));
-Obj _35reg2017 = primCdr(_35reg2016);
-Obj more = _35reg2017;
-Obj _35reg2018 = primCons(lam, more);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = _35reg2018;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1434;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1434;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1434;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label3:
-{
-Obj _35val2048 = __arg1;
-Obj _35val2045= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#union"));
-__arg1 = _35val2045;
-__arg2 = _35val2048;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj _35val2046 = __arg1;
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35val2045= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2047 = primCons(a, Nil);
-pushCont(co, 3, _35clofun3244, 1, _35val2045);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = _35val2046;
-__arg2 = _35reg2047;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35val2045 = __arg1;
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 4, _35clofun3244, 2, a, _35val2045);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35cc1433 = makeNative(2, _35clofun3244, 0, 1, closureRef(co, 0));
-Obj _35reg2019 = primIsCons(closureRef(co, 0));
-if (True == _35reg2019) {
-Obj _35reg2020 = primCar(closureRef(co, 0));
-Obj _35reg2021 = primEQ(intern("let"), _35reg2020);
-if (True == _35reg2021) {
-Obj _35reg2022 = primCdr(closureRef(co, 0));
-Obj _35reg2023 = primIsCons(_35reg2022);
-if (True == _35reg2023) {
-Obj _35reg2024 = primCdr(closureRef(co, 0));
-Obj _35reg2025 = primCar(_35reg2024);
-Obj a = _35reg2025;
-Obj _35reg2026 = primCdr(closureRef(co, 0));
-Obj _35reg2027 = primCdr(_35reg2026);
-Obj _35reg2028 = primIsCons(_35reg2027);
-if (True == _35reg2028) {
-Obj _35reg2029 = primCdr(closureRef(co, 0));
-Obj _35reg2030 = primCdr(_35reg2029);
-Obj _35reg2031 = primCar(_35reg2030);
-Obj b = _35reg2031;
-Obj _35reg2032 = primCdr(closureRef(co, 0));
-Obj _35reg2033 = primCdr(_35reg2032);
-Obj _35reg2034 = primCdr(_35reg2033);
-Obj _35reg2035 = primIsCons(_35reg2034);
-if (True == _35reg2035) {
-Obj _35reg2036 = primCdr(closureRef(co, 0));
-Obj _35reg2037 = primCdr(_35reg2036);
-Obj _35reg2038 = primCdr(_35reg2037);
-Obj _35reg2039 = primCar(_35reg2038);
-Obj c = _35reg2039;
-Obj _35reg2040 = primCdr(closureRef(co, 0));
-Obj _35reg2041 = primCdr(_35reg2040);
-Obj _35reg2042 = primCdr(_35reg2041);
-Obj _35reg2043 = primCdr(_35reg2042);
-Obj _35reg2044 = primEQ(Nil, _35reg2043);
-if (True == _35reg2044) {
-pushCont(co, 5, _35clofun3244, 2, c, a);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = b;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1433;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1433;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1433;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1433;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1433;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1433;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label7:
-{
-Obj _35val2068 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#foldl"));
-__arg1 = globalRef(intern("cora/lib/toc#union"));
-__arg2 = Nil;
-__arg3 = _35val2068;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35cc1432 = makeNative(6, _35clofun3244, 0, 1, closureRef(co, 0));
-Obj _35reg2049 = primIsCons(closureRef(co, 0));
-if (True == _35reg2049) {
-Obj _35reg2050 = primCar(closureRef(co, 0));
-Obj _35reg2051 = primEQ(intern("do"), _35reg2050);
-if (True == _35reg2051) {
-Obj _35reg2052 = primCdr(closureRef(co, 0));
-Obj _35reg2053 = primIsCons(_35reg2052);
-if (True == _35reg2053) {
-Obj _35reg2054 = primCdr(closureRef(co, 0));
-Obj _35reg2055 = primCar(_35reg2054);
-Obj x = _35reg2055;
-Obj _35reg2056 = primCdr(closureRef(co, 0));
-Obj _35reg2057 = primCdr(_35reg2056);
-Obj _35reg2058 = primIsCons(_35reg2057);
-if (True == _35reg2058) {
-Obj _35reg2059 = primCdr(closureRef(co, 0));
-Obj _35reg2060 = primCdr(_35reg2059);
-Obj _35reg2061 = primCar(_35reg2060);
-Obj y = _35reg2061;
-Obj _35reg2062 = primCdr(closureRef(co, 0));
-Obj _35reg2063 = primCdr(_35reg2062);
-Obj _35reg2064 = primCdr(_35reg2063);
-Obj _35reg2065 = primEQ(Nil, _35reg2064);
-if (True == _35reg2065) {
-Obj _35reg2066 = primCons(y, Nil);
-Obj _35reg2067 = primCons(x, _35reg2066);
-pushCont(co, 7, _35clofun3244, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg2 = _35reg2067;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1432;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1432;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1432;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1432;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1432;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label9:
-{
-Obj _35val2098 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#foldl"));
-__arg1 = globalRef(intern("cora/lib/toc#union"));
-__arg2 = Nil;
-__arg3 = _35val2098;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35cc1431 = makeNative(8, _35clofun3244, 0, 1, closureRef(co, 0));
-Obj _35reg2069 = primIsCons(closureRef(co, 0));
-if (True == _35reg2069) {
-Obj _35reg2070 = primCar(closureRef(co, 0));
-Obj _35reg2071 = primEQ(intern("if"), _35reg2070);
-if (True == _35reg2071) {
-Obj _35reg2072 = primCdr(closureRef(co, 0));
-Obj _35reg2073 = primIsCons(_35reg2072);
-if (True == _35reg2073) {
-Obj _35reg2074 = primCdr(closureRef(co, 0));
-Obj _35reg2075 = primCar(_35reg2074);
-Obj x = _35reg2075;
-Obj _35reg2076 = primCdr(closureRef(co, 0));
-Obj _35reg2077 = primCdr(_35reg2076);
-Obj _35reg2078 = primIsCons(_35reg2077);
-if (True == _35reg2078) {
-Obj _35reg2079 = primCdr(closureRef(co, 0));
-Obj _35reg2080 = primCdr(_35reg2079);
-Obj _35reg2081 = primCar(_35reg2080);
-Obj y = _35reg2081;
-Obj _35reg2082 = primCdr(closureRef(co, 0));
-Obj _35reg2083 = primCdr(_35reg2082);
-Obj _35reg2084 = primCdr(_35reg2083);
-Obj _35reg2085 = primIsCons(_35reg2084);
-if (True == _35reg2085) {
-Obj _35reg2086 = primCdr(closureRef(co, 0));
-Obj _35reg2087 = primCdr(_35reg2086);
-Obj _35reg2088 = primCdr(_35reg2087);
-Obj _35reg2089 = primCar(_35reg2088);
-Obj z = _35reg2089;
-Obj _35reg2090 = primCdr(closureRef(co, 0));
-Obj _35reg2091 = primCdr(_35reg2090);
-Obj _35reg2092 = primCdr(_35reg2091);
-Obj _35reg2093 = primCdr(_35reg2092);
-Obj _35reg2094 = primEQ(Nil, _35reg2093);
-if (True == _35reg2094) {
-Obj _35reg2095 = primCons(z, Nil);
-Obj _35reg2096 = primCons(y, _35reg2095);
-Obj _35reg2097 = primCons(x, _35reg2096);
-pushCont(co, 9, _35clofun3244, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg2 = _35reg2097;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1431;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label11:
-{
-Obj _35val2116 = __arg1;
+Obj _35val2280 = __arg1;
 Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = _35val2116;
-__arg2 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label12:
-{
-Obj _35cc1430 = makeNative(10, _35clofun3244, 0, 1, closureRef(co, 0));
-Obj _35reg2099 = primIsCons(closureRef(co, 0));
-if (True == _35reg2099) {
-Obj _35reg2100 = primCar(closureRef(co, 0));
-Obj _35reg2101 = primEQ(intern("lambda"), _35reg2100);
-if (True == _35reg2101) {
-Obj _35reg2102 = primCdr(closureRef(co, 0));
-Obj _35reg2103 = primIsCons(_35reg2102);
-if (True == _35reg2103) {
-Obj _35reg2104 = primCdr(closureRef(co, 0));
-Obj _35reg2105 = primCar(_35reg2104);
-Obj args = _35reg2105;
-Obj _35reg2106 = primCdr(closureRef(co, 0));
-Obj _35reg2107 = primCdr(_35reg2106);
-Obj _35reg2108 = primIsCons(_35reg2107);
-if (True == _35reg2108) {
-Obj _35reg2109 = primCdr(closureRef(co, 0));
-Obj _35reg2110 = primCdr(_35reg2109);
-Obj _35reg2111 = primCar(_35reg2110);
-Obj body = _35reg2111;
-Obj _35reg2112 = primCdr(closureRef(co, 0));
-Obj _35reg2113 = primCdr(_35reg2112);
-Obj _35reg2114 = primCdr(_35reg2113);
-Obj _35reg2115 = primEQ(Nil, _35reg2114);
-if (True == _35reg2115) {
-pushCont(co, 11, _35clofun3244, 1, args);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1430;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1430;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1430;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1430;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1430;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
-{
-Obj _35cc1429 = makeNative(12, _35clofun3244, 0, 1, closureRef(co, 0));
-Obj x = closureRef(co, 0);
-Obj _35reg2117 = primIsSymbol(x);
-if (True == _35reg2117) {
-Obj _35reg2118 = primCons(x, Nil);
-__nargs = 2;
-__arg1 = _35reg2118;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3244) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1429;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label14:
-{
-Obj _35val2119 = __arg1;
-Obj _35cc1428= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val2119) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3244) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1428;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label15:
-{
-Obj _35p1427 = __arg1;
-Obj _35cc1428 = makeNative(13, _35clofun3244, 0, 1, _35p1427);
-Obj x = _35p1427;
-pushCont(co, 14, _35clofun3244, 1, _35cc1428);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val2124 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2125 = primCons(f, args);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val2124;
-__arg2 = _35reg2125;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35cc1446 = makeNative(16, _35clofun3244, 0, 0);
-Obj fvs = closureRef(co, 0);
-Obj _35reg2121 = primIsCons(closureRef(co, 1));
-if (True == _35reg2121) {
-Obj _35reg2122 = primCar(closureRef(co, 1));
-Obj f = _35reg2122;
-Obj _35reg2123 = primCdr(closureRef(co, 1));
-Obj args = _35reg2123;
-pushCont(co, 17, _35clofun3244, 2, f, args);
+Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj _35reg2281 = primCons(_35val2280, Nil);
+Obj _35reg2282 = primCons(args, _35reg2281);
+Obj _35reg2283 = primCons(intern("lambda"), _35reg2282);
+pushCont(co, 2, clofun55, 2, fvs1, _35reg2283);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun55) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1446;
+}
+
+label2:
+{
+Obj _35val2284 = __arg1;
+Obj fvs1= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2283= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 3, clofun55, 1, _35reg2283);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = _35val2284;
+__arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun55) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2285 = __arg1;
+Obj _35reg2283= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg2286 = primCons(_35reg2283, _35val2285);
+Obj _35reg2287 = primCons(intern("%closure"), _35reg2286);
+__nargs = 2;
+__arg1 = _35reg2287;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun55) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
+{
+Obj _35cc1538 = makeNative(1, clofun56, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj fvs = closureRef(co, 0);
+Obj _35reg2227 = primIsCons(closureRef(co, 1));
+if (True == _35reg2227) {
+Obj _35reg2228 = primCar(closureRef(co, 1));
+Obj _35reg2229 = primEQ(intern("let"), _35reg2228);
+if (True == _35reg2229) {
+Obj _35reg2230 = primCdr(closureRef(co, 1));
+Obj _35reg2231 = primIsCons(_35reg2230);
+if (True == _35reg2231) {
+Obj _35reg2232 = primCdr(closureRef(co, 1));
+Obj _35reg2233 = primCar(_35reg2232);
+Obj a = _35reg2233;
+Obj _35reg2234 = primCdr(closureRef(co, 1));
+Obj _35reg2235 = primCdr(_35reg2234);
+Obj _35reg2236 = primIsCons(_35reg2235);
+if (True == _35reg2236) {
+Obj _35reg2237 = primCdr(closureRef(co, 1));
+Obj _35reg2238 = primCdr(_35reg2237);
+Obj _35reg2239 = primCar(_35reg2238);
+Obj b = _35reg2239;
+Obj _35reg2240 = primCdr(closureRef(co, 1));
+Obj _35reg2241 = primCdr(_35reg2240);
+Obj _35reg2242 = primCdr(_35reg2241);
+Obj _35reg2243 = primIsCons(_35reg2242);
+if (True == _35reg2243) {
+Obj _35reg2244 = primCdr(closureRef(co, 1));
+Obj _35reg2245 = primCdr(_35reg2244);
+Obj _35reg2246 = primCdr(_35reg2245);
+Obj _35reg2247 = primCar(_35reg2246);
+Obj c = _35reg2247;
+Obj _35reg2248 = primCdr(closureRef(co, 1));
+Obj _35reg2249 = primCdr(_35reg2248);
+Obj _35reg2250 = primCdr(_35reg2249);
+Obj _35reg2251 = primCdr(_35reg2250);
+Obj _35reg2252 = primEQ(Nil, _35reg2251);
+if (True == _35reg2252) {
+pushCont(co, 5, clofun55, 3, fvs, c, a);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
+__arg1 = fvs;
+__arg2 = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun55) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1538;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun55) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1538;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun55) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1538;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun55) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1538;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun55) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1538;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun55) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1538;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun55) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label19:
+label5:
 {
-Obj _35val2153 = __arg1;
-Obj _35val2152= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg2154 = primCons(_35val2153, Nil);
-Obj _35reg2155 = primCons(_35val2152, _35reg2154);
-Obj _35reg2156 = primCons(a, _35reg2155);
-Obj _35reg2157 = primCons(intern("let"), _35reg2156);
-__nargs = 2;
-__arg1 = _35reg2157;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3244) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label20:
-{
-Obj _35val2152 = __arg1;
+Obj _35val2253 = __arg1;
 Obj fvs= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj c= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj a= co->ctx.stk.stack[co->ctx.stk.base + 2];
-pushCont(co, 19, _35clofun3244, 2, _35val2152, a);
+pushCont(co, 0, clofun56, 2, _35val2253, a);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
 __arg1 = fvs;
@@ -10229,7 +9957,7 @@ __arg2 = c;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3244) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun55) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -10242,42 +9970,81 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3243(struct Cora* co){
+void clofun56(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35p1410 = __arg1;
-Obj _35p1411 = __arg2;
-Obj _35cc1412 = makeNative(20, _35clofun3242, 0, 2, _35p1410, _35p1411);
-Obj _35reg1882 = primEQ(Nil, _35p1410);
-if (True == _35reg1882) {
-Obj s2 = _35p1411;
+Obj _35val2254 = __arg1;
+Obj _35val2253= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2255 = primCons(_35val2254, Nil);
+Obj _35reg2256 = primCons(_35val2253, _35reg2255);
+Obj _35reg2257 = primCons(a, _35reg2256);
+Obj _35reg2258 = primCons(intern("let"), _35reg2257);
 __nargs = 2;
-__arg1 = s2;
+__arg1 = _35reg2258;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3243) { goto fail; }
+if (co->ctx.pc.func != clofun56) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1412;
+}
+
+label1:
+{
+Obj _35cc1539 = makeNative(3, clofun56, 0, 0);
+Obj fvs = closureRef(co, 0);
+Obj _35reg2222 = primIsCons(closureRef(co, 1));
+if (True == _35reg2222) {
+Obj _35reg2223 = primCar(closureRef(co, 1));
+Obj f = _35reg2223;
+Obj _35reg2224 = primCdr(closureRef(co, 1));
+Obj args = _35reg2224;
+pushCont(co, 2, clofun56, 2, f, args);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#closure-convert"));
+__arg1 = fvs;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun56) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1539;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun56) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label1:
+label2:
+{
+Obj _35val2225 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2226 = primCons(f, args);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = _35val2225;
+__arg2 = _35reg2226;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun56) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -10285,91 +10052,1447 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun56) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35p1520 = __arg1;
+Obj _35cc1521 = makeNative(0, clofun57, 0, 1, _35p1520);
+Obj x = _35p1520;
+pushCont(co, 5, clofun56, 1, _35cc1521);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#convert-protect?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun56) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val2220 = __arg1;
+Obj _35cc1521= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val2220) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun56) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1521;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun56) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun57(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc1522 = makeNative(1, clofun57, 0, 1, closureRef(co, 0));
+Obj x = closureRef(co, 0);
+Obj _35reg2218 = primIsSymbol(x);
+if (True == _35reg2218) {
+Obj _35reg2219 = primCons(x, Nil);
+__nargs = 2;
+__arg1 = _35reg2219;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun57) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1522;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35cc1523 = makeNative(3, clofun57, 0, 1, closureRef(co, 0));
+Obj _35reg2200 = primIsCons(closureRef(co, 0));
+if (True == _35reg2200) {
+Obj _35reg2201 = primCar(closureRef(co, 0));
+Obj _35reg2202 = primEQ(intern("lambda"), _35reg2201);
+if (True == _35reg2202) {
+Obj _35reg2203 = primCdr(closureRef(co, 0));
+Obj _35reg2204 = primIsCons(_35reg2203);
+if (True == _35reg2204) {
+Obj _35reg2205 = primCdr(closureRef(co, 0));
+Obj _35reg2206 = primCar(_35reg2205);
+Obj args = _35reg2206;
+Obj _35reg2207 = primCdr(closureRef(co, 0));
+Obj _35reg2208 = primCdr(_35reg2207);
+Obj _35reg2209 = primIsCons(_35reg2208);
+if (True == _35reg2209) {
+Obj _35reg2210 = primCdr(closureRef(co, 0));
+Obj _35reg2211 = primCdr(_35reg2210);
+Obj _35reg2212 = primCar(_35reg2211);
+Obj body = _35reg2212;
+Obj _35reg2213 = primCdr(closureRef(co, 0));
+Obj _35reg2214 = primCdr(_35reg2213);
+Obj _35reg2215 = primCdr(_35reg2214);
+Obj _35reg2216 = primEQ(Nil, _35reg2215);
+if (True == _35reg2216) {
+pushCont(co, 2, clofun57, 1, args);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1523;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1523;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1523;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1523;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1523;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label2:
 {
-Obj _35val1887 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1888 = primCons(x, _35val1887);
-__nargs = 2;
-__arg1 = _35reg1888;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3243) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
+Obj _35val2217 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#diff"));
+__arg1 = _35val2217;
+__arg2 = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
 }
 
 label3:
 {
-Obj _35cc1419 = makeNative(1, _35clofun3243, 0, 0);
-Obj _35reg1884 = primIsCons(closureRef(co, 0));
-if (True == _35reg1884) {
-Obj _35reg1885 = primCar(closureRef(co, 0));
-Obj x = _35reg1885;
-Obj _35reg1886 = primCdr(closureRef(co, 0));
-Obj y = _35reg1886;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 2, _35clofun3243, 1, x);
+Obj _35cc1524 = makeNative(5, clofun57, 0, 1, closureRef(co, 0));
+Obj _35reg2170 = primIsCons(closureRef(co, 0));
+if (True == _35reg2170) {
+Obj _35reg2171 = primCar(closureRef(co, 0));
+Obj _35reg2172 = primEQ(intern("if"), _35reg2171);
+if (True == _35reg2172) {
+Obj _35reg2173 = primCdr(closureRef(co, 0));
+Obj _35reg2174 = primIsCons(_35reg2173);
+if (True == _35reg2174) {
+Obj _35reg2175 = primCdr(closureRef(co, 0));
+Obj _35reg2176 = primCar(_35reg2175);
+Obj x = _35reg2176;
+Obj _35reg2177 = primCdr(closureRef(co, 0));
+Obj _35reg2178 = primCdr(_35reg2177);
+Obj _35reg2179 = primIsCons(_35reg2178);
+if (True == _35reg2179) {
+Obj _35reg2180 = primCdr(closureRef(co, 0));
+Obj _35reg2181 = primCdr(_35reg2180);
+Obj _35reg2182 = primCar(_35reg2181);
+Obj y = _35reg2182;
+Obj _35reg2183 = primCdr(closureRef(co, 0));
+Obj _35reg2184 = primCdr(_35reg2183);
+Obj _35reg2185 = primCdr(_35reg2184);
+Obj _35reg2186 = primIsCons(_35reg2185);
+if (True == _35reg2186) {
+Obj _35reg2187 = primCdr(closureRef(co, 0));
+Obj _35reg2188 = primCdr(_35reg2187);
+Obj _35reg2189 = primCdr(_35reg2188);
+Obj _35reg2190 = primCar(_35reg2189);
+Obj z = _35reg2190;
+Obj _35reg2191 = primCdr(closureRef(co, 0));
+Obj _35reg2192 = primCdr(_35reg2191);
+Obj _35reg2193 = primCdr(_35reg2192);
+Obj _35reg2194 = primCdr(_35reg2193);
+Obj _35reg2195 = primEQ(Nil, _35reg2194);
+if (True == _35reg2195) {
+Obj _35reg2196 = primCons(z, Nil);
+Obj _35reg2197 = primCons(y, _35reg2196);
+Obj _35reg2198 = primCons(x, _35reg2197);
+pushCont(co, 4, clofun57, 0);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = y;
-__arg2 = s2;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg2 = _35reg2198;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1419;
+__arg0 = _35cc1524;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1524;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1524;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1524;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1524;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1524;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label4:
 {
-Obj _35val1892 = __arg1;
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc1418= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1892) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = y;
-__arg2 = s2;
+Obj _35val2199 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#foldl"));
+__arg1 = globalRef(intern("cora/lib/toc#union"));
+__arg2 = Nil;
+__arg3 = _35val2199;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35cc1525 = makeNative(1, clofun58, 0, 1, closureRef(co, 0));
+Obj _35reg2150 = primIsCons(closureRef(co, 0));
+if (True == _35reg2150) {
+Obj _35reg2151 = primCar(closureRef(co, 0));
+Obj _35reg2152 = primEQ(intern("do"), _35reg2151);
+if (True == _35reg2152) {
+Obj _35reg2153 = primCdr(closureRef(co, 0));
+Obj _35reg2154 = primIsCons(_35reg2153);
+if (True == _35reg2154) {
+Obj _35reg2155 = primCdr(closureRef(co, 0));
+Obj _35reg2156 = primCar(_35reg2155);
+Obj x = _35reg2156;
+Obj _35reg2157 = primCdr(closureRef(co, 0));
+Obj _35reg2158 = primCdr(_35reg2157);
+Obj _35reg2159 = primIsCons(_35reg2158);
+if (True == _35reg2159) {
+Obj _35reg2160 = primCdr(closureRef(co, 0));
+Obj _35reg2161 = primCdr(_35reg2160);
+Obj _35reg2162 = primCar(_35reg2161);
+Obj y = _35reg2162;
+Obj _35reg2163 = primCdr(closureRef(co, 0));
+Obj _35reg2164 = primCdr(_35reg2163);
+Obj _35reg2165 = primCdr(_35reg2164);
+Obj _35reg2166 = primEQ(Nil, _35reg2165);
+if (True == _35reg2166) {
+Obj _35reg2167 = primCons(y, Nil);
+Obj _35reg2168 = primCons(x, _35reg2167);
+pushCont(co, 0, clofun58, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg2 = _35reg2168;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1418;
+__arg0 = _35cc1525;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1525;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1525;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1525;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1525;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun57) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun58(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val2169 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#foldl"));
+__arg1 = globalRef(intern("cora/lib/toc#union"));
+__arg2 = Nil;
+__arg3 = _35val2169;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35cc1526 = makeNative(5, clofun58, 0, 1, closureRef(co, 0));
+Obj _35reg2120 = primIsCons(closureRef(co, 0));
+if (True == _35reg2120) {
+Obj _35reg2121 = primCar(closureRef(co, 0));
+Obj _35reg2122 = primEQ(intern("let"), _35reg2121);
+if (True == _35reg2122) {
+Obj _35reg2123 = primCdr(closureRef(co, 0));
+Obj _35reg2124 = primIsCons(_35reg2123);
+if (True == _35reg2124) {
+Obj _35reg2125 = primCdr(closureRef(co, 0));
+Obj _35reg2126 = primCar(_35reg2125);
+Obj a = _35reg2126;
+Obj _35reg2127 = primCdr(closureRef(co, 0));
+Obj _35reg2128 = primCdr(_35reg2127);
+Obj _35reg2129 = primIsCons(_35reg2128);
+if (True == _35reg2129) {
+Obj _35reg2130 = primCdr(closureRef(co, 0));
+Obj _35reg2131 = primCdr(_35reg2130);
+Obj _35reg2132 = primCar(_35reg2131);
+Obj b = _35reg2132;
+Obj _35reg2133 = primCdr(closureRef(co, 0));
+Obj _35reg2134 = primCdr(_35reg2133);
+Obj _35reg2135 = primCdr(_35reg2134);
+Obj _35reg2136 = primIsCons(_35reg2135);
+if (True == _35reg2136) {
+Obj _35reg2137 = primCdr(closureRef(co, 0));
+Obj _35reg2138 = primCdr(_35reg2137);
+Obj _35reg2139 = primCdr(_35reg2138);
+Obj _35reg2140 = primCar(_35reg2139);
+Obj c = _35reg2140;
+Obj _35reg2141 = primCdr(closureRef(co, 0));
+Obj _35reg2142 = primCdr(_35reg2141);
+Obj _35reg2143 = primCdr(_35reg2142);
+Obj _35reg2144 = primCdr(_35reg2143);
+Obj _35reg2145 = primEQ(Nil, _35reg2144);
+if (True == _35reg2145) {
+pushCont(co, 2, clofun58, 2, c, a);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1526;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1526;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1526;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1526;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1526;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1526;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35val2146 = __arg1;
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 3, clofun58, 2, a, _35val2146);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = c;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val2147 = __arg1;
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35val2146= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg2148 = primCons(a, Nil);
+pushCont(co, 4, clofun58, 1, _35val2146);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#diff"));
+__arg1 = _35val2147;
+__arg2 = _35reg2148;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val2149 = __arg1;
+Obj _35val2146= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#union"));
+__arg1 = _35val2146;
+__arg2 = _35val2149;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35cc1527 = makeNative(0, clofun59, 0, 1, closureRef(co, 0));
+Obj _35reg2110 = primIsCons(closureRef(co, 0));
+if (True == _35reg2110) {
+Obj _35reg2111 = primCar(closureRef(co, 0));
+Obj _35reg2112 = primEQ(intern("%closure"), _35reg2111);
+if (True == _35reg2112) {
+Obj _35reg2113 = primCdr(closureRef(co, 0));
+Obj _35reg2114 = primIsCons(_35reg2113);
+if (True == _35reg2114) {
+Obj _35reg2115 = primCdr(closureRef(co, 0));
+Obj _35reg2116 = primCar(_35reg2115);
+Obj lam = _35reg2116;
+Obj _35reg2117 = primCdr(closureRef(co, 0));
+Obj _35reg2118 = primCdr(_35reg2117);
+Obj more = _35reg2118;
+Obj _35reg2119 = primCons(lam, more);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = _35reg2119;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1527;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1527;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1527;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun58) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun59(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc1528 = makeNative(1, clofun59, 0, 1, closureRef(co, 0));
+Obj _35reg2100 = primIsCons(closureRef(co, 0));
+if (True == _35reg2100) {
+Obj _35reg2101 = primCar(closureRef(co, 0));
+Obj _35reg2102 = primEQ(intern("return"), _35reg2101);
+if (True == _35reg2102) {
+Obj _35reg2103 = primCdr(closureRef(co, 0));
+Obj _35reg2104 = primIsCons(_35reg2103);
+if (True == _35reg2104) {
+Obj _35reg2105 = primCdr(closureRef(co, 0));
+Obj _35reg2106 = primCar(_35reg2105);
+Obj x = _35reg2106;
+Obj _35reg2107 = primCdr(closureRef(co, 0));
+Obj _35reg2108 = primCdr(_35reg2107);
+Obj _35reg2109 = primEQ(Nil, _35reg2108);
+if (True == _35reg2109) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1528;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1528;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1528;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1528;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35cc1529 = makeNative(3, clofun59, 0, 1, closureRef(co, 0));
+Obj _35reg2080 = primIsCons(closureRef(co, 0));
+if (True == _35reg2080) {
+Obj _35reg2081 = primCar(closureRef(co, 0));
+Obj _35reg2082 = primEQ(intern("call"), _35reg2081);
+if (True == _35reg2082) {
+Obj _35reg2083 = primCdr(closureRef(co, 0));
+Obj _35reg2084 = primIsCons(_35reg2083);
+if (True == _35reg2084) {
+Obj _35reg2085 = primCdr(closureRef(co, 0));
+Obj _35reg2086 = primCar(_35reg2085);
+Obj exp = _35reg2086;
+Obj _35reg2087 = primCdr(closureRef(co, 0));
+Obj _35reg2088 = primCdr(_35reg2087);
+Obj _35reg2089 = primIsCons(_35reg2088);
+if (True == _35reg2089) {
+Obj _35reg2090 = primCdr(closureRef(co, 0));
+Obj _35reg2091 = primCdr(_35reg2090);
+Obj _35reg2092 = primCar(_35reg2091);
+Obj cont = _35reg2092;
+Obj _35reg2093 = primCdr(closureRef(co, 0));
+Obj _35reg2094 = primCdr(_35reg2093);
+Obj _35reg2095 = primCdr(_35reg2094);
+Obj _35reg2096 = primEQ(Nil, _35reg2095);
+if (True == _35reg2096) {
+Obj _35reg2097 = primCons(cont, Nil);
+Obj _35reg2098 = primCons(exp, _35reg2097);
+pushCont(co, 2, clofun59, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg2 = _35reg2098;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1529;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1529;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1529;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1529;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1529;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35val2099 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#foldl"));
+__arg1 = globalRef(intern("cora/lib/toc#union"));
+__arg2 = Nil;
+__arg3 = _35val2099;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35cc1530 = makeNative(4, clofun59, 0, 1, closureRef(co, 0));
+Obj _35reg2070 = primIsCons(closureRef(co, 0));
+if (True == _35reg2070) {
+Obj _35reg2071 = primCar(closureRef(co, 0));
+Obj _35reg2072 = primEQ(intern("tailcall"), _35reg2071);
+if (True == _35reg2072) {
+Obj _35reg2073 = primCdr(closureRef(co, 0));
+Obj _35reg2074 = primIsCons(_35reg2073);
+if (True == _35reg2074) {
+Obj _35reg2075 = primCdr(closureRef(co, 0));
+Obj _35reg2076 = primCar(_35reg2075);
+Obj exp = _35reg2076;
+Obj _35reg2077 = primCdr(closureRef(co, 0));
+Obj _35reg2078 = primCdr(_35reg2077);
+Obj _35reg2079 = primEQ(Nil, _35reg2078);
+if (True == _35reg2079) {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = exp;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1530;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1530;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1530;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1530;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35cc1531 = makeNative(0, clofun60, 0, 1, closureRef(co, 0));
+Obj _35reg2052 = primIsCons(closureRef(co, 0));
+if (True == _35reg2052) {
+Obj _35reg2053 = primCar(closureRef(co, 0));
+Obj _35reg2054 = primEQ(intern("continuation"), _35reg2053);
+if (True == _35reg2054) {
+Obj _35reg2055 = primCdr(closureRef(co, 0));
+Obj _35reg2056 = primIsCons(_35reg2055);
+if (True == _35reg2056) {
+Obj _35reg2057 = primCdr(closureRef(co, 0));
+Obj _35reg2058 = primCar(_35reg2057);
+Obj arg = _35reg2058;
+Obj _35reg2059 = primCdr(closureRef(co, 0));
+Obj _35reg2060 = primCdr(_35reg2059);
+Obj _35reg2061 = primIsCons(_35reg2060);
+if (True == _35reg2061) {
+Obj _35reg2062 = primCdr(closureRef(co, 0));
+Obj _35reg2063 = primCdr(_35reg2062);
+Obj _35reg2064 = primCar(_35reg2063);
+Obj body = _35reg2064;
+Obj _35reg2065 = primCdr(closureRef(co, 0));
+Obj _35reg2066 = primCdr(_35reg2065);
+Obj _35reg2067 = primCdr(_35reg2066);
+Obj _35reg2068 = primEQ(Nil, _35reg2067);
+if (True == _35reg2068) {
+pushCont(co, 5, clofun59, 1, arg);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg1 = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1531;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1531;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1531;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1531;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1531;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label5:
 {
-Obj _35cc1418 = makeNative(3, _35clofun3243, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1889 = primIsCons(closureRef(co, 0));
-if (True == _35reg1889) {
-Obj _35reg1890 = primCar(closureRef(co, 0));
-Obj x = _35reg1890;
-Obj _35reg1891 = primCdr(closureRef(co, 0));
-Obj y = _35reg1891;
+Obj _35val2069 = __arg1;
+Obj arg= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#diff"));
+__arg1 = _35val2069;
+__arg2 = arg;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun59) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun60(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc1532 = makeNative(2, clofun60, 0, 0);
+Obj _35reg2047 = primIsCons(closureRef(co, 0));
+if (True == _35reg2047) {
+Obj _35reg2048 = primCar(closureRef(co, 0));
+Obj f = _35reg2048;
+Obj _35reg2049 = primCdr(closureRef(co, 0));
+Obj args = _35reg2049;
+Obj _35reg2050 = primCons(f, args);
+pushCont(co, 1, clofun60, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
+__arg2 = _35reg2050;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1532;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35val2051 = __arg1;
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#foldl"));
+__arg1 = globalRef(intern("cora/lib/toc#union"));
+__arg2 = Nil;
+__arg3 = _35val2051;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35p1513 = __arg1;
+Obj _35cc1514 = makeNative(4, clofun60, 0, 1, _35p1513);
+Obj _35reg2036 = primIsCons(_35p1513);
+if (True == _35reg2036) {
+Obj _35reg2037 = primCar(_35p1513);
+Obj _35reg2038 = primEQ(intern("%const"), _35reg2037);
+if (True == _35reg2038) {
+Obj _35reg2039 = primCdr(_35p1513);
+Obj _35reg2040 = primIsCons(_35reg2039);
+if (True == _35reg2040) {
+Obj _35reg2041 = primCdr(_35p1513);
+Obj _35reg2042 = primCar(_35reg2041);
+Obj x = _35reg2042;
+Obj _35reg2043 = primCdr(_35p1513);
+Obj _35reg2044 = primCdr(_35reg2043);
+Obj _35reg2045 = primEQ(Nil, _35reg2044);
+if (True == _35reg2045) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun60) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1514;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1514;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1514;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1514;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35cc1515 = makeNative(5, clofun60, 0, 1, closureRef(co, 0));
+Obj _35reg2026 = primIsCons(closureRef(co, 0));
+if (True == _35reg2026) {
+Obj _35reg2027 = primCar(closureRef(co, 0));
+Obj _35reg2028 = primEQ(intern("%global"), _35reg2027);
+if (True == _35reg2028) {
+Obj _35reg2029 = primCdr(closureRef(co, 0));
+Obj _35reg2030 = primIsCons(_35reg2029);
+if (True == _35reg2030) {
+Obj _35reg2031 = primCdr(closureRef(co, 0));
+Obj _35reg2032 = primCar(_35reg2031);
+Obj x = _35reg2032;
+Obj _35reg2033 = primCdr(closureRef(co, 0));
+Obj _35reg2034 = primCdr(_35reg2033);
+Obj _35reg2035 = primEQ(Nil, _35reg2034);
+if (True == _35reg2035) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun60) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1515;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1515;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1515;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1515;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35cc1516 = makeNative(0, clofun61, 0, 1, closureRef(co, 0));
+Obj _35reg2016 = primIsCons(closureRef(co, 0));
+if (True == _35reg2016) {
+Obj _35reg2017 = primCar(closureRef(co, 0));
+Obj _35reg2018 = primEQ(intern("%builtin"), _35reg2017);
+if (True == _35reg2018) {
+Obj _35reg2019 = primCdr(closureRef(co, 0));
+Obj _35reg2020 = primIsCons(_35reg2019);
+if (True == _35reg2020) {
+Obj _35reg2021 = primCdr(closureRef(co, 0));
+Obj _35reg2022 = primCar(_35reg2021);
+Obj op = _35reg2022;
+Obj _35reg2023 = primCdr(closureRef(co, 0));
+Obj _35reg2024 = primCdr(_35reg2023);
+Obj _35reg2025 = primEQ(Nil, _35reg2024);
+if (True == _35reg2025) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun60) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1516;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1516;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1516;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1516;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun60) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun61(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc1517 = makeNative(1, clofun61, 0, 1, closureRef(co, 0));
+Obj _35reg2006 = primIsCons(closureRef(co, 0));
+if (True == _35reg2006) {
+Obj _35reg2007 = primCar(closureRef(co, 0));
+Obj _35reg2008 = primEQ(intern("quote"), _35reg2007);
+if (True == _35reg2008) {
+Obj _35reg2009 = primCdr(closureRef(co, 0));
+Obj _35reg2010 = primIsCons(_35reg2009);
+if (True == _35reg2010) {
+Obj _35reg2011 = primCdr(closureRef(co, 0));
+Obj _35reg2012 = primCar(_35reg2011);
+Obj x = _35reg2012;
+Obj _35reg2013 = primCdr(closureRef(co, 0));
+Obj _35reg2014 = primCdr(_35reg2013);
+Obj _35reg2015 = primEQ(Nil, _35reg2014);
+if (True == _35reg2015) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun61) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1517;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun61) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1517;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun61) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1517;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun61) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1517;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun61) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35cc1518 = makeNative(2, clofun61, 0, 1, closureRef(co, 0));
+Obj _35reg1996 = primIsCons(closureRef(co, 0));
+if (True == _35reg1996) {
+Obj _35reg1997 = primCar(closureRef(co, 0));
+Obj _35reg1998 = primEQ(intern("%closure-ref"), _35reg1997);
+if (True == _35reg1998) {
+Obj _35reg1999 = primCdr(closureRef(co, 0));
+Obj _35reg2000 = primIsCons(_35reg1999);
+if (True == _35reg2000) {
+Obj _35reg2001 = primCdr(closureRef(co, 0));
+Obj _35reg2002 = primCar(_35reg2001);
+Obj __ = _35reg2002;
+Obj _35reg2003 = primCdr(closureRef(co, 0));
+Obj _35reg2004 = primCdr(_35reg2003);
+Obj _35reg2005 = primEQ(Nil, _35reg2004);
+if (True == _35reg2005) {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun61) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1518;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun61) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1518;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun61) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1518;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun61) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1518;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun61) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35cc1519 = makeNative(3, clofun61, 0, 0);
+Obj x = closureRef(co, 0);
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun61) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label3:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun61) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35p1508 = __arg1;
+Obj _35p1509 = __arg2;
+Obj _35cc1510 = makeNative(5, clofun61, 0, 2, _35p1508, _35p1509);
+Obj _35reg1994 = primEQ(Nil, _35p1508);
+if (True == _35reg1994) {
+Obj __ = _35p1509;
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun61) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1510;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun61) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35cc1511 = makeNative(1, clofun62, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1990 = primIsCons(closureRef(co, 0));
+if (True == _35reg1990) {
+Obj _35reg1991 = primCar(closureRef(co, 0));
+Obj x = _35reg1991;
+Obj _35reg1992 = primCdr(closureRef(co, 0));
+Obj y = _35reg1992;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 4, _35clofun3243, 3, y, s2, _35cc1418);
+pushCont(co, 0, clofun62, 3, y, s2, _35cc1511);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#elem?"));
 __arg1 = x;
@@ -10377,605 +11500,17 @@ __arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun61) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1418;
+__arg0 = _35cc1511;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun61) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
-}
-
-label6:
-{
-Obj _35p1415 = __arg1;
-Obj _35p1416 = __arg2;
-Obj _35cc1417 = makeNative(5, _35clofun3243, 0, 2, _35p1415, _35p1416);
-Obj _35reg1893 = primEQ(Nil, _35p1415);
-if (True == _35reg1893) {
-Obj __ = _35p1416;
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3243) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1417;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label7:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35cc1426 = makeNative(7, _35clofun3243, 0, 0);
-Obj x = closureRef(co, 0);
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3243) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label9:
-{
-Obj _35cc1425 = makeNative(8, _35clofun3243, 0, 1, closureRef(co, 0));
-Obj _35reg1895 = primIsCons(closureRef(co, 0));
-if (True == _35reg1895) {
-Obj _35reg1896 = primCar(closureRef(co, 0));
-Obj _35reg1897 = primEQ(intern("%closure-ref"), _35reg1896);
-if (True == _35reg1897) {
-Obj _35reg1898 = primCdr(closureRef(co, 0));
-Obj _35reg1899 = primIsCons(_35reg1898);
-if (True == _35reg1899) {
-Obj _35reg1900 = primCdr(closureRef(co, 0));
-Obj _35reg1901 = primCar(_35reg1900);
-Obj __ = _35reg1901;
-Obj _35reg1902 = primCdr(closureRef(co, 0));
-Obj _35reg1903 = primCdr(_35reg1902);
-Obj _35reg1904 = primEQ(Nil, _35reg1903);
-if (True == _35reg1904) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3243) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1425;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1425;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1425;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1425;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj _35cc1424 = makeNative(9, _35clofun3243, 0, 1, closureRef(co, 0));
-Obj _35reg1905 = primIsCons(closureRef(co, 0));
-if (True == _35reg1905) {
-Obj _35reg1906 = primCar(closureRef(co, 0));
-Obj _35reg1907 = primEQ(intern("quote"), _35reg1906);
-if (True == _35reg1907) {
-Obj _35reg1908 = primCdr(closureRef(co, 0));
-Obj _35reg1909 = primIsCons(_35reg1908);
-if (True == _35reg1909) {
-Obj _35reg1910 = primCdr(closureRef(co, 0));
-Obj _35reg1911 = primCar(_35reg1910);
-Obj x = _35reg1911;
-Obj _35reg1912 = primCdr(closureRef(co, 0));
-Obj _35reg1913 = primCdr(_35reg1912);
-Obj _35reg1914 = primEQ(Nil, _35reg1913);
-if (True == _35reg1914) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3243) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1424;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1424;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1424;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1424;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label11:
-{
-Obj _35cc1423 = makeNative(10, _35clofun3243, 0, 1, closureRef(co, 0));
-Obj _35reg1915 = primIsCons(closureRef(co, 0));
-if (True == _35reg1915) {
-Obj _35reg1916 = primCar(closureRef(co, 0));
-Obj _35reg1917 = primEQ(intern("%builtin"), _35reg1916);
-if (True == _35reg1917) {
-Obj _35reg1918 = primCdr(closureRef(co, 0));
-Obj _35reg1919 = primIsCons(_35reg1918);
-if (True == _35reg1919) {
-Obj _35reg1920 = primCdr(closureRef(co, 0));
-Obj _35reg1921 = primCar(_35reg1920);
-Obj op = _35reg1921;
-Obj _35reg1922 = primCdr(closureRef(co, 0));
-Obj _35reg1923 = primCdr(_35reg1922);
-Obj _35reg1924 = primEQ(Nil, _35reg1923);
-if (True == _35reg1924) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3243) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1423;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1423;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1423;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1423;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35cc1422 = makeNative(11, _35clofun3243, 0, 1, closureRef(co, 0));
-Obj _35reg1925 = primIsCons(closureRef(co, 0));
-if (True == _35reg1925) {
-Obj _35reg1926 = primCar(closureRef(co, 0));
-Obj _35reg1927 = primEQ(intern("%global"), _35reg1926);
-if (True == _35reg1927) {
-Obj _35reg1928 = primCdr(closureRef(co, 0));
-Obj _35reg1929 = primIsCons(_35reg1928);
-if (True == _35reg1929) {
-Obj _35reg1930 = primCdr(closureRef(co, 0));
-Obj _35reg1931 = primCar(_35reg1930);
-Obj x = _35reg1931;
-Obj _35reg1932 = primCdr(closureRef(co, 0));
-Obj _35reg1933 = primCdr(_35reg1932);
-Obj _35reg1934 = primEQ(Nil, _35reg1933);
-if (True == _35reg1934) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3243) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1422;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1422;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1422;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1422;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
-{
-Obj _35p1420 = __arg1;
-Obj _35cc1421 = makeNative(12, _35clofun3243, 0, 1, _35p1420);
-Obj _35reg1935 = primIsCons(_35p1420);
-if (True == _35reg1935) {
-Obj _35reg1936 = primCar(_35p1420);
-Obj _35reg1937 = primEQ(intern("%const"), _35reg1936);
-if (True == _35reg1937) {
-Obj _35reg1938 = primCdr(_35p1420);
-Obj _35reg1939 = primIsCons(_35reg1938);
-if (True == _35reg1939) {
-Obj _35reg1940 = primCdr(_35p1420);
-Obj _35reg1941 = primCar(_35reg1940);
-Obj x = _35reg1941;
-Obj _35reg1942 = primCdr(_35p1420);
-Obj _35reg1943 = primCdr(_35reg1942);
-Obj _35reg1944 = primEQ(Nil, _35reg1943);
-if (True == _35reg1944) {
-__nargs = 2;
-__arg1 = True;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3243) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1421;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1421;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1421;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1421;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label14:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35val1950 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#foldl"));
-__arg1 = globalRef(intern("cora/lib/toc#union"));
-__arg2 = Nil;
-__arg3 = _35val1950;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35cc1439 = makeNative(14, _35clofun3243, 0, 0);
-Obj _35reg1946 = primIsCons(closureRef(co, 0));
-if (True == _35reg1946) {
-Obj _35reg1947 = primCar(closureRef(co, 0));
-Obj f = _35reg1947;
-Obj _35reg1948 = primCdr(closureRef(co, 0));
-Obj args = _35reg1948;
-Obj _35reg1949 = primCons(f, args);
-pushCont(co, 15, _35clofun3243, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg2 = _35reg1949;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1439;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label17:
-{
-Obj _35val1968 = __arg1;
-Obj arg= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#diff"));
-__arg1 = _35val1968;
-__arg2 = arg;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label18:
-{
-Obj _35cc1438 = makeNative(16, _35clofun3243, 0, 1, closureRef(co, 0));
-Obj _35reg1951 = primIsCons(closureRef(co, 0));
-if (True == _35reg1951) {
-Obj _35reg1952 = primCar(closureRef(co, 0));
-Obj _35reg1953 = primEQ(intern("continuation"), _35reg1952);
-if (True == _35reg1953) {
-Obj _35reg1954 = primCdr(closureRef(co, 0));
-Obj _35reg1955 = primIsCons(_35reg1954);
-if (True == _35reg1955) {
-Obj _35reg1956 = primCdr(closureRef(co, 0));
-Obj _35reg1957 = primCar(_35reg1956);
-Obj arg = _35reg1957;
-Obj _35reg1958 = primCdr(closureRef(co, 0));
-Obj _35reg1959 = primCdr(_35reg1958);
-Obj _35reg1960 = primIsCons(_35reg1959);
-if (True == _35reg1960) {
-Obj _35reg1961 = primCdr(closureRef(co, 0));
-Obj _35reg1962 = primCdr(_35reg1961);
-Obj _35reg1963 = primCar(_35reg1962);
-Obj body = _35reg1963;
-Obj _35reg1964 = primCdr(closureRef(co, 0));
-Obj _35reg1965 = primCdr(_35reg1964);
-Obj _35reg1966 = primCdr(_35reg1965);
-Obj _35reg1967 = primEQ(Nil, _35reg1966);
-if (True == _35reg1967) {
-pushCont(co, 17, _35clofun3243, 1, arg);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1438;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1438;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1438;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1438;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1438;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label19:
-{
-Obj _35cc1437 = makeNative(18, _35clofun3243, 0, 1, closureRef(co, 0));
-Obj _35reg1969 = primIsCons(closureRef(co, 0));
-if (True == _35reg1969) {
-Obj _35reg1970 = primCar(closureRef(co, 0));
-Obj _35reg1971 = primEQ(intern("tailcall"), _35reg1970);
-if (True == _35reg1971) {
-Obj _35reg1972 = primCdr(closureRef(co, 0));
-Obj _35reg1973 = primIsCons(_35reg1972);
-if (True == _35reg1973) {
-Obj _35reg1974 = primCdr(closureRef(co, 0));
-Obj _35reg1975 = primCar(_35reg1974);
-Obj exp = _35reg1975;
-Obj _35reg1976 = primCdr(closureRef(co, 0));
-Obj _35reg1977 = primCdr(_35reg1976);
-Obj _35reg1978 = primEQ(Nil, _35reg1977);
-if (True == _35reg1978) {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#free-vars"));
-__arg1 = exp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1437;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1437;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1437;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1437;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
-{
-Obj _35val1998 = __arg1;
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#foldl"));
-__arg1 = globalRef(intern("cora/lib/toc#union"));
-__arg2 = Nil;
-__arg3 = _35val1998;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3243) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
 }
 
 fail:
@@ -10987,69 +11522,834 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3242(struct Cora* co){
+void clofun62(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1807 = __arg1;
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 20, _35clofun3241, 1, _35val1807);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = y;
+Obj _35val1993 = __arg1;
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc1511= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val1993) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#diff"));
+__arg1 = y;
+__arg2 = s2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun62) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1511;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun62) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
 label1:
 {
-Obj _35cc1404 = makeNative(19, _35clofun3241, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj _35cc1512 = makeNative(3, clofun62, 0, 0);
+Obj _35reg1985 = primIsCons(closureRef(co, 0));
+if (True == _35reg1985) {
+Obj _35reg1986 = primCar(closureRef(co, 0));
+Obj x = _35reg1986;
+Obj _35reg1987 = primCdr(closureRef(co, 0));
+Obj y = _35reg1987;
+Obj s2 = closureRef(co, 1);
+pushCont(co, 2, clofun62, 1, x);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#diff"));
+__arg1 = y;
+__arg2 = s2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun62) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1512;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun62) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35val1988 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1989 = primCons(x, _35val1988);
+__nargs = 2;
+__arg1 = _35reg1989;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun62) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label3:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun62) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35p1503 = __arg1;
+Obj _35p1504 = __arg2;
+Obj _35cc1505 = makeNative(5, clofun62, 0, 2, _35p1503, _35p1504);
+Obj _35reg1983 = primEQ(Nil, _35p1503);
+if (True == _35reg1983) {
+Obj s2 = _35p1504;
+__nargs = 2;
+__arg1 = s2;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun62) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1505;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun62) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35cc1506 = makeNative(1, clofun63, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj _35reg1979 = primIsCons(closureRef(co, 0));
+if (True == _35reg1979) {
+Obj _35reg1980 = primCar(closureRef(co, 0));
+Obj x = _35reg1980;
+Obj _35reg1981 = primCdr(closureRef(co, 0));
+Obj y = _35reg1981;
+Obj s2 = closureRef(co, 1);
+pushCont(co, 0, clofun63, 3, y, s2, _35cc1506);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#elem?"));
+__arg1 = x;
+__arg2 = s2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun62) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1506;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun62) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun63(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val1982 = __arg1;
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35cc1506= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val1982) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#union"));
+__arg1 = y;
+__arg2 = s2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun63) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1506;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun63) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35cc1507 = makeNative(3, clofun63, 0, 0);
+Obj _35reg1974 = primIsCons(closureRef(co, 0));
+if (True == _35reg1974) {
+Obj _35reg1975 = primCar(closureRef(co, 0));
+Obj x = _35reg1975;
+Obj _35reg1976 = primCdr(closureRef(co, 0));
+Obj y = _35reg1976;
+Obj s2 = closureRef(co, 1);
+pushCont(co, 2, clofun63, 1, x);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#union"));
+__arg1 = y;
+__arg2 = s2;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun63) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1507;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun63) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35val1977 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1978 = primCons(x, _35val1977);
+__nargs = 2;
+__arg1 = _35reg1978;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun63) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label3:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun63) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35p1488 = __arg1;
+Obj _35p1489 = __arg2;
+Obj _35p1490 = __arg3;
+Obj _35p1491 = co->args[4];
+Obj _35cc1492 = makeNative(2, clofun64, 0, 4, _35p1488, _35p1489, _35p1490, _35p1491);
+Obj __ = _35p1488;
+__ = _35p1489;
+__ = _35p1490;
+Obj x = _35p1491;
+pushCont(co, 5, clofun63, 2, x, _35cc1492);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#number?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun63) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val1959 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1492= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1959) {
+if (True == True) {
+Obj _35reg1960 = primCons(x, Nil);
+Obj _35reg1961 = primCons(intern("%const"), _35reg1960);
+__nargs = 2;
+__arg1 = _35reg1961;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun63) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1492;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun63) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+Obj _35reg1962 = primIsString(x);
+if (True == _35reg1962) {
+if (True == True) {
+Obj _35reg1963 = primCons(x, Nil);
+Obj _35reg1964 = primCons(intern("%const"), _35reg1963);
+__nargs = 2;
+__arg1 = _35reg1964;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun63) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1492;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun63) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+pushCont(co, 0, clofun64, 2, x, _35cc1492);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#boolean?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun63) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun64(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val1965 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1492= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1965) {
+if (True == True) {
+Obj _35reg1966 = primCons(x, Nil);
+Obj _35reg1967 = primCons(intern("%const"), _35reg1966);
+__nargs = 2;
+__arg1 = _35reg1967;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun64) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1492;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun64) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+pushCont(co, 1, clofun64, 2, x, _35cc1492);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#null?"));
+__arg1 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun64) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35val1968 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35cc1492= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1968) {
+if (True == True) {
+Obj _35reg1969 = primCons(x, Nil);
+Obj _35reg1970 = primCons(intern("%const"), _35reg1969);
+__nargs = 2;
+__arg1 = _35reg1970;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun64) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1492;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun64) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+if (True == False) {
+Obj _35reg1971 = primCons(x, Nil);
+Obj _35reg1972 = primCons(intern("%const"), _35reg1971);
+__nargs = 2;
+__arg1 = _35reg1972;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun64) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1492;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun64) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+}
+
+label2:
+{
+Obj _35cc1493 = makeNative(3, clofun64, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj __ = closureRef(co, 0);
+__ = closureRef(co, 1);
+__ = closureRef(co, 2);
+Obj _35reg1947 = primIsCons(closureRef(co, 3));
+if (True == _35reg1947) {
+Obj _35reg1948 = primCar(closureRef(co, 3));
+Obj _35reg1949 = primEQ(intern("quote"), _35reg1948);
+if (True == _35reg1949) {
+Obj _35reg1950 = primCdr(closureRef(co, 3));
+Obj _35reg1951 = primIsCons(_35reg1950);
+if (True == _35reg1951) {
+Obj _35reg1952 = primCdr(closureRef(co, 3));
+Obj _35reg1953 = primCar(_35reg1952);
+Obj x = _35reg1953;
+Obj _35reg1954 = primCdr(closureRef(co, 3));
+Obj _35reg1955 = primCdr(_35reg1954);
+Obj _35reg1956 = primEQ(Nil, _35reg1955);
+if (True == _35reg1956) {
+Obj _35reg1957 = primCons(x, Nil);
+Obj _35reg1958 = primCons(intern("%const"), _35reg1957);
+__nargs = 2;
+__arg1 = _35reg1958;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun64) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1493;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun64) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1493;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun64) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1493;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun64) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1493;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun64) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35cc1494 = makeNative(0, clofun65, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj _35reg1790 = primIsCons(closureRef(co, 3));
-if (True == _35reg1790) {
-Obj _35reg1791 = primCar(closureRef(co, 3));
-Obj _35reg1792 = primEQ(intern("do"), _35reg1791);
-if (True == _35reg1792) {
-Obj _35reg1793 = primCdr(closureRef(co, 3));
-Obj _35reg1794 = primIsCons(_35reg1793);
-if (True == _35reg1794) {
-Obj _35reg1795 = primCdr(closureRef(co, 3));
-Obj _35reg1796 = primCar(_35reg1795);
-Obj x = _35reg1796;
-Obj _35reg1797 = primCdr(closureRef(co, 3));
-Obj _35reg1798 = primCdr(_35reg1797);
-Obj _35reg1799 = primIsCons(_35reg1798);
-if (True == _35reg1799) {
-Obj _35reg1800 = primCdr(closureRef(co, 3));
-Obj _35reg1801 = primCdr(_35reg1800);
-Obj _35reg1802 = primCar(_35reg1801);
-Obj y = _35reg1802;
-Obj _35reg1803 = primCdr(closureRef(co, 3));
-Obj _35reg1804 = primCdr(_35reg1803);
-Obj _35reg1805 = primCdr(_35reg1804);
-Obj _35reg1806 = primEQ(Nil, _35reg1805);
-if (True == _35reg1806) {
-pushCont(co, 0, _35clofun3242, 4, env, ns, import, y);
+Obj x = closureRef(co, 3);
+Obj _35reg1942 = primIsSymbol(x);
+if (True == _35reg1942) {
+pushCont(co, 4, clofun64, 3, x, ns, import);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#elem?"));
+__arg1 = x;
+__arg2 = env;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun64) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1494;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun64) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val1943 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
+if (True == _35val1943) {
+__nargs = 2;
+__arg1 = x;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun64) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+pushCont(co, 5, clofun64, 0);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#lookup-var"));
+__arg1 = x;
+__arg2 = ns;
+__arg3 = import;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun64) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35val1944 = __arg1;
+Obj _35reg1945 = primCons(_35val1944, Nil);
+Obj _35reg1946 = primCons(intern("%global"), _35reg1945);
+__nargs = 2;
+__arg1 = _35reg1946;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun64) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun65(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc1495 = makeNative(3, clofun65, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj _35reg1920 = primIsCons(closureRef(co, 3));
+if (True == _35reg1920) {
+Obj _35reg1921 = primCar(closureRef(co, 3));
+Obj _35reg1922 = primEQ(intern("lambda"), _35reg1921);
+if (True == _35reg1922) {
+Obj _35reg1923 = primCdr(closureRef(co, 3));
+Obj _35reg1924 = primIsCons(_35reg1923);
+if (True == _35reg1924) {
+Obj _35reg1925 = primCdr(closureRef(co, 3));
+Obj _35reg1926 = primCar(_35reg1925);
+Obj args = _35reg1926;
+Obj _35reg1927 = primCdr(closureRef(co, 3));
+Obj _35reg1928 = primCdr(_35reg1927);
+Obj _35reg1929 = primIsCons(_35reg1928);
+if (True == _35reg1929) {
+Obj _35reg1930 = primCdr(closureRef(co, 3));
+Obj _35reg1931 = primCdr(_35reg1930);
+Obj _35reg1932 = primCar(_35reg1931);
+Obj body = _35reg1932;
+Obj _35reg1933 = primCdr(closureRef(co, 3));
+Obj _35reg1934 = primCdr(_35reg1933);
+Obj _35reg1935 = primCdr(_35reg1934);
+Obj _35reg1936 = primEQ(Nil, _35reg1935);
+if (True == _35reg1936) {
+pushCont(co, 1, clofun65, 4, ns, import, body, args);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#append"));
+__arg1 = args;
+__arg2 = env;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun65) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1495;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun65) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1495;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun65) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1495;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun65) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1495;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun65) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1495;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun65) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35val1937 = __arg1;
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 2, clofun65, 1, args);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#parse"));
+__arg1 = _35val1937;
+__arg2 = ns;
+__arg3 = import;
+co->args[4] = body;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun65) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val1938 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1939 = primCons(_35val1938, Nil);
+Obj _35reg1940 = primCons(args, _35reg1939);
+Obj _35reg1941 = primCons(intern("lambda"), _35reg1940);
+__nargs = 2;
+__arg1 = _35reg1941;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun65) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label3:
+{
+Obj _35cc1496 = makeNative(0, clofun66, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj _35reg1913 = primIsCons(closureRef(co, 3));
+if (True == _35reg1913) {
+Obj _35reg1914 = primCar(closureRef(co, 3));
+Obj _35reg1915 = primEQ(intern("if"), _35reg1914);
+if (True == _35reg1915) {
+Obj _35reg1916 = primCdr(closureRef(co, 3));
+Obj args = _35reg1916;
+pushCont(co, 4, clofun65, 1, args);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#parse"));
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun65) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1496;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun65) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1496;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun65) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label4:
+{
+Obj _35val1917 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 5, clofun65, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = _35val1917;
+__arg2 = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun65) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val1918 = __arg1;
+Obj _35reg1919 = primCons(intern("if"), _35val1918);
+__nargs = 2;
+__arg1 = _35reg1919;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun65) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun66(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc1497 = makeNative(3, clofun66, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj _35reg1891 = primIsCons(closureRef(co, 3));
+if (True == _35reg1891) {
+Obj _35reg1892 = primCar(closureRef(co, 3));
+Obj _35reg1893 = primEQ(intern("do"), _35reg1892);
+if (True == _35reg1893) {
+Obj _35reg1894 = primCdr(closureRef(co, 3));
+Obj _35reg1895 = primIsCons(_35reg1894);
+if (True == _35reg1895) {
+Obj _35reg1896 = primCdr(closureRef(co, 3));
+Obj _35reg1897 = primCar(_35reg1896);
+Obj x = _35reg1897;
+Obj _35reg1898 = primCdr(closureRef(co, 3));
+Obj _35reg1899 = primCdr(_35reg1898);
+Obj _35reg1900 = primIsCons(_35reg1899);
+if (True == _35reg1900) {
+Obj _35reg1901 = primCdr(closureRef(co, 3));
+Obj _35reg1902 = primCdr(_35reg1901);
+Obj _35reg1903 = primCar(_35reg1902);
+Obj y = _35reg1903;
+Obj _35reg1904 = primCdr(closureRef(co, 3));
+Obj _35reg1905 = primCdr(_35reg1904);
+Obj _35reg1906 = primCdr(_35reg1905);
+Obj _35reg1907 = primEQ(Nil, _35reg1906);
+if (True == _35reg1907) {
+pushCont(co, 1, clofun66, 4, env, ns, import, y);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -11059,1309 +12359,132 @@ co->args[4] = x;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1404;
+__arg0 = _35cc1497;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1404;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1404;
+__arg0 = _35cc1497;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1404;
+__arg0 = _35cc1497;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1404;
+__arg0 = _35cc1497;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label2:
-{
-Obj _35val1817 = __arg1;
-Obj _35reg1818 = primCons(intern("if"), _35val1817);
-__nargs = 2;
-__arg1 = _35reg1818;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3242) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label3:
-{
-Obj _35val1816 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 2, _35clofun3242, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val1816;
-__arg2 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj _35cc1403 = makeNative(1, _35clofun3242, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj _35reg1812 = primIsCons(closureRef(co, 3));
-if (True == _35reg1812) {
-Obj _35reg1813 = primCar(closureRef(co, 3));
-Obj _35reg1814 = primEQ(intern("if"), _35reg1813);
-if (True == _35reg1814) {
-Obj _35reg1815 = primCdr(closureRef(co, 3));
-Obj args = _35reg1815;
-pushCont(co, 3, _35clofun3242, 1, args);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1403;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1403;
+__arg0 = _35cc1497;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label5:
-{
-Obj _35val1837 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1838 = primCons(_35val1837, Nil);
-Obj _35reg1839 = primCons(args, _35reg1838);
-Obj _35reg1840 = primCons(intern("lambda"), _35reg1839);
-__nargs = 2;
-__arg1 = _35reg1840;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3242) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label6:
-{
-Obj _35val1836 = __arg1;
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj body= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 5, _35clofun3242, 1, args);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = _35val1836;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35cc1402 = makeNative(4, _35clofun3242, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj _35reg1819 = primIsCons(closureRef(co, 3));
-if (True == _35reg1819) {
-Obj _35reg1820 = primCar(closureRef(co, 3));
-Obj _35reg1821 = primEQ(intern("lambda"), _35reg1820);
-if (True == _35reg1821) {
-Obj _35reg1822 = primCdr(closureRef(co, 3));
-Obj _35reg1823 = primIsCons(_35reg1822);
-if (True == _35reg1823) {
-Obj _35reg1824 = primCdr(closureRef(co, 3));
-Obj _35reg1825 = primCar(_35reg1824);
-Obj args = _35reg1825;
-Obj _35reg1826 = primCdr(closureRef(co, 3));
-Obj _35reg1827 = primCdr(_35reg1826);
-Obj _35reg1828 = primIsCons(_35reg1827);
-if (True == _35reg1828) {
-Obj _35reg1829 = primCdr(closureRef(co, 3));
-Obj _35reg1830 = primCdr(_35reg1829);
-Obj _35reg1831 = primCar(_35reg1830);
-Obj body = _35reg1831;
-Obj _35reg1832 = primCdr(closureRef(co, 3));
-Obj _35reg1833 = primCdr(_35reg1832);
-Obj _35reg1834 = primCdr(_35reg1833);
-Obj _35reg1835 = primEQ(Nil, _35reg1834);
-if (True == _35reg1835) {
-pushCont(co, 6, _35clofun3242, 4, ns, import, body, args);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#append"));
-__arg1 = args;
-__arg2 = env;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1402;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1402;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1402;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1402;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1402;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label8:
-{
-Obj _35val1843 = __arg1;
-Obj _35reg1844 = primCons(_35val1843, Nil);
-Obj _35reg1845 = primCons(intern("%global"), _35reg1844);
-__nargs = 2;
-__arg1 = _35reg1845;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3242) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label9:
-{
-Obj _35val1842 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1842) {
-__nargs = 2;
-__arg1 = x;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3242) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 8, _35clofun3242, 0);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#lookup-var"));
-__arg1 = x;
-__arg2 = ns;
-__arg3 = import;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label10:
-{
-Obj _35cc1401 = makeNative(7, _35clofun3242, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj x = closureRef(co, 3);
-Obj _35reg1841 = primIsSymbol(x);
-if (True == _35reg1841) {
-pushCont(co, 9, _35clofun3242, 3, x, ns, import);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#elem?"));
-__arg1 = x;
-__arg2 = env;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1401;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label11:
-{
-Obj _35cc1400 = makeNative(10, _35clofun3242, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj __ = closureRef(co, 0);
-__ = closureRef(co, 1);
-__ = closureRef(co, 2);
-Obj _35reg1846 = primIsCons(closureRef(co, 3));
-if (True == _35reg1846) {
-Obj _35reg1847 = primCar(closureRef(co, 3));
-Obj _35reg1848 = primEQ(intern("quote"), _35reg1847);
-if (True == _35reg1848) {
-Obj _35reg1849 = primCdr(closureRef(co, 3));
-Obj _35reg1850 = primIsCons(_35reg1849);
-if (True == _35reg1850) {
-Obj _35reg1851 = primCdr(closureRef(co, 3));
-Obj _35reg1852 = primCar(_35reg1851);
-Obj x = _35reg1852;
-Obj _35reg1853 = primCdr(closureRef(co, 3));
-Obj _35reg1854 = primCdr(_35reg1853);
-Obj _35reg1855 = primEQ(Nil, _35reg1854);
-if (True == _35reg1855) {
-Obj _35reg1856 = primCons(x, Nil);
-Obj _35reg1857 = primCons(intern("%const"), _35reg1856);
-__nargs = 2;
-__arg1 = _35reg1857;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3242) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1400;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1400;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1400;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1400;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35val1867 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1399= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1867) {
-if (True == True) {
-Obj _35reg1868 = primCons(x, Nil);
-Obj _35reg1869 = primCons(intern("%const"), _35reg1868);
-__nargs = 2;
-__arg1 = _35reg1869;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3242) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-if (True == False) {
-Obj _35reg1870 = primCons(x, Nil);
-Obj _35reg1871 = primCons(intern("%const"), _35reg1870);
-__nargs = 2;
-__arg1 = _35reg1871;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3242) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label13:
-{
-Obj _35val1864 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1399= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1864) {
-if (True == True) {
-Obj _35reg1865 = primCons(x, Nil);
-Obj _35reg1866 = primCons(intern("%const"), _35reg1865);
-__nargs = 2;
-__arg1 = _35reg1866;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3242) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 12, _35clofun3242, 2, x, _35cc1399);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#null?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label14:
-{
-Obj _35val1858 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35cc1399= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1858) {
-if (True == True) {
-Obj _35reg1859 = primCons(x, Nil);
-Obj _35reg1860 = primCons(intern("%const"), _35reg1859);
-__nargs = 2;
-__arg1 = _35reg1860;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3242) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-Obj _35reg1861 = primIsString(x);
-if (True == _35reg1861) {
-if (True == True) {
-Obj _35reg1862 = primCons(x, Nil);
-Obj _35reg1863 = primCons(intern("%const"), _35reg1862);
-__nargs = 2;
-__arg1 = _35reg1863;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3242) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1399;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-pushCont(co, 13, _35clofun3242, 2, x, _35cc1399);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#boolean?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label15:
-{
-Obj _35p1395 = __arg1;
-Obj _35p1396 = __arg2;
-Obj _35p1397 = __arg3;
-Obj _35p1398 = co->args[4];
-Obj _35cc1399 = makeNative(11, _35clofun3242, 0, 4, _35p1395, _35p1396, _35p1397, _35p1398);
-Obj __ = _35p1395;
-__ = _35p1396;
-__ = _35p1397;
-Obj x = _35p1398;
-pushCont(co, 14, _35clofun3242, 2, x, _35cc1399);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#number?"));
-__arg1 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label16:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label17:
-{
-Obj _35val1876 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1877 = primCons(x, _35val1876);
-__nargs = 2;
-__arg1 = _35reg1877;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3242) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label18:
-{
-Obj _35cc1414 = makeNative(16, _35clofun3242, 0, 0);
-Obj _35reg1873 = primIsCons(closureRef(co, 0));
-if (True == _35reg1873) {
-Obj _35reg1874 = primCar(closureRef(co, 0));
-Obj x = _35reg1874;
-Obj _35reg1875 = primCdr(closureRef(co, 0));
-Obj y = _35reg1875;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 17, _35clofun3242, 1, x);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#union"));
-__arg1 = y;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1414;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label19:
-{
-Obj _35val1881 = __arg1;
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj s2= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35cc1413= co->ctx.stk.stack[co->ctx.stk.base + 2];
-if (True == _35val1881) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#union"));
-__arg1 = y;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1413;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label20:
-{
-Obj _35cc1413 = makeNative(18, _35clofun3242, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg1878 = primIsCons(closureRef(co, 0));
-if (True == _35reg1878) {
-Obj _35reg1879 = primCar(closureRef(co, 0));
-Obj x = _35reg1879;
-Obj _35reg1880 = primCdr(closureRef(co, 0));
-Obj y = _35reg1880;
-Obj s2 = closureRef(co, 1);
-pushCont(co, 19, _35clofun3242, 3, y, s2, _35cc1413);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#elem?"));
-__arg1 = x;
-__arg2 = s2;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1413;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3242) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-fail:
-co->nargs = __nargs;
-co->args[0] = __arg0;
-co->args[1] = __arg1;
-co->args[2] = __arg2;
-co->args[3] = __arg3;
-
-}
-
-void _35clofun3241(struct Cora* co){
-int __nargs = co->nargs;
-Obj __arg0 = co->args[0];
-Obj __arg1 = co->args[1];
-Obj __arg2 = co->args[2];
-Obj __arg3 = co->args[3];
-
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
-
-goto *jumpTable[co->ctx.pc.label];
-
-label0:
-{
-Obj _35cc1394 = makeNative(13, _35clofun3240, 0, 0);
-Obj s = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj _35reg1672 = primIsCons(closureRef(co, 2));
-if (True == _35reg1672) {
-Obj _35reg1673 = primCar(closureRef(co, 2));
-Obj import = _35reg1673;
-Obj _35reg1674 = primCdr(closureRef(co, 2));
-Obj more = _35reg1674;
-pushCont(co, 20, _35clofun3240, 4, import, s, ns, more);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#string-append"));
-__arg1 = import;
-__arg2 = makeCString("#*ns-export*");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1394;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label1:
 {
-Obj _35p1390 = __arg1;
-Obj _35p1391 = __arg2;
-Obj _35p1392 = __arg3;
-Obj _35cc1393 = makeNative(0, _35clofun3241, 0, 3, _35p1390, _35p1391, _35p1392);
-Obj s = _35p1390;
-Obj ns = _35p1391;
-Obj _35reg1682 = primEQ(Nil, _35p1392);
-if (True == _35reg1682) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#var-with-ns"));
-__arg1 = s;
+Obj _35val1908 = __arg1;
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 2, clofun66, 1, _35val1908);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#parse"));
+__arg1 = env;
 __arg2 = ns;
+__arg3 = import;
+co->args[4] = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1393;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
 label2:
 {
+Obj _35val1909 = __arg1;
+Obj _35val1908= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1910 = primCons(_35val1909, Nil);
+Obj _35reg1911 = primCons(_35val1908, _35reg1910);
+Obj _35reg1912 = primCons(intern("do"), _35reg1911);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+__arg1 = _35reg1912;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun66) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 }
 
 label3:
 {
-Obj _35val1684 = __arg1;
-Obj ls= co->ctx.stk.stack[co->ctx.stk.base + 0];
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val1684;
-__arg2 = ls;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label4:
-{
-Obj _35cc1409 = makeNative(2, _35clofun3241, 0, 0);
+Obj _35cc1498 = makeNative(0, clofun67, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
-Obj ls = closureRef(co, 3);
-pushCont(co, 3, _35clofun3241, 1, ls);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label5:
-{
-Obj _35val1695 = __arg1;
-Obj _35reg1693= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1696 = primCons(_35reg1693, _35val1695);
-__nargs = 2;
-__arg1 = _35reg1696;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3241) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label6:
-{
-Obj _35val1694 = __arg1;
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1693= co->ctx.stk.stack[co->ctx.stk.base + 1];
-pushCont(co, 5, _35clofun3241, 1, _35reg1693);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#map"));
-__arg1 = _35val1694;
-__arg2 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35val1701 = __arg1;
-Obj tmp= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj _35reg1702 = primCons(_35val1701, Nil);
-Obj _35reg1703 = primCons(tmp, _35reg1702);
-Obj _35reg1704 = primCons(intern("lambda"), _35reg1703);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = _35reg1704;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label8:
-{
-Obj _35val1699 = __arg1;
-Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj tmp = _35val1699;
-Obj _35reg1700 = primCons(op, args);
-pushCont(co, 7, _35clofun3241, 4, tmp, env, ns, import);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#append"));
-__arg1 = _35reg1700;
-__arg2 = tmp;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val1690 = __arg1;
-Obj required= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj op= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 5];
-Obj provided = _35val1690;
-Obj _35reg1691 = primEQ(required, provided);
-if (True == _35reg1691) {
-Obj _35reg1692 = primCons(op, Nil);
-Obj _35reg1693 = primCons(intern("%builtin"), _35reg1692);
-pushCont(co, 6, _35clofun3241, 2, args, _35reg1693);
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-Obj _35reg1697 = primGT(required, provided);
-if (True == _35reg1697) {
-Obj _35reg1698 = primSub(required, provided);
-pushCont(co, 8, _35clofun3241, 5, op, args, env, ns, import);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#temp-list"));
-__arg1 = _35reg1698;
-__arg2 = Nil;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("primitive call mismatch");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-}
-
-label10:
-{
-Obj _35val1689 = __arg1;
-Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj required = _35val1689;
-pushCont(co, 9, _35clofun3241, 6, required, op, args, env, ns, import);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#length"));
-__arg1 = args;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val1688 = __arg1;
-Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35cc1408= co->ctx.stk.stack[co->ctx.stk.base + 5];
-if (True == _35val1688) {
-pushCont(co, 10, _35clofun3241, 5, op, args, env, ns, import);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#builtin->args"));
-__arg1 = op;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1408;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj _35cc1408 = makeNative(4, _35clofun3241, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj _35reg1685 = primIsCons(closureRef(co, 3));
-if (True == _35reg1685) {
-Obj _35reg1686 = primCar(closureRef(co, 3));
-Obj op = _35reg1686;
-Obj _35reg1687 = primCdr(closureRef(co, 3));
-Obj args = _35reg1687;
-pushCont(co, 11, _35clofun3241, 6, op, args, env, ns, import, _35cc1408);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#builtin?"));
-__arg1 = op;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1408;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
-{
-Obj _35val1727 = __arg1;
-Obj _35reg1726= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1724= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1728 = primCons(_35val1727, Nil);
-Obj _35reg1729 = primCons(_35reg1726, _35reg1728);
-Obj _35reg1730 = primCons(_35reg1724, _35reg1729);
-__nargs = 2;
-__arg1 = _35reg1730;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3241) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label14:
-{
-Obj _35val1722 = __arg1;
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj val= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj var1 = _35val1722;
-Obj _35reg1723 = primCons(intern("set"), Nil);
-Obj _35reg1724 = primCons(intern("%builtin"), _35reg1723);
-Obj _35reg1725 = primCons(var1, Nil);
-Obj _35reg1726 = primCons(intern("%const"), _35reg1725);
-pushCont(co, 13, _35clofun3241, 2, _35reg1726, _35reg1724);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = env;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = val;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35cc1407 = makeNative(12, _35clofun3241, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj _35reg1705 = primIsCons(closureRef(co, 3));
-if (True == _35reg1705) {
-Obj _35reg1706 = primCar(closureRef(co, 3));
-Obj _35reg1707 = primEQ(intern("def"), _35reg1706);
-if (True == _35reg1707) {
-Obj _35reg1708 = primCdr(closureRef(co, 3));
-Obj _35reg1709 = primIsCons(_35reg1708);
-if (True == _35reg1709) {
-Obj _35reg1710 = primCdr(closureRef(co, 3));
-Obj _35reg1711 = primCar(_35reg1710);
-Obj var = _35reg1711;
-Obj _35reg1712 = primCdr(closureRef(co, 3));
-Obj _35reg1713 = primCdr(_35reg1712);
-Obj _35reg1714 = primIsCons(_35reg1713);
-if (True == _35reg1714) {
-Obj _35reg1715 = primCdr(closureRef(co, 3));
-Obj _35reg1716 = primCdr(_35reg1715);
-Obj _35reg1717 = primCar(_35reg1716);
-Obj val = _35reg1717;
-Obj _35reg1718 = primCdr(closureRef(co, 3));
-Obj _35reg1719 = primCdr(_35reg1718);
-Obj _35reg1720 = primCdr(_35reg1719);
-Obj _35reg1721 = primEQ(Nil, _35reg1720);
-if (True == _35reg1721) {
-pushCont(co, 14, _35clofun3241, 4, env, ns, import, val);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#var-with-ns"));
-__arg1 = var;
-__arg2 = ns;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1407;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label16:
-{
-Obj _35cc1406 = makeNative(15, _35clofun3241, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj __ = closureRef(co, 1);
-__ = closureRef(co, 2);
-Obj _35reg1731 = primIsCons(closureRef(co, 3));
-if (True == _35reg1731) {
-Obj _35reg1732 = primCar(closureRef(co, 3));
-Obj _35reg1733 = primEQ(intern("ns"), _35reg1732);
-if (True == _35reg1733) {
-Obj _35reg1734 = primCdr(closureRef(co, 3));
-Obj _35reg1735 = primIsCons(_35reg1734);
-if (True == _35reg1735) {
-Obj _35reg1736 = primCdr(closureRef(co, 3));
-Obj _35reg1737 = primCar(_35reg1736);
-Obj path = _35reg1737;
-Obj _35reg1738 = primCdr(closureRef(co, 3));
-Obj _35reg1739 = primCdr(_35reg1738);
-Obj _35reg1740 = primIsCons(_35reg1739);
-if (True == _35reg1740) {
-Obj _35reg1741 = primCdr(closureRef(co, 3));
-Obj _35reg1742 = primCdr(_35reg1741);
-Obj _35reg1743 = primCar(_35reg1742);
-Obj import = _35reg1743;
-Obj _35reg1744 = primCdr(closureRef(co, 3));
-Obj _35reg1745 = primCdr(_35reg1744);
-Obj _35reg1746 = primCdr(_35reg1745);
-Obj _35reg1747 = primIsCons(_35reg1746);
-if (True == _35reg1747) {
-Obj _35reg1748 = primCdr(closureRef(co, 3));
-Obj _35reg1749 = primCdr(_35reg1748);
-Obj _35reg1750 = primCdr(_35reg1749);
-Obj _35reg1751 = primCar(_35reg1750);
-Obj body = _35reg1751;
-Obj _35reg1752 = primCdr(closureRef(co, 3));
-Obj _35reg1753 = primCdr(_35reg1752);
-Obj _35reg1754 = primCdr(_35reg1753);
-Obj _35reg1755 = primCdr(_35reg1754);
-Obj _35reg1756 = primEQ(Nil, _35reg1755);
-if (True == _35reg1756) {
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = env;
-__arg2 = path;
-__arg3 = import;
-co->args[4] = body;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1406;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1406;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1406;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1406;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1406;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1406;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label17:
-{
-Obj _35val1785 = __arg1;
-Obj _35val1783= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1786 = primCons(_35val1785, Nil);
-Obj _35reg1787 = primCons(_35val1783, _35reg1786);
-Obj _35reg1788 = primCons(a, _35reg1787);
-Obj _35reg1789 = primCons(intern("let"), _35reg1788);
-__nargs = 2;
-__arg1 = _35reg1789;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3241) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-
-label18:
-{
-Obj _35val1783 = __arg1;
-Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj a= co->ctx.stk.stack[co->ctx.stk.base + 4];
-Obj _35reg1784 = primCons(a, env);
-pushCont(co, 17, _35clofun3241, 2, _35val1783, a);
-__nargs = 5;
-__arg0 = globalRef(intern("cora/lib/toc#parse"));
-__arg1 = _35reg1784;
-__arg2 = ns;
-__arg3 = import;
-co->args[4] = c;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label19:
-{
-Obj _35cc1405 = makeNative(16, _35clofun3241, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj env = closureRef(co, 0);
-Obj ns = closureRef(co, 1);
-Obj import = closureRef(co, 2);
-Obj _35reg1757 = primIsCons(closureRef(co, 3));
-if (True == _35reg1757) {
-Obj _35reg1758 = primCar(closureRef(co, 3));
-Obj _35reg1759 = primEQ(intern("let"), _35reg1758);
-if (True == _35reg1759) {
-Obj _35reg1760 = primCdr(closureRef(co, 3));
-Obj _35reg1761 = primIsCons(_35reg1760);
-if (True == _35reg1761) {
-Obj _35reg1762 = primCdr(closureRef(co, 3));
-Obj _35reg1763 = primCar(_35reg1762);
-Obj a = _35reg1763;
-Obj _35reg1764 = primCdr(closureRef(co, 3));
-Obj _35reg1765 = primCdr(_35reg1764);
-Obj _35reg1766 = primIsCons(_35reg1765);
-if (True == _35reg1766) {
-Obj _35reg1767 = primCdr(closureRef(co, 3));
-Obj _35reg1768 = primCdr(_35reg1767);
-Obj _35reg1769 = primCar(_35reg1768);
-Obj b = _35reg1769;
-Obj _35reg1770 = primCdr(closureRef(co, 3));
-Obj _35reg1771 = primCdr(_35reg1770);
-Obj _35reg1772 = primCdr(_35reg1771);
-Obj _35reg1773 = primIsCons(_35reg1772);
-if (True == _35reg1773) {
-Obj _35reg1774 = primCdr(closureRef(co, 3));
-Obj _35reg1775 = primCdr(_35reg1774);
-Obj _35reg1776 = primCdr(_35reg1775);
-Obj _35reg1777 = primCar(_35reg1776);
-Obj c = _35reg1777;
-Obj _35reg1778 = primCdr(closureRef(co, 3));
-Obj _35reg1779 = primCdr(_35reg1778);
-Obj _35reg1780 = primCdr(_35reg1779);
-Obj _35reg1781 = primCdr(_35reg1780);
-Obj _35reg1782 = primEQ(Nil, _35reg1781);
-if (True == _35reg1782) {
-pushCont(co, 18, _35clofun3241, 5, env, ns, import, c, a);
+Obj _35reg1858 = primIsCons(closureRef(co, 3));
+if (True == _35reg1858) {
+Obj _35reg1859 = primCar(closureRef(co, 3));
+Obj _35reg1860 = primEQ(intern("let"), _35reg1859);
+if (True == _35reg1860) {
+Obj _35reg1861 = primCdr(closureRef(co, 3));
+Obj _35reg1862 = primIsCons(_35reg1861);
+if (True == _35reg1862) {
+Obj _35reg1863 = primCdr(closureRef(co, 3));
+Obj _35reg1864 = primCar(_35reg1863);
+Obj a = _35reg1864;
+Obj _35reg1865 = primCdr(closureRef(co, 3));
+Obj _35reg1866 = primCdr(_35reg1865);
+Obj _35reg1867 = primIsCons(_35reg1866);
+if (True == _35reg1867) {
+Obj _35reg1868 = primCdr(closureRef(co, 3));
+Obj _35reg1869 = primCdr(_35reg1868);
+Obj _35reg1870 = primCar(_35reg1869);
+Obj b = _35reg1870;
+Obj _35reg1871 = primCdr(closureRef(co, 3));
+Obj _35reg1872 = primCdr(_35reg1871);
+Obj _35reg1873 = primCdr(_35reg1872);
+Obj _35reg1874 = primIsCons(_35reg1873);
+if (True == _35reg1874) {
+Obj _35reg1875 = primCdr(closureRef(co, 3));
+Obj _35reg1876 = primCdr(_35reg1875);
+Obj _35reg1877 = primCdr(_35reg1876);
+Obj _35reg1878 = primCar(_35reg1877);
+Obj c = _35reg1878;
+Obj _35reg1879 = primCdr(closureRef(co, 3));
+Obj _35reg1880 = primCdr(_35reg1879);
+Obj _35reg1881 = primCdr(_35reg1880);
+Obj _35reg1882 = primCdr(_35reg1881);
+Obj _35reg1883 = primEQ(Nil, _35reg1882);
+if (True == _35reg1883) {
+pushCont(co, 4, clofun66, 5, env, ns, import, c, a);
 __nargs = 5;
 __arg0 = globalRef(intern("cora/lib/toc#parse"));
 __arg1 = env;
@@ -12371,75 +12494,100 @@ co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1405;
+__arg0 = _35cc1498;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1405;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1405;
+__arg0 = _35cc1498;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1405;
+__arg0 = _35cc1498;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1405;
+__arg0 = _35cc1498;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1405;
+__arg0 = _35cc1498;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3241) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1498;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label20:
+label4:
 {
-Obj _35val1808 = __arg1;
-Obj _35val1807= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj _35reg1809 = primCons(_35val1808, Nil);
-Obj _35reg1810 = primCons(_35val1807, _35reg1809);
-Obj _35reg1811 = primCons(intern("do"), _35reg1810);
+Obj _35val1884 = __arg1;
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj c= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj _35reg1885 = primCons(a, env);
+pushCont(co, 5, clofun66, 2, _35val1884, a);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#parse"));
+__arg1 = _35reg1885;
+__arg2 = ns;
+__arg3 = import;
+co->args[4] = c;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun66) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val1886 = __arg1;
+Obj _35val1884= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj a= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1887 = primCons(_35val1886, Nil);
+Obj _35reg1888 = primCons(_35val1884, _35reg1887);
+Obj _35reg1889 = primCons(a, _35reg1888);
+Obj _35reg1890 = primCons(intern("let"), _35reg1889);
 __nargs = 2;
-__arg1 = _35reg1811;
+__arg1 = _35reg1890;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3241) { goto fail; }
+if (co->ctx.pc.func != clofun66) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 
@@ -12452,320 +12600,703 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3240(struct Cora* co){
+void clofun67(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val1655 = __arg1;
-Obj find = _35val1655;
-pushCont(co, 20, _35clofun3239, 1, find);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#null?"));
-__arg1 = find;
+Obj _35cc1499 = makeNative(1, clofun67, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj __ = closureRef(co, 1);
+__ = closureRef(co, 2);
+Obj _35reg1832 = primIsCons(closureRef(co, 3));
+if (True == _35reg1832) {
+Obj _35reg1833 = primCar(closureRef(co, 3));
+Obj _35reg1834 = primEQ(intern("ns"), _35reg1833);
+if (True == _35reg1834) {
+Obj _35reg1835 = primCdr(closureRef(co, 3));
+Obj _35reg1836 = primIsCons(_35reg1835);
+if (True == _35reg1836) {
+Obj _35reg1837 = primCdr(closureRef(co, 3));
+Obj _35reg1838 = primCar(_35reg1837);
+Obj path = _35reg1838;
+Obj _35reg1839 = primCdr(closureRef(co, 3));
+Obj _35reg1840 = primCdr(_35reg1839);
+Obj _35reg1841 = primIsCons(_35reg1840);
+if (True == _35reg1841) {
+Obj _35reg1842 = primCdr(closureRef(co, 3));
+Obj _35reg1843 = primCdr(_35reg1842);
+Obj _35reg1844 = primCar(_35reg1843);
+Obj import = _35reg1844;
+Obj _35reg1845 = primCdr(closureRef(co, 3));
+Obj _35reg1846 = primCdr(_35reg1845);
+Obj _35reg1847 = primCdr(_35reg1846);
+Obj _35reg1848 = primIsCons(_35reg1847);
+if (True == _35reg1848) {
+Obj _35reg1849 = primCdr(closureRef(co, 3));
+Obj _35reg1850 = primCdr(_35reg1849);
+Obj _35reg1851 = primCdr(_35reg1850);
+Obj _35reg1852 = primCar(_35reg1851);
+Obj body = _35reg1852;
+Obj _35reg1853 = primCdr(closureRef(co, 3));
+Obj _35reg1854 = primCdr(_35reg1853);
+Obj _35reg1855 = primCdr(_35reg1854);
+Obj _35reg1856 = primCdr(_35reg1855);
+Obj _35reg1857 = primEQ(Nil, _35reg1856);
+if (True == _35reg1857) {
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#parse"));
+__arg1 = env;
+__arg2 = path;
+__arg3 = import;
+co->args[4] = body;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1499;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1499;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1499;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1499;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1499;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1499;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35cc1500 = makeNative(4, clofun67, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj _35reg1806 = primIsCons(closureRef(co, 3));
+if (True == _35reg1806) {
+Obj _35reg1807 = primCar(closureRef(co, 3));
+Obj _35reg1808 = primEQ(intern("def"), _35reg1807);
+if (True == _35reg1808) {
+Obj _35reg1809 = primCdr(closureRef(co, 3));
+Obj _35reg1810 = primIsCons(_35reg1809);
+if (True == _35reg1810) {
+Obj _35reg1811 = primCdr(closureRef(co, 3));
+Obj _35reg1812 = primCar(_35reg1811);
+Obj var = _35reg1812;
+Obj _35reg1813 = primCdr(closureRef(co, 3));
+Obj _35reg1814 = primCdr(_35reg1813);
+Obj _35reg1815 = primIsCons(_35reg1814);
+if (True == _35reg1815) {
+Obj _35reg1816 = primCdr(closureRef(co, 3));
+Obj _35reg1817 = primCdr(_35reg1816);
+Obj _35reg1818 = primCar(_35reg1817);
+Obj val = _35reg1818;
+Obj _35reg1819 = primCdr(closureRef(co, 3));
+Obj _35reg1820 = primCdr(_35reg1819);
+Obj _35reg1821 = primCdr(_35reg1820);
+Obj _35reg1822 = primEQ(Nil, _35reg1821);
+if (True == _35reg1822) {
+pushCont(co, 2, clofun67, 4, env, ns, import, val);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#var-with-ns"));
+__arg1 = var;
+__arg2 = ns;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1500;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1500;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1500;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1500;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1500;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35val1823 = __arg1;
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj val= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj var1 = _35val1823;
+Obj _35reg1824 = primCons(intern("set"), Nil);
+Obj _35reg1825 = primCons(intern("%builtin"), _35reg1824);
+Obj _35reg1826 = primCons(var1, Nil);
+Obj _35reg1827 = primCons(intern("%const"), _35reg1826);
+pushCont(co, 3, clofun67, 2, _35reg1827, _35reg1825);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#parse"));
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->args[4] = val;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label3:
+{
+Obj _35val1828 = __arg1;
+Obj _35reg1827= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1825= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1829 = primCons(_35val1828, Nil);
+Obj _35reg1830 = primCons(_35reg1827, _35reg1829);
+Obj _35reg1831 = primCons(_35reg1825, _35reg1830);
+__nargs = 2;
+__arg1 = _35reg1831;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun67) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+label4:
+{
+Obj _35cc1501 = makeNative(0, clofun69, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj _35reg1786 = primIsCons(closureRef(co, 3));
+if (True == _35reg1786) {
+Obj _35reg1787 = primCar(closureRef(co, 3));
+Obj op = _35reg1787;
+Obj _35reg1788 = primCdr(closureRef(co, 3));
+Obj args = _35reg1788;
+pushCont(co, 5, clofun67, 6, op, args, env, ns, import, _35cc1501);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#builtin?"));
+__arg1 = op;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1501;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35val1789 = __arg1;
+Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj _35cc1501= co->ctx.stk.stack[co->ctx.stk.base + 5];
+if (True == _35val1789) {
+pushCont(co, 0, clofun68, 5, op, args, env, ns, import);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#builtin->args"));
+__arg1 = op;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1501;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun67) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun68(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val1790 = __arg1;
+Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj required = _35val1790;
+pushCont(co, 1, clofun68, 6, required, op, args, env, ns, import);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#length"));
+__arg1 = args;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun68) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj x = __arg1;
-pushCont(co, 0, _35clofun3240, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#assq"));
-__arg1 = x;
-__arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
+Obj _35val1791 = __arg1;
+Obj required= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj op= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 5];
+Obj provided = _35val1791;
+Obj _35reg1792 = primEQ(required, provided);
+if (True == _35reg1792) {
+Obj _35reg1793 = primCons(op, Nil);
+Obj _35reg1794 = primCons(intern("%builtin"), _35reg1793);
+pushCont(co, 4, clofun68, 2, args, _35reg1794);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#parse"));
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun68) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+Obj _35reg1798 = primGT(required, provided);
+if (True == _35reg1798) {
+Obj _35reg1799 = primSub(required, provided);
+pushCont(co, 2, clofun68, 5, op, args, env, ns, import);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#temp-list"));
+__arg1 = _35reg1799;
+__arg2 = Nil;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun68) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("primitive call mismatch");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun68) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
 }
 
 label2:
 {
-Obj _35val1659 = __arg1;
-Obj find= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1659) {
-__nargs = 2;
-__arg1 = makeCString("ERROR");
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3240) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#cadr"));
-__arg1 = find;
+Obj _35val1800 = __arg1;
+Obj op= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 4];
+Obj tmp = _35val1800;
+Obj _35reg1801 = primCons(op, args);
+pushCont(co, 3, clofun68, 4, tmp, env, ns, import);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#append"));
+__arg1 = _35reg1801;
+__arg2 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun68) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 
 label3:
 {
-Obj _35val1658 = __arg1;
-Obj find = _35val1658;
-pushCont(co, 2, _35clofun3240, 1, find);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#null?"));
-__arg1 = find;
+Obj _35val1802 = __arg1;
+Obj tmp= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj env= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj _35reg1803 = primCons(_35val1802, Nil);
+Obj _35reg1804 = primCons(tmp, _35reg1803);
+Obj _35reg1805 = primCons(intern("lambda"), _35reg1804);
+__nargs = 5;
+__arg0 = globalRef(intern("cora/lib/toc#parse"));
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->args[4] = _35reg1805;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun68) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label4:
 {
-Obj x = __arg1;
-pushCont(co, 3, _35clofun3240, 0);
+Obj _35val1795 = __arg1;
+Obj args= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1794= co->ctx.stk.stack[co->ctx.stk.base + 1];
+pushCont(co, 5, clofun68, 1, _35reg1794);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#assq"));
-__arg1 = x;
-__arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = _35val1795;
+__arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun68) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
+Obj _35val1796 = __arg1;
+Obj _35reg1794= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj _35reg1797 = primCons(_35reg1794, _35val1796);
+__nargs = 2;
+__arg1 = _35reg1797;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun68) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun69(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc1502 = makeNative(2, clofun69, 0, 0);
+Obj env = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj import = closureRef(co, 2);
+Obj ls = closureRef(co, 3);
+pushCont(co, 1, clofun69, 1, ls);
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#parse"));
+__arg1 = env;
+__arg2 = ns;
+__arg3 = import;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun69) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val1785 = __arg1;
+Obj ls= co->ctx.stk.stack[co->ctx.stk.base + 0];
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#map"));
+__arg1 = _35val1785;
+__arg2 = ls;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun69) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
 __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun69) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label6:
+label3:
 {
-Obj _35cc1389 = makeNative(5, _35clofun3240, 0, 0);
-Obj n = closureRef(co, 0);
-Obj res = closureRef(co, 1);
-Obj _35reg1661 = primSub(n, makeNumber(1));
-Obj _35reg1662 = primGenSym(intern("tmp"));
-Obj _35reg1663 = primCons(_35reg1662, res);
+Obj _35p1483 = __arg1;
+Obj _35p1484 = __arg2;
+Obj _35p1485 = __arg3;
+Obj _35cc1486 = makeNative(4, clofun69, 0, 3, _35p1483, _35p1484, _35p1485);
+Obj s = _35p1483;
+Obj ns = _35p1484;
+Obj _35reg1783 = primEQ(Nil, _35p1485);
+if (True == _35reg1783) {
 __nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#temp-list"));
-__arg1 = _35reg1661;
-__arg2 = _35reg1663;
+__arg0 = globalRef(intern("cora/lib/toc#var-with-ns"));
+__arg1 = s;
+__arg2 = ns;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun69) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-
-label7:
-{
-Obj _35p1386 = __arg1;
-Obj _35p1387 = __arg2;
-Obj _35cc1388 = makeNative(6, _35clofun3240, 0, 2, _35p1386, _35p1387);
-Obj _35reg1664 = primEQ(makeNumber(0), _35p1386);
-if (True == _35reg1664) {
-Obj res = _35p1387;
-__nargs = 2;
-__arg1 = res;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3240) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1388;
+__arg0 = _35cc1486;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun69) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label8:
+label4:
 {
-Obj _35val1670 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#intern"));
-__arg1 = _35val1670;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label9:
-{
-Obj _35val1669 = __arg1;
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 8, _35clofun3240, 0);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#string-append"));
-__arg1 = ns;
-__arg2 = _35val1669;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label10:
-{
-Obj _35val1668 = __arg1;
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 9, _35clofun3240, 1, ns);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#string-append"));
-__arg1 = makeCString("#");
-__arg2 = _35val1668;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label11:
-{
-Obj _35val1667 = __arg1;
-Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
-if (True == _35val1667) {
-__nargs = 2;
-__arg1 = var;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3240) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 10, _35clofun3240, 1, ns);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#symbol->string"));
-__arg1 = var;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label12:
-{
-Obj var = __arg1;
-Obj ns = __arg2;
-Obj _35reg1666 = primEQ(ns, makeCString(""));
-if (True == _35reg1666) {
-__nargs = 2;
-__arg1 = var;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3240) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-pushCont(co, 11, _35clofun3240, 2, var, ns);
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc/internal#symbol-cooked?"));
-__arg1 = var;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label13:
-{
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label14:
-{
-Obj _35val1681 = __arg1;
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#intern"));
-__arg1 = _35val1681;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label15:
-{
-Obj _35val1680 = __arg1;
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 14, _35clofun3240, 0);
+Obj _35cc1487 = makeNative(0, clofun71, 0, 0);
+Obj s = closureRef(co, 0);
+Obj ns = closureRef(co, 1);
+Obj _35reg1773 = primIsCons(closureRef(co, 2));
+if (True == _35reg1773) {
+Obj _35reg1774 = primCar(closureRef(co, 2));
+Obj import = _35reg1774;
+Obj _35reg1775 = primCdr(closureRef(co, 2));
+Obj more = _35reg1775;
+pushCont(co, 5, clofun69, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(intern("cora/init#string-append"));
 __arg1 = import;
-__arg2 = _35val1680;
+__arg2 = makeCString("#*ns-export*");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun69) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
-
-label16:
-{
-Obj _35val1679 = __arg1;
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
-pushCont(co, 15, _35clofun3240, 1, import);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/init#string-append"));
-__arg1 = makeCString("#");
-__arg2 = _35val1679;
+} else {
+__nargs = 1;
+__arg0 = _35cc1487;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun69) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
+}
 
-label17:
+label5:
 {
-Obj _35val1678 = __arg1;
+Obj _35val1776 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
 Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
 Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
 Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-if (True == _35val1678) {
-pushCont(co, 16, _35clofun3240, 1, import);
+pushCont(co, 0, clofun70, 4, import, s, ns, more);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#intern"));
+__arg1 = _35val1776;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun69) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun70(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35val1777 = __arg1;
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
+pushCont(co, 1, clofun70, 4, import, s, ns, more);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#value-or"));
+__arg1 = _35val1777;
+__arg2 = Nil;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun70) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val1778 = __arg1;
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
+Obj export = _35val1778;
+pushCont(co, 2, clofun70, 4, import, s, ns, more);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#elem?"));
+__arg1 = s;
+__arg2 = export;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun70) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val1779 = __arg1;
+Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
+Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
+if (True == _35val1779) {
+pushCont(co, 3, clofun70, 1, import);
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#symbol->string"));
 __arg1 = s;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun70) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 4;
@@ -12776,65 +13307,53 @@ __arg3 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun70) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label18:
+label3:
 {
-Obj _35val1677 = __arg1;
+Obj _35val1780 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-Obj export = _35val1677;
-pushCont(co, 17, _35clofun3240, 4, import, s, ns, more);
+pushCont(co, 4, clofun70, 1, import);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#elem?"));
-__arg1 = s;
-__arg2 = export;
+__arg0 = globalRef(intern("cora/init#string-append"));
+__arg1 = makeCString("#");
+__arg2 = _35val1780;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun70) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label4:
 {
-Obj _35val1676 = __arg1;
+Obj _35val1781 = __arg1;
 Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 18, _35clofun3240, 4, import, s, ns, more);
+pushCont(co, 5, clofun70, 0);
 __nargs = 3;
-__arg0 = globalRef(intern("cora/init#value-or"));
-__arg1 = _35val1676;
-__arg2 = Nil;
+__arg0 = globalRef(intern("cora/init#string-append"));
+__arg1 = import;
+__arg2 = _35val1781;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun70) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label20:
+label5:
 {
-Obj _35val1675 = __arg1;
-Obj import= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj s= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 2];
-Obj more= co->ctx.stk.stack[co->ctx.stk.base + 3];
-pushCont(co, 19, _35clofun3240, 4, import, s, ns, more);
+Obj _35val1782 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(intern("cora/init#intern"));
-__arg1 = _35val1675;
+__arg1 = _35val1782;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3240) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun70) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
@@ -12847,14 +13366,14 @@ co->args[3] = __arg3;
 
 }
 
-void _35clofun3239(struct Cora* co){
+void clofun71(struct Cora* co){
 int __nargs = co->nargs;
 Obj __arg0 = co->args[0];
 Obj __arg1 = co->args[1];
 Obj __arg2 = co->args[2];
 Obj __arg3 = co->args[3];
 
-static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5, &&label6, &&label7, &&label8, &&label9, &&label10, &&label11, &&label12, &&label13, &&label14, &&label15, &&label16, &&label17, &&label18, &&label19, &&label20};
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
 
 goto *jumpTable[co->ctx.pc.label];
 
@@ -12866,206 +13385,167 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun71) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label1:
 {
-Obj _35cc1370 = makeNative(0, _35clofun3239, 0, 0);
-Obj var = closureRef(co, 0);
-Obj _35reg1543 = primIsCons(closureRef(co, 1));
-if (True == _35reg1543) {
-Obj _35reg1544 = primCar(closureRef(co, 1));
-Obj __ = _35reg1544;
-Obj _35reg1545 = primCdr(closureRef(co, 1));
-Obj y = _35reg1545;
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#assq"));
+Obj var = __arg1;
+Obj ns = __arg2;
+Obj _35reg1767 = primEQ(ns, makeCString(""));
+if (True == _35reg1767) {
+__nargs = 2;
 __arg1 = var;
-__arg2 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun71) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = _35cc1370;
+pushCont(co, 2, clofun71, 2, var, ns);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc/internal#symbol-cooked?"));
+__arg1 = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun71) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label2:
 {
-Obj _35cc1369 = makeNative(1, _35clofun3239, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj var = closureRef(co, 0);
-Obj _35reg1546 = primIsCons(closureRef(co, 1));
-if (True == _35reg1546) {
-Obj _35reg1547 = primCar(closureRef(co, 1));
-Obj _35reg1548 = primIsCons(_35reg1547);
-if (True == _35reg1548) {
-Obj _35reg1549 = primCar(closureRef(co, 1));
-Obj _35reg1550 = primCar(_35reg1549);
-Obj x = _35reg1550;
-Obj _35reg1551 = primCar(closureRef(co, 1));
-Obj _35reg1552 = primCdr(_35reg1551);
-Obj y = _35reg1552;
-Obj _35reg1553 = primCdr(closureRef(co, 1));
-Obj __ = _35reg1553;
-Obj _35reg1554 = primEQ(var, x);
-if (True == _35reg1554) {
-Obj _35reg1555 = primCons(x, y);
+Obj _35val1768 = __arg1;
+Obj var= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 1];
+if (True == _35val1768) {
 __nargs = 2;
-__arg1 = _35reg1555;
+__arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3239) { goto fail; }
+if (co->ctx.pc.func != clofun71) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-__nargs = 1;
-__arg0 = _35cc1369;
+pushCont(co, 3, clofun71, 1, ns);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#symbol->string"));
+__arg1 = var;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1369;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1369;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun71) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
 label3:
 {
-Obj _35p1366 = __arg1;
-Obj _35p1367 = __arg2;
-Obj _35cc1368 = makeNative(2, _35clofun3239, 0, 2, _35p1366, _35p1367);
-Obj var = _35p1366;
-Obj _35reg1556 = primEQ(Nil, _35p1367);
-if (True == _35reg1556) {
-__nargs = 2;
-__arg1 = Nil;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3239) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1368;
+Obj _35val1769 = __arg1;
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 4, clofun71, 1, ns);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#string-append"));
+__arg1 = makeCString("#");
+__arg2 = _35val1769;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun71) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 
 label4:
 {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/lib/toc#error"));
-__arg1 = makeCString("no match-help found!");
+Obj _35val1770 = __arg1;
+Obj ns= co->ctx.stk.stack[co->ctx.stk.base + 0];
+pushCont(co, 5, clofun71, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/init#string-append"));
+__arg1 = ns;
+__arg2 = _35val1770;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun71) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
 label5:
 {
-Obj _35val1561 = __arg1;
-Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#foldl"));
-__arg1 = f;
-__arg2 = _35val1561;
-__arg3 = y;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-
-label6:
-{
-Obj _35cc1375 = makeNative(4, _35clofun3239, 0, 0);
-Obj f = closureRef(co, 0);
-Obj acc = closureRef(co, 1);
-Obj _35reg1558 = primIsCons(closureRef(co, 2));
-if (True == _35reg1558) {
-Obj _35reg1559 = primCar(closureRef(co, 2));
-Obj x = _35reg1559;
-Obj _35reg1560 = primCdr(closureRef(co, 2));
-Obj y = _35reg1560;
-pushCont(co, 5, _35clofun3239, 2, f, y);
-__nargs = 3;
-__arg0 = f;
-__arg1 = acc;
-__arg2 = x;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1375;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label7:
-{
-Obj _35p1371 = __arg1;
-Obj _35p1372 = __arg2;
-Obj _35p1373 = __arg3;
-Obj _35cc1374 = makeNative(6, _35clofun3239, 0, 3, _35p1371, _35p1372, _35p1373);
-Obj f = _35p1371;
-Obj acc = _35p1372;
-Obj _35reg1562 = primEQ(Nil, _35p1373);
-if (True == _35reg1562) {
+Obj _35val1771 = __arg1;
 __nargs = 2;
-__arg1 = acc;
+__arg0 = globalRef(intern("cora/init#intern"));
+__arg1 = _35val1771;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun71) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun72(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35p1479 = __arg1;
+Obj _35p1480 = __arg2;
+Obj _35cc1481 = makeNative(1, clofun72, 0, 2, _35p1479, _35p1480);
+Obj _35reg1765 = primEQ(makeNumber(0), _35p1479);
+if (True == _35reg1765) {
+Obj res = _35p1480;
+__nargs = 2;
+__arg1 = res;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3239) { goto fail; }
+if (co->ctx.pc.func != clofun72) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1374;
+__arg0 = _35cc1481;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun72) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label8:
+label1:
+{
+Obj _35cc1482 = makeNative(2, clofun72, 0, 0);
+Obj n = closureRef(co, 0);
+Obj res = closureRef(co, 1);
+Obj _35reg1762 = primSub(n, makeNumber(1));
+Obj _35reg1763 = primGenSym(intern("tmp"));
+Obj _35reg1764 = primCons(_35reg1763, res);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#temp-list"));
+__arg1 = _35reg1762;
+__arg2 = _35reg1764;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun72) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -13073,108 +13553,287 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun72) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label9:
+label3:
 {
-Obj _35cc1381 = makeNative(8, _35clofun3239, 0, 0);
-Obj pos = closureRef(co, 0);
-Obj x = closureRef(co, 1);
-Obj _35reg1564 = primIsCons(closureRef(co, 2));
-if (True == _35reg1564) {
-Obj _35reg1565 = primCar(closureRef(co, 2));
-Obj a = _35reg1565;
-Obj _35reg1566 = primCdr(closureRef(co, 2));
-Obj b = _35reg1566;
-Obj _35reg1567 = primAdd(pos, makeNumber(1));
-__nargs = 4;
-__arg0 = globalRef(intern("cora/lib/toc#pos-in-list0"));
-__arg1 = _35reg1567;
-__arg2 = x;
-__arg3 = b;
+Obj x = __arg1;
+pushCont(co, 4, clofun72, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#assq"));
+__arg1 = x;
+__arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun72) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1381;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
 }
 
-label10:
+label4:
 {
-Obj _35cc1380 = makeNative(9, _35clofun3239, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj pos = closureRef(co, 0);
-Obj x = closureRef(co, 1);
-Obj _35reg1568 = primIsCons(closureRef(co, 2));
-if (True == _35reg1568) {
-Obj _35reg1569 = primCar(closureRef(co, 2));
-Obj a = _35reg1569;
-Obj _35reg1570 = primCdr(closureRef(co, 2));
-Obj b = _35reg1570;
-Obj _35reg1571 = primEQ(x, a);
-if (True == _35reg1571) {
+Obj _35val1759 = __arg1;
+Obj find = _35val1759;
+pushCont(co, 5, clofun72, 1, find);
 __nargs = 2;
-__arg1 = pos;
+__arg0 = globalRef(intern("cora/init#null?"));
+__arg1 = find;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun72) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val1760 = __arg1;
+Obj find= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1760) {
+__nargs = 2;
+__arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3239) { goto fail; }
+if (co->ctx.pc.func != clofun72) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#cadr"));
+__arg1 = find;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun72) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun73(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj x = __arg1;
+pushCont(co, 1, clofun73, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#assq"));
+__arg1 = x;
+__arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun73) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label1:
+{
+Obj _35val1756 = __arg1;
+Obj find = _35val1756;
+pushCont(co, 2, clofun73, 1, find);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#null?"));
+__arg1 = find;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun73) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label2:
+{
+Obj _35val1757 = __arg1;
+Obj find= co->ctx.stk.stack[co->ctx.stk.base + 0];
+if (True == _35val1757) {
+__nargs = 2;
+__arg1 = makeCString("ERROR");
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun73) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#caddr"));
+__arg1 = find;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun73) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj x = __arg1;
+pushCont(co, 4, clofun73, 0);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#assq"));
+__arg1 = x;
+__arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun73) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
+{
+Obj _35val1752 = __arg1;
+pushCont(co, 5, clofun73, 0);
+__nargs = 2;
+__arg0 = globalRef(intern("cora/init#null?"));
+__arg1 = _35val1752;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun73) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label5:
+{
+Obj _35val1753 = __arg1;
+Obj _35reg1754 = primNot(_35val1753);
+__nargs = 2;
+__arg1 = _35reg1754;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun73) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun74(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35p1475 = __arg1;
+Obj _35p1476 = __arg2;
+Obj _35cc1477 = makeNative(1, clofun74, 0, 2, _35p1475, _35p1476);
+Obj x = _35p1475;
+Obj _35reg1681 = primEQ(Nil, _35p1476);
+if (True == _35reg1681) {
+__nargs = 2;
+__arg1 = False;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun74) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1380;
+__arg0 = _35cc1477;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1380;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun74) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label11:
+label1:
 {
-Obj _35p1376 = __arg1;
-Obj _35p1377 = __arg2;
-Obj _35p1378 = __arg3;
-Obj _35cc1379 = makeNative(10, _35clofun3239, 0, 3, _35p1376, _35p1377, _35p1378);
-Obj __ = _35p1376;
-Obj x = _35p1377;
-Obj _35reg1572 = primEQ(Nil, _35p1378);
-if (True == _35reg1572) {
-__nargs = 2;
-__arg1 = makeNumber(-1);
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3239) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1379;
+Obj _35cc1478 = makeNative(3, clofun74, 0, 0);
+Obj x = closureRef(co, 0);
+Obj _35reg1676 = primIsCons(closureRef(co, 1));
+if (True == _35reg1676) {
+Obj _35reg1677 = primCar(closureRef(co, 1));
+Obj hd = _35reg1677;
+Obj _35reg1678 = primCdr(closureRef(co, 1));
+Obj tl = _35reg1678;
+pushCont(co, 2, clofun74, 2, x, tl);
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#index"));
+__arg1 = x;
+__arg2 = hd;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun74) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1478;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun74) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label12:
+label2:
+{
+Obj _35val1679 = __arg1;
+Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj tl= co->ctx.stk.stack[co->ctx.stk.base + 1];
+Obj _35reg1680 = primLT(_35val1679, makeNumber(0));
+if (True == _35reg1680) {
+__nargs = 3;
+__arg0 = globalRef(intern("cora/lib/toc#exist-in-env"));
+__arg1 = x;
+__arg2 = tl;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun74) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 2;
+__arg1 = True;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun74) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+}
+}
+
+label3:
+{
+__nargs = 2;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun74) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+label4:
 {
 Obj x = __arg1;
 Obj l = __arg2;
@@ -13186,11 +13845,128 @@ __arg3 = l;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun74) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label13:
+label5:
+{
+Obj _35p1469 = __arg1;
+Obj _35p1470 = __arg2;
+Obj _35p1471 = __arg3;
+Obj _35cc1472 = makeNative(0, clofun75, 0, 3, _35p1469, _35p1470, _35p1471);
+Obj __ = _35p1469;
+Obj x = _35p1470;
+Obj _35reg1673 = primEQ(Nil, _35p1471);
+if (True == _35reg1673) {
+__nargs = 2;
+__arg1 = makeNumber(-1);
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun74) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1472;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun74) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun75(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4, &&label5};
+
+goto *jumpTable[co->ctx.pc.label];
+
+label0:
+{
+Obj _35cc1473 = makeNative(1, clofun75, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj pos = closureRef(co, 0);
+Obj x = closureRef(co, 1);
+Obj _35reg1669 = primIsCons(closureRef(co, 2));
+if (True == _35reg1669) {
+Obj _35reg1670 = primCar(closureRef(co, 2));
+Obj a = _35reg1670;
+Obj _35reg1671 = primCdr(closureRef(co, 2));
+Obj b = _35reg1671;
+Obj _35reg1672 = primEQ(x, a);
+if (True == _35reg1672) {
+__nargs = 2;
+__arg1 = pos;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun75) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1473;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun75) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1473;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun75) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label1:
+{
+Obj _35cc1474 = makeNative(2, clofun75, 0, 0);
+Obj pos = closureRef(co, 0);
+Obj x = closureRef(co, 1);
+Obj _35reg1665 = primIsCons(closureRef(co, 2));
+if (True == _35reg1665) {
+Obj _35reg1666 = primCar(closureRef(co, 2));
+Obj a = _35reg1666;
+Obj _35reg1667 = primCdr(closureRef(co, 2));
+Obj b = _35reg1667;
+Obj _35reg1668 = primAdd(pos, makeNumber(1));
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#pos-in-list0"));
+__arg1 = _35reg1668;
+__arg2 = x;
+__arg3 = b;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun75) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1474;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun75) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
 {
 __nargs = 2;
 __arg0 = globalRef(intern("cora/lib/toc#error"));
@@ -13198,150 +13974,235 @@ __arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun75) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label14:
+label3:
 {
-Obj _35val1578 = __arg1;
-Obj x= co->ctx.stk.stack[co->ctx.stk.base + 0];
-Obj tl= co->ctx.stk.stack[co->ctx.stk.base + 1];
-Obj _35reg1579 = primLT(_35val1578, makeNumber(0));
-if (True == _35reg1579) {
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#exist-in-env"));
-__arg1 = x;
-__arg2 = tl;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
+Obj _35p1464 = __arg1;
+Obj _35p1465 = __arg2;
+Obj _35p1466 = __arg3;
+Obj _35cc1467 = makeNative(4, clofun75, 0, 3, _35p1464, _35p1465, _35p1466);
+Obj f = _35p1464;
+Obj acc = _35p1465;
+Obj _35reg1663 = primEQ(Nil, _35p1466);
+if (True == _35reg1663) {
 __nargs = 2;
-__arg1 = True;
+__arg1 = acc;
 co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3239) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-}
-}
-
-label15:
-{
-Obj _35cc1385 = makeNative(13, _35clofun3239, 0, 0);
-Obj x = closureRef(co, 0);
-Obj _35reg1575 = primIsCons(closureRef(co, 1));
-if (True == _35reg1575) {
-Obj _35reg1576 = primCar(closureRef(co, 1));
-Obj hd = _35reg1576;
-Obj _35reg1577 = primCdr(closureRef(co, 1));
-Obj tl = _35reg1577;
-pushCont(co, 14, _35clofun3239, 2, x, tl);
-__nargs = 3;
-__arg0 = globalRef(intern("cora/lib/toc#index"));
-__arg1 = x;
-__arg2 = hd;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-} else {
-__nargs = 1;
-__arg0 = _35cc1385;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-}
-
-label16:
-{
-Obj _35p1382 = __arg1;
-Obj _35p1383 = __arg2;
-Obj _35cc1384 = makeNative(15, _35clofun3239, 0, 2, _35p1382, _35p1383);
-Obj x = _35p1382;
-Obj _35reg1580 = primEQ(Nil, _35p1383);
-if (True == _35reg1580) {
-__nargs = 2;
-__arg1 = False;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3239) { goto fail; }
+if (co->ctx.pc.func != clofun75) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1384;
+__arg0 = _35cc1467;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun75) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 }
 
-label17:
+label4:
 {
-Obj _35val1652 = __arg1;
-Obj _35reg1653 = primNot(_35val1652);
-__nargs = 2;
-__arg1 = _35reg1653;
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3239) { goto fail; }
+Obj _35cc1468 = makeNative(0, clofun76, 0, 0);
+Obj f = closureRef(co, 0);
+Obj acc = closureRef(co, 1);
+Obj _35reg1659 = primIsCons(closureRef(co, 2));
+if (True == _35reg1659) {
+Obj _35reg1660 = primCar(closureRef(co, 2));
+Obj x = _35reg1660;
+Obj _35reg1661 = primCdr(closureRef(co, 2));
+Obj y = _35reg1661;
+pushCont(co, 5, clofun75, 2, f, y);
+__nargs = 3;
+__arg0 = f;
+__arg1 = acc;
+__arg2 = x;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun75) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1468;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun75) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label5:
+{
+Obj _35val1662 = __arg1;
+Obj f= co->ctx.stk.stack[co->ctx.stk.base + 0];
+Obj y= co->ctx.stk.stack[co->ctx.stk.base + 1];
+__nargs = 4;
+__arg0 = globalRef(intern("cora/lib/toc#foldl"));
+__arg1 = f;
+__arg2 = _35val1662;
+__arg3 = y;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun75) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+
+fail:
+co->nargs = __nargs;
+co->args[0] = __arg0;
+co->args[1] = __arg1;
+co->args[2] = __arg2;
+co->args[3] = __arg3;
+
+}
+
+void clofun76(struct Cora* co){
+int __nargs = co->nargs;
+Obj __arg0 = co->args[0];
+Obj __arg1 = co->args[1];
+Obj __arg2 = co->args[2];
+Obj __arg3 = co->args[3];
+
+static void* jumpTable[] = {&&label0, &&label1, &&label2, &&label3, &&label4};
+
 goto *jumpTable[co->ctx.pc.label];
-}
 
-label18:
+label0:
 {
-Obj _35val1651 = __arg1;
-pushCont(co, 17, _35clofun3239, 0);
 __nargs = 2;
-__arg0 = globalRef(intern("cora/init#null?"));
-__arg1 = _35val1651;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun76) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 
-label19:
+label1:
 {
-Obj x = __arg1;
-pushCont(co, 18, _35clofun3239, 0);
+Obj _35p1459 = __arg1;
+Obj _35p1460 = __arg2;
+Obj _35cc1461 = makeNative(2, clofun76, 0, 2, _35p1459, _35p1460);
+Obj var = _35p1459;
+Obj _35reg1657 = primEQ(Nil, _35p1460);
+if (True == _35reg1657) {
+__nargs = 2;
+__arg1 = Nil;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun76) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1461;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun76) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label2:
+{
+Obj _35cc1462 = makeNative(3, clofun76, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj var = closureRef(co, 0);
+Obj _35reg1647 = primIsCons(closureRef(co, 1));
+if (True == _35reg1647) {
+Obj _35reg1648 = primCar(closureRef(co, 1));
+Obj _35reg1649 = primIsCons(_35reg1648);
+if (True == _35reg1649) {
+Obj _35reg1650 = primCar(closureRef(co, 1));
+Obj _35reg1651 = primCar(_35reg1650);
+Obj x = _35reg1651;
+Obj _35reg1652 = primCar(closureRef(co, 1));
+Obj _35reg1653 = primCdr(_35reg1652);
+Obj y = _35reg1653;
+Obj _35reg1654 = primCdr(closureRef(co, 1));
+Obj __ = _35reg1654;
+Obj _35reg1655 = primEQ(var, x);
+if (True == _35reg1655) {
+Obj _35reg1656 = primCons(x, y);
+__nargs = 2;
+__arg1 = _35reg1656;
+co->ctx = co->callstack.data[--co->callstack.len];
+if (co->ctx.pc.func != clofun76) { goto fail; }
+goto *jumpTable[co->ctx.pc.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1462;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun76) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1462;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun76) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = _35cc1462;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun76) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+}
+
+label3:
+{
+Obj _35cc1463 = makeNative(4, clofun76, 0, 0);
+Obj var = closureRef(co, 0);
+Obj _35reg1644 = primIsCons(closureRef(co, 1));
+if (True == _35reg1644) {
+Obj _35reg1645 = primCar(closureRef(co, 1));
+Obj __ = _35reg1645;
+Obj _35reg1646 = primCdr(closureRef(co, 1));
+Obj y = _35reg1646;
 __nargs = 3;
 __arg0 = globalRef(intern("cora/lib/toc#assq"));
-__arg1 = x;
-__arg2 = globalRef(intern("cora/lib/toc#*builtin-prims*"));
+__arg1 = var;
+__arg2 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun76) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
+} else {
+__nargs = 1;
+__arg0 = _35cc1463;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun76) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
 }
 
-label20:
+label4:
 {
-Obj _35val1656 = __arg1;
-Obj find= co->ctx.stk.stack[co->ctx.stk.base + 0];
-if (True == _35val1656) {
 __nargs = 2;
-__arg1 = makeCString("ERROR");
-co->ctx = co->callstack.data[--co->callstack.len];
-if (co->ctx.pc.func != _35clofun3239) { goto fail; }
-goto *jumpTable[co->ctx.pc.label];
-} else {
-__nargs = 2;
-__arg0 = globalRef(intern("cora/init#caddr"));
-__arg1 = find;
+__arg0 = globalRef(intern("cora/lib/toc#error"));
+__arg1 = makeCString("no match-help found!");
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != _35clofun3239) { co->ctx.pc = ps; goto fail; };
+if (ps.func != clofun76) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
-}
 }
 
 fail:

--- a/lib/toc.cora
+++ b/lib/toc.cora
@@ -1,6 +1,7 @@
 (define-library "cora/lib/toc"
   (import "cora/lib/toc/internal")
   (import "cora/lib/io")
+  (import "cora/lib/hash-h")
 
   (func assq
 	var [] => ()
@@ -189,30 +190,26 @@
   ;; collect the result to v (vector idx cur final)
   (func collect-lambda
 	v [clo-or-cont ['lambda params body] . fvs] => (let body1 (collect-lambda v body)
-							 (let idx (vector-ref v 0)
-							   cur (vector-ref v 1)
-							   (let name (if (= idx 0) (gensym 'clofun) (car (caar cur)))
-							     (if (= clo-or-cont '%closure)
-								 (begin
-								   (append-result v idx cur name ['lambda params () body1])
-								   [clo-or-cont (cons name idx) (length params) . fvs])
-								 (begin
-								   (append-result v idx cur name ['lambda params fvs body1])
-								   [clo-or-cont (cons name idx) . fvs])))))
+							 cur (vector-ref v 0)
+							 (if (= clo-or-cont '%closure)
+							     (begin
+							       (append-result v ['lambda params () body1])
+							       [clo-or-cont cur (length params) . fvs])
+							     (begin
+							       (append-result v ['lambda params fvs body1])
+							       [clo-or-cont cur . fvs])))
 	where (or (= clo-or-cont '%closure) (= clo-or-cont '%continuation))
 	v f-args => (map (lambda (e)
 			   (collect-lambda v e)) f-args) where (cons? f-args)
 			   v x => x)
 
-  (defun append-result (v idx cur name val)
-    (let cur1 (cons [(cons name idx) val] cur)
-      (if (< idx 20)
-	  (begin (vector-set! v 0 (+ idx 1))
-		 (vector-set! v 1 cur1))
-	  (begin (vector-set! v 0 0)
-		 (vector-set! v 1 ())
-		 (let res (vector-ref v 2)
-		   (vector-set! v 2 (cons (reverse cur1) res)))))))
+  (defun append-result (v val)
+    (let idx (vector-ref v 0)
+      cur (vector-ref v 1)
+      (let cur1 (cons [idx val] cur)
+	(begin
+	  (vector-set! v 0 (+ idx 1))
+	  (vector-set! v 1 cur1)))))
 
   (defun wrap-var(x k)
     (let tmp (gensym 'reg)
@@ -289,9 +286,9 @@
 				    (generate-str w "}\n"))
 	self env w ['%closure label nargs . frees] => (begin
 							(generate-str w "makeNative(")
-							(generate-num w (cdr label))
+							(generate-num w (mod (- (car self) label) *mod-num*))
 							(generate-str w ", ")
-							(generate-sym w (car label))
+							(generate-group-name w label (car self))
 							(generate-str w ", ")
 							(generate-num w nargs)
 							(generate-str w ", ")
@@ -313,7 +310,7 @@
 				    (generate-str w ";\n")
 				    (generate-str w "co->ctx = co->callstack.data[--co->callstack.len];\n")
 				    (generate-str w "if (co->ctx.pc.func != ")
-				    (generate-sym w self)
+				    (generate-group-name w (cdr self) (car self))
 				    (generate-str w ") { goto fail; }\n")
 				    (generate-str w "goto *jumpTable[co->ctx.pc.label];\n"))
 	self env w ['tailcall exp] => (generate-inst self env w exp)
@@ -329,7 +326,7 @@
 				   (generate-str w "struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);\n")
 				   (generate-str w "if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };\n")
 				   (generate-str w "if (ps.func != ")
-				   (generate-sym w self)
+				   (generate-group-name w (cdr self) (car self))
 				   (generate-str w ") { co->ctx.pc = ps; goto fail; };\n")
 				   (generate-str w "goto *jumpTable[ps.label];\n")))
 
@@ -346,9 +343,9 @@
   (func generate-cont
 	self w ['%continuation label . stacks] => (begin
 						    (generate-str w "pushCont(co, ")
-						    (generate-num w (cdr label))
+						    (generate-num w (mod (- (car self) label) *mod-num*))
 						    (generate-str w ", ")
-						    (generate-sym w (car label))
+						    (generate-group-name w label (car self))
 						    (generate-str w ", ")
 						    (generate-num w (length stacks))
 						    (if (not (null? stacks))
@@ -371,10 +368,20 @@
   (defun generate-inst-list (self env w l)
     (generate-inst-list-h self env generate-inst w l))
 
-  (defun code-gen-func-declare (w label)
+  (def *mod-num* 6)
+
+  (defun generate-group-name (w label maxid)
+    (let gid (/ (- maxid label) *mod-num*)
+      (if (= gid 0)
+	  (generate-str w "entry")
+	  (begin
+	    (generate-str w "clofun")
+	    (generate-num w gid)))))
+
+  (defun code-gen-func-declare (w label maxid)
     (begin
       (generate-str w "void ")
-      (generate-sym w (car label))
+      (generate-group-name w label maxid)
       (generate-str w "(struct Cora* co")
       (generate-str w ")")))
 
@@ -405,15 +412,15 @@
 			      (generate-call-args-reverse fn w (+ idx 1) b)))
 
   (func code-gen-toplevel
-	w [label ['lambda params actives body]] => (begin
+	w [label ['lambda params actives body]] maxid => (begin
 						     (generate-str w "label")
-						     (generate-num w (cdr label))
+						     (generate-num w (mod (- maxid label) *mod-num*))
 						     (generate-str w ":\n{\n")
 						     (generate-call-args-reverse local-from-params w 1 params)
 						     (generate-call-args-reverse local-from-cont w 0 actives)
-						     (generate-inst (car label) params w body)
+						     (generate-inst (cons maxid label) params w body)
 						     (generate-str w "}\n\n"))
-	w other =>  (begin (display "wrong format of toplevel\n")
+	w other maxid =>  (begin (display "wrong format of toplevel\n")
 			   (display other)
 			   (display "\n")))
 
@@ -430,16 +437,13 @@
     (explicit-stack [] exp))
 
   (defun collect-lambda-pass (exp)
-    (let v (vector 3)
+    (let v (vector 2)
       (begin (vector-set! v 0 0)
 	     (vector-set! v 1 ())
-	     (vector-set! v 2 ())
 	     (let e1 (collect-lambda v exp)
-	       cur (vector-ref v 1)
-	       (let res (if (null? cur)
-			    (vector-ref v 2)
-			    (cons (reverse cur) (vector-ref v 2)))
-		 (cons [[(cons 'entry 0) ['lambda () () e1]]] res))))))
+	       (begin
+		 (append-result v ['lambda () () e1])
+		 (vector-ref v 1))))))
 
   (func rewrite-->macro
 	obj [] => obj
@@ -475,9 +479,9 @@
 		(generate-jumptable to (+ i 1) n)))
      (true ())))
 
-  (defun generate-toplevel-group (to group)
+  (defun generate-toplevel-group (to group maxid)
     (begin
-      (code-gen-func-declare to (caar group))
+      (code-gen-func-declare to (caar group) maxid)
       (generate-str to "{\n")
 
       (generate-str to "int __nargs = co->nargs;\n")
@@ -491,7 +495,7 @@
       (generate-str to "};\n\n")
       (generate-str to "goto *jumpTable[co->ctx.pc.label];\n\n")
 
-      (for-each (lambda (x) (code-gen-toplevel to x)) group)
+      (for-each (lambda (x) (code-gen-toplevel to x maxid)) group)
 
       (generate-str to "fail:\n")
       (generate-str to "co->nargs = __nargs;\n")
@@ -502,20 +506,29 @@
 
       (generate-str to "\n}\n\n")))
 
+  (func group-by-mod-h
+	res idx acc [] => (reverse (if (not (null? acc))
+				       (cons (reverse acc) res)
+				       res))
+	res idx acc [bc . more] => (if (= idx *mod-num*)
+				       (group-by-mod-h (cons (reverse acc) res) 0 [] [bc . more])
+				       (group-by-mod-h res (+ idx 1) (cons bc acc) more)))
 
   (defun generate-c (to bc)
-    (begin
-      (generate-str to "#include \"types.h\"\n")
-      (generate-str to "#include \"runtime.h\"\n\n")
-      (for-each (lambda (group)
-		  (begin
-		    (code-gen-func-declare to (caar group))
-		    (generate-str to ";\n")))
-		bc)
-      (generate-str to "\n\n")
-      (for-each (lambda (group)
-		  (generate-toplevel-group to group))
-		bc)))
+    (let groups (group-by-mod-h [] 0 [] bc)
+      maxid (caar bc)
+      (begin
+	(generate-str to "#include \"types.h\"\n")
+	(generate-str to "#include \"runtime.h\"\n\n")
+	(for-each (lambda (group)
+		    (begin
+		      (code-gen-func-declare to (caar group) maxid)
+		      (generate-str to ";\n")))
+		  groups)
+	(generate-str to "\n\n")
+	(for-each (lambda (group)
+		    (generate-toplevel-group to group maxid))
+		  groups))))
 
   (func handle-import-eagerly
 	['define-library _ . remain] => (handle-import-eagerly remain)


### PR DESCRIPTION
```
    (cora/lib/toc#compile (macroexpand '(defun fact (n) (if (= n 0) 1 (* n (fact (- n 1)))))))
```

    before:
```
        ((((entry . 0) (lambda () () (let #reg139 ((%builtin set) (%const fact) (%closure (#clofun140 . 1) 1)) (return #reg139)))))
        (((#clofun140 . 0) (lambda (#val137) (n) (let #reg138 ((%builtin *) n #val137) (return #reg138))))
        ((#clofun140 . 1) (lambda (n) () (let #reg135 ((%builtin =) n (%const 0)) (if #reg135 (return (%const 1)) (let #reg136 ((%builtin -) n (%const 1)) (call ((%global fact) #reg136) (%continuation (#clofun140 . 0) n)))))))))
```
    after:
```
        ((2 (lambda () () (let #reg1994 ((%builtin set) (%const fact) (%closure 1 1)) (return #reg1994))))
        (1 (lambda (n) () (let #reg1990 ((%builtin =) n (%const 0)) (if #reg1990 (return (%const 1)) (let #reg1991 ((%builtin -) n (%const 1)) (call ((%global fact) #reg1991) (%continuation 0 n)))))))
        (0 (lambda (#val1992) (n) (let #reg1993 ((%builtin *) n #val1992) (return #reg1993)))))
```