### PR TITLE
gc: fix two bugs for generational GC

### DIFF
--- a/lib/toc.c
+++ b/lib/toc.c
@@ -9242,6 +9242,11 @@ label4:
 Obj _35cc1541 = makeNative(6, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
+ printf("closure convert for ===\n");
+ printObj(stderr, var);
+ printf("in env ==\n");
+ printObj(stderr, fvs);
+ printf("===\n");
 Obj _35reg2336 = primIsSymbol(var);
 if (True == _35reg2336) {
 pushCont(co, 5, clofun7, 1, var);
@@ -10578,6 +10583,7 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
+	assert(false);
 __nargs = 1;
 __arg0 = _35cc1537;
 co->ctx.frees = __arg0;

--- a/lib/toc.c
+++ b/lib/toc.c
@@ -9242,11 +9242,6 @@ label4:
 Obj _35cc1541 = makeNative(6, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
- printf("closure convert for ===\n");
- printObj(stderr, var);
- printf("in env ==\n");
- printObj(stderr, fvs);
- printf("===\n");
 Obj _35reg2336 = primIsSymbol(var);
 if (True == _35reg2336) {
 pushCont(co, 5, clofun7, 1, var);
@@ -10583,7 +10578,6 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-	assert(false);
 __nargs = 1;
 __arg0 = _35cc1537;
 co->ctx.frees = __arg0;

--- a/src/gc.c
+++ b/src/gc.c
@@ -860,7 +860,6 @@ gcRunIncremental(struct GC *gc) {
 		if (fn != NULL) {
 			assert((curr->version & 1) == 1);
 			fn(gc, curr);
-			/* curr->version = (curr->version + 1) % 64; */
 			curr->version =
 				(curr->
 				 version & (3 << 6)) | ((curr->version +
@@ -937,7 +936,6 @@ sweepLargeObjects(struct GC *gc, struct runDoneProgress *pg) {
 
 static void
 gcRunSweep(struct GC *gc) {
-	/* printf("run gc sweep ===\n"); */
 	struct runDoneProgress *pg = &gc->progress;
 	// First handle size classes
 	if (pg->sizeClassPos < sizeClassSZ) {

--- a/src/gc.c
+++ b/src/gc.c
@@ -661,7 +661,7 @@ checkPointer(struct GC *gc, uintptr_t p) {
 #define GEN_SHIFT VERSION_BITS
 
 // Increment values for each generation
-static const int GEN_INCREMENTS[] = { 3, 5, 11, 31 };
+static const int GEN_INCREMENTS[] = { 3, 5, 11, 29 };
 
 // A smart generational GC strategy
 // Higher 2bits are for generation mark and lower 6bits are for version,
@@ -850,7 +850,7 @@ gcRunIncremental(struct GC *gc) {
 		scmHead *curr = gcDequeue(gc);
 		if (curr == NULL) {
 			// Queue is empty, check whether we need to enter gcStateSweep
-			if (gc->version % 30 == 0) {
+			if (gc->version % 28 == 0) {
 				gc->state = gcStateSweep;
 				gc->progress.sizeClassPos = 0;
 				gc->progress.b = NULL;

--- a/src/gc.c
+++ b/src/gc.c
@@ -677,13 +677,7 @@ nextVersion(version_t ver) {
 	int new_version = (curr_version + GEN_INCREMENTS[gen]) & VERSION_MASK;
 
 	// If not the last generation, upgrade to next generation
-	/* int new_gen = (gen < GEN_MASK) ? gen + 1 : gen; */
-	int new_gen;
-	if (gen < GEN_MASK) {
-		new_gen = gen + 1;
-	} else {
-		new_gen = gen;
-	}
+	int new_gen = (gen < GEN_MASK) ? gen + 1 : gen;
 
 	return new_version | (new_gen << GEN_SHIFT);
 }
@@ -778,8 +772,8 @@ gcRunMark(struct GC *gc) {
 
 static void
 gcFlip(struct GC *gc) {
-	printf("run gc, before size = %d, inuse = size(%d) count(%d), incremental size=%d, mark skip=%d\n",
-	       gc->nextSize, gc->inuseSize, gc->inuseCount, gc->allocated, gc->markSkip);
+	/* printf("run gc, before size = %d, inuse = size(%d) count(%d), incremental size=%d, mark skip=%d\n", */
+	/*        gc->nextSize, gc->inuseSize, gc->inuseCount, gc->allocated, gc->markSkip); */
 	gc->nextSize = 2 * gc->inuseSize + gc->allocated;
 	if (gc->nextSize < MEM_BLOCK_SIZE) {
 		// Because a block is at least that size, GC smaller then this is meanless.
@@ -867,7 +861,10 @@ gcRunIncremental(struct GC *gc) {
 			assert((curr->version & 1) == 1);
 			fn(gc, curr);
 			/* curr->version = (curr->version + 1) % 64; */
-			curr->version = (curr->version & (3<<6)) | ((curr->version + 1) % 64);
+			curr->version =
+				(curr->
+				 version & (3 << 6)) | ((curr->version +
+							 1) % 64);
 			gcInuseSizeInc(gc, curr->size);
 		}
 		steps--;
@@ -940,7 +937,7 @@ sweepLargeObjects(struct GC *gc, struct runDoneProgress *pg) {
 
 static void
 gcRunSweep(struct GC *gc) {
-	printf("run gc sweep ===\n");
+	/* printf("run gc sweep ===\n"); */
 	struct runDoneProgress *pg = &gc->progress;
 	// First handle size classes
 	if (pg->sizeClassPos < sizeClassSZ) {

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -194,8 +194,9 @@ trampoline(struct Cora *co, int label, basicBlock pc) {
 
 Obj
 closureRef(struct Cora *co, int idx) {
-	Obj *frees = nativeData(co->ctx.frees);
-	return frees[idx];
+	struct scmNative* ntv = mustNative(co->ctx.frees);
+	assert(ntv->captured > idx);
+	return ntv->data[idx];
 }
 
 Obj

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -194,7 +194,7 @@ trampoline(struct Cora *co, int label, basicBlock pc) {
 
 Obj
 closureRef(struct Cora *co, int idx) {
-	struct scmNative* ntv = mustNative(co->ctx.frees);
+	struct scmNative *ntv = mustNative(co->ctx.frees);
 	assert(ntv->captured > idx);
 	return ntv->data[idx];
 }

--- a/src/types.c
+++ b/src/types.c
@@ -251,6 +251,14 @@ isNative(Obj c) {
 	return h->type == scmHeadNative;
 }
 
+
+struct scmNative*
+mustNative(Obj o) {
+	struct scmNative *native = ptr(o);
+	assert(native->head.type == scmHeadNative);
+	return native;
+}
+
 Obj *
 nativeData(Obj o) {
 	struct scmNative *native = ptr(o);

--- a/src/types.c
+++ b/src/types.c
@@ -252,7 +252,7 @@ isNative(Obj c) {
 }
 
 
-struct scmNative*
+struct scmNative *
 mustNative(Obj o) {
 	struct scmNative *native = ptr(o);
 	assert(native->head.type == scmHeadNative);

--- a/src/types.h
+++ b/src/types.h
@@ -142,6 +142,7 @@ Obj* nativeData(Obj o);
 int nativeCaptured(Obj o);
 int nativeRequired(Obj o);
 struct pcState* nativeFuncPtr(Obj o);
+struct scmNative* mustNative(Obj o);
 
 struct stackState {
 	Obj stack;


### PR DESCRIPTION
1. after gcDequeue, `curr->version = (curr->version + 1) % 64` mistakenly reset the generation
2. bump version corner case +-1 issue, for example, current gc version 26, then a object bump to 26+31 -> 57,
57 -> 58 (mark done) ... inuse(26, 57) return true but inuse(26, 58) return false!!!