### PR TITLE
lib/cml: fix non-tail call of the schedule code

### DIFF
--- a/lib/chan.cora
+++ b/lib/chan.cora
@@ -17,7 +17,7 @@
 			       (if (= 'Done (value state))
 				   (recv-try [sendq recvq]) ;; ignore stale item and continue
 				   (begin
-				     (spawn (lambda () (resume (wrap ()))))
+				     (enqueue-task (lambda () (resume (wrap ()))))
 				     (set state 'Done)
 				     val)))))
 
@@ -39,16 +39,16 @@
 	[sendq recvq] val => (if (queue-empty? recvq)
 				 false
 				 (match (dequeue recvq)
-				   [state resume wrap]
-				   (if (= 'Done (value state))
-				       (send-try [sendq recvq]) ;; ignore stale
-				       (begin
-					 (spawn (lambda ()
-						      (begin
-							;; (io.display "resume recv op\n")
-							(resume (wrap val)))))
-					 (set state 'Done)
-					 ())))))
+					[state resume wrap]
+					(if (= 'Done (value state))
+					    (send-try [sendq recvq]) ;; ignore stale
+					    (begin
+					      (enqueue-task (lambda ()
+							      (begin
+								;; (io.display "resume recv op\n")
+								(resume (wrap val)))))
+					      (set state 'Done)
+					      ())))))
 
   (defun send-block (sendq k val wrap)
     (let state (gensym 'state)

--- a/lib/cml.cora
+++ b/lib/cml.cora
@@ -33,7 +33,7 @@
 	       false
 	       external-schedulers))
 
-  ;; smchedule take a task out and execute it
+  ;; schedule take a task out and execute it
   ;; return false if no more tasks
   (defun schedule ()
     (begin

--- a/lib/cml.cora
+++ b/lib/cml.cora
@@ -8,7 +8,7 @@
   (import "cora/lib/queue")
   (import "cora/lib/rand")
   (import "cora/lib/sys")
-  (import "cora/lib/io")
+  ;; (import "cora/lib/io")
   (export spawn yield main wrap perform schedule enqueue-task register-scheduler)
 
   (def task-queue (queue-make))
@@ -33,11 +33,11 @@
 	       false
 	       external-schedulers))
 
-  ;; schedule take a task out and execute it
+  ;; smchedule take a task out and execute it
   ;; return false if no more tasks
   (defun schedule ()
     (begin
-     (display "schedule()\n")
+     ;; (display "schedule()\n")
      (let more-work (run-external-schedulers 0)
 	  (if (queue-empty? task-queue)
 	      (if more-work
@@ -51,7 +51,15 @@
 		    (task)))))))
 
   (defun main ()
-    (schedule))
+    (schedule-loop))
+
+  (defun schedule-loop ()
+    (begin
+     (schedule)
+     (if (and (queue-empty? task-queue)
+	      (not (run-external-schedulers 0)))
+	 ()
+	 (schedule-loop))))
 
   (defun yield ()
     (throw (lambda (k)

--- a/lib/cml.cora
+++ b/lib/cml.cora
@@ -8,17 +8,19 @@
   (import "cora/lib/queue")
   (import "cora/lib/rand")
   (import "cora/lib/sys")
-  ;; (import "cora/lib/io")
-  (export spawn yield main wrap perform schedule register-scheduler)
+  (import "cora/lib/io")
+  (export spawn yield main wrap perform schedule enqueue-task register-scheduler)
 
   (def task-queue (queue-make))
 
-  (defun spawn (thunk)
-    (enqueue task-queue (lambda ()
-			  (try thunk
-			       (lambda (v k)
-				 (v k))))))
+  (defun enqueue-task (thunk)
+    (enqueue task-queue thunk))
 
+  (defun spawn (thunk)
+    (enqueue-task (lambda ()
+		    (try thunk
+			 (lambda (v k)
+			   (v k))))))
 
   (def external-schedulers ())
   (defun register-scheduler (fn)
@@ -35,7 +37,7 @@
   ;; return false if no more tasks
   (defun schedule ()
     (begin
-     ;; (display "schedule()\n")
+     (display "schedule()\n")
      (let more-work (run-external-schedulers 0)
 	  (if (queue-empty? task-queue)
 	      (if more-work
@@ -49,9 +51,6 @@
 		    (task)))))))
 
   (defun main ()
-    ;; (try schedule
-    ;; 	 (lambda (v k)
-    ;; 	   (v k))))
     (schedule))
 
   (defun yield ()

--- a/lib/cml.cora
+++ b/lib/cml.cora
@@ -14,7 +14,10 @@
   (def task-queue (queue-make))
 
   (defun spawn (thunk)
-    (enqueue task-queue thunk))
+    (enqueue task-queue (lambda ()
+			  (try thunk
+			       (lambda (v k)
+				 (v k))))))
 
 
   (def external-schedulers ())
@@ -32,26 +35,24 @@
   ;; return false if no more tasks
   (defun schedule ()
     (begin
-      ;; (display "schedule()\n")
-      (let more-work (run-external-schedulers 0)
-	(if (queue-empty? task-queue)
-	    (if more-work
-		(begin
-		  ;; (display "schedule 2()\n")
-		  (run-external-schedulers -1))
-		false)
-	    (let task (dequeue task-queue)
-	      (begin (task) true))))))
-
-  (defun schedule-loop ()
-    (if (= false (schedule))
-	()
-	(schedule-loop)))
+     ;; (display "schedule()\n")
+     (let more-work (run-external-schedulers 0)
+	  (if (queue-empty? task-queue)
+	      (if more-work
+		  (begin
+		   ;; (display "schedule 2()\n")
+		   (run-external-schedulers -1))
+		  ())
+	      (let task (dequeue task-queue)
+		   (begin
+		    ;; (display "dequeue and run task\n")
+		    (task)))))))
 
   (defun main ()
-    (try schedule-loop
-	 (lambda (v k)
-	   (v k))))
+    ;; (try schedule
+    ;; 	 (lambda (v k)
+    ;; 	   (v k))))
+    (schedule))
 
   (defun yield ()
     (throw (lambda (k)
@@ -117,12 +118,16 @@
   ;; ;; 		   (lambda (v) ...))
   ;; ;; 	  (wrap (send ch2)
   ;; ;; 		   (lambda (v) ...))))
-  (func perform
-	[try block wrap] => (match (try)
-			      false (throw (lambda (k)
-					     (begin
-					       (block k wrap)
-					       (main))))
-			      v (wrap v)))
+  (defun perform (op)
+    (let try (car op)
+	 block (cadr op)
+	 wrap (caddr op)
+	 (let v (try)
+	      (if (= v false)
+		  (throw (lambda (k)
+			   (begin
+			    (block k wrap)
+			    (schedule))))
+		  (wrap v)))))
   )
 

--- a/lib/epoll.c
+++ b/lib/epoll.c
@@ -2,7 +2,7 @@
 
 static int
 pollCreate() {
-  pollfd = epoll_create(1);
+  return epoll_create(1);
 }
 
 static void


### PR DESCRIPTION
The scheduler should not expand the call stack, so it should be tail call.
Before this fix, example/ping-pong will enlarge the call stack unlimited
Now it's constant size.