### PR TITLE
gc: fix a leak and rename gcDone to gcSweep

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -128,7 +128,7 @@ coraGet(struct Cora *co, int idx) {
 	return co->args[idx];
 }
 
-const int INIT_STACK_SIZE = 256;
+const int INIT_STACK_SIZE = 5000;
 
 
 extern struct trieNode gRoot;


### PR DESCRIPTION
In `sweepSizeClass`, the progress update is buggy, causing the gcDone never finish.
So it's always allocating new object, and not recycling, causing memory leak.

Rename gcDone to gcSweep, None -> Incremental Mark -> Sweep