### PR TITLE
src: implement generational GC

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -686,7 +686,8 @@ gcMarkAndEnsure(struct GC *gc, uintptr_t p, int minv) {
   }
   assert(from->type > scmHeadUnused && from->type < scmHeadMax);
 
-  // write barrior for generational gc
+  // barrior for generational gc
+  // That is, old generation to young generation is forbidden.
   if (versionCmp(minv, from->version) > 0) {
     from->version = minv;
     gcEnqueue(gc, from);
@@ -820,7 +821,7 @@ gcRunIncremental(struct GC *gc) {
 		  assert((curr->version & 1) == 1);
 			fn(gc, curr);
 			/* printf("gcMark handle %p ==%ld, sz=%d tp=%d version=%d\n", curr, curr, curr->size, curr->type, curr->version); */
-			/* curr->version = (curr->version+ 1) %64; */
+			curr->version = (curr->version+ 1) %64;
 			gcInuseSizeInc(gc, curr->size);
 		}
 		N--;

--- a/src/gc.h
+++ b/src/gc.h
@@ -45,7 +45,7 @@ struct GC *getGC();
 void* gcAlloc(struct GC* gc, int size);
 
 void writeBarrier(struct GC *gc, uintptr_t *slot, uintptr_t val);
-void gcMark(struct GC *gc, uintptr_t head);
+scmHead* gcMark(struct GC *gc, uintptr_t head);
 
 typedef void (*gcFunc)(struct GC *gc, void* from);
 bool gcRegistForType(uint8_t type, gcFunc fn);

--- a/src/gc.h
+++ b/src/gc.h
@@ -24,6 +24,7 @@ enum {
   scmHeadMax,
 };
 
+// 2bits generation and 6bits version
 typedef uint8_t version_t;
 
 typedef struct {
@@ -44,8 +45,8 @@ struct GC *getGC();
 
 void* gcAlloc(struct GC* gc, int size);
 
-int versionCmp(int v1, int v2);
-void writeBarrier(struct GC *gc, uintptr_t *slot, uintptr_t val);
+void writeBarrierForGeneration(scmHead* from, uintptr_t val);
+void writeBarrierForIncremental(struct GC *gc, uintptr_t *slot, uintptr_t val);
 void gcMark(struct GC *gc, uintptr_t head);
 void gcMarkAndEnsure(struct GC *gc, uintptr_t head, version_t minv);
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -47,7 +47,7 @@ void* gcAlloc(struct GC* gc, int size);
 int versionCmp(int v1, int v2);
 void writeBarrier(struct GC *gc, uintptr_t *slot, uintptr_t val);
 scmHead* gcMark(struct GC *gc, uintptr_t head);
-scmHead* gcMarkAndEnsure(struct GC *gc, uintptr_t head, int minv);
+scmHead* gcMarkAndEnsure(struct GC *gc, uintptr_t head, version_t minv);
 
 typedef void (*gcFunc)(struct GC *gc, void* from);
 bool gcRegistForType(uint8_t type, gcFunc fn);

--- a/src/gc.h
+++ b/src/gc.h
@@ -44,8 +44,10 @@ struct GC *getGC();
 
 void* gcAlloc(struct GC* gc, int size);
 
+int versionCmp(int v1, int v2);
 void writeBarrier(struct GC *gc, uintptr_t *slot, uintptr_t val);
 scmHead* gcMark(struct GC *gc, uintptr_t head);
+scmHead* gcMarkAndEnsure(struct GC *gc, uintptr_t head, int minv);
 
 typedef void (*gcFunc)(struct GC *gc, void* from);
 bool gcRegistForType(uint8_t type, gcFunc fn);

--- a/src/gc.h
+++ b/src/gc.h
@@ -24,9 +24,7 @@ enum {
   scmHeadMax,
 };
 
-typedef struct _version {
-  uint8_t val;
-}version_t;
+typedef uint8_t version_t;
 
 typedef struct {
   uint32_t size;

--- a/src/gc.h
+++ b/src/gc.h
@@ -46,8 +46,8 @@ void* gcAlloc(struct GC* gc, int size);
 
 int versionCmp(int v1, int v2);
 void writeBarrier(struct GC *gc, uintptr_t *slot, uintptr_t val);
-scmHead* gcMark(struct GC *gc, uintptr_t head);
-scmHead* gcMarkAndEnsure(struct GC *gc, uintptr_t head, version_t minv);
+void gcMark(struct GC *gc, uintptr_t head);
+void gcMarkAndEnsure(struct GC *gc, uintptr_t head, version_t minv);
 
 typedef void (*gcFunc)(struct GC *gc, void* from);
 bool gcRegistForType(uint8_t type, gcFunc fn);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -289,7 +289,7 @@ Obj
 primSet(struct Cora *co, Obj key, Obj val) {
 	assert(issymbol(key));
 	struct trieNode *s = ptr(key);
-	writeBarrier(getGC(), &s->value, val);	// s->value = val;
+	writeBarrierForIncremental(getGC(), &s->value, val);	// s->value = val;
 	if (s->next == NULL) {
 		s->next = co->globals;
 		s->owner = co;

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -101,7 +101,7 @@ coraDispatch(struct Cora *co) {
 		co->ctx.frees = fn;
 	} else if (co->nargs < required + 1) {
 		Obj ret = makeCurry(required + 1 - co->nargs, co->nargs,
-				     co->args);
+				    co->args);
 		coraReturn(co, ret);
 	} else {
 		// save the extra args.

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -82,7 +82,7 @@ callCurry(struct Cora *co) {
 }
 
 Obj
-makeCurry1(int required, int captured, Obj * data) {
+makeCurry(int required, int captured, Obj * data) {
 	int sz = sizeof(struct scmNative) + captured * sizeof(Obj);
 	struct scmNative *clo = newObj(scmHeadNative, sz);
 	clo->code.func = callCurry;
@@ -100,7 +100,7 @@ coraDispatch(struct Cora *co) {
 		co->ctx.pc = *nativeFuncPtr(fn);
 		co->ctx.frees = fn;
 	} else if (co->nargs < required + 1) {
-		Obj ret = makeCurry1(required + 1 - co->nargs, co->nargs,
+		Obj ret = makeCurry(required + 1 - co->nargs, co->nargs,
 				     co->args);
 		coraReturn(co, ret);
 	} else {

--- a/src/types.c
+++ b/src/types.c
@@ -392,15 +392,12 @@ eq(Obj x, Obj y) {
 struct scmContinuation {
 	scmHead head;
 	struct callStack cs;
-	/* int pos; */
 };
 
 Obj
-/* makeContinuation(int pos) { */
 makeContinuation() {
 	struct scmContinuation *cont =
 		newObj(scmHeadContinuation, sizeof(struct scmContinuation));
-	/* cont->pos = pos; */
 	struct callStack *stack = &cont->cs;
 	stack->data = malloc(64 * sizeof(struct returnAddr));
 	stack->len = 0;

--- a/src/types.c
+++ b/src/types.c
@@ -249,10 +249,6 @@ makeNative(int label, basicBlock fn, int required, int captured, ...) {
 		va_start(ap, captured);
 		for (int i = 0; i < captured; i++) {
 			clo->data[i] = va_arg(ap, Obj);
-			scmHead *h = getScmHead(clo->data[i]);
-			if (h != NULL) {
-				/* assert(versionCmp(clo->head.version, h->version) >=0); */
-			}
 		}
 		va_end(ap);
 	}
@@ -437,7 +433,7 @@ gcMarkCallStack(struct GC *gc, struct callStack *stack) {
 	}
 }
 
-void
+static void
 gcMarkCallStackAndEnsure(struct GC *gc, struct callStack *stack, int minv) {
 	for (int i = 0; i < stack->len; i++) {
 		struct returnAddr *addr = &stack->data[i];

--- a/src/types.c
+++ b/src/types.c
@@ -336,13 +336,8 @@ vectorSet(Obj vec, int idx, Obj val) {
 	struct scmVector *v = ptr(vec);
 	assert(v->head.type == scmHeadVector);
 	assert(idx >= 0 && idx < v->size);
-	writeBarrier(getGC(), &v->data[idx], val);
-	// barrier for generational GC
-	scmHead *h = getScmHead(val);
-	if (h != NULL &&
-	    versionCmp(v->head.version % 64, h->version % 64) > 0) {
-		h->version = v->head.version;
-	}
+	writeBarrierForIncremental(getGC(), &v->data[idx], val);
+	writeBarrierForGeneration(&v->head, val);
 	return vec;
 }
 

--- a/src/types.c
+++ b/src/types.c
@@ -83,7 +83,6 @@ consGCFunc(struct GC *gc, void *f) {
 	int minv = from->head.version;
 	gcMarkAndEnsure(gc, from->car, minv);
 	gcMarkAndEnsure(gc, from->cdr, minv);
-	from->head.version = (from->head.version+ 1) %64;
 }
 
 Obj
@@ -194,8 +193,6 @@ stringStr(Obj o) {
 
 static void
 bytesGCFunc(struct GC *gc, void *f) {
-  scmHead* from = f;
-	from->version = (from->version+ 1) %64;
 }
 
 
@@ -270,7 +267,6 @@ nativeGCFunc(struct GC *gc, void *f) {
 	for (int i = 0; i < from->captured; i++) {
 	  gcMarkAndEnsure(gc, from->data[i], minv);
 	}
-	from->head.version = (from->head.version+ 1) %64;
 }
 
 bool
@@ -378,7 +374,6 @@ vectorGCFunc(struct GC *gc, void *f) {
 	for (int i = 0; i < from->size; i++) {
 	  gcMarkAndEnsure(gc, from->data[i], minv);
 	}
-	from->head.version = (from->head.version+ 1) %64;
 }
 
 bool
@@ -459,7 +454,6 @@ continuationGCFunc(struct GC *gc, void *f) {
 	struct scmContinuation *from = f;
 	int minv = from->head.version;
 	gcMarkCallStackAndEnsure(gc, &from->cs, minv);
-	from->head.version = (from->head.version+ 1) %64;
 }
 
 void


### PR DESCRIPTION
The observation is that using version = version + N instead of +1
It is possible to divide objects into different generation
Older generation can skip several rounds of GC