### PR TITLE
*: symbol generated by gensym() should be GC

### DIFF
--- a/init.c
+++ b/init.c
@@ -310,17 +310,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35reg372 = primSet(co, symnull_63, makeNative(25, clofun4, 1, 0));
-Obj _35reg375 = primSet(co, symcadr, makeNative(24, clofun4, 1, 0));
-Obj _35reg378 = primSet(co, symcaar, makeNative(23, clofun4, 1, 0));
-Obj _35reg381 = primSet(co, symcdar, makeNative(22, clofun4, 1, 0));
-Obj _35reg384 = primSet(co, symcddr, makeNative(21, clofun4, 1, 0));
-Obj _35reg388 = primSet(co, symcaddr, makeNative(20, clofun4, 1, 0));
-Obj _35reg393 = primSet(co, symcadddr, makeNative(19, clofun4, 1, 0));
-Obj _35reg397 = primSet(co, symcdddr, makeNative(18, clofun4, 1, 0));
-Obj _35reg405 = primSet(co, symrcons, makeNative(16, clofun4, 1, 0));
-Obj _35reg407 = primSet(co, sympair_63, makeNative(15, clofun4, 1, 0));
-Obj _35reg412 = primSet(co, symcora_47init_35reverse_45h, makeNative(14, clofun4, 2, 0));
+Obj v0x7f1f23eddf20 = primSet(co, symnull_63, makeNative(25, clofun4, 1, 0));
+Obj v0x7f1f23ed5200 = primSet(co, symcadr, makeNative(24, clofun4, 1, 0));
+Obj v0x7f1f23ed54e0 = primSet(co, symcaar, makeNative(23, clofun4, 1, 0));
+Obj v0x7f1f23ed57c0 = primSet(co, symcdar, makeNative(22, clofun4, 1, 0));
+Obj v0x7f1f23f5c360 = primSet(co, symcddr, makeNative(21, clofun4, 1, 0));
+Obj v0x7f1f23f5c800 = primSet(co, symcaddr, makeNative(20, clofun4, 1, 0));
+Obj v0x7f1f23f5cdc0 = primSet(co, symcadddr, makeNative(19, clofun4, 1, 0));
+Obj v0x7f1f23f58240 = primSet(co, symcdddr, makeNative(18, clofun4, 1, 0));
+Obj v0x7f1f23f58a40 = primSet(co, symrcons, makeNative(16, clofun4, 1, 0));
+Obj v0x7f1f23f58c80 = primSet(co, sympair_63, makeNative(15, clofun4, 1, 0));
+Obj v0x7f1f23f49200 = primSet(co, symcora_47init_35reverse_45h, makeNative(14, clofun4, 2, 0));
 PUSH_CONT_0(co, 1, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse_45h);
@@ -334,19 +334,19 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj _35val413 = __arg1;
-Obj _35reg414 = primSet(co, symreverse, _35val413);
-Obj _35reg420 = primSet(co, symmap_45h, makeNative(12, clofun4, 3, 0));
-Obj _35reg421 = primSet(co, symmap, makeNative(11, clofun4, 2, 0));
-Obj _35reg422 = primSet(co, sym_42macros_42, Nil);
-Obj _35reg423 = primGenSym(symprotect);
-Obj _35reg424 = primSet(co, sym_42protect_45symbol_42, _35reg423);
-Obj _35reg428 = primSet(co, symcora_47init_35add_45to_45_42macros_42, makeNative(10, clofun4, 2, 0));
-Obj _35reg441 = primSet(co, symcora_47init_35macroexpand1_45h, makeNative(8, clofun4, 2, 0));
-Obj _35reg442 = primSet(co, symcora_47init_35macroexpand1, makeNative(7, clofun4, 1, 0));
-Obj _35reg459 = primSet(co, symcora_47init_35macroexpand_45boot, makeNative(1, clofun4, 1, 0));
-Obj _35reg460 = primSet(co, symmacroexpand, globalRef(symcora_47init_35macroexpand_45boot));
-Obj _35reg471 = primSet(co, symdefmacro_45macro, makeNative(47, clofun3, 1, 0));
+Obj v0x7f1f23f493c0 = __arg1;
+Obj v0x7f1f23f493e0 = primSet(co, symreverse, v0x7f1f23f493c0);
+Obj v0x7f1f23f49ae0 = primSet(co, symmap_45h, makeNative(12, clofun4, 3, 0));
+Obj v0x7f1f23f49d20 = primSet(co, symmap, makeNative(11, clofun4, 2, 0));
+Obj v0x7f1f23f49e40 = primSet(co, sym_42macros_42, Nil);
+Obj v0x7f1f23f43000 = primGenSym(symprotect);
+Obj v0x7f1f23f43020 = primSet(co, sym_42protect_45symbol_42, v0x7f1f23f43000);
+Obj v0x7f1f23f43420 = primSet(co, symcora_47init_35add_45to_45_42macros_42, makeNative(10, clofun4, 2, 0));
+Obj v0x7f1f23f3c4c0 = primSet(co, symcora_47init_35macroexpand1_45h, makeNative(8, clofun4, 2, 0));
+Obj v0x7f1f23f3c6e0 = primSet(co, symcora_47init_35macroexpand1, makeNative(7, clofun4, 1, 0));
+Obj v0x7f1f23efe8c0 = primSet(co, symcora_47init_35macroexpand_45boot, makeNative(1, clofun4, 1, 0));
+Obj v0x7f1f23efe9e0 = primSet(co, symmacroexpand, globalRef(symcora_47init_35macroexpand_45boot));
+Obj v0x7f1f23ef86a0 = primSet(co, symdefmacro_45macro, makeNative(47, clofun3, 1, 0));
 PUSH_CONT_0(co, 2, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -361,7 +361,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj _35val472 = __arg1;
+Obj v0x7f1f23ef87c0 = __arg1;
 PUSH_CONT_0(co, 3, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -376,7 +376,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj _35val474 = __arg1;
+Obj v0x7f1f23ef8a80 = __arg1;
 PUSH_CONT_0(co, 4, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -391,10 +391,10 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35val484 = __arg1;
-Obj _35reg489 = primSet(co, symelem_63, makeNative(41, clofun3, 2, 0));
-Obj _35reg492 = primSet(co, symatom_63, makeNative(40, clofun3, 1, 0));
-Obj _35reg504 = primSet(co, symcora_47init_35rewrite_45let, makeNative(35, clofun3, 1, 0));
+Obj v0x7f1f23edd360 = __arg1;
+Obj v0x7f1f23edd920 = primSet(co, symelem_63, makeNative(41, clofun3, 2, 0));
+Obj v0x7f1f23eddc00 = primSet(co, symatom_63, makeNative(40, clofun3, 1, 0));
+Obj v0x7f1f23ed5ac0 = primSet(co, symcora_47init_35rewrite_45let, makeNative(35, clofun3, 1, 0));
 PUSH_CONT_0(co, 5, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -409,7 +409,7 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35val506 = __arg1;
+Obj v0x7f1f23ed5d80 = __arg1;
 PUSH_CONT_0(co, 6, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -424,8 +424,8 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj _35val520 = __arg1;
-Obj _35reg532 = primSet(co, symcora_47init_35rewrite_45or, makeNative(28, clofun3, 1, 0));
+Obj v0x7f1f23ecca20 = __arg1;
+Obj v0x7f1f23eb15a0 = primSet(co, symcora_47init_35rewrite_45or, makeNative(28, clofun3, 1, 0));
 PUSH_CONT_0(co, 7, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -440,8 +440,8 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35val534 = __arg1;
-Obj _35reg546 = primSet(co, symcora_47init_35rewrite_45and, makeNative(25, clofun3, 1, 0));
+Obj v0x7f1f23eb1860 = __arg1;
+Obj v0x7f1f23e9b3e0 = primSet(co, symcora_47init_35rewrite_45and, makeNative(25, clofun3, 1, 0));
 PUSH_CONT_0(co, 8, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -456,9 +456,9 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35val548 = __arg1;
-Obj _35reg551 = primSet(co, symboolean_63, makeNative(23, clofun3, 1, 0));
-Obj _35reg561 = primSet(co, symcora_47init_35rcons1, makeNative(20, clofun3, 1, 0));
+Obj v0x7f1f23e9b6a0 = __arg1;
+Obj v0x7f1f23f5c060 = primSet(co, symboolean_63, makeNative(23, clofun3, 1, 0));
+Obj v0x7f1f23f5cea0 = primSet(co, symcora_47init_35rcons1, makeNative(20, clofun3, 1, 0));
 PUSH_CONT_0(co, 9, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -473,12 +473,12 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj _35val563 = __arg1;
-Obj _35reg617 = primSet(co, symcora_47init_35match_45cons_45expander, makeNative(1, clofun3, 4, 0));
-Obj _35reg650 = primSet(co, symcora_47init_35match1, makeNative(45, clofun2, 4, 0));
-Obj _35reg677 = primSet(co, symcora_47init_35extract_45rule_45action, makeNative(37, clofun2, 2, 0));
-Obj _35reg729 = primSet(co, symcora_47init_35match_45helper, makeNative(21, clofun2, 2, 0));
-Obj _35reg755 = primSet(co, symcora_47init_35rewrite_45match, makeNative(14, clofun2, 1, 0));
+Obj v0x7f1f23f58280 = __arg1;
+Obj v0x7f1f23efe060 = primSet(co, symcora_47init_35match_45cons_45expander, makeNative(1, clofun3, 4, 0));
+Obj v0x7f1f23edd9a0 = primSet(co, symcora_47init_35match1, makeNative(45, clofun2, 4, 0));
+Obj v0x7f1f23ecc5c0 = primSet(co, symcora_47init_35extract_45rule_45action, makeNative(37, clofun2, 2, 0));
+Obj v0x7f1f23f5c1a0 = primSet(co, symcora_47init_35match_45helper, makeNative(21, clofun2, 2, 0));
+Obj v0x7f1f23f49840 = primSet(co, symcora_47init_35rewrite_45match, makeNative(14, clofun2, 1, 0));
 PUSH_CONT_0(co, 10, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -493,17 +493,17 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj _35val756 = __arg1;
-Obj _35reg808 = primSet(co, symcora_47init_35extract_45rules1, makeNative(6, clofun2, 3, 0));
-Obj _35reg809 = primSet(co, symcora_47init_35extract_45rules, makeNative(5, clofun2, 1, 0));
-Obj _35reg814 = primSet(co, symcora_47init_35rules_45patterns, makeNative(2, clofun2, 2, 0));
-Obj _35reg818 = primSet(co, symcora_47init_35length_45h, makeNative(1, clofun2, 2, 0));
-Obj _35reg819 = primSet(co, symlength, makeNative(0, clofun2, 1, 0));
-Obj _35reg827 = primSet(co, symcora_47init_35filter_45h, makeNative(48, clofun1, 3, 0));
-Obj _35reg828 = primSet(co, symfilter, makeNative(47, clofun1, 2, 0));
-Obj _35reg834 = primSet(co, symappend, makeNative(45, clofun1, 2, 0));
-Obj _35reg845 = primSet(co, symcora_47init_35rules_45arg_45count, makeNative(38, clofun1, 1, 0));
-Obj _35reg851 = primSet(co, symcora_47init_35gen_45paramenters, makeNative(36, clofun1, 1, 0));
+Obj v0x7f1f23f49b60 = __arg1;
+Obj v0x7f1f23edd9c0 = primSet(co, symcora_47init_35extract_45rules1, makeNative(6, clofun2, 3, 0));
+Obj v0x7f1f23eddc60 = primSet(co, symcora_47init_35extract_45rules, makeNative(5, clofun2, 1, 0));
+Obj v0x7f1f23ed5480 = primSet(co, symcora_47init_35rules_45patterns, makeNative(2, clofun2, 2, 0));
+Obj v0x7f1f23ed5be0 = primSet(co, symcora_47init_35length_45h, makeNative(1, clofun2, 2, 0));
+Obj v0x7f1f23ed5e80 = primSet(co, symlength, makeNative(0, clofun2, 1, 0));
+Obj v0x7f1f23eccbc0 = primSet(co, symcora_47init_35filter_45h, makeNative(48, clofun1, 3, 0));
+Obj v0x7f1f23eccec0 = primSet(co, symfilter, makeNative(47, clofun1, 2, 0));
+Obj v0x7f1f23eb1640 = primSet(co, symappend, makeNative(45, clofun1, 2, 0));
+Obj v0x7f1f23e9b640 = primSet(co, symcora_47init_35rules_45arg_45count, makeNative(38, clofun1, 1, 0));
+Obj v0x7f1f23e9bca0 = primSet(co, symcora_47init_35gen_45paramenters, makeNative(36, clofun1, 1, 0));
 PUSH_CONT_0(co, 11, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -518,11 +518,11 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj _35val864 = __arg1;
-Obj _35reg1127 = primSet(co, symcora_47init_35propagate_45boolean0, makeNative(18, clofun1, 1, 0));
-Obj _35reg1285 = primSet(co, symcora_47init_35propagate_45boolean, makeNative(45, clofun0, 1, 0));
-Obj _35reg1287 = primSet(co, symmacroexpand, makeNative(43, clofun0, 1, 0));
-Obj _35reg1311 = primSet(co, symcora_47init_35rewrite_45begin, makeNative(38, clofun0, 1, 0));
+Obj v0x7f1f23e9aa80 = __arg1;
+Obj v0x7f1f23f5c960 = primSet(co, symcora_47init_35propagate_45boolean0, makeNative(18, clofun1, 1, 0));
+Obj v0x7f1f2401f640 = primSet(co, symcora_47init_35propagate_45boolean, makeNative(45, clofun0, 1, 0));
+Obj v0x7f1f2401f900 = primSet(co, symmacroexpand, makeNative(43, clofun0, 1, 0));
+Obj v0x7f1f24024480 = primSet(co, symcora_47init_35rewrite_45begin, makeNative(38, clofun0, 1, 0));
 PUSH_CONT_0(co, 12, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -537,8 +537,8 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj _35val1313 = __arg1;
-Obj _35reg1333 = primSet(co, symcora_47init_35rewrite_45backquote, makeNative(31, clofun0, 1, 0));
+Obj v0x7f1f24024740 = __arg1;
+Obj v0x7f1f24022a00 = primSet(co, symcora_47init_35rewrite_45backquote, makeNative(31, clofun0, 1, 0));
 PUSH_CONT_0(co, 13, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -553,9 +553,9 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35val1335 = __arg1;
-Obj _35reg1364 = primSet(co, symcora_47init_35parse_45define_45library_45h, makeNative(24, clofun0, 4, 0));
-Obj _35reg1365 = primSet(co, symcora_47init_35parse_45define_45library, makeNative(23, clofun0, 2, 0));
+Obj v0x7f1f24022d20 = __arg1;
+Obj v0x7f1f240137e0 = primSet(co, symcora_47init_35parse_45define_45library_45h, makeNative(24, clofun0, 4, 0));
+Obj v0x7f1f24013aa0 = primSet(co, symcora_47init_35parse_45define_45library, makeNative(23, clofun0, 2, 0));
 PUSH_CONT_0(co, 14, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -570,84 +570,84 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj _35val1385 = __arg1;
-Obj _35reg1386 = makeCons(symappend, Nil);
-Obj _35reg1387 = makeCons(symfilter, _35reg1386);
-Obj _35reg1388 = makeCons(symlength, _35reg1387);
-Obj _35reg1389 = makeCons(symelem_63, _35reg1388);
-Obj _35reg1390 = makeCons(symmacroexpand, _35reg1389);
-Obj _35reg1391 = makeCons(symmap, _35reg1390);
-Obj _35reg1392 = makeCons(symreverse, _35reg1391);
-Obj _35reg1393 = makeCons(symthrow, _35reg1392);
-Obj _35reg1394 = makeCons(symtry, _35reg1393);
-Obj _35reg1395 = makeCons(symload, _35reg1394);
-Obj _35reg1396 = makeCons(symimport, _35reg1395);
-Obj _35reg1397 = makeCons(symload_45so, _35reg1396);
-Obj _35reg1398 = makeCons(symapply, _35reg1397);
-Obj _35reg1399 = makeCons(symvalue_45or, _35reg1398);
-Obj _35reg1400 = makeCons(symvalue, _35reg1399);
-Obj _35reg1401 = makeCons(symread_45file_45as_45sexp, _35reg1400);
-Obj _35reg1402 = makeCons(symbytes_45length, _35reg1401);
-Obj _35reg1403 = makeCons(symbytes, _35reg1402);
-Obj _35reg1404 = makeCons(symvector_45length, _35reg1403);
-Obj _35reg1405 = makeCons(symvector_45ref, _35reg1404);
-Obj _35reg1406 = makeCons(symvector_45set_33, _35reg1405);
-Obj _35reg1407 = makeCons(symvector, _35reg1406);
-Obj _35reg1408 = makeCons(symsymbol_45_62string, _35reg1407);
-Obj _35reg1409 = makeCons(symintern, _35reg1408);
-Obj _35reg1410 = makeCons(symstring_45append, _35reg1409);
-Obj _35reg1411 = makeCons(symnull_63, _35reg1410);
-Obj _35reg1412 = makeCons(symnumber_63, _35reg1411);
-Obj _35reg1413 = makeCons(symboolean_63, _35reg1412);
-Obj _35reg1414 = makeCons(symatom_63, _35reg1413);
-Obj _35reg1415 = makeCons(sympair_63, _35reg1414);
-Obj _35reg1416 = makeCons(symcdddr, _35reg1415);
-Obj _35reg1417 = makeCons(symcadddr, _35reg1416);
-Obj _35reg1418 = makeCons(symcaddr, _35reg1417);
-Obj _35reg1419 = makeCons(symcddr, _35reg1418);
-Obj _35reg1420 = makeCons(symcdar, _35reg1419);
-Obj _35reg1421 = makeCons(symcaar, _35reg1420);
-Obj _35reg1422 = makeCons(symcadr, _35reg1421);
-Obj _35reg1423 = primSet(co, symcora_47init_35_42ns_45export_42, _35reg1422);
-Obj _35reg1424 = primSet(co, symcora_47init_35cadr, globalRef(symcadr));
-Obj _35reg1425 = primSet(co, symcora_47init_35caar, globalRef(symcaar));
-Obj _35reg1426 = primSet(co, symcora_47init_35cdar, globalRef(symcdar));
-Obj _35reg1427 = primSet(co, symcora_47init_35cddr, globalRef(symcddr));
-Obj _35reg1428 = primSet(co, symcora_47init_35caddr, globalRef(symcaddr));
-Obj _35reg1429 = primSet(co, symcora_47init_35cadddr, globalRef(symcadddr));
-Obj _35reg1430 = primSet(co, symcora_47init_35cdddr, globalRef(symcdddr));
-Obj _35reg1431 = primSet(co, symcora_47init_35pair_63, globalRef(sympair_63));
-Obj _35reg1432 = primSet(co, symcora_47init_35atom_63, globalRef(symatom_63));
-Obj _35reg1433 = primSet(co, symcora_47init_35boolean_63, globalRef(symboolean_63));
-Obj _35reg1434 = primSet(co, symcora_47init_35null_63, globalRef(symnull_63));
-Obj _35reg1435 = primSet(co, symcora_47init_35number_63, globalRef(symnumber_63));
-Obj _35reg1436 = primSet(co, symcora_47init_35string_45append, globalRef(symstring_45append));
-Obj _35reg1437 = primSet(co, symcora_47init_35intern, globalRef(symintern));
-Obj _35reg1438 = primSet(co, symcora_47init_35symbol_45_62string, globalRef(symsymbol_45_62string));
-Obj _35reg1439 = primSet(co, symcora_47init_35vector, globalRef(symvector));
-Obj _35reg1440 = primSet(co, symcora_47init_35vector_45set_33, globalRef(symvector_45set_33));
-Obj _35reg1441 = primSet(co, symcora_47init_35vector_45ref, globalRef(symvector_45ref));
-Obj _35reg1442 = primSet(co, symcora_47init_35vector_45length, globalRef(symvector_45length));
-Obj _35reg1443 = primSet(co, symcora_47init_35bytes, globalRef(symbytes));
-Obj _35reg1444 = primSet(co, symcora_47init_35bytes_45length, globalRef(symbytes_45length));
-Obj _35reg1445 = primSet(co, symcora_47init_35value, globalRef(symvalue));
-Obj _35reg1446 = primSet(co, symcora_47init_35value_45or, globalRef(symvalue_45or));
-Obj _35reg1447 = primSet(co, symcora_47init_35read_45file_45as_45sexp, globalRef(symread_45file_45as_45sexp));
-Obj _35reg1448 = primSet(co, symcora_47init_35apply, globalRef(symapply));
-Obj _35reg1449 = primSet(co, symcora_47init_35load, globalRef(symload));
-Obj _35reg1450 = primSet(co, symcora_47init_35load_45so, globalRef(symload_45so));
-Obj _35reg1451 = primSet(co, symcora_47init_35import, globalRef(symimport));
-Obj _35reg1452 = primSet(co, symcora_47init_35try, globalRef(symtry));
-Obj _35reg1453 = primSet(co, symcora_47init_35throw, globalRef(symthrow));
-Obj _35reg1454 = primSet(co, symcora_47init_35reverse, globalRef(symreverse));
-Obj _35reg1455 = primSet(co, symcora_47init_35map, globalRef(symmap));
-Obj _35reg1456 = primSet(co, symcora_47init_35macroexpand, globalRef(symmacroexpand));
-Obj _35reg1457 = primSet(co, symcora_47init_35elem_63, globalRef(symelem_63));
-Obj _35reg1458 = primSet(co, symcora_47init_35length, globalRef(symlength));
-Obj _35reg1459 = primSet(co, symcora_47init_35filter, globalRef(symfilter));
-Obj _35reg1460 = primSet(co, symcora_47init_35append, globalRef(symappend));
+Obj v0x7f1f23f58ee0 = __arg1;
+Obj v0x7f1f23efe440 = makeCons(symappend, Nil);
+Obj v0x7f1f23efe480 = makeCons(symfilter, v0x7f1f23efe440);
+Obj v0x7f1f23efe500 = makeCons(symlength, v0x7f1f23efe480);
+Obj v0x7f1f23efe520 = makeCons(symelem_63, v0x7f1f23efe500);
+Obj v0x7f1f23efe580 = makeCons(symmacroexpand, v0x7f1f23efe520);
+Obj v0x7f1f23efe680 = makeCons(symmap, v0x7f1f23efe580);
+Obj v0x7f1f23efe6a0 = makeCons(symreverse, v0x7f1f23efe680);
+Obj v0x7f1f23efe6c0 = makeCons(symthrow, v0x7f1f23efe6a0);
+Obj v0x7f1f23efe6e0 = makeCons(symtry, v0x7f1f23efe6c0);
+Obj v0x7f1f23efe720 = makeCons(symload, v0x7f1f23efe6e0);
+Obj v0x7f1f23efe740 = makeCons(symimport, v0x7f1f23efe720);
+Obj v0x7f1f23efe760 = makeCons(symload_45so, v0x7f1f23efe740);
+Obj v0x7f1f23efe780 = makeCons(symapply, v0x7f1f23efe760);
+Obj v0x7f1f23efe7e0 = makeCons(symvalue_45or, v0x7f1f23efe780);
+Obj v0x7f1f23efe800 = makeCons(symvalue, v0x7f1f23efe7e0);
+Obj v0x7f1f23efe840 = makeCons(symread_45file_45as_45sexp, v0x7f1f23efe800);
+Obj v0x7f1f23efe860 = makeCons(symbytes_45length, v0x7f1f23efe840);
+Obj v0x7f1f23efe880 = makeCons(symbytes, v0x7f1f23efe860);
+Obj v0x7f1f23efe960 = makeCons(symvector_45length, v0x7f1f23efe880);
+Obj v0x7f1f23efe980 = makeCons(symvector_45ref, v0x7f1f23efe960);
+Obj v0x7f1f23efe9a0 = makeCons(symvector_45set_33, v0x7f1f23efe980);
+Obj v0x7f1f23efe9c0 = makeCons(symvector, v0x7f1f23efe9a0);
+Obj v0x7f1f23efea00 = makeCons(symsymbol_45_62string, v0x7f1f23efe9c0);
+Obj v0x7f1f23efea20 = makeCons(symintern, v0x7f1f23efea00);
+Obj v0x7f1f23efea40 = makeCons(symstring_45append, v0x7f1f23efea20);
+Obj v0x7f1f23efea60 = makeCons(symnull_63, v0x7f1f23efea40);
+Obj v0x7f1f23efea80 = makeCons(symnumber_63, v0x7f1f23efea60);
+Obj v0x7f1f23efeb80 = makeCons(symboolean_63, v0x7f1f23efea80);
+Obj v0x7f1f23efeba0 = makeCons(symatom_63, v0x7f1f23efeb80);
+Obj v0x7f1f23efebc0 = makeCons(sympair_63, v0x7f1f23efeba0);
+Obj v0x7f1f23efebe0 = makeCons(symcdddr, v0x7f1f23efebc0);
+Obj v0x7f1f23efec00 = makeCons(symcadddr, v0x7f1f23efebe0);
+Obj v0x7f1f23efec20 = makeCons(symcaddr, v0x7f1f23efec00);
+Obj v0x7f1f23efefe0 = makeCons(symcddr, v0x7f1f23efec20);
+Obj v0x7f1f23ef8000 = makeCons(symcdar, v0x7f1f23efefe0);
+Obj v0x7f1f23ef8020 = makeCons(symcaar, v0x7f1f23ef8000);
+Obj v0x7f1f23ef8040 = makeCons(symcadr, v0x7f1f23ef8020);
+Obj v0x7f1f23ef8060 = primSet(co, symcora_47init_35_42ns_45export_42, v0x7f1f23ef8040);
+Obj v0x7f1f23ef81e0 = primSet(co, symcora_47init_35cadr, globalRef(symcadr));
+Obj v0x7f1f23ef85a0 = primSet(co, symcora_47init_35caar, globalRef(symcaar));
+Obj v0x7f1f23ef87a0 = primSet(co, symcora_47init_35cdar, globalRef(symcdar));
+Obj v0x7f1f23ef8ac0 = primSet(co, symcora_47init_35cddr, globalRef(symcddr));
+Obj v0x7f1f23ef8d00 = primSet(co, symcora_47init_35caddr, globalRef(symcaddr));
+Obj v0x7f1f23ef8f00 = primSet(co, symcora_47init_35cadddr, globalRef(symcadddr));
+Obj v0x7f1f23edd120 = primSet(co, symcora_47init_35cdddr, globalRef(symcdddr));
+Obj v0x7f1f23edd4c0 = primSet(co, symcora_47init_35pair_63, globalRef(sympair_63));
+Obj v0x7f1f23edd640 = primSet(co, symcora_47init_35atom_63, globalRef(symatom_63));
+Obj v0x7f1f23edd840 = primSet(co, symcora_47init_35boolean_63, globalRef(symboolean_63));
+Obj v0x7f1f23eddaa0 = primSet(co, symcora_47init_35null_63, globalRef(symnull_63));
+Obj v0x7f1f23eddc20 = primSet(co, symcora_47init_35number_63, globalRef(symnumber_63));
+Obj v0x7f1f23eddda0 = primSet(co, symcora_47init_35string_45append, globalRef(symstring_45append));
+Obj v0x7f1f23ed50a0 = primSet(co, symcora_47init_35intern, globalRef(symintern));
+Obj v0x7f1f23ed52a0 = primSet(co, symcora_47init_35symbol_45_62string, globalRef(symsymbol_45_62string));
+Obj v0x7f1f23ed5540 = primSet(co, symcora_47init_35vector, globalRef(symvector));
+Obj v0x7f1f23ed56c0 = primSet(co, symcora_47init_35vector_45set_33, globalRef(symvector_45set_33));
+Obj v0x7f1f23ed5940 = primSet(co, symcora_47init_35vector_45ref, globalRef(symvector_45ref));
+Obj v0x7f1f23ed5b80 = primSet(co, symcora_47init_35vector_45length, globalRef(symvector_45length));
+Obj v0x7f1f23ed5dc0 = primSet(co, symcora_47init_35bytes, globalRef(symbytes));
+Obj v0x7f1f23ed5fc0 = primSet(co, symcora_47init_35bytes_45length, globalRef(symbytes_45length));
+Obj v0x7f1f23ecc180 = primSet(co, symcora_47init_35value, globalRef(symvalue));
+Obj v0x7f1f23ecc400 = primSet(co, symcora_47init_35value_45or, globalRef(symvalue_45or));
+Obj v0x7f1f23ecc600 = primSet(co, symcora_47init_35read_45file_45as_45sexp, globalRef(symread_45file_45as_45sexp));
+Obj v0x7f1f23ecc800 = primSet(co, symcora_47init_35apply, globalRef(symapply));
+Obj v0x7f1f23ecca40 = primSet(co, symcora_47init_35load, globalRef(symload));
+Obj v0x7f1f23ecccc0 = primSet(co, symcora_47init_35load_45so, globalRef(symload_45so));
+Obj v0x7f1f23eccea0 = primSet(co, symcora_47init_35import, globalRef(symimport));
+Obj v0x7f1f23eb10c0 = primSet(co, symcora_47init_35try, globalRef(symtry));
+Obj v0x7f1f23eb1280 = primSet(co, symcora_47init_35throw, globalRef(symthrow));
+Obj v0x7f1f23eb14c0 = primSet(co, symcora_47init_35reverse, globalRef(symreverse));
+Obj v0x7f1f23eb1780 = primSet(co, symcora_47init_35map, globalRef(symmap));
+Obj v0x7f1f23eb1960 = primSet(co, symcora_47init_35macroexpand, globalRef(symmacroexpand));
+Obj v0x7f1f23eb1ae0 = primSet(co, symcora_47init_35elem_63, globalRef(symelem_63));
+Obj v0x7f1f23eb1d40 = primSet(co, symcora_47init_35length, globalRef(symlength));
+Obj v0x7f1f23eb1f40 = primSet(co, symcora_47init_35filter, globalRef(symfilter));
+Obj v0x7f1f23e9b080 = primSet(co, symcora_47init_35append, globalRef(symappend));
 __nargs = 2;
-__arg1 = _35reg1460;
+__arg1 = v0x7f1f23e9b080;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -669,9 +669,9 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35val1366 = __arg1;
+Obj v0x7f1f24013d60 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj path = _35val1366;
+Obj path = v0x7f1f24013d60;
 pushCont(co, 17, clofun0, 1, path);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
@@ -685,12 +685,12 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj _35val1367 = __arg1;
+Obj v0x7f1f24013f40 = __arg1;
 Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 18, clofun0, 1, path);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35parse_45define_45library);
-__arg1 = _35val1367;
+__arg1 = v0x7f1f24013f40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -700,10 +700,10 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35val1368 = __arg1;
+Obj v0x7f1f24013f60 = __arg1;
 Obj path= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
-__arg0 = _35val1368;
+__arg0 = v0x7f1f24013f60;
 __arg1 = makeNative(19, clofun0, 3, 1, path);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -717,8 +717,8 @@ label19:
 Obj import = __arg1;
 Obj export = __arg2;
 Obj body = __arg3;
-Obj _35reg1369 = makeCons(makeCString("cora/init"), import);
-pushCont(co, 20, clofun0, 3, export, body, _35reg1369);
+Obj v0x7f1f23f5c6e0 = makeCons(makeCString("cora/init"), import);
+pushCont(co, 20, clofun0, 3, export, body, v0x7f1f23f5c6e0);
 __nargs = 3;
 __arg0 = globalRef(symmap);
 __arg1 = makeNative(22, clofun0, 1, 0);
@@ -732,21 +732,21 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj _35val1372 = __arg1;
+Obj v0x7f1f23f58300 = __arg1;
 Obj export= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg1369= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg1373 = makeCons(export, Nil);
-Obj _35reg1374 = makeCons(symbackquote, _35reg1373);
-Obj _35reg1375 = makeCons(_35reg1374, Nil);
-Obj _35reg1376 = makeCons(sym_42ns_45export_42, _35reg1375);
-Obj _35reg1377 = makeCons(symdef, _35reg1376);
-Obj _35reg1378 = makeCons(_35reg1377, body);
-pushCont(co, 21, clofun0, 1, _35reg1369);
+Obj v0x7f1f23f5c6e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+Obj v0x7f1f23f58b80 = makeCons(export, Nil);
+Obj v0x7f1f23f58bc0 = makeCons(symbackquote, v0x7f1f23f58b80);
+Obj v0x7f1f23f58c00 = makeCons(v0x7f1f23f58bc0, Nil);
+Obj v0x7f1f23f58c20 = makeCons(sym_42ns_45export_42, v0x7f1f23f58c00);
+Obj v0x7f1f23f58ca0 = makeCons(symdef, v0x7f1f23f58c20);
+Obj v0x7f1f23f58d20 = makeCons(v0x7f1f23f58ca0, body);
+pushCont(co, 21, clofun0, 1, v0x7f1f23f5c6e0);
 __nargs = 3;
 __arg0 = globalRef(symappend);
-__arg1 = _35val1372;
-__arg2 = _35reg1378;
+__arg1 = v0x7f1f23f58300;
+__arg2 = v0x7f1f23f58d20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -756,15 +756,15 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj _35val1379 = __arg1;
-Obj _35reg1369= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg1380 = makeCons(symbegin, _35val1379);
-Obj _35reg1381 = makeCons(_35reg1380, Nil);
-Obj _35reg1382 = makeCons(_35reg1369, _35reg1381);
-Obj _35reg1383 = makeCons(closureRef(co, 0), _35reg1382);
-Obj _35reg1384 = makeCons(symns, _35reg1383);
+Obj v0x7f1f23f58d40 = __arg1;
+Obj v0x7f1f23f5c6e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f23f58de0 = makeCons(symbegin, v0x7f1f23f58d40);
+Obj v0x7f1f23f58e20 = makeCons(v0x7f1f23f58de0, Nil);
+Obj v0x7f1f23f58e40 = makeCons(v0x7f1f23f5c6e0, v0x7f1f23f58e20);
+Obj v0x7f1f23f58e80 = makeCons(closureRef(co, 0), v0x7f1f23f58e40);
+Obj v0x7f1f23f58ea0 = makeCons(symns, v0x7f1f23f58e80);
 __nargs = 2;
-__arg1 = _35reg1384;
+__arg1 = v0x7f1f23f58ea0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -773,10 +773,10 @@ goto *jumpTable[co->ctx.pc.label];
 label22:
 {
 Obj imp = __arg1;
-Obj _35reg1370 = makeCons(imp, Nil);
-Obj _35reg1371 = makeCons(symimport, _35reg1370);
+Obj v0x7f1f23f582a0 = makeCons(imp, Nil);
+Obj v0x7f1f23f582c0 = makeCons(symimport, v0x7f1f23f582a0);
 __nargs = 2;
-__arg1 = _35reg1371;
+__arg1 = v0x7f1f23f582c0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -801,43 +801,43 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj _35p364 = __arg1;
-Obj _35p365 = __arg2;
-Obj _35p366 = __arg3;
-Obj _35p367 = co->args[4];
-Obj _35cc368 = makeNative(25, clofun0, 0, 4, _35p364, _35p365, _35p366, _35p367);
-Obj _35reg1346 = PRIM_ISCONS(_35p364);
-if (True == _35reg1346) {
-Obj _35reg1347 = PRIM_CAR(_35p364);
-Obj _35reg1348 = PRIM_ISCONS(_35reg1347);
-if (True == _35reg1348) {
-Obj _35reg1349 = PRIM_CAR(_35p364);
-Obj _35reg1350 = PRIM_CAR(_35reg1349);
-Obj _35reg1351 = PRIM_EQ(symimport, _35reg1350);
-if (True == _35reg1351) {
-Obj _35reg1352 = PRIM_CAR(_35p364);
-Obj _35reg1353 = PRIM_CDR(_35reg1352);
-Obj _35reg1354 = PRIM_ISCONS(_35reg1353);
-if (True == _35reg1354) {
-Obj _35reg1355 = PRIM_CAR(_35p364);
-Obj _35reg1356 = PRIM_CDR(_35reg1355);
-Obj _35reg1357 = PRIM_CAR(_35reg1356);
-Obj lib = _35reg1357;
-Obj _35reg1358 = PRIM_CAR(_35p364);
-Obj _35reg1359 = PRIM_CDR(_35reg1358);
-Obj _35reg1360 = PRIM_CDR(_35reg1359);
-Obj _35reg1361 = PRIM_EQ(Nil, _35reg1360);
-if (True == _35reg1361) {
-Obj _35reg1362 = PRIM_CDR(_35p364);
-Obj rest = _35reg1362;
-Obj imports = _35p365;
-Obj exports = _35p366;
-Obj k = _35p367;
-Obj _35reg1363 = makeCons(lib, imports);
+Obj v0x7f1f23f5ca20 = __arg1;
+Obj v0x7f1f23f5ca40 = __arg2;
+Obj v0x7f1f23f5ca80 = __arg3;
+Obj v0x7f1f23f5caa0 = co->args[4];
+Obj v0x7f1f23f5cbe0 = makeNative(25, clofun0, 0, 4, v0x7f1f23f5ca20, v0x7f1f23f5ca40, v0x7f1f23f5ca80, v0x7f1f23f5caa0);
+Obj v0x7f1f24017160 = PRIM_ISCONS(v0x7f1f23f5ca20);
+if (True == v0x7f1f24017160) {
+Obj v0x7f1f24017380 = PRIM_CAR(v0x7f1f23f5ca20);
+Obj v0x7f1f240173a0 = PRIM_ISCONS(v0x7f1f24017380);
+if (True == v0x7f1f240173a0) {
+Obj v0x7f1f24017600 = PRIM_CAR(v0x7f1f23f5ca20);
+Obj v0x7f1f24017620 = PRIM_CAR(v0x7f1f24017600);
+Obj v0x7f1f24017640 = PRIM_EQ(symimport, v0x7f1f24017620);
+if (True == v0x7f1f24017640) {
+Obj v0x7f1f24017920 = PRIM_CAR(v0x7f1f23f5ca20);
+Obj v0x7f1f24017940 = PRIM_CDR(v0x7f1f24017920);
+Obj v0x7f1f24017960 = PRIM_ISCONS(v0x7f1f24017940);
+if (True == v0x7f1f24017960) {
+Obj v0x7f1f24017c40 = PRIM_CAR(v0x7f1f23f5ca20);
+Obj v0x7f1f24017c60 = PRIM_CDR(v0x7f1f24017c40);
+Obj v0x7f1f24017c80 = PRIM_CAR(v0x7f1f24017c60);
+Obj lib = v0x7f1f24017c80;
+Obj v0x7f1f24013040 = PRIM_CAR(v0x7f1f23f5ca20);
+Obj v0x7f1f24013060 = PRIM_CDR(v0x7f1f24013040);
+Obj v0x7f1f24013080 = PRIM_CDR(v0x7f1f24013060);
+Obj v0x7f1f240130a0 = PRIM_EQ(Nil, v0x7f1f24013080);
+if (True == v0x7f1f240130a0) {
+Obj v0x7f1f240131a0 = PRIM_CDR(v0x7f1f23f5ca20);
+Obj rest = v0x7f1f240131a0;
+Obj imports = v0x7f1f23f5ca40;
+Obj exports = v0x7f1f23f5ca80;
+Obj k = v0x7f1f23f5caa0;
+Obj v0x7f1f24013480 = makeCons(lib, imports);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35parse_45define_45library_45h);
 __arg1 = rest;
-__arg2 = _35reg1363;
+__arg2 = v0x7f1f24013480;
 __arg3 = exports;
 co->args[4] = k;
 co->ctx.frees = __arg0;
@@ -847,7 +847,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc368;
+__arg0 = v0x7f1f23f5cbe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -856,7 +856,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc368;
+__arg0 = v0x7f1f23f5cbe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -865,7 +865,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc368;
+__arg0 = v0x7f1f23f5cbe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -874,7 +874,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc368;
+__arg0 = v0x7f1f23f5cbe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -883,7 +883,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc368;
+__arg0 = v0x7f1f23f5cbe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -894,21 +894,21 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj _35cc369 = makeNative(26, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg1337 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1337) {
-Obj _35reg1338 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1339 = PRIM_ISCONS(_35reg1338);
-if (True == _35reg1339) {
-Obj _35reg1340 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1341 = PRIM_CAR(_35reg1340);
-Obj _35reg1342 = PRIM_EQ(symexport, _35reg1341);
-if (True == _35reg1342) {
-Obj _35reg1343 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1344 = PRIM_CDR(_35reg1343);
-Obj more = _35reg1344;
-Obj _35reg1345 = PRIM_CDR(closureRef(co, 0));
-Obj rest = _35reg1345;
+Obj v0x7f1f23f58080 = makeNative(26, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj v0x7f1f2401f520 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2401f520) {
+Obj v0x7f1f2401f6e0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2401f700 = PRIM_ISCONS(v0x7f1f2401f6e0);
+if (True == v0x7f1f2401f700) {
+Obj v0x7f1f2401f9a0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2401f9c0 = PRIM_CAR(v0x7f1f2401f9a0);
+Obj v0x7f1f2401f9e0 = PRIM_EQ(symexport, v0x7f1f2401f9c0);
+if (True == v0x7f1f2401f9e0) {
+Obj v0x7f1f2401fb80 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2401fba0 = PRIM_CDR(v0x7f1f2401fb80);
+Obj more = v0x7f1f2401fba0;
+Obj v0x7f1f2401fca0 = PRIM_CDR(closureRef(co, 0));
+Obj rest = v0x7f1f2401fca0;
 Obj imports = closureRef(co, 1);
 Obj exports = closureRef(co, 2);
 Obj k = closureRef(co, 3);
@@ -925,7 +925,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc369;
+__arg0 = v0x7f1f23f58080;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -934,7 +934,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc369;
+__arg0 = v0x7f1f23f58080;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -943,7 +943,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc369;
+__arg0 = v0x7f1f23f58080;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -954,7 +954,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35cc370 = makeNative(28, clofun0, 0, 0);
+Obj v0x7f1f23f58420 = makeNative(28, clofun0, 0, 0);
 Obj body = closureRef(co, 0);
 Obj imports = closureRef(co, 1);
 Obj exports = closureRef(co, 2);
@@ -972,13 +972,13 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj _35val1336 = __arg1;
+Obj v0x7f1f2401f3a0 = __arg1;
 Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exports= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 __nargs = 4;
 __arg0 = k;
-__arg1 = _35val1336;
+__arg1 = v0x7f1f2401f3a0;
 __arg2 = exports;
 __arg3 = body;
 co->ctx.frees = __arg0;
@@ -1016,10 +1016,10 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj _35val1334 = __arg1;
+Obj v0x7f1f24022d00 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45backquote);
-__arg1 = _35val1334;
+__arg1 = v0x7f1f24022d00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1029,21 +1029,21 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj _35p359 = __arg1;
-Obj _35cc360 = makeNative(32, clofun0, 0, 1, _35p359);
-Obj x = _35p359;
-Obj _35reg1330 = primIsSymbol(x);
-if (True == _35reg1330) {
-Obj _35reg1331 = makeCons(x, Nil);
-Obj _35reg1332 = makeCons(symquote, _35reg1331);
+Obj v0x7f1f23f5c160 = __arg1;
+Obj v0x7f1f23f5c1e0 = makeNative(32, clofun0, 0, 1, v0x7f1f23f5c160);
+Obj x = v0x7f1f23f5c160;
+Obj v0x7f1f24022760 = primIsSymbol(x);
+if (True == v0x7f1f24022760) {
+Obj v0x7f1f24022940 = makeCons(x, Nil);
+Obj v0x7f1f24022960 = makeCons(symquote, v0x7f1f24022940);
 __nargs = 2;
-__arg1 = _35reg1332;
+__arg1 = v0x7f1f24022960;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc360;
+__arg0 = v0x7f1f23f5c1e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1054,22 +1054,22 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj _35cc361 = makeNative(33, clofun0, 0, 1, closureRef(co, 0));
-Obj _35reg1320 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1320) {
-Obj _35reg1321 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1322 = PRIM_EQ(symunquote, _35reg1321);
-if (True == _35reg1322) {
-Obj _35reg1323 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1324 = PRIM_ISCONS(_35reg1323);
-if (True == _35reg1324) {
-Obj _35reg1325 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1326 = PRIM_CAR(_35reg1325);
-Obj x = _35reg1326;
-Obj _35reg1327 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1328 = PRIM_CDR(_35reg1327);
-Obj _35reg1329 = PRIM_EQ(Nil, _35reg1328);
-if (True == _35reg1329) {
+Obj v0x7f1f23f5c380 = makeNative(33, clofun0, 0, 1, closureRef(co, 0));
+Obj v0x7f1f24024800 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24024800) {
+Obj v0x7f1f24024ce0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f24024d00 = PRIM_EQ(symunquote, v0x7f1f24024ce0);
+if (True == v0x7f1f24024d00) {
+Obj v0x7f1f24024ea0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24024ec0 = PRIM_ISCONS(v0x7f1f24024ea0);
+if (True == v0x7f1f24024ec0) {
+Obj v0x7f1f24022060 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24022080 = PRIM_CAR(v0x7f1f24022060);
+Obj x = v0x7f1f24022080;
+Obj v0x7f1f24022360 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24022380 = PRIM_CDR(v0x7f1f24022360);
+Obj v0x7f1f240223a0 = PRIM_EQ(Nil, v0x7f1f24022380);
+if (True == v0x7f1f240223a0) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -1077,7 +1077,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc361;
+__arg0 = v0x7f1f23f5c380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1086,7 +1086,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc361;
+__arg0 = v0x7f1f23f5c380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1095,7 +1095,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc361;
+__arg0 = v0x7f1f23f5c380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1104,7 +1104,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc361;
+__arg0 = v0x7f1f23f5c380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1115,19 +1115,19 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj _35cc362 = makeNative(35, clofun0, 0, 1, closureRef(co, 0));
-Obj _35reg1314 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1314) {
-Obj _35reg1315 = PRIM_CAR(closureRef(co, 0));
-Obj x = _35reg1315;
-Obj _35reg1316 = PRIM_CDR(closureRef(co, 0));
-Obj more = _35reg1316;
-Obj _35reg1317 = makeCons(x, more);
+Obj v0x7f1f23f5c5a0 = makeNative(35, clofun0, 0, 1, closureRef(co, 0));
+Obj v0x7f1f24024100 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24024100) {
+Obj v0x7f1f24024220 = PRIM_CAR(closureRef(co, 0));
+Obj x = v0x7f1f24024220;
+Obj v0x7f1f24024320 = PRIM_CDR(closureRef(co, 0));
+Obj more = v0x7f1f24024320;
+Obj v0x7f1f240245e0 = makeCons(x, more);
 PUSH_CONT_0(co, 34, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symmap);
 __arg1 = globalRef(symcora_47init_35rewrite_45backquote);
-__arg2 = _35reg1317;
+__arg2 = v0x7f1f240245e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1135,7 +1135,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc362;
+__arg0 = v0x7f1f23f5c5a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1146,10 +1146,10 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj _35val1318 = __arg1;
-Obj _35reg1319 = makeCons(symlist, _35val1318);
+Obj v0x7f1f24024600 = __arg1;
+Obj v0x7f1f24024620 = makeCons(symlist, v0x7f1f24024600);
 __nargs = 2;
-__arg1 = _35reg1319;
+__arg1 = v0x7f1f24024620;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1157,7 +1157,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label35:
 {
-Obj _35cc363 = makeNative(36, clofun0, 0, 0);
+Obj v0x7f1f23f5c740 = makeNative(36, clofun0, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = x;
@@ -1181,10 +1181,10 @@ goto *jumpTable[ps.label];
 label37:
 {
 Obj exp = __arg1;
-Obj _35reg1312 = PRIM_CDR(exp);
+Obj v0x7f1f24024720 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45begin);
-__arg1 = _35reg1312;
+__arg1 = v0x7f1f24024720;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1194,15 +1194,15 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj _35p355 = __arg1;
-Obj _35cc356 = makeNative(39, clofun0, 0, 1, _35p355);
-Obj _35reg1307 = PRIM_ISCONS(_35p355);
-if (True == _35reg1307) {
-Obj _35reg1308 = PRIM_CAR(_35p355);
-Obj x = _35reg1308;
-Obj _35reg1309 = PRIM_CDR(_35p355);
-Obj _35reg1310 = PRIM_EQ(Nil, _35reg1309);
-if (True == _35reg1310) {
+Obj v0x7f1f23f5cfc0 = __arg1;
+Obj v0x7f1f23f58060 = makeNative(39, clofun0, 0, 1, v0x7f1f23f5cfc0);
+Obj v0x7f1f24024080 = PRIM_ISCONS(v0x7f1f23f5cfc0);
+if (True == v0x7f1f24024080) {
+Obj v0x7f1f24024180 = PRIM_CAR(v0x7f1f23f5cfc0);
+Obj x = v0x7f1f24024180;
+Obj v0x7f1f24024340 = PRIM_CDR(v0x7f1f23f5cfc0);
+Obj v0x7f1f24024360 = PRIM_EQ(Nil, v0x7f1f24024340);
+if (True == v0x7f1f24024360) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -1210,7 +1210,7 @@ if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc356;
+__arg0 = v0x7f1f23f58060;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1219,7 +1219,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc356;
+__arg0 = v0x7f1f23f58060;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1230,32 +1230,32 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj _35cc357 = makeNative(40, clofun0, 0, 1, closureRef(co, 0));
-Obj _35reg1295 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1295) {
-Obj _35reg1296 = PRIM_CAR(closureRef(co, 0));
-Obj x = _35reg1296;
-Obj _35reg1297 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1298 = PRIM_ISCONS(_35reg1297);
-if (True == _35reg1298) {
-Obj _35reg1299 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1300 = PRIM_CAR(_35reg1299);
-Obj y = _35reg1300;
-Obj _35reg1301 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1302 = PRIM_CDR(_35reg1301);
-Obj _35reg1303 = PRIM_EQ(Nil, _35reg1302);
-if (True == _35reg1303) {
-Obj _35reg1304 = makeCons(y, Nil);
-Obj _35reg1305 = makeCons(x, _35reg1304);
-Obj _35reg1306 = makeCons(symdo, _35reg1305);
+Obj v0x7f1f23f581c0 = makeNative(40, clofun0, 0, 1, closureRef(co, 0));
+Obj v0x7f1f24022440 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24022440) {
+Obj v0x7f1f24022540 = PRIM_CAR(closureRef(co, 0));
+Obj x = v0x7f1f24022540;
+Obj v0x7f1f240226e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24022700 = PRIM_ISCONS(v0x7f1f240226e0);
+if (True == v0x7f1f24022700) {
+Obj v0x7f1f240228a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240228c0 = PRIM_CAR(v0x7f1f240228a0);
+Obj y = v0x7f1f240228c0;
+Obj v0x7f1f24022b20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24022b40 = PRIM_CDR(v0x7f1f24022b20);
+Obj v0x7f1f24022b60 = PRIM_EQ(Nil, v0x7f1f24022b40);
+if (True == v0x7f1f24022b60) {
+Obj v0x7f1f24022dc0 = makeCons(y, Nil);
+Obj v0x7f1f24022de0 = makeCons(x, v0x7f1f24022dc0);
+Obj v0x7f1f24022e00 = makeCons(symdo, v0x7f1f24022de0);
 __nargs = 2;
-__arg1 = _35reg1306;
+__arg1 = v0x7f1f24022e00;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc357;
+__arg0 = v0x7f1f23f581c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1264,7 +1264,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc357;
+__arg0 = v0x7f1f23f581c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1273,7 +1273,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc357;
+__arg0 = v0x7f1f23f581c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1284,13 +1284,13 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj _35cc358 = makeNative(42, clofun0, 0, 0);
-Obj _35reg1288 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1288) {
-Obj _35reg1289 = PRIM_CAR(closureRef(co, 0));
-Obj x = _35reg1289;
-Obj _35reg1290 = PRIM_CDR(closureRef(co, 0));
-Obj y = _35reg1290;
+Obj v0x7f1f23f583c0 = makeNative(42, clofun0, 0, 0);
+Obj v0x7f1f2401fd60 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2401fd60) {
+Obj v0x7f1f2401fe60 = PRIM_CAR(closureRef(co, 0));
+Obj x = v0x7f1f2401fe60;
+Obj v0x7f1f2401ff60 = PRIM_CDR(closureRef(co, 0));
+Obj y = v0x7f1f2401ff60;
 pushCont(co, 41, clofun0, 1, x);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45begin);
@@ -1302,7 +1302,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc358;
+__arg0 = v0x7f1f23f583c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1313,13 +1313,13 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj _35val1291 = __arg1;
+Obj v0x7f1f24022240 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg1292 = makeCons(_35val1291, Nil);
-Obj _35reg1293 = makeCons(x, _35reg1292);
-Obj _35reg1294 = makeCons(symdo, _35reg1293);
+Obj v0x7f1f24022280 = makeCons(v0x7f1f24022240, Nil);
+Obj v0x7f1f240222a0 = makeCons(x, v0x7f1f24022280);
+Obj v0x7f1f240222c0 = makeCons(symdo, v0x7f1f240222a0);
 __nargs = 2;
-__arg1 = _35reg1294;
+__arg1 = v0x7f1f240222c0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -1353,10 +1353,10 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj _35val1286 = __arg1;
+Obj v0x7f1f2401f8e0 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
-__arg1 = _35val1286;
+__arg1 = v0x7f1f2401f8e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1366,33 +1366,33 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj _35p343 = __arg1;
-Obj _35cc344 = makeNative(46, clofun0, 0, 1, _35p343);
-Obj _35reg1273 = PRIM_ISCONS(_35p343);
-if (True == _35reg1273) {
-Obj _35reg1274 = PRIM_CAR(_35p343);
-Obj _35reg1275 = PRIM_EQ(symquote, _35reg1274);
-if (True == _35reg1275) {
-Obj _35reg1276 = PRIM_CDR(_35p343);
-Obj _35reg1277 = PRIM_ISCONS(_35reg1276);
-if (True == _35reg1277) {
-Obj _35reg1278 = PRIM_CDR(_35p343);
-Obj _35reg1279 = PRIM_CAR(_35reg1278);
-Obj x = _35reg1279;
-Obj _35reg1280 = PRIM_CDR(_35p343);
-Obj _35reg1281 = PRIM_CDR(_35reg1280);
-Obj _35reg1282 = PRIM_EQ(Nil, _35reg1281);
-if (True == _35reg1282) {
-Obj _35reg1283 = makeCons(x, Nil);
-Obj _35reg1284 = makeCons(symquote, _35reg1283);
+Obj v0x7f1f23f5c240 = __arg1;
+Obj v0x7f1f23f5c2e0 = makeNative(46, clofun0, 0, 1, v0x7f1f23f5c240);
+Obj v0x7f1f23e3f980 = PRIM_ISCONS(v0x7f1f23f5c240);
+if (True == v0x7f1f23e3f980) {
+Obj v0x7f1f23e3fc00 = PRIM_CAR(v0x7f1f23f5c240);
+Obj v0x7f1f23e3fc20 = PRIM_EQ(symquote, v0x7f1f23e3fc00);
+if (True == v0x7f1f23e3fc20) {
+Obj v0x7f1f23e3fe20 = PRIM_CDR(v0x7f1f23f5c240);
+Obj v0x7f1f23e3fe40 = PRIM_ISCONS(v0x7f1f23e3fe20);
+if (True == v0x7f1f23e3fe40) {
+Obj v0x7f1f23e3ffe0 = PRIM_CDR(v0x7f1f23f5c240);
+Obj v0x7f1f23e39a20 = PRIM_CAR(v0x7f1f23e3ffe0);
+Obj x = v0x7f1f23e39a20;
+Obj v0x7f1f2401f220 = PRIM_CDR(v0x7f1f23f5c240);
+Obj v0x7f1f2401f240 = PRIM_CDR(v0x7f1f2401f220);
+Obj v0x7f1f2401f260 = PRIM_EQ(Nil, v0x7f1f2401f240);
+if (True == v0x7f1f2401f260) {
+Obj v0x7f1f2401f400 = makeCons(x, Nil);
+Obj v0x7f1f2401f420 = makeCons(symquote, v0x7f1f2401f400);
 __nargs = 2;
-__arg1 = _35reg1284;
+__arg1 = v0x7f1f2401f420;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc344;
+__arg0 = v0x7f1f23f5c2e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1401,7 +1401,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc344;
+__arg0 = v0x7f1f23f5c2e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1410,7 +1410,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc344;
+__arg0 = v0x7f1f23f5c2e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1419,7 +1419,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc344;
+__arg0 = v0x7f1f23f5c2e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1430,22 +1430,22 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj _35cc345 = makeNative(48, clofun0, 0, 1, closureRef(co, 0));
-Obj _35reg1260 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1260) {
-Obj _35reg1261 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1262 = PRIM_EQ(symcons_63, _35reg1261);
-if (True == _35reg1262) {
-Obj _35reg1263 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1264 = PRIM_ISCONS(_35reg1263);
-if (True == _35reg1264) {
-Obj _35reg1265 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1266 = PRIM_CAR(_35reg1265);
-Obj x = _35reg1266;
-Obj _35reg1267 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1268 = PRIM_CDR(_35reg1267);
-Obj _35reg1269 = PRIM_EQ(Nil, _35reg1268);
-if (True == _35reg1269) {
+Obj v0x7f1f23f5c4e0 = makeNative(48, clofun0, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23e5f5a0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23e5f5a0) {
+Obj v0x7f1f23e5f760 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23e5f780 = PRIM_EQ(symcons_63, v0x7f1f23e5f760);
+if (True == v0x7f1f23e5f780) {
+Obj v0x7f1f23e5f9a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e5f9c0 = PRIM_ISCONS(v0x7f1f23e5f9a0);
+if (True == v0x7f1f23e5f9c0) {
+Obj v0x7f1f23e5fbe0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e5fc00 = PRIM_CAR(v0x7f1f23e5fbe0);
+Obj x = v0x7f1f23e5fc00;
+Obj v0x7f1f23e5fe60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e5fe80 = PRIM_CDR(v0x7f1f23e5fe60);
+Obj v0x7f1f23e5fea0 = PRIM_EQ(Nil, v0x7f1f23e5fe80);
+if (True == v0x7f1f23e5fea0) {
 PUSH_CONT_0(co, 47, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -1457,7 +1457,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc345;
+__arg0 = v0x7f1f23f5c4e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1466,7 +1466,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc345;
+__arg0 = v0x7f1f23f5c4e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1475,7 +1475,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc345;
+__arg0 = v0x7f1f23f5c4e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1484,7 +1484,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc345;
+__arg0 = v0x7f1f23f5c4e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1495,13 +1495,13 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj _35val1270 = __arg1;
-Obj x1 = _35val1270;
-Obj _35reg1271 = makeCons(x1, Nil);
-Obj _35reg1272 = makeCons(symcons_63, _35reg1271);
+Obj v0x7f1f23e3f380 = __arg1;
+Obj x1 = v0x7f1f23e3f380;
+Obj v0x7f1f23e3f5c0 = makeCons(x1, Nil);
+Obj v0x7f1f23e3f5e0 = makeCons(symcons_63, v0x7f1f23e3f5c0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = _35reg1272;
+__arg1 = v0x7f1f23e3f5e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1511,22 +1511,22 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj _35cc346 = makeNative(0, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg1247 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1247) {
-Obj _35reg1248 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1249 = PRIM_EQ(symcar, _35reg1248);
-if (True == _35reg1249) {
-Obj _35reg1250 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1251 = PRIM_ISCONS(_35reg1250);
-if (True == _35reg1251) {
-Obj _35reg1252 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1253 = PRIM_CAR(_35reg1252);
-Obj x = _35reg1253;
-Obj _35reg1254 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1255 = PRIM_CDR(_35reg1254);
-Obj _35reg1256 = PRIM_EQ(Nil, _35reg1255);
-if (True == _35reg1256) {
+Obj v0x7f1f23f5c6c0 = makeNative(0, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23e90420 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23e90420) {
+Obj v0x7f1f23e90660 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23e90680 = PRIM_EQ(symcar, v0x7f1f23e90660);
+if (True == v0x7f1f23e90680) {
+Obj v0x7f1f23e90840 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e90860 = PRIM_ISCONS(v0x7f1f23e90840);
+if (True == v0x7f1f23e90860) {
+Obj v0x7f1f23e90ac0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e90ae0 = PRIM_CAR(v0x7f1f23e90ac0);
+Obj x = v0x7f1f23e90ae0;
+Obj v0x7f1f23e90e20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e90e40 = PRIM_CDR(v0x7f1f23e90e20);
+Obj v0x7f1f23e90e60 = PRIM_EQ(Nil, v0x7f1f23e90e40);
+if (True == v0x7f1f23e90e60) {
 PUSH_CONT_0(co, 49, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -1538,7 +1538,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc346;
+__arg0 = v0x7f1f23f5c6c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1547,7 +1547,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc346;
+__arg0 = v0x7f1f23f5c6c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1556,7 +1556,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc346;
+__arg0 = v0x7f1f23f5c6c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1565,7 +1565,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc346;
+__arg0 = v0x7f1f23f5c6c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1576,13 +1576,13 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj _35val1257 = __arg1;
-Obj x1 = _35val1257;
-Obj _35reg1258 = makeCons(x1, Nil);
-Obj _35reg1259 = makeCons(symcar, _35reg1258);
+Obj v0x7f1f23e90f60 = __arg1;
+Obj x1 = v0x7f1f23e90f60;
+Obj v0x7f1f23e5f200 = makeCons(x1, Nil);
+Obj v0x7f1f23e5f220 = makeCons(symcar, v0x7f1f23e5f200);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = _35reg1259;
+__arg1 = v0x7f1f23e5f220;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1612,22 +1612,22 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc347 = makeNative(2, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg1234 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1234) {
-Obj _35reg1235 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1236 = PRIM_EQ(symcdr, _35reg1235);
-if (True == _35reg1236) {
-Obj _35reg1237 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1238 = PRIM_ISCONS(_35reg1237);
-if (True == _35reg1238) {
-Obj _35reg1239 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1240 = PRIM_CAR(_35reg1239);
-Obj x = _35reg1240;
-Obj _35reg1241 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1242 = PRIM_CDR(_35reg1241);
-Obj _35reg1243 = PRIM_EQ(Nil, _35reg1242);
-if (True == _35reg1243) {
+Obj v0x7f1f23f5c880 = makeNative(2, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23e960c0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23e960c0) {
+Obj v0x7f1f23e96360 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23e96380 = PRIM_EQ(symcdr, v0x7f1f23e96360);
+if (True == v0x7f1f23e96380) {
+Obj v0x7f1f23e965c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e965e0 = PRIM_ISCONS(v0x7f1f23e965c0);
+if (True == v0x7f1f23e965e0) {
+Obj v0x7f1f23e96780 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e967c0 = PRIM_CAR(v0x7f1f23e96780);
+Obj x = v0x7f1f23e967c0;
+Obj v0x7f1f23e96b00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e96b60 = PRIM_CDR(v0x7f1f23e96b00);
+Obj v0x7f1f23e96b80 = PRIM_EQ(Nil, v0x7f1f23e96b60);
+if (True == v0x7f1f23e96b80) {
 PUSH_CONT_0(co, 1, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -1639,7 +1639,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc347;
+__arg0 = v0x7f1f23f5c880;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1648,7 +1648,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc347;
+__arg0 = v0x7f1f23f5c880;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1657,7 +1657,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc347;
+__arg0 = v0x7f1f23f5c880;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1666,7 +1666,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc347;
+__arg0 = v0x7f1f23f5c880;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1677,13 +1677,13 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj _35val1244 = __arg1;
-Obj x1 = _35val1244;
-Obj _35reg1245 = makeCons(x1, Nil);
-Obj _35reg1246 = makeCons(symcdr, _35reg1245);
+Obj v0x7f1f23e96c80 = __arg1;
+Obj x1 = v0x7f1f23e96c80;
+Obj v0x7f1f23e96fe0 = makeCons(x1, Nil);
+Obj v0x7f1f23e90000 = makeCons(symcdr, v0x7f1f23e96fe0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = _35reg1246;
+__arg1 = v0x7f1f23e90000;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1693,31 +1693,31 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj _35cc348 = makeNative(5, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg1212 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1212) {
-Obj _35reg1213 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1214 = PRIM_EQ(symand, _35reg1213);
-if (True == _35reg1214) {
-Obj _35reg1215 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1216 = PRIM_ISCONS(_35reg1215);
-if (True == _35reg1216) {
-Obj _35reg1217 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1218 = PRIM_CAR(_35reg1217);
-Obj x = _35reg1218;
-Obj _35reg1219 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1220 = PRIM_CDR(_35reg1219);
-Obj _35reg1221 = PRIM_ISCONS(_35reg1220);
-if (True == _35reg1221) {
-Obj _35reg1222 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1223 = PRIM_CDR(_35reg1222);
-Obj _35reg1224 = PRIM_CAR(_35reg1223);
-Obj y = _35reg1224;
-Obj _35reg1225 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1226 = PRIM_CDR(_35reg1225);
-Obj _35reg1227 = PRIM_CDR(_35reg1226);
-Obj _35reg1228 = PRIM_EQ(Nil, _35reg1227);
-if (True == _35reg1228) {
+Obj v0x7f1f23f5ca60 = makeNative(5, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23eb1f60 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23eb1f60) {
+Obj v0x7f1f23e9b280 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23e9b2a0 = PRIM_EQ(symand, v0x7f1f23e9b280);
+if (True == v0x7f1f23e9b2a0) {
+Obj v0x7f1f23e9b4e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e9b500 = PRIM_ISCONS(v0x7f1f23e9b4e0);
+if (True == v0x7f1f23e9b500) {
+Obj v0x7f1f23e9b800 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e9b820 = PRIM_CAR(v0x7f1f23e9b800);
+Obj x = v0x7f1f23e9b820;
+Obj v0x7f1f23e9bae0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e9bb00 = PRIM_CDR(v0x7f1f23e9bae0);
+Obj v0x7f1f23e9bb20 = PRIM_ISCONS(v0x7f1f23e9bb00);
+if (True == v0x7f1f23e9bb20) {
+Obj v0x7f1f23e9bec0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e9bee0 = PRIM_CDR(v0x7f1f23e9bec0);
+Obj v0x7f1f23e9bf00 = PRIM_CAR(v0x7f1f23e9bee0);
+Obj y = v0x7f1f23e9bf00;
+Obj v0x7f1f23e9a320 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e9a420 = PRIM_CDR(v0x7f1f23e9a320);
+Obj v0x7f1f23e9a440 = PRIM_CDR(v0x7f1f23e9a420);
+Obj v0x7f1f23e9a460 = PRIM_EQ(Nil, v0x7f1f23e9a440);
+if (True == v0x7f1f23e9a460) {
 pushCont(co, 3, clofun1, 1, y);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -1729,7 +1729,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc348;
+__arg0 = v0x7f1f23f5ca60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1738,7 +1738,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc348;
+__arg0 = v0x7f1f23f5ca60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1747,7 +1747,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc348;
+__arg0 = v0x7f1f23f5ca60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1756,7 +1756,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc348;
+__arg0 = v0x7f1f23f5ca60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1765,7 +1765,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc348;
+__arg0 = v0x7f1f23f5ca60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1776,9 +1776,9 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj _35val1229 = __arg1;
+Obj v0x7f1f23e9a580 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj x1 = _35val1229;
+Obj x1 = v0x7f1f23e9a580;
 pushCont(co, 4, clofun1, 1, x1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -1792,15 +1792,15 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35val1230 = __arg1;
+Obj v0x7f1f23e9a6c0 = __arg1;
 Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj y1 = _35val1230;
-Obj _35reg1231 = makeCons(y1, Nil);
-Obj _35reg1232 = makeCons(x1, _35reg1231);
-Obj _35reg1233 = makeCons(symand, _35reg1232);
+Obj y1 = v0x7f1f23e9a6c0;
+Obj v0x7f1f23e9aba0 = makeCons(y1, Nil);
+Obj v0x7f1f23e9abc0 = makeCons(x1, v0x7f1f23e9aba0);
+Obj v0x7f1f23e9abe0 = makeCons(symand, v0x7f1f23e9abc0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = _35reg1233;
+__arg1 = v0x7f1f23e9abe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1810,22 +1810,22 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35cc349 = makeNative(7, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg1199 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1199) {
-Obj _35reg1200 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1201 = PRIM_EQ(symnull_63, _35reg1200);
-if (True == _35reg1201) {
-Obj _35reg1202 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1203 = PRIM_ISCONS(_35reg1202);
-if (True == _35reg1203) {
-Obj _35reg1204 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1205 = PRIM_CAR(_35reg1204);
-Obj x = _35reg1205;
-Obj _35reg1206 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1207 = PRIM_CDR(_35reg1206);
-Obj _35reg1208 = PRIM_EQ(Nil, _35reg1207);
-if (True == _35reg1208) {
+Obj v0x7f1f23f5c0a0 = makeNative(7, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23ecc7a0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23ecc7a0) {
+Obj v0x7f1f23eccb40 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23eccb60 = PRIM_EQ(symnull_63, v0x7f1f23eccb40);
+if (True == v0x7f1f23eccb60) {
+Obj v0x7f1f23eccd60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23eccd80 = PRIM_ISCONS(v0x7f1f23eccd60);
+if (True == v0x7f1f23eccd80) {
+Obj v0x7f1f23eb1040 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23eb1080 = PRIM_CAR(v0x7f1f23eb1040);
+Obj x = v0x7f1f23eb1080;
+Obj v0x7f1f23eb1400 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23eb1420 = PRIM_CDR(v0x7f1f23eb1400);
+Obj v0x7f1f23eb1440 = PRIM_EQ(Nil, v0x7f1f23eb1420);
+if (True == v0x7f1f23eb1440) {
 PUSH_CONT_0(co, 6, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -1837,7 +1837,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc349;
+__arg0 = v0x7f1f23f5c0a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1846,7 +1846,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc349;
+__arg0 = v0x7f1f23f5c0a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1855,7 +1855,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc349;
+__arg0 = v0x7f1f23f5c0a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1864,7 +1864,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc349;
+__arg0 = v0x7f1f23f5c0a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1875,13 +1875,13 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj _35val1209 = __arg1;
-Obj x1 = _35val1209;
-Obj _35reg1210 = makeCons(x1, Nil);
-Obj _35reg1211 = makeCons(symnull_63, _35reg1210);
+Obj v0x7f1f23eb16a0 = __arg1;
+Obj x1 = v0x7f1f23eb16a0;
+Obj v0x7f1f23eb1a00 = makeCons(x1, Nil);
+Obj v0x7f1f23eb1a20 = makeCons(symnull_63, v0x7f1f23eb1a00);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = _35reg1211;
+__arg1 = v0x7f1f23eb1a20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1891,22 +1891,22 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35cc350 = makeNative(9, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg1186 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1186) {
-Obj _35reg1187 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1188 = PRIM_EQ(symnot, _35reg1187);
-if (True == _35reg1188) {
-Obj _35reg1189 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1190 = PRIM_ISCONS(_35reg1189);
-if (True == _35reg1190) {
-Obj _35reg1191 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1192 = PRIM_CAR(_35reg1191);
-Obj x = _35reg1192;
-Obj _35reg1193 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1194 = PRIM_CDR(_35reg1193);
-Obj _35reg1195 = PRIM_EQ(Nil, _35reg1194);
-if (True == _35reg1195) {
+Obj v0x7f1f23f5c320 = makeNative(9, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23edde20 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23edde20) {
+Obj v0x7f1f23ed5220 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23ed5240 = PRIM_EQ(symnot, v0x7f1f23ed5220);
+if (True == v0x7f1f23ed5240) {
+Obj v0x7f1f23ed55a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ed55c0 = PRIM_ISCONS(v0x7f1f23ed55a0);
+if (True == v0x7f1f23ed55c0) {
+Obj v0x7f1f23ed5880 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ed58a0 = PRIM_CAR(v0x7f1f23ed5880);
+Obj x = v0x7f1f23ed58a0;
+Obj v0x7f1f23ed5c60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ed5ca0 = PRIM_CDR(v0x7f1f23ed5c60);
+Obj v0x7f1f23ed5cc0 = PRIM_EQ(Nil, v0x7f1f23ed5ca0);
+if (True == v0x7f1f23ed5cc0) {
 PUSH_CONT_0(co, 8, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -1918,7 +1918,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc350;
+__arg0 = v0x7f1f23f5c320;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1927,7 +1927,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc350;
+__arg0 = v0x7f1f23f5c320;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1936,7 +1936,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc350;
+__arg0 = v0x7f1f23f5c320;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1945,7 +1945,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc350;
+__arg0 = v0x7f1f23f5c320;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1956,13 +1956,13 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35val1196 = __arg1;
-Obj x1 = _35val1196;
-Obj _35reg1197 = makeCons(x1, Nil);
-Obj _35reg1198 = makeCons(symnot, _35reg1197);
+Obj v0x7f1f23ed5e20 = __arg1;
+Obj x1 = v0x7f1f23ed5e20;
+Obj v0x7f1f23ecc1e0 = makeCons(x1, Nil);
+Obj v0x7f1f23ecc200 = makeCons(symnot, v0x7f1f23ecc1e0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = _35reg1198;
+__arg1 = v0x7f1f23ecc200;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1972,42 +1972,42 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj _35cc351 = makeNative(13, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg1153 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1153) {
-Obj _35reg1154 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1155 = PRIM_EQ(symif, _35reg1154);
-if (True == _35reg1155) {
-Obj _35reg1156 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1157 = PRIM_ISCONS(_35reg1156);
-if (True == _35reg1157) {
-Obj _35reg1158 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1159 = PRIM_CAR(_35reg1158);
-Obj x = _35reg1159;
-Obj _35reg1160 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1161 = PRIM_CDR(_35reg1160);
-Obj _35reg1162 = PRIM_ISCONS(_35reg1161);
-if (True == _35reg1162) {
-Obj _35reg1163 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1164 = PRIM_CDR(_35reg1163);
-Obj _35reg1165 = PRIM_CAR(_35reg1164);
-Obj y = _35reg1165;
-Obj _35reg1166 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1167 = PRIM_CDR(_35reg1166);
-Obj _35reg1168 = PRIM_CDR(_35reg1167);
-Obj _35reg1169 = PRIM_ISCONS(_35reg1168);
-if (True == _35reg1169) {
-Obj _35reg1170 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1171 = PRIM_CDR(_35reg1170);
-Obj _35reg1172 = PRIM_CDR(_35reg1171);
-Obj _35reg1173 = PRIM_CAR(_35reg1172);
-Obj z = _35reg1173;
-Obj _35reg1174 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1175 = PRIM_CDR(_35reg1174);
-Obj _35reg1176 = PRIM_CDR(_35reg1175);
-Obj _35reg1177 = PRIM_CDR(_35reg1176);
-Obj _35reg1178 = PRIM_EQ(Nil, _35reg1177);
-if (True == _35reg1178) {
+Obj v0x7f1f23f5c520 = makeNative(13, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23f3c4e0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23f3c4e0) {
+Obj v0x7f1f23f3c780 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23f3c7a0 = PRIM_EQ(symif, v0x7f1f23f3c780);
+if (True == v0x7f1f23f3c7a0) {
+Obj v0x7f1f23f3ca20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f3ca40 = PRIM_ISCONS(v0x7f1f23f3ca20);
+if (True == v0x7f1f23f3ca40) {
+Obj v0x7f1f23f3cd20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f3cd40 = PRIM_CAR(v0x7f1f23f3cd20);
+Obj x = v0x7f1f23f3cd40;
+Obj v0x7f1f23efe120 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23efe180 = PRIM_CDR(v0x7f1f23efe120);
+Obj v0x7f1f23efe1a0 = PRIM_ISCONS(v0x7f1f23efe180);
+if (True == v0x7f1f23efe1a0) {
+Obj v0x7f1f23efe5e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23efe600 = PRIM_CDR(v0x7f1f23efe5e0);
+Obj v0x7f1f23efe620 = PRIM_CAR(v0x7f1f23efe600);
+Obj y = v0x7f1f23efe620;
+Obj v0x7f1f23efeaa0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23efeac0 = PRIM_CDR(v0x7f1f23efeaa0);
+Obj v0x7f1f23efeae0 = PRIM_CDR(v0x7f1f23efeac0);
+Obj v0x7f1f23efeb60 = PRIM_ISCONS(v0x7f1f23efeae0);
+if (True == v0x7f1f23efeb60) {
+Obj v0x7f1f23ef83a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ef83c0 = PRIM_CDR(v0x7f1f23ef83a0);
+Obj v0x7f1f23ef8480 = PRIM_CDR(v0x7f1f23ef83c0);
+Obj v0x7f1f23ef84a0 = PRIM_CAR(v0x7f1f23ef8480);
+Obj z = v0x7f1f23ef84a0;
+Obj v0x7f1f23ef8b40 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ef8be0 = PRIM_CDR(v0x7f1f23ef8b40);
+Obj v0x7f1f23ef8c00 = PRIM_CDR(v0x7f1f23ef8be0);
+Obj v0x7f1f23ef8c20 = PRIM_CDR(v0x7f1f23ef8c00);
+Obj v0x7f1f23ef8c40 = PRIM_EQ(Nil, v0x7f1f23ef8c20);
+if (True == v0x7f1f23ef8c40) {
 pushCont(co, 10, clofun1, 2, y, z);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -2019,7 +2019,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc351;
+__arg0 = v0x7f1f23f5c520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2028,7 +2028,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc351;
+__arg0 = v0x7f1f23f5c520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2037,7 +2037,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc351;
+__arg0 = v0x7f1f23f5c520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2046,7 +2046,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc351;
+__arg0 = v0x7f1f23f5c520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2055,7 +2055,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc351;
+__arg0 = v0x7f1f23f5c520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2064,7 +2064,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc351;
+__arg0 = v0x7f1f23f5c520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2075,10 +2075,10 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj _35val1179 = __arg1;
+Obj v0x7f1f23ef8dc0 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj z= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj x1 = _35val1179;
+Obj x1 = v0x7f1f23ef8dc0;
 pushCont(co, 11, clofun1, 2, z, x1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -2092,10 +2092,10 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj _35val1180 = __arg1;
+Obj v0x7f1f23ef8ee0 = __arg1;
 Obj z= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj y1 = _35val1180;
+Obj y1 = v0x7f1f23ef8ee0;
 pushCont(co, 12, clofun1, 2, y1, x1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -2109,17 +2109,17 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj _35val1181 = __arg1;
+Obj v0x7f1f23edd0a0 = __arg1;
 Obj y1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj x1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj z1 = _35val1181;
-Obj _35reg1182 = makeCons(z1, Nil);
-Obj _35reg1183 = makeCons(y1, _35reg1182);
-Obj _35reg1184 = makeCons(x1, _35reg1183);
-Obj _35reg1185 = makeCons(symif, _35reg1184);
+Obj z1 = v0x7f1f23edd0a0;
+Obj v0x7f1f23edd7a0 = makeCons(z1, Nil);
+Obj v0x7f1f23edd7c0 = makeCons(y1, v0x7f1f23edd7a0);
+Obj v0x7f1f23edd7e0 = makeCons(x1, v0x7f1f23edd7c0);
+Obj v0x7f1f23edd820 = makeCons(symif, v0x7f1f23edd7e0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean0);
-__arg1 = _35reg1185;
+__arg1 = v0x7f1f23edd820;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2129,31 +2129,31 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35cc352 = makeNative(15, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg1132 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1132) {
-Obj _35reg1133 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1134 = PRIM_EQ(symlambda, _35reg1133);
-if (True == _35reg1134) {
-Obj _35reg1135 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1136 = PRIM_ISCONS(_35reg1135);
-if (True == _35reg1136) {
-Obj _35reg1137 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1138 = PRIM_CAR(_35reg1137);
-Obj args = _35reg1138;
-Obj _35reg1139 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1140 = PRIM_CDR(_35reg1139);
-Obj _35reg1141 = PRIM_ISCONS(_35reg1140);
-if (True == _35reg1141) {
-Obj _35reg1142 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1143 = PRIM_CDR(_35reg1142);
-Obj _35reg1144 = PRIM_CAR(_35reg1143);
-Obj body = _35reg1144;
-Obj _35reg1145 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1146 = PRIM_CDR(_35reg1145);
-Obj _35reg1147 = PRIM_CDR(_35reg1146);
-Obj _35reg1148 = PRIM_EQ(Nil, _35reg1147);
-if (True == _35reg1148) {
+Obj v0x7f1f23f5c820 = makeNative(15, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23f49400 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23f49400) {
+Obj v0x7f1f23f495c0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23f495e0 = PRIM_EQ(symlambda, v0x7f1f23f495c0);
+if (True == v0x7f1f23f495e0) {
+Obj v0x7f1f23f49a00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f49a60 = PRIM_ISCONS(v0x7f1f23f49a00);
+if (True == v0x7f1f23f49a60) {
+Obj v0x7f1f23f49ce0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f49d00 = PRIM_CAR(v0x7f1f23f49ce0);
+Obj args = v0x7f1f23f49d00;
+Obj v0x7f1f23f49fe0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f43040 = PRIM_CDR(v0x7f1f23f49fe0);
+Obj v0x7f1f23f43060 = PRIM_ISCONS(v0x7f1f23f43040);
+if (True == v0x7f1f23f43060) {
+Obj v0x7f1f23f43380 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f433c0 = PRIM_CDR(v0x7f1f23f43380);
+Obj v0x7f1f23f43460 = PRIM_CAR(v0x7f1f23f433c0);
+Obj body = v0x7f1f23f43460;
+Obj v0x7f1f23f438c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f438e0 = PRIM_CDR(v0x7f1f23f438c0);
+Obj v0x7f1f23f43900 = PRIM_CDR(v0x7f1f23f438e0);
+Obj v0x7f1f23f43920 = PRIM_EQ(Nil, v0x7f1f23f43900);
+if (True == v0x7f1f23f43920) {
 pushCont(co, 14, clofun1, 1, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35propagate_45boolean);
@@ -2165,7 +2165,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc352;
+__arg0 = v0x7f1f23f5c820;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2174,7 +2174,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc352;
+__arg0 = v0x7f1f23f5c820;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2183,7 +2183,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc352;
+__arg0 = v0x7f1f23f5c820;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2192,7 +2192,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc352;
+__arg0 = v0x7f1f23f5c820;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2201,7 +2201,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc352;
+__arg0 = v0x7f1f23f5c820;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2212,13 +2212,13 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj _35val1149 = __arg1;
+Obj v0x7f1f23f43ea0 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg1150 = makeCons(_35val1149, Nil);
-Obj _35reg1151 = makeCons(args, _35reg1150);
-Obj _35reg1152 = makeCons(symlambda, _35reg1151);
+Obj v0x7f1f23f43ee0 = makeCons(v0x7f1f23f43ea0, Nil);
+Obj v0x7f1f23f43f00 = makeCons(args, v0x7f1f23f43ee0);
+Obj v0x7f1f23f43f20 = makeCons(symlambda, v0x7f1f23f43f00);
 __nargs = 2;
-__arg1 = _35reg1152;
+__arg1 = v0x7f1f23f43f20;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -2226,18 +2226,18 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj _35cc353 = makeNative(16, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg1128 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1128) {
-Obj _35reg1129 = PRIM_CAR(closureRef(co, 0));
-Obj f = _35reg1129;
-Obj _35reg1130 = PRIM_CDR(closureRef(co, 0));
-Obj args = _35reg1130;
-Obj _35reg1131 = makeCons(f, args);
+Obj v0x7f1f23f5cce0 = makeNative(16, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23f58b40 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23f58b40) {
+Obj v0x7f1f23f58cc0 = PRIM_CAR(closureRef(co, 0));
+Obj f = v0x7f1f23f58cc0;
+Obj v0x7f1f23f58e60 = PRIM_CDR(closureRef(co, 0));
+Obj args = v0x7f1f23f58e60;
+Obj v0x7f1f23f49120 = makeCons(f, args);
 __nargs = 3;
 __arg0 = globalRef(symmap);
 __arg1 = globalRef(symcora_47init_35propagate_45boolean);
-__arg2 = _35reg1131;
+__arg2 = v0x7f1f23f49120;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2245,7 +2245,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc353;
+__arg0 = v0x7f1f23f5cce0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2256,7 +2256,7 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35cc354 = makeNative(17, clofun1, 0, 0);
+Obj v0x7f1f23f5ce40 = makeNative(17, clofun1, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = x;
@@ -2279,58 +2279,58 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35p331 = __arg1;
-Obj _35cc332 = makeNative(19, clofun1, 0, 1, _35p331);
-Obj _35reg1088 = PRIM_ISCONS(_35p331);
-if (True == _35reg1088) {
-Obj _35reg1089 = PRIM_CAR(_35p331);
-Obj _35reg1090 = PRIM_EQ(symcar, _35reg1089);
-if (True == _35reg1090) {
-Obj _35reg1091 = PRIM_CDR(_35p331);
-Obj _35reg1092 = PRIM_ISCONS(_35reg1091);
-if (True == _35reg1092) {
-Obj _35reg1093 = PRIM_CDR(_35p331);
-Obj _35reg1094 = PRIM_CAR(_35reg1093);
-Obj _35reg1095 = PRIM_ISCONS(_35reg1094);
-if (True == _35reg1095) {
-Obj _35reg1096 = PRIM_CDR(_35p331);
-Obj _35reg1097 = PRIM_CAR(_35reg1096);
-Obj _35reg1098 = PRIM_CAR(_35reg1097);
-Obj _35reg1099 = PRIM_EQ(symcons, _35reg1098);
-if (True == _35reg1099) {
-Obj _35reg1100 = PRIM_CDR(_35p331);
-Obj _35reg1101 = PRIM_CAR(_35reg1100);
-Obj _35reg1102 = PRIM_CDR(_35reg1101);
-Obj _35reg1103 = PRIM_ISCONS(_35reg1102);
-if (True == _35reg1103) {
-Obj _35reg1104 = PRIM_CDR(_35p331);
-Obj _35reg1105 = PRIM_CAR(_35reg1104);
-Obj _35reg1106 = PRIM_CDR(_35reg1105);
-Obj _35reg1107 = PRIM_CAR(_35reg1106);
-Obj x = _35reg1107;
-Obj _35reg1108 = PRIM_CDR(_35p331);
-Obj _35reg1109 = PRIM_CAR(_35reg1108);
-Obj _35reg1110 = PRIM_CDR(_35reg1109);
-Obj _35reg1111 = PRIM_CDR(_35reg1110);
-Obj _35reg1112 = PRIM_ISCONS(_35reg1111);
-if (True == _35reg1112) {
-Obj _35reg1113 = PRIM_CDR(_35p331);
-Obj _35reg1114 = PRIM_CAR(_35reg1113);
-Obj _35reg1115 = PRIM_CDR(_35reg1114);
-Obj _35reg1116 = PRIM_CDR(_35reg1115);
-Obj _35reg1117 = PRIM_CAR(_35reg1116);
-Obj __ = _35reg1117;
-Obj _35reg1118 = PRIM_CDR(_35p331);
-Obj _35reg1119 = PRIM_CAR(_35reg1118);
-Obj _35reg1120 = PRIM_CDR(_35reg1119);
-Obj _35reg1121 = PRIM_CDR(_35reg1120);
-Obj _35reg1122 = PRIM_CDR(_35reg1121);
-Obj _35reg1123 = PRIM_EQ(Nil, _35reg1122);
-if (True == _35reg1123) {
-Obj _35reg1124 = PRIM_CDR(_35p331);
-Obj _35reg1125 = PRIM_CDR(_35reg1124);
-Obj _35reg1126 = PRIM_EQ(Nil, _35reg1125);
-if (True == _35reg1126) {
+Obj v0x7f1f23f5c220 = __arg1;
+Obj v0x7f1f23f5c2a0 = makeNative(19, clofun1, 0, 1, v0x7f1f23f5c220);
+Obj v0x7f1f24013340 = PRIM_ISCONS(v0x7f1f23f5c220);
+if (True == v0x7f1f24013340) {
+Obj v0x7f1f24013500 = PRIM_CAR(v0x7f1f23f5c220);
+Obj v0x7f1f24013520 = PRIM_EQ(symcar, v0x7f1f24013500);
+if (True == v0x7f1f24013520) {
+Obj v0x7f1f240136c0 = PRIM_CDR(v0x7f1f23f5c220);
+Obj v0x7f1f240136e0 = PRIM_ISCONS(v0x7f1f240136c0);
+if (True == v0x7f1f240136e0) {
+Obj v0x7f1f24013920 = PRIM_CDR(v0x7f1f23f5c220);
+Obj v0x7f1f24013940 = PRIM_CAR(v0x7f1f24013920);
+Obj v0x7f1f24013960 = PRIM_ISCONS(v0x7f1f24013940);
+if (True == v0x7f1f24013960) {
+Obj v0x7f1f24013c60 = PRIM_CDR(v0x7f1f23f5c220);
+Obj v0x7f1f24013c80 = PRIM_CAR(v0x7f1f24013c60);
+Obj v0x7f1f24013ca0 = PRIM_CAR(v0x7f1f24013c80);
+Obj v0x7f1f24013cc0 = PRIM_EQ(symcons, v0x7f1f24013ca0);
+if (True == v0x7f1f24013cc0) {
+Obj v0x7f1f24013fa0 = PRIM_CDR(v0x7f1f23f5c220);
+Obj v0x7f1f24013fc0 = PRIM_CAR(v0x7f1f24013fa0);
+Obj v0x7f1f24013fe0 = PRIM_CDR(v0x7f1f24013fc0);
+Obj v0x7f1f24017000 = PRIM_ISCONS(v0x7f1f24013fe0);
+if (True == v0x7f1f24017000) {
+Obj v0x7f1f240172e0 = PRIM_CDR(v0x7f1f23f5c220);
+Obj v0x7f1f24017300 = PRIM_CAR(v0x7f1f240172e0);
+Obj v0x7f1f24017320 = PRIM_CDR(v0x7f1f24017300);
+Obj v0x7f1f24017340 = PRIM_CAR(v0x7f1f24017320);
+Obj x = v0x7f1f24017340;
+Obj v0x7f1f240176c0 = PRIM_CDR(v0x7f1f23f5c220);
+Obj v0x7f1f240176e0 = PRIM_CAR(v0x7f1f240176c0);
+Obj v0x7f1f24017700 = PRIM_CDR(v0x7f1f240176e0);
+Obj v0x7f1f24017720 = PRIM_CDR(v0x7f1f24017700);
+Obj v0x7f1f24017740 = PRIM_ISCONS(v0x7f1f24017720);
+if (True == v0x7f1f24017740) {
+Obj v0x7f1f24017ac0 = PRIM_CDR(v0x7f1f23f5c220);
+Obj v0x7f1f24017ae0 = PRIM_CAR(v0x7f1f24017ac0);
+Obj v0x7f1f24017b00 = PRIM_CDR(v0x7f1f24017ae0);
+Obj v0x7f1f24017b20 = PRIM_CDR(v0x7f1f24017b00);
+Obj v0x7f1f24017b40 = PRIM_CAR(v0x7f1f24017b20);
+Obj __ = v0x7f1f24017b40;
+Obj v0x7f1f24017f80 = PRIM_CDR(v0x7f1f23f5c220);
+Obj v0x7f1f24017fa0 = PRIM_CAR(v0x7f1f24017f80);
+Obj v0x7f1f24017fc0 = PRIM_CDR(v0x7f1f24017fa0);
+Obj v0x7f1f24017fe0 = PRIM_CDR(v0x7f1f24017fc0);
+Obj v0x7f1f24013000 = PRIM_CDR(v0x7f1f24017fe0);
+Obj v0x7f1f24013020 = PRIM_EQ(Nil, v0x7f1f24013000);
+if (True == v0x7f1f24013020) {
+Obj v0x7f1f24013280 = PRIM_CDR(v0x7f1f23f5c220);
+Obj v0x7f1f240132a0 = PRIM_CDR(v0x7f1f24013280);
+Obj v0x7f1f240132c0 = PRIM_EQ(Nil, v0x7f1f240132a0);
+if (True == v0x7f1f240132c0) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2338,7 +2338,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc332;
+__arg0 = v0x7f1f23f5c2a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2347,7 +2347,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc332;
+__arg0 = v0x7f1f23f5c2a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2356,7 +2356,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc332;
+__arg0 = v0x7f1f23f5c2a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2365,7 +2365,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc332;
+__arg0 = v0x7f1f23f5c2a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2374,7 +2374,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc332;
+__arg0 = v0x7f1f23f5c2a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2383,7 +2383,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc332;
+__arg0 = v0x7f1f23f5c2a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2392,7 +2392,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc332;
+__arg0 = v0x7f1f23f5c2a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2401,7 +2401,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc332;
+__arg0 = v0x7f1f23f5c2a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2410,7 +2410,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc332;
+__arg0 = v0x7f1f23f5c2a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2421,57 +2421,57 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj _35cc333 = makeNative(20, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg1049 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1049) {
-Obj _35reg1050 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1051 = PRIM_EQ(symcdr, _35reg1050);
-if (True == _35reg1051) {
-Obj _35reg1052 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1053 = PRIM_ISCONS(_35reg1052);
-if (True == _35reg1053) {
-Obj _35reg1054 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1055 = PRIM_CAR(_35reg1054);
-Obj _35reg1056 = PRIM_ISCONS(_35reg1055);
-if (True == _35reg1056) {
-Obj _35reg1057 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1058 = PRIM_CAR(_35reg1057);
-Obj _35reg1059 = PRIM_CAR(_35reg1058);
-Obj _35reg1060 = PRIM_EQ(symcons, _35reg1059);
-if (True == _35reg1060) {
-Obj _35reg1061 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1062 = PRIM_CAR(_35reg1061);
-Obj _35reg1063 = PRIM_CDR(_35reg1062);
-Obj _35reg1064 = PRIM_ISCONS(_35reg1063);
-if (True == _35reg1064) {
-Obj _35reg1065 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1066 = PRIM_CAR(_35reg1065);
-Obj _35reg1067 = PRIM_CDR(_35reg1066);
-Obj _35reg1068 = PRIM_CAR(_35reg1067);
-Obj __ = _35reg1068;
-Obj _35reg1069 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1070 = PRIM_CAR(_35reg1069);
-Obj _35reg1071 = PRIM_CDR(_35reg1070);
-Obj _35reg1072 = PRIM_CDR(_35reg1071);
-Obj _35reg1073 = PRIM_ISCONS(_35reg1072);
-if (True == _35reg1073) {
-Obj _35reg1074 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1075 = PRIM_CAR(_35reg1074);
-Obj _35reg1076 = PRIM_CDR(_35reg1075);
-Obj _35reg1077 = PRIM_CDR(_35reg1076);
-Obj _35reg1078 = PRIM_CAR(_35reg1077);
-Obj x = _35reg1078;
-Obj _35reg1079 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1080 = PRIM_CAR(_35reg1079);
-Obj _35reg1081 = PRIM_CDR(_35reg1080);
-Obj _35reg1082 = PRIM_CDR(_35reg1081);
-Obj _35reg1083 = PRIM_CDR(_35reg1082);
-Obj _35reg1084 = PRIM_EQ(Nil, _35reg1083);
-if (True == _35reg1084) {
-Obj _35reg1085 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1086 = PRIM_CDR(_35reg1085);
-Obj _35reg1087 = PRIM_EQ(Nil, _35reg1086);
-if (True == _35reg1087) {
+Obj v0x7f1f23f5c600 = makeNative(20, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23e90820 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23e90820) {
+Obj v0x7f1f23e90a60 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23e90a80 = PRIM_EQ(symcdr, v0x7f1f23e90a60);
+if (True == v0x7f1f23e90a80) {
+Obj v0x7f1f23e90c20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e90c40 = PRIM_ISCONS(v0x7f1f23e90c20);
+if (True == v0x7f1f23e90c40) {
+Obj v0x7f1f23e5f120 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e5f140 = PRIM_CAR(v0x7f1f23e5f120);
+Obj v0x7f1f23e5f160 = PRIM_ISCONS(v0x7f1f23e5f140);
+if (True == v0x7f1f23e5f160) {
+Obj v0x7f1f23e5f460 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e5f480 = PRIM_CAR(v0x7f1f23e5f460);
+Obj v0x7f1f23e5f4a0 = PRIM_CAR(v0x7f1f23e5f480);
+Obj v0x7f1f23e5f4c0 = PRIM_EQ(symcons, v0x7f1f23e5f4a0);
+if (True == v0x7f1f23e5f4c0) {
+Obj v0x7f1f23e5f7a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e5f7c0 = PRIM_CAR(v0x7f1f23e5f7a0);
+Obj v0x7f1f23e5f7e0 = PRIM_CDR(v0x7f1f23e5f7c0);
+Obj v0x7f1f23e5f800 = PRIM_ISCONS(v0x7f1f23e5f7e0);
+if (True == v0x7f1f23e5f800) {
+Obj v0x7f1f23e5fae0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e5fb00 = PRIM_CAR(v0x7f1f23e5fae0);
+Obj v0x7f1f23e5fb20 = PRIM_CDR(v0x7f1f23e5fb00);
+Obj v0x7f1f23e5fb40 = PRIM_CAR(v0x7f1f23e5fb20);
+Obj __ = v0x7f1f23e5fb40;
+Obj v0x7f1f23e5fec0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e5fee0 = PRIM_CAR(v0x7f1f23e5fec0);
+Obj v0x7f1f23e5ff00 = PRIM_CDR(v0x7f1f23e5fee0);
+Obj v0x7f1f23e5ff20 = PRIM_CDR(v0x7f1f23e5ff00);
+Obj v0x7f1f23e5ff40 = PRIM_ISCONS(v0x7f1f23e5ff20);
+if (True == v0x7f1f23e5ff40) {
+Obj v0x7f1f23e3f600 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e3f620 = PRIM_CAR(v0x7f1f23e3f600);
+Obj v0x7f1f23e3f640 = PRIM_CDR(v0x7f1f23e3f620);
+Obj v0x7f1f23e3f660 = PRIM_CDR(v0x7f1f23e3f640);
+Obj v0x7f1f23e3f680 = PRIM_CAR(v0x7f1f23e3f660);
+Obj x = v0x7f1f23e3f680;
+Obj v0x7f1f23e3fac0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e3fae0 = PRIM_CAR(v0x7f1f23e3fac0);
+Obj v0x7f1f23e3fb00 = PRIM_CDR(v0x7f1f23e3fae0);
+Obj v0x7f1f23e3fb20 = PRIM_CDR(v0x7f1f23e3fb00);
+Obj v0x7f1f23e3fb40 = PRIM_CDR(v0x7f1f23e3fb20);
+Obj v0x7f1f23e3fb60 = PRIM_EQ(Nil, v0x7f1f23e3fb40);
+if (True == v0x7f1f23e3fb60) {
+Obj v0x7f1f23e3fdc0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e3fde0 = PRIM_CDR(v0x7f1f23e3fdc0);
+Obj v0x7f1f23e3fe00 = PRIM_EQ(Nil, v0x7f1f23e3fde0);
+if (True == v0x7f1f23e3fe00) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2479,7 +2479,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc333;
+__arg0 = v0x7f1f23f5c600;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2488,7 +2488,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc333;
+__arg0 = v0x7f1f23f5c600;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2497,7 +2497,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc333;
+__arg0 = v0x7f1f23f5c600;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2506,7 +2506,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc333;
+__arg0 = v0x7f1f23f5c600;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2515,7 +2515,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc333;
+__arg0 = v0x7f1f23f5c600;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2524,7 +2524,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc333;
+__arg0 = v0x7f1f23f5c600;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2533,7 +2533,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc333;
+__arg0 = v0x7f1f23f5c600;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2542,7 +2542,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc333;
+__arg0 = v0x7f1f23f5c600;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2551,7 +2551,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc333;
+__arg0 = v0x7f1f23f5c600;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2562,57 +2562,57 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj _35cc334 = makeNative(21, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg1010 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg1010) {
-Obj _35reg1011 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg1012 = PRIM_EQ(symcons_63, _35reg1011);
-if (True == _35reg1012) {
-Obj _35reg1013 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1014 = PRIM_ISCONS(_35reg1013);
-if (True == _35reg1014) {
-Obj _35reg1015 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1016 = PRIM_CAR(_35reg1015);
-Obj _35reg1017 = PRIM_ISCONS(_35reg1016);
-if (True == _35reg1017) {
-Obj _35reg1018 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1019 = PRIM_CAR(_35reg1018);
-Obj _35reg1020 = PRIM_CAR(_35reg1019);
-Obj _35reg1021 = PRIM_EQ(symcons, _35reg1020);
-if (True == _35reg1021) {
-Obj _35reg1022 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1023 = PRIM_CAR(_35reg1022);
-Obj _35reg1024 = PRIM_CDR(_35reg1023);
-Obj _35reg1025 = PRIM_ISCONS(_35reg1024);
-if (True == _35reg1025) {
-Obj _35reg1026 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1027 = PRIM_CAR(_35reg1026);
-Obj _35reg1028 = PRIM_CDR(_35reg1027);
-Obj _35reg1029 = PRIM_CAR(_35reg1028);
-Obj __ = _35reg1029;
-Obj _35reg1030 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1031 = PRIM_CAR(_35reg1030);
-Obj _35reg1032 = PRIM_CDR(_35reg1031);
-Obj _35reg1033 = PRIM_CDR(_35reg1032);
-Obj _35reg1034 = PRIM_ISCONS(_35reg1033);
-if (True == _35reg1034) {
-Obj _35reg1035 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1036 = PRIM_CAR(_35reg1035);
-Obj _35reg1037 = PRIM_CDR(_35reg1036);
-Obj _35reg1038 = PRIM_CDR(_35reg1037);
-Obj _35reg1039 = PRIM_CAR(_35reg1038);
-__ = _35reg1039;
-Obj _35reg1040 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1041 = PRIM_CAR(_35reg1040);
-Obj _35reg1042 = PRIM_CDR(_35reg1041);
-Obj _35reg1043 = PRIM_CDR(_35reg1042);
-Obj _35reg1044 = PRIM_CDR(_35reg1043);
-Obj _35reg1045 = PRIM_EQ(Nil, _35reg1044);
-if (True == _35reg1045) {
-Obj _35reg1046 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1047 = PRIM_CDR(_35reg1046);
-Obj _35reg1048 = PRIM_EQ(Nil, _35reg1047);
-if (True == _35reg1048) {
+Obj v0x7f1f23f5c920 = makeNative(21, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23e9bba0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23e9bba0) {
+Obj v0x7f1f23e9be40 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23e9be60 = PRIM_EQ(symcons_63, v0x7f1f23e9be40);
+if (True == v0x7f1f23e9be60) {
+Obj v0x7f1f23e9a040 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e9a060 = PRIM_ISCONS(v0x7f1f23e9a040);
+if (True == v0x7f1f23e9a060) {
+Obj v0x7f1f23e9a340 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e9a360 = PRIM_CAR(v0x7f1f23e9a340);
+Obj v0x7f1f23e9a380 = PRIM_ISCONS(v0x7f1f23e9a360);
+if (True == v0x7f1f23e9a380) {
+Obj v0x7f1f23e9a760 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e9a780 = PRIM_CAR(v0x7f1f23e9a760);
+Obj v0x7f1f23e9a7a0 = PRIM_CAR(v0x7f1f23e9a780);
+Obj v0x7f1f23e9a7e0 = PRIM_EQ(symcons, v0x7f1f23e9a7a0);
+if (True == v0x7f1f23e9a7e0) {
+Obj v0x7f1f23e9ac00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e9ac20 = PRIM_CAR(v0x7f1f23e9ac00);
+Obj v0x7f1f23e9aca0 = PRIM_CDR(v0x7f1f23e9ac20);
+Obj v0x7f1f23e9acc0 = PRIM_ISCONS(v0x7f1f23e9aca0);
+if (True == v0x7f1f23e9acc0) {
+Obj v0x7f1f23e9afa0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e9afc0 = PRIM_CAR(v0x7f1f23e9afa0);
+Obj v0x7f1f23e9afe0 = PRIM_CDR(v0x7f1f23e9afc0);
+Obj v0x7f1f23e96000 = PRIM_CAR(v0x7f1f23e9afe0);
+Obj __ = v0x7f1f23e96000;
+Obj v0x7f1f23e96460 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e96480 = PRIM_CAR(v0x7f1f23e96460);
+Obj v0x7f1f23e964a0 = PRIM_CDR(v0x7f1f23e96480);
+Obj v0x7f1f23e964c0 = PRIM_CDR(v0x7f1f23e964a0);
+Obj v0x7f1f23e964e0 = PRIM_ISCONS(v0x7f1f23e964c0);
+if (True == v0x7f1f23e964e0) {
+Obj v0x7f1f23e96880 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e968a0 = PRIM_CAR(v0x7f1f23e96880);
+Obj v0x7f1f23e968c0 = PRIM_CDR(v0x7f1f23e968a0);
+Obj v0x7f1f23e968e0 = PRIM_CDR(v0x7f1f23e968c0);
+Obj v0x7f1f23e96900 = PRIM_CAR(v0x7f1f23e968e0);
+__ = v0x7f1f23e96900;
+Obj v0x7f1f23e96e20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e96e40 = PRIM_CAR(v0x7f1f23e96e20);
+Obj v0x7f1f23e96e60 = PRIM_CDR(v0x7f1f23e96e40);
+Obj v0x7f1f23e96e80 = PRIM_CDR(v0x7f1f23e96e60);
+Obj v0x7f1f23e96ea0 = PRIM_CDR(v0x7f1f23e96e80);
+Obj v0x7f1f23e96ec0 = PRIM_EQ(Nil, v0x7f1f23e96ea0);
+if (True == v0x7f1f23e96ec0) {
+Obj v0x7f1f23e90180 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e901a0 = PRIM_CDR(v0x7f1f23e90180);
+Obj v0x7f1f23e901c0 = PRIM_EQ(Nil, v0x7f1f23e901a0);
+if (True == v0x7f1f23e901c0) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2620,7 +2620,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc334;
+__arg0 = v0x7f1f23f5c920;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2629,7 +2629,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc334;
+__arg0 = v0x7f1f23f5c920;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2638,7 +2638,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc334;
+__arg0 = v0x7f1f23f5c920;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2647,7 +2647,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc334;
+__arg0 = v0x7f1f23f5c920;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2656,7 +2656,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc334;
+__arg0 = v0x7f1f23f5c920;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2665,7 +2665,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc334;
+__arg0 = v0x7f1f23f5c920;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2674,7 +2674,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc334;
+__arg0 = v0x7f1f23f5c920;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2683,7 +2683,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc334;
+__arg0 = v0x7f1f23f5c920;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2692,7 +2692,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc334;
+__arg0 = v0x7f1f23f5c920;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2703,33 +2703,33 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj _35cc335 = makeNative(22, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg991 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg991) {
-Obj _35reg992 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg993 = PRIM_EQ(symand, _35reg992);
-if (True == _35reg993) {
-Obj _35reg994 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg995 = PRIM_ISCONS(_35reg994);
-if (True == _35reg995) {
-Obj _35reg996 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg997 = PRIM_CAR(_35reg996);
-Obj _35reg998 = PRIM_EQ(True, _35reg997);
-if (True == _35reg998) {
-Obj _35reg999 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1000 = PRIM_CDR(_35reg999);
-Obj _35reg1001 = PRIM_ISCONS(_35reg1000);
-if (True == _35reg1001) {
-Obj _35reg1002 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1003 = PRIM_CDR(_35reg1002);
-Obj _35reg1004 = PRIM_CAR(_35reg1003);
-Obj _35reg1005 = PRIM_EQ(True, _35reg1004);
-if (True == _35reg1005) {
-Obj _35reg1006 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg1007 = PRIM_CDR(_35reg1006);
-Obj _35reg1008 = PRIM_CDR(_35reg1007);
-Obj _35reg1009 = PRIM_EQ(Nil, _35reg1008);
-if (True == _35reg1009) {
+Obj v0x7f1f23f5cc40 = makeNative(22, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23eccfa0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23eccfa0) {
+Obj v0x7f1f23eb1220 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23eb1240 = PRIM_EQ(symand, v0x7f1f23eb1220);
+if (True == v0x7f1f23eb1240) {
+Obj v0x7f1f23eb1460 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23eb1480 = PRIM_ISCONS(v0x7f1f23eb1460);
+if (True == v0x7f1f23eb1480) {
+Obj v0x7f1f23eb18a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23eb18c0 = PRIM_CAR(v0x7f1f23eb18a0);
+Obj v0x7f1f23eb18e0 = PRIM_EQ(True, v0x7f1f23eb18c0);
+if (True == v0x7f1f23eb18e0) {
+Obj v0x7f1f23eb1b80 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23eb1ba0 = PRIM_CDR(v0x7f1f23eb1b80);
+Obj v0x7f1f23eb1bc0 = PRIM_ISCONS(v0x7f1f23eb1ba0);
+if (True == v0x7f1f23eb1bc0) {
+Obj v0x7f1f23e9b0a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e9b0c0 = PRIM_CDR(v0x7f1f23e9b0a0);
+Obj v0x7f1f23e9b100 = PRIM_CAR(v0x7f1f23e9b0c0);
+Obj v0x7f1f23e9b160 = PRIM_EQ(True, v0x7f1f23e9b100);
+if (True == v0x7f1f23e9b160) {
+Obj v0x7f1f23e9b5c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e9b5e0 = PRIM_CDR(v0x7f1f23e9b5c0);
+Obj v0x7f1f23e9b600 = PRIM_CDR(v0x7f1f23e9b5e0);
+Obj v0x7f1f23e9b620 = PRIM_EQ(Nil, v0x7f1f23e9b600);
+if (True == v0x7f1f23e9b620) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2737,7 +2737,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc335;
+__arg0 = v0x7f1f23f5cc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2746,7 +2746,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc335;
+__arg0 = v0x7f1f23f5cc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2755,7 +2755,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc335;
+__arg0 = v0x7f1f23f5cc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2764,7 +2764,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc335;
+__arg0 = v0x7f1f23f5cc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2773,7 +2773,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc335;
+__arg0 = v0x7f1f23f5cc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2782,7 +2782,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc335;
+__arg0 = v0x7f1f23f5cc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2791,7 +2791,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc335;
+__arg0 = v0x7f1f23f5cc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2802,23 +2802,23 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj _35cc336 = makeNative(23, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg980 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg980) {
-Obj _35reg981 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg982 = PRIM_EQ(symnull_63, _35reg981);
-if (True == _35reg982) {
-Obj _35reg983 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg984 = PRIM_ISCONS(_35reg983);
-if (True == _35reg984) {
-Obj _35reg985 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg986 = PRIM_CAR(_35reg985);
-Obj _35reg987 = PRIM_EQ(Nil, _35reg986);
-if (True == _35reg987) {
-Obj _35reg988 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg989 = PRIM_CDR(_35reg988);
-Obj _35reg990 = PRIM_EQ(Nil, _35reg989);
-if (True == _35reg990) {
+Obj v0x7f1f23f5ce80 = makeNative(23, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23ed5d20 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23ed5d20) {
+Obj v0x7f1f23ed5fe0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23ecc000 = PRIM_EQ(symnull_63, v0x7f1f23ed5fe0);
+if (True == v0x7f1f23ecc000) {
+Obj v0x7f1f23ecc220 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ecc280 = PRIM_ISCONS(v0x7f1f23ecc220);
+if (True == v0x7f1f23ecc280) {
+Obj v0x7f1f23ecc640 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ecc660 = PRIM_CAR(v0x7f1f23ecc640);
+Obj v0x7f1f23ecc680 = PRIM_EQ(Nil, v0x7f1f23ecc660);
+if (True == v0x7f1f23ecc680) {
+Obj v0x7f1f23ecca60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ecca80 = PRIM_CDR(v0x7f1f23ecca60);
+Obj v0x7f1f23eccae0 = PRIM_EQ(Nil, v0x7f1f23ecca80);
+if (True == v0x7f1f23eccae0) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2826,7 +2826,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc336;
+__arg0 = v0x7f1f23f5ce80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2835,7 +2835,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc336;
+__arg0 = v0x7f1f23f5ce80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2844,7 +2844,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc336;
+__arg0 = v0x7f1f23f5ce80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2853,7 +2853,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc336;
+__arg0 = v0x7f1f23f5ce80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2862,7 +2862,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc336;
+__arg0 = v0x7f1f23f5ce80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2873,57 +2873,57 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj _35cc337 = makeNative(24, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg941 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg941) {
-Obj _35reg942 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg943 = PRIM_EQ(symnull_63, _35reg942);
-if (True == _35reg943) {
-Obj _35reg944 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg945 = PRIM_ISCONS(_35reg944);
-if (True == _35reg945) {
-Obj _35reg946 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg947 = PRIM_CAR(_35reg946);
-Obj _35reg948 = PRIM_ISCONS(_35reg947);
-if (True == _35reg948) {
-Obj _35reg949 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg950 = PRIM_CAR(_35reg949);
-Obj _35reg951 = PRIM_CAR(_35reg950);
-Obj _35reg952 = PRIM_EQ(symcons, _35reg951);
-if (True == _35reg952) {
-Obj _35reg953 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg954 = PRIM_CAR(_35reg953);
-Obj _35reg955 = PRIM_CDR(_35reg954);
-Obj _35reg956 = PRIM_ISCONS(_35reg955);
-if (True == _35reg956) {
-Obj _35reg957 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg958 = PRIM_CAR(_35reg957);
-Obj _35reg959 = PRIM_CDR(_35reg958);
-Obj _35reg960 = PRIM_CAR(_35reg959);
-Obj __ = _35reg960;
-Obj _35reg961 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg962 = PRIM_CAR(_35reg961);
-Obj _35reg963 = PRIM_CDR(_35reg962);
-Obj _35reg964 = PRIM_CDR(_35reg963);
-Obj _35reg965 = PRIM_ISCONS(_35reg964);
-if (True == _35reg965) {
-Obj _35reg966 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg967 = PRIM_CAR(_35reg966);
-Obj _35reg968 = PRIM_CDR(_35reg967);
-Obj _35reg969 = PRIM_CDR(_35reg968);
-Obj _35reg970 = PRIM_CAR(_35reg969);
-__ = _35reg970;
-Obj _35reg971 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg972 = PRIM_CAR(_35reg971);
-Obj _35reg973 = PRIM_CDR(_35reg972);
-Obj _35reg974 = PRIM_CDR(_35reg973);
-Obj _35reg975 = PRIM_CDR(_35reg974);
-Obj _35reg976 = PRIM_EQ(Nil, _35reg975);
-if (True == _35reg976) {
-Obj _35reg977 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg978 = PRIM_CDR(_35reg977);
-Obj _35reg979 = PRIM_EQ(Nil, _35reg978);
-if (True == _35reg979) {
+Obj v0x7f1f23f58040 = makeNative(24, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23efe2c0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23efe2c0) {
+Obj v0x7f1f23efe540 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23efe560 = PRIM_EQ(symnull_63, v0x7f1f23efe540);
+if (True == v0x7f1f23efe560) {
+Obj v0x7f1f23efe7a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23efe7c0 = PRIM_ISCONS(v0x7f1f23efe7a0);
+if (True == v0x7f1f23efe7c0) {
+Obj v0x7f1f23efeb00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23efeb20 = PRIM_CAR(v0x7f1f23efeb00);
+Obj v0x7f1f23efeb40 = PRIM_ISCONS(v0x7f1f23efeb20);
+if (True == v0x7f1f23efeb40) {
+Obj v0x7f1f23ef8320 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ef8340 = PRIM_CAR(v0x7f1f23ef8320);
+Obj v0x7f1f23ef8360 = PRIM_CAR(v0x7f1f23ef8340);
+Obj v0x7f1f23ef8380 = PRIM_EQ(symcons, v0x7f1f23ef8360);
+if (True == v0x7f1f23ef8380) {
+Obj v0x7f1f23ef88a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ef88c0 = PRIM_CAR(v0x7f1f23ef88a0);
+Obj v0x7f1f23ef8960 = PRIM_CDR(v0x7f1f23ef88c0);
+Obj v0x7f1f23ef89a0 = PRIM_ISCONS(v0x7f1f23ef8960);
+if (True == v0x7f1f23ef89a0) {
+Obj v0x7f1f23ef8d40 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ef8d60 = PRIM_CAR(v0x7f1f23ef8d40);
+Obj v0x7f1f23ef8d80 = PRIM_CDR(v0x7f1f23ef8d60);
+Obj v0x7f1f23ef8da0 = PRIM_CAR(v0x7f1f23ef8d80);
+Obj __ = v0x7f1f23ef8da0;
+Obj v0x7f1f23edd400 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23edd420 = PRIM_CAR(v0x7f1f23edd400);
+Obj v0x7f1f23edd440 = PRIM_CDR(v0x7f1f23edd420);
+Obj v0x7f1f23edd460 = PRIM_CDR(v0x7f1f23edd440);
+Obj v0x7f1f23edd480 = PRIM_ISCONS(v0x7f1f23edd460);
+if (True == v0x7f1f23edd480) {
+Obj v0x7f1f23edd8c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23edd8e0 = PRIM_CAR(v0x7f1f23edd8c0);
+Obj v0x7f1f23edd940 = PRIM_CDR(v0x7f1f23edd8e0);
+Obj v0x7f1f23edd960 = PRIM_CDR(v0x7f1f23edd940);
+Obj v0x7f1f23edd9e0 = PRIM_CAR(v0x7f1f23edd960);
+__ = v0x7f1f23edd9e0;
+Obj v0x7f1f23eddfa0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23eddfc0 = PRIM_CAR(v0x7f1f23eddfa0);
+Obj v0x7f1f23eddfe0 = PRIM_CDR(v0x7f1f23eddfc0);
+Obj v0x7f1f23ed5020 = PRIM_CDR(v0x7f1f23eddfe0);
+Obj v0x7f1f23ed5040 = PRIM_CDR(v0x7f1f23ed5020);
+Obj v0x7f1f23ed5060 = PRIM_EQ(Nil, v0x7f1f23ed5040);
+if (True == v0x7f1f23ed5060) {
+Obj v0x7f1f23ed53e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ed5420 = PRIM_CDR(v0x7f1f23ed53e0);
+Obj v0x7f1f23ed5440 = PRIM_EQ(Nil, v0x7f1f23ed5420);
+if (True == v0x7f1f23ed5440) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2931,7 +2931,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc337;
+__arg0 = v0x7f1f23f58040;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2940,7 +2940,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc337;
+__arg0 = v0x7f1f23f58040;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2949,7 +2949,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc337;
+__arg0 = v0x7f1f23f58040;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2958,7 +2958,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc337;
+__arg0 = v0x7f1f23f58040;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2967,7 +2967,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc337;
+__arg0 = v0x7f1f23f58040;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2976,7 +2976,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc337;
+__arg0 = v0x7f1f23f58040;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2985,7 +2985,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc337;
+__arg0 = v0x7f1f23f58040;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2994,7 +2994,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc337;
+__arg0 = v0x7f1f23f58040;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3003,7 +3003,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc337;
+__arg0 = v0x7f1f23f58040;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3014,23 +3014,23 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj _35cc338 = makeNative(25, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg930 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg930) {
-Obj _35reg931 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg932 = PRIM_EQ(symnot, _35reg931);
-if (True == _35reg932) {
-Obj _35reg933 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg934 = PRIM_ISCONS(_35reg933);
-if (True == _35reg934) {
-Obj _35reg935 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg936 = PRIM_CAR(_35reg935);
-Obj _35reg937 = PRIM_EQ(True, _35reg936);
-if (True == _35reg937) {
-Obj _35reg938 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg939 = PRIM_CDR(_35reg938);
-Obj _35reg940 = PRIM_EQ(Nil, _35reg939);
-if (True == _35reg940) {
+Obj v0x7f1f23f58360 = makeNative(25, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23f3c080 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23f3c080) {
+Obj v0x7f1f23f3c300 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23f3c320 = PRIM_EQ(symnot, v0x7f1f23f3c300);
+if (True == v0x7f1f23f3c320) {
+Obj v0x7f1f23f3c560 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f3c580 = PRIM_ISCONS(v0x7f1f23f3c560);
+if (True == v0x7f1f23f3c580) {
+Obj v0x7f1f23f3c880 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f3c8a0 = PRIM_CAR(v0x7f1f23f3c880);
+Obj v0x7f1f23f3c8c0 = PRIM_EQ(True, v0x7f1f23f3c8a0);
+if (True == v0x7f1f23f3c8c0) {
+Obj v0x7f1f23f3cc00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f3cc60 = PRIM_CDR(v0x7f1f23f3cc00);
+Obj v0x7f1f23f3cc80 = PRIM_EQ(Nil, v0x7f1f23f3cc60);
+if (True == v0x7f1f23f3cc80) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -3038,7 +3038,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc338;
+__arg0 = v0x7f1f23f58360;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3047,7 +3047,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc338;
+__arg0 = v0x7f1f23f58360;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3056,7 +3056,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc338;
+__arg0 = v0x7f1f23f58360;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3065,7 +3065,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc338;
+__arg0 = v0x7f1f23f58360;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3074,7 +3074,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc338;
+__arg0 = v0x7f1f23f58360;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3085,23 +3085,23 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj _35cc339 = makeNative(26, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg919 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg919) {
-Obj _35reg920 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg921 = PRIM_EQ(symnot, _35reg920);
-if (True == _35reg921) {
-Obj _35reg922 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg923 = PRIM_ISCONS(_35reg922);
-if (True == _35reg923) {
-Obj _35reg924 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg925 = PRIM_CAR(_35reg924);
-Obj _35reg926 = PRIM_EQ(False, _35reg925);
-if (True == _35reg926) {
-Obj _35reg927 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg928 = PRIM_CDR(_35reg927);
-Obj _35reg929 = PRIM_EQ(Nil, _35reg928);
-if (True == _35reg929) {
+Obj v0x7f1f23f58520 = makeNative(26, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23f49f20 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23f49f20) {
+Obj v0x7f1f23f43140 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23f43160 = PRIM_EQ(symnot, v0x7f1f23f43140);
+if (True == v0x7f1f23f43160) {
+Obj v0x7f1f23f43340 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f43360 = PRIM_ISCONS(v0x7f1f23f43340);
+if (True == v0x7f1f23f43360) {
+Obj v0x7f1f23f436e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f43700 = PRIM_CAR(v0x7f1f23f436e0);
+Obj v0x7f1f23f43720 = PRIM_EQ(False, v0x7f1f23f43700);
+if (True == v0x7f1f23f43720) {
+Obj v0x7f1f23f43a60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f43a80 = PRIM_CDR(v0x7f1f23f43a60);
+Obj v0x7f1f23f43aa0 = PRIM_EQ(Nil, v0x7f1f23f43a80);
+if (True == v0x7f1f23f43aa0) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -3109,7 +3109,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc339;
+__arg0 = v0x7f1f23f58520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3118,7 +3118,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc339;
+__arg0 = v0x7f1f23f58520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3127,7 +3127,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc339;
+__arg0 = v0x7f1f23f58520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3136,7 +3136,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc339;
+__arg0 = v0x7f1f23f58520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3145,7 +3145,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc339;
+__arg0 = v0x7f1f23f58520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3156,43 +3156,43 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35cc340 = makeNative(27, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg892 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg892) {
-Obj _35reg893 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg894 = PRIM_EQ(symif, _35reg893);
-if (True == _35reg894) {
-Obj _35reg895 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg896 = PRIM_ISCONS(_35reg895);
-if (True == _35reg896) {
-Obj _35reg897 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg898 = PRIM_CAR(_35reg897);
-Obj _35reg899 = PRIM_EQ(True, _35reg898);
-if (True == _35reg899) {
-Obj _35reg900 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg901 = PRIM_CDR(_35reg900);
-Obj _35reg902 = PRIM_ISCONS(_35reg901);
-if (True == _35reg902) {
-Obj _35reg903 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg904 = PRIM_CDR(_35reg903);
-Obj _35reg905 = PRIM_CAR(_35reg904);
-Obj y = _35reg905;
-Obj _35reg906 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg907 = PRIM_CDR(_35reg906);
-Obj _35reg908 = PRIM_CDR(_35reg907);
-Obj _35reg909 = PRIM_ISCONS(_35reg908);
-if (True == _35reg909) {
-Obj _35reg910 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg911 = PRIM_CDR(_35reg910);
-Obj _35reg912 = PRIM_CDR(_35reg911);
-Obj _35reg913 = PRIM_CAR(_35reg912);
-Obj z = _35reg913;
-Obj _35reg914 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg915 = PRIM_CDR(_35reg914);
-Obj _35reg916 = PRIM_CDR(_35reg915);
-Obj _35reg917 = PRIM_CDR(_35reg916);
-Obj _35reg918 = PRIM_EQ(Nil, _35reg917);
-if (True == _35reg918) {
+Obj v0x7f1f23f586e0 = makeNative(27, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23f5c460 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23f5c460) {
+Obj v0x7f1f23f5c780 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23f5c840 = PRIM_EQ(symif, v0x7f1f23f5c780);
+if (True == v0x7f1f23f5c840) {
+Obj v0x7f1f23f5cb00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f5cb40 = PRIM_ISCONS(v0x7f1f23f5cb00);
+if (True == v0x7f1f23f5cb40) {
+Obj v0x7f1f23f58020 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f580a0 = PRIM_CAR(v0x7f1f23f58020);
+Obj v0x7f1f23f580c0 = PRIM_EQ(True, v0x7f1f23f580a0);
+if (True == v0x7f1f23f580c0) {
+Obj v0x7f1f23f58460 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f58480 = PRIM_CDR(v0x7f1f23f58460);
+Obj v0x7f1f23f584a0 = PRIM_ISCONS(v0x7f1f23f58480);
+if (True == v0x7f1f23f584a0) {
+Obj v0x7f1f23f58860 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f58880 = PRIM_CDR(v0x7f1f23f58860);
+Obj v0x7f1f23f588a0 = PRIM_CAR(v0x7f1f23f58880);
+Obj y = v0x7f1f23f588a0;
+Obj v0x7f1f23f58d60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f58d80 = PRIM_CDR(v0x7f1f23f58d60);
+Obj v0x7f1f23f58da0 = PRIM_CDR(v0x7f1f23f58d80);
+Obj v0x7f1f23f58dc0 = PRIM_ISCONS(v0x7f1f23f58da0);
+if (True == v0x7f1f23f58dc0) {
+Obj v0x7f1f23f491c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f49240 = PRIM_CDR(v0x7f1f23f491c0);
+Obj v0x7f1f23f49260 = PRIM_CDR(v0x7f1f23f49240);
+Obj v0x7f1f23f49280 = PRIM_CAR(v0x7f1f23f49260);
+Obj z = v0x7f1f23f49280;
+Obj v0x7f1f23f497a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f497c0 = PRIM_CDR(v0x7f1f23f497a0);
+Obj v0x7f1f23f497e0 = PRIM_CDR(v0x7f1f23f497c0);
+Obj v0x7f1f23f49800 = PRIM_CDR(v0x7f1f23f497e0);
+Obj v0x7f1f23f49820 = PRIM_EQ(Nil, v0x7f1f23f49800);
+if (True == v0x7f1f23f49820) {
 __nargs = 2;
 __arg1 = y;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -3200,7 +3200,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc340;
+__arg0 = v0x7f1f23f586e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3209,7 +3209,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc340;
+__arg0 = v0x7f1f23f586e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3218,7 +3218,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc340;
+__arg0 = v0x7f1f23f586e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3227,7 +3227,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc340;
+__arg0 = v0x7f1f23f586e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3236,7 +3236,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc340;
+__arg0 = v0x7f1f23f586e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3245,7 +3245,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc340;
+__arg0 = v0x7f1f23f586e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3254,7 +3254,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc340;
+__arg0 = v0x7f1f23f586e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3265,43 +3265,43 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj _35cc341 = makeNative(28, clofun1, 0, 1, closureRef(co, 0));
-Obj _35reg865 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg865) {
-Obj _35reg866 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg867 = PRIM_EQ(symif, _35reg866);
-if (True == _35reg867) {
-Obj _35reg868 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg869 = PRIM_ISCONS(_35reg868);
-if (True == _35reg869) {
-Obj _35reg870 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg871 = PRIM_CAR(_35reg870);
-Obj _35reg872 = PRIM_EQ(False, _35reg871);
-if (True == _35reg872) {
-Obj _35reg873 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg874 = PRIM_CDR(_35reg873);
-Obj _35reg875 = PRIM_ISCONS(_35reg874);
-if (True == _35reg875) {
-Obj _35reg876 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg877 = PRIM_CDR(_35reg876);
-Obj _35reg878 = PRIM_CAR(_35reg877);
-Obj y = _35reg878;
-Obj _35reg879 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg880 = PRIM_CDR(_35reg879);
-Obj _35reg881 = PRIM_CDR(_35reg880);
-Obj _35reg882 = PRIM_ISCONS(_35reg881);
-if (True == _35reg882) {
-Obj _35reg883 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg884 = PRIM_CDR(_35reg883);
-Obj _35reg885 = PRIM_CDR(_35reg884);
-Obj _35reg886 = PRIM_CAR(_35reg885);
-Obj z = _35reg886;
-Obj _35reg887 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg888 = PRIM_CDR(_35reg887);
-Obj _35reg889 = PRIM_CDR(_35reg888);
-Obj _35reg890 = PRIM_CDR(_35reg889);
-Obj _35reg891 = PRIM_EQ(Nil, _35reg890);
-if (True == _35reg891) {
+Obj v0x7f1f23f589a0 = makeNative(28, clofun1, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23e967a0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23e967a0) {
+Obj v0x7f1f23e96960 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23e96980 = PRIM_EQ(symif, v0x7f1f23e96960);
+if (True == v0x7f1f23e96980) {
+Obj v0x7f1f23e96b20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e96b40 = PRIM_ISCONS(v0x7f1f23e96b20);
+if (True == v0x7f1f23e96b40) {
+Obj v0x7f1f23e96da0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e96dc0 = PRIM_CAR(v0x7f1f23e96da0);
+Obj v0x7f1f23e96de0 = PRIM_EQ(False, v0x7f1f23e96dc0);
+if (True == v0x7f1f23e96de0) {
+Obj v0x7f1f23e90020 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e90040 = PRIM_CDR(v0x7f1f23e90020);
+Obj v0x7f1f23e90060 = PRIM_ISCONS(v0x7f1f23e90040);
+if (True == v0x7f1f23e90060) {
+Obj v0x7f1f23e902a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e902c0 = PRIM_CDR(v0x7f1f23e902a0);
+Obj v0x7f1f23e902e0 = PRIM_CAR(v0x7f1f23e902c0);
+Obj y = v0x7f1f23e902e0;
+Obj v0x7f1f23e905c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e905e0 = PRIM_CDR(v0x7f1f23e905c0);
+Obj v0x7f1f23e90600 = PRIM_CDR(v0x7f1f23e905e0);
+Obj v0x7f1f23e90620 = PRIM_ISCONS(v0x7f1f23e90600);
+if (True == v0x7f1f23e90620) {
+Obj v0x7f1f23e90900 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e90920 = PRIM_CDR(v0x7f1f23e90900);
+Obj v0x7f1f23e90940 = PRIM_CDR(v0x7f1f23e90920);
+Obj v0x7f1f23e90960 = PRIM_CAR(v0x7f1f23e90940);
+Obj z = v0x7f1f23e90960;
+Obj v0x7f1f23e90d00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23e90d20 = PRIM_CDR(v0x7f1f23e90d00);
+Obj v0x7f1f23e90d40 = PRIM_CDR(v0x7f1f23e90d20);
+Obj v0x7f1f23e90d60 = PRIM_CDR(v0x7f1f23e90d40);
+Obj v0x7f1f23e90d80 = PRIM_EQ(Nil, v0x7f1f23e90d60);
+if (True == v0x7f1f23e90d80) {
 __nargs = 2;
 __arg1 = z;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -3309,7 +3309,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc341;
+__arg0 = v0x7f1f23f589a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3318,7 +3318,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc341;
+__arg0 = v0x7f1f23f589a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3327,7 +3327,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc341;
+__arg0 = v0x7f1f23f589a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3336,7 +3336,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc341;
+__arg0 = v0x7f1f23f589a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3345,7 +3345,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc341;
+__arg0 = v0x7f1f23f589a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3354,7 +3354,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc341;
+__arg0 = v0x7f1f23f589a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3363,7 +3363,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc341;
+__arg0 = v0x7f1f23f589a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3374,7 +3374,7 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj _35cc342 = makeNative(29, clofun1, 0, 0);
+Obj v0x7f1f23f58c60 = makeNative(29, clofun1, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = x;
@@ -3411,12 +3411,12 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj _35val852 = __arg1;
+Obj v0x7f1f23e9bfe0 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 32, clofun1, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35extract_45rules);
-__arg1 = _35val852;
+__arg1 = v0x7f1f23e9bfe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3426,9 +3426,9 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj _35val853 = __arg1;
+Obj v0x7f1f23e9a000 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj body = _35val853;
+Obj body = v0x7f1f23e9a000;
 pushCont(co, 33, clofun1, 2, exp, body);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rules_45arg_45count);
@@ -3442,10 +3442,10 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj _35val854 = __arg1;
+Obj v0x7f1f23e9a100 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj nargs = _35val854;
+Obj nargs = v0x7f1f23e9a100;
 pushCont(co, 34, clofun1, 2, exp, body);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35gen_45paramenters);
@@ -3459,10 +3459,10 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj _35val855 = __arg1;
+Obj v0x7f1f23e9a200 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj args = _35val855;
+Obj args = v0x7f1f23e9a200;
 pushCont(co, 35, clofun1, 2, body, args);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
@@ -3476,18 +3476,18 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj _35val856 = __arg1;
+Obj v0x7f1f23e9a500 = __arg1;
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg857 = makeCons(symlist, args);
-Obj _35reg858 = makeCons(_35reg857, body);
-Obj _35reg859 = makeCons(symmatch, _35reg858);
-Obj _35reg860 = makeCons(_35reg859, Nil);
-Obj _35reg861 = makeCons(args, _35reg860);
-Obj _35reg862 = makeCons(_35val856, _35reg861);
-Obj _35reg863 = makeCons(symdefun, _35reg862);
+Obj v0x7f1f23e9a920 = makeCons(symlist, args);
+Obj v0x7f1f23e9a980 = makeCons(v0x7f1f23e9a920, body);
+Obj v0x7f1f23e9a9a0 = makeCons(symmatch, v0x7f1f23e9a980);
+Obj v0x7f1f23e9aa00 = makeCons(v0x7f1f23e9a9a0, Nil);
+Obj v0x7f1f23e9aa20 = makeCons(args, v0x7f1f23e9aa00);
+Obj v0x7f1f23e9aa40 = makeCons(v0x7f1f23e9a500, v0x7f1f23e9aa20);
+Obj v0x7f1f23e9aa60 = makeCons(symdefun, v0x7f1f23e9aa40);
 __nargs = 2;
-__arg1 = _35reg863;
+__arg1 = v0x7f1f23e9aa60;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3496,20 +3496,20 @@ goto *jumpTable[co->ctx.pc.label];
 label36:
 {
 Obj n = __arg1;
-Obj _35reg846 = PRIM_EQ(n, MAKE_NUMBER(0));
-if (True == _35reg846) {
+Obj v0x7f1f23e9b8e0 = PRIM_EQ(n, MAKE_NUMBER(0));
+if (True == v0x7f1f23e9b8e0) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg847 = primGenSym(symp);
-Obj _35reg848 = PRIM_SUB(n, MAKE_NUMBER(1));
-pushCont(co, 37, clofun1, 1, _35reg847);
+Obj v0x7f1f23e9ba60 = primGenSym(symp);
+Obj v0x7f1f23e9bc40 = PRIM_SUB(n, MAKE_NUMBER(1));
+pushCont(co, 37, clofun1, 1, v0x7f1f23e9ba60);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35gen_45paramenters);
-__arg1 = _35reg848;
+__arg1 = v0x7f1f23e9bc40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3520,11 +3520,11 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj _35val849 = __arg1;
-Obj _35reg847= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg850 = makeCons(_35reg847, _35val849);
+Obj v0x7f1f23e9bc60 = __arg1;
+Obj v0x7f1f23e9ba60= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f23e9bc80 = makeCons(v0x7f1f23e9ba60, v0x7f1f23e9bc60);
 __nargs = 2;
-__arg1 = _35reg850;
+__arg1 = v0x7f1f23e9bc80;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3547,8 +3547,8 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj _35val835 = __arg1;
-Obj pats = _35val835;
+Obj v0x7f1f23eb1940 = __arg1;
+Obj pats = v0x7f1f23eb1940;
 Obj len = makeNative(44, clofun1, 1, 0);
 PUSH_CONT_0(co, 40, clofun1);
 __nargs = 3;
@@ -3564,17 +3564,17 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj _35val837 = __arg1;
-Obj counts = _35val837;
-Obj _35reg838 = PRIM_CAR(counts);
-Obj n = _35reg838;
+Obj v0x7f1f23eb1d00 = __arg1;
+Obj counts = v0x7f1f23eb1d00;
+Obj v0x7f1f23eb1ec0 = PRIM_CAR(counts);
+Obj n = v0x7f1f23eb1ec0;
 Obj dif = makeNative(43, clofun1, 1, 1, n);
-Obj _35reg841 = PRIM_CDR(counts);
+Obj v0x7f1f23e9b520 = PRIM_CDR(counts);
 pushCont(co, 41, clofun1, 1, n);
 __nargs = 3;
 __arg0 = globalRef(symfilter);
 __arg1 = dif;
-__arg2 = _35reg841;
+__arg2 = v0x7f1f23e9b520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3584,12 +3584,12 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj _35val842 = __arg1;
+Obj v0x7f1f23e9b540 = __arg1;
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 42, clofun1, 1, n);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = _35val842;
+__arg1 = v0x7f1f23e9b540;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3599,10 +3599,10 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj _35val843 = __arg1;
+Obj v0x7f1f23e9b560 = __arg1;
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg844 = primNot(_35val843);
-if (True == _35reg844) {
+Obj v0x7f1f23e9b580 = primNot(v0x7f1f23e9b560);
+if (True == v0x7f1f23e9b580) {
 __nargs = 2;
 __arg0 = globalRef(symerror);
 __arg1 = makeCString("inconsistent func rule args count");
@@ -3623,10 +3623,10 @@ goto *jumpTable[co->ctx.pc.label];
 label43:
 {
 Obj x = __arg1;
-Obj _35reg839 = PRIM_EQ(closureRef(co, 0), x);
-Obj _35reg840 = primNot(_35reg839);
+Obj v0x7f1f23e9b120 = PRIM_EQ(closureRef(co, 0), x);
+Obj v0x7f1f23e9b140 = primNot(v0x7f1f23e9b120);
 __nargs = 2;
-__arg1 = _35reg840;
+__arg1 = v0x7f1f23e9b140;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3635,10 +3635,10 @@ goto *jumpTable[co->ctx.pc.label];
 label44:
 {
 Obj x = __arg1;
-Obj _35reg836 = PRIM_CDR(x);
+Obj v0x7f1f23eb1b40 = PRIM_CDR(x);
 __nargs = 2;
 __arg0 = globalRef(symlength);
-__arg1 = _35reg836;
+__arg1 = v0x7f1f23eb1b40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3650,20 +3650,20 @@ label45:
 {
 Obj l1 = __arg1;
 Obj l2 = __arg2;
-Obj _35reg829 = PRIM_EQ(l1, Nil);
-if (True == _35reg829) {
+Obj v0x7f1f23eb11e0 = PRIM_EQ(l1, Nil);
+if (True == v0x7f1f23eb11e0) {
 __nargs = 2;
 __arg1 = l2;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg830 = PRIM_CAR(l1);
-Obj _35reg831 = PRIM_CDR(l1);
-pushCont(co, 46, clofun1, 1, _35reg830);
+Obj v0x7f1f23eb1380 = PRIM_CAR(l1);
+Obj v0x7f1f23eb15c0 = PRIM_CDR(l1);
+pushCont(co, 46, clofun1, 1, v0x7f1f23eb1380);
 __nargs = 3;
 __arg0 = globalRef(symappend);
-__arg1 = _35reg831;
+__arg1 = v0x7f1f23eb15c0;
 __arg2 = l2;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3675,11 +3675,11 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj _35val832 = __arg1;
-Obj _35reg830= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg833 = makeCons(_35reg830, _35val832);
+Obj v0x7f1f23eb1600 = __arg1;
+Obj v0x7f1f23eb1380= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f23eb1620 = makeCons(v0x7f1f23eb1380, v0x7f1f23eb1600);
 __nargs = 2;
-__arg1 = _35reg833;
+__arg1 = v0x7f1f23eb1620;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -3706,13 +3706,13 @@ label48:
 Obj res = __arg1;
 Obj fn = __arg2;
 Obj l = __arg3;
-Obj _35reg820 = PRIM_ISCONS(l);
-if (True == _35reg820) {
-Obj _35reg821 = PRIM_CAR(l);
+Obj v0x7f1f23ecc1a0 = PRIM_ISCONS(l);
+if (True == v0x7f1f23ecc1a0) {
+Obj v0x7f1f23ecc3c0 = PRIM_CAR(l);
 pushCont(co, 49, clofun1, 3, l, res, fn);
 __nargs = 2;
 __arg0 = fn;
-__arg1 = _35reg821;
+__arg1 = v0x7f1f23ecc3c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3732,31 +3732,31 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj _35val822 = __arg1;
+Obj v0x7f1f23ecc3e0 = __arg1;
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == _35val822) {
-Obj _35reg823 = PRIM_CAR(l);
-Obj _35reg824 = makeCons(_35reg823, res);
-Obj _35reg825 = PRIM_CDR(l);
+if (True == v0x7f1f23ecc3e0) {
+Obj v0x7f1f23ecc6c0 = PRIM_CAR(l);
+Obj v0x7f1f23ecc720 = makeCons(v0x7f1f23ecc6c0, res);
+Obj v0x7f1f23ecc840 = PRIM_CDR(l);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35filter_45h);
-__arg1 = _35reg824;
+__arg1 = v0x7f1f23ecc720;
 __arg2 = fn;
-__arg3 = _35reg825;
+__arg3 = v0x7f1f23ecc840;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg826 = PRIM_CDR(l);
+Obj v0x7f1f23eccb00 = PRIM_CDR(l);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35filter_45h);
 __arg1 = res;
 __arg2 = fn;
-__arg3 = _35reg826;
+__arg3 = v0x7f1f23eccb00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3803,20 +3803,20 @@ label1:
 {
 Obj i = __arg1;
 Obj l = __arg2;
-Obj _35reg815 = PRIM_EQ(l, Nil);
-if (True == _35reg815) {
+Obj v0x7f1f23ed5860 = PRIM_EQ(l, Nil);
+if (True == v0x7f1f23ed5860) {
 __nargs = 2;
 __arg1 = i;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg816 = PRIM_ADD(i, MAKE_NUMBER(1));
-Obj _35reg817 = PRIM_CDR(l);
+Obj v0x7f1f23ed5a20 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj v0x7f1f23ed5bc0 = PRIM_CDR(l);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35length_45h);
-__arg1 = _35reg816;
-__arg2 = _35reg817;
+__arg1 = v0x7f1f23ed5a20;
+__arg2 = v0x7f1f23ed5bc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3842,10 +3842,10 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj _35val810 = __arg1;
+Obj v0x7f1f23eddf80 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val810) {
+if (True == v0x7f1f23eddf80) {
 __nargs = 2;
 __arg0 = globalRef(symreverse);
 __arg1 = res;
@@ -3855,9 +3855,9 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg811 = PRIM_CAR(rules);
-Obj _35reg812 = makeCons(_35reg811, res);
-pushCont(co, 4, clofun2, 1, _35reg812);
+Obj v0x7f1f23ed5300 = PRIM_CAR(rules);
+Obj v0x7f1f23ed5340 = makeCons(v0x7f1f23ed5300, res);
+pushCont(co, 4, clofun2, 1, v0x7f1f23ed5340);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
 __arg1 = rules;
@@ -3871,12 +3871,12 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35val813 = __arg1;
-Obj _35reg812= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f23ed5460 = __arg1;
+Obj v0x7f1f23ed5340= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35rules_45patterns);
-__arg1 = _35reg812;
-__arg2 = _35val813;
+__arg1 = v0x7f1f23ed5340;
+__arg2 = v0x7f1f23ed5460;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3904,9 +3904,9 @@ label6:
 Obj input = __arg1;
 Obj current = __arg2;
 Obj result = __arg3;
-Obj _35cc327 = makeNative(7, clofun2, 0, 3, input, current, result);
-Obj _35reg807 = PRIM_EQ(Nil, input);
-if (True == _35reg807) {
+Obj v0x7f1f23f5c080 = makeNative(7, clofun2, 0, 3, input, current, result);
+Obj v0x7f1f23edd800 = PRIM_EQ(Nil, input);
+if (True == v0x7f1f23edd800) {
 __nargs = 2;
 __arg0 = globalRef(symreverse);
 __arg1 = result;
@@ -3917,7 +3917,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc327;
+__arg0 = v0x7f1f23f5c080;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3928,42 +3928,42 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35cc328 = makeNative(9, clofun2, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj _35reg774 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg774) {
-Obj _35reg775 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg776 = PRIM_EQ(sym_61_62, _35reg775);
-if (True == _35reg776) {
-Obj _35reg777 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg778 = PRIM_ISCONS(_35reg777);
-if (True == _35reg778) {
-Obj _35reg779 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg780 = PRIM_CAR(_35reg779);
-Obj act = _35reg780;
-Obj _35reg781 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg782 = PRIM_CDR(_35reg781);
-Obj _35reg783 = PRIM_ISCONS(_35reg782);
-if (True == _35reg783) {
-Obj _35reg784 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg785 = PRIM_CDR(_35reg784);
-Obj _35reg786 = PRIM_CAR(_35reg785);
-Obj _35reg787 = PRIM_EQ(symwhere, _35reg786);
-if (True == _35reg787) {
-Obj _35reg788 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg789 = PRIM_CDR(_35reg788);
-Obj _35reg790 = PRIM_CDR(_35reg789);
-Obj _35reg791 = PRIM_ISCONS(_35reg790);
-if (True == _35reg791) {
-Obj _35reg792 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg793 = PRIM_CDR(_35reg792);
-Obj _35reg794 = PRIM_CDR(_35reg793);
-Obj _35reg795 = PRIM_CAR(_35reg794);
-Obj pred = _35reg795;
-Obj _35reg796 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg797 = PRIM_CDR(_35reg796);
-Obj _35reg798 = PRIM_CDR(_35reg797);
-Obj _35reg799 = PRIM_CDR(_35reg798);
-Obj remain = _35reg799;
+Obj v0x7f1f23f5c0e0 = makeNative(9, clofun2, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj v0x7f1f23f3c9c0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23f3c9c0) {
+Obj v0x7f1f23f3cc20 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23f3cc40 = PRIM_EQ(sym_61_62, v0x7f1f23f3cc20);
+if (True == v0x7f1f23f3cc40) {
+Obj v0x7f1f23f3cea0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f3cec0 = PRIM_ISCONS(v0x7f1f23f3cea0);
+if (True == v0x7f1f23f3cec0) {
+Obj v0x7f1f23efe140 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23efe160 = PRIM_CAR(v0x7f1f23efe140);
+Obj act = v0x7f1f23efe160;
+Obj v0x7f1f23efe4a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23efe4c0 = PRIM_CDR(v0x7f1f23efe4a0);
+Obj v0x7f1f23efe4e0 = PRIM_ISCONS(v0x7f1f23efe4c0);
+if (True == v0x7f1f23efe4e0) {
+Obj v0x7f1f23efe8e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23efe900 = PRIM_CDR(v0x7f1f23efe8e0);
+Obj v0x7f1f23efe920 = PRIM_CAR(v0x7f1f23efe900);
+Obj v0x7f1f23efe940 = PRIM_EQ(symwhere, v0x7f1f23efe920);
+if (True == v0x7f1f23efe940) {
+Obj v0x7f1f23efeca0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23efecc0 = PRIM_CDR(v0x7f1f23efeca0);
+Obj v0x7f1f23efece0 = PRIM_CDR(v0x7f1f23efecc0);
+Obj v0x7f1f23efed00 = PRIM_ISCONS(v0x7f1f23efece0);
+if (True == v0x7f1f23efed00) {
+Obj v0x7f1f23ef8400 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ef8420 = PRIM_CDR(v0x7f1f23ef8400);
+Obj v0x7f1f23ef8440 = PRIM_CDR(v0x7f1f23ef8420);
+Obj v0x7f1f23ef8460 = PRIM_CAR(v0x7f1f23ef8440);
+Obj pred = v0x7f1f23ef8460;
+Obj v0x7f1f23ef88e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23ef8900 = PRIM_CDR(v0x7f1f23ef88e0);
+Obj v0x7f1f23ef8920 = PRIM_CDR(v0x7f1f23ef8900);
+Obj v0x7f1f23ef8940 = PRIM_CDR(v0x7f1f23ef8920);
+Obj remain = v0x7f1f23ef8940;
 pushCont(co, 8, clofun2, 3, act, pred, remain);
 __nargs = 2;
 __arg0 = globalRef(symreverse);
@@ -3975,7 +3975,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc328;
+__arg0 = v0x7f1f23f5c0e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3984,7 +3984,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc328;
+__arg0 = v0x7f1f23f5c0e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3993,7 +3993,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc328;
+__arg0 = v0x7f1f23f5c0e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4002,7 +4002,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc328;
+__arg0 = v0x7f1f23f5c0e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4011,7 +4011,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc328;
+__arg0 = v0x7f1f23f5c0e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4020,7 +4020,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc328;
+__arg0 = v0x7f1f23f5c0e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4031,22 +4031,22 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35val800 = __arg1;
+Obj v0x7f1f23ef8b80 = __arg1;
 Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj pred= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg801 = makeCons(symlist, _35val800);
-Obj pat = _35reg801;
-Obj _35reg802 = makeCons(act, Nil);
-Obj _35reg803 = makeCons(pred, _35reg802);
-Obj _35reg804 = makeCons(symwhere, _35reg803);
-Obj _35reg805 = makeCons(pat, closureRef(co, 2));
-Obj _35reg806 = makeCons(_35reg804, _35reg805);
+Obj v0x7f1f23ef8bc0 = makeCons(symlist, v0x7f1f23ef8b80);
+Obj pat = v0x7f1f23ef8bc0;
+Obj v0x7f1f23edd020 = makeCons(act, Nil);
+Obj v0x7f1f23edd040 = makeCons(pred, v0x7f1f23edd020);
+Obj v0x7f1f23edd060 = makeCons(symwhere, v0x7f1f23edd040);
+Obj v0x7f1f23edd180 = makeCons(pat, closureRef(co, 2));
+Obj v0x7f1f23edd1a0 = makeCons(v0x7f1f23edd060, v0x7f1f23edd180);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35extract_45rules1);
 __arg1 = remain;
 __arg2 = Nil;
-__arg3 = _35reg806;
+__arg3 = v0x7f1f23edd1a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4056,21 +4056,21 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj _35cc329 = makeNative(11, clofun2, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
-Obj _35reg761 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg761) {
-Obj _35reg762 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg763 = PRIM_EQ(sym_61_62, _35reg762);
-if (True == _35reg763) {
-Obj _35reg764 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg765 = PRIM_ISCONS(_35reg764);
-if (True == _35reg765) {
-Obj _35reg766 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg767 = PRIM_CAR(_35reg766);
-Obj act = _35reg767;
-Obj _35reg768 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg769 = PRIM_CDR(_35reg768);
-Obj remain = _35reg769;
+Obj v0x7f1f23f5c300 = makeNative(11, clofun2, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj v0x7f1f23f437e0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23f437e0) {
+Obj v0x7f1f23f43a00 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23f43a40 = PRIM_EQ(sym_61_62, v0x7f1f23f43a00);
+if (True == v0x7f1f23f43a40) {
+Obj v0x7f1f23f43cc0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f43ce0 = PRIM_ISCONS(v0x7f1f23f43cc0);
+if (True == v0x7f1f23f43ce0) {
+Obj v0x7f1f23f43f60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f43f80 = PRIM_CAR(v0x7f1f23f43f60);
+Obj act = v0x7f1f23f43f80;
+Obj v0x7f1f23f3c180 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f3c1a0 = PRIM_CDR(v0x7f1f23f3c180);
+Obj remain = v0x7f1f23f3c1a0;
 pushCont(co, 10, clofun2, 2, act, remain);
 __nargs = 2;
 __arg0 = globalRef(symreverse);
@@ -4082,7 +4082,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc329;
+__arg0 = v0x7f1f23f5c300;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4091,7 +4091,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc329;
+__arg0 = v0x7f1f23f5c300;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4100,7 +4100,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc329;
+__arg0 = v0x7f1f23f5c300;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4111,18 +4111,18 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj _35val770 = __arg1;
+Obj v0x7f1f23f3c3a0 = __arg1;
 Obj act= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg771 = makeCons(symlist, _35val770);
-Obj pat = _35reg771;
-Obj _35reg772 = makeCons(pat, closureRef(co, 2));
-Obj _35reg773 = makeCons(act, _35reg772);
+Obj v0x7f1f23f3c3e0 = makeCons(symlist, v0x7f1f23f3c3a0);
+Obj pat = v0x7f1f23f3c3e0;
+Obj v0x7f1f23f3c700 = makeCons(pat, closureRef(co, 2));
+Obj v0x7f1f23f3c720 = makeCons(act, v0x7f1f23f3c700);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35extract_45rules1);
 __arg1 = remain;
 __arg2 = Nil;
-__arg3 = _35reg773;
+__arg3 = v0x7f1f23f3c720;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4132,18 +4132,18 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj _35cc330 = makeNative(12, clofun2, 0, 0);
-Obj _35reg757 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg757) {
-Obj _35reg758 = PRIM_CAR(closureRef(co, 0));
-Obj x = _35reg758;
-Obj _35reg759 = PRIM_CDR(closureRef(co, 0));
-Obj y = _35reg759;
-Obj _35reg760 = makeCons(x, closureRef(co, 1));
+Obj v0x7f1f23f5c440 = makeNative(12, clofun2, 0, 0);
+Obj v0x7f1f23f431c0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23f431c0) {
+Obj v0x7f1f23f432c0 = PRIM_CAR(closureRef(co, 0));
+Obj x = v0x7f1f23f432c0;
+Obj v0x7f1f23f43440 = PRIM_CDR(closureRef(co, 0));
+Obj y = v0x7f1f23f43440;
+Obj v0x7f1f23f43620 = makeCons(x, closureRef(co, 1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35extract_45rules1);
 __arg1 = y;
-__arg2 = _35reg760;
+__arg2 = v0x7f1f23f43620;
 __arg3 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4152,7 +4152,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc330;
+__arg0 = v0x7f1f23f5c440;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4202,12 +4202,12 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj _35val730 = __arg1;
+Obj v0x7f1f23f5c700 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 16, clofun2, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symmacroexpand);
-__arg1 = _35val730;
+__arg1 = v0x7f1f23f5c700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4217,9 +4217,9 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35val731 = __arg1;
+Obj v0x7f1f23f5c720 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj value = _35val731;
+Obj value = v0x7f1f23f5c720;
 pushCont(co, 17, clofun2, 1, value);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
@@ -4233,18 +4233,18 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj _35val732 = __arg1;
+Obj v0x7f1f23f5c900 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj rules = _35val732;
-Obj _35reg733 = PRIM_ISCONS(value);
-if (True == _35reg733) {
-Obj _35reg734 = PRIM_CAR(value);
-Obj _35reg735 = PRIM_EQ(symcons, _35reg734);
-Obj _35reg736 = primNot(_35reg735);
-if (True == _35reg736) {
+Obj rules = v0x7f1f23f5c900;
+Obj v0x7f1f23f5cb20 = PRIM_ISCONS(value);
+if (True == v0x7f1f23f5cb20) {
+Obj v0x7f1f23f5cf80 = PRIM_CAR(value);
+Obj v0x7f1f23f5cfa0 = PRIM_EQ(symcons, v0x7f1f23f5cf80);
+Obj v0x7f1f23f5cfe0 = primNot(v0x7f1f23f5cfa0);
+if (True == v0x7f1f23f5cfe0) {
 if (True == True) {
-Obj _35reg737 = primGenSym(symval);
-Obj val = _35reg737;
+Obj v0x7f1f23f58140 = primGenSym(symval);
+Obj val = v0x7f1f23f58140;
 pushCont(co, 20, clofun2, 2, value, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
@@ -4268,8 +4268,8 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj _35reg743 = primGenSym(symval);
-Obj val = _35reg743;
+Obj v0x7f1f23f58a80 = primGenSym(symval);
+Obj val = v0x7f1f23f58a80;
 pushCont(co, 19, clofun2, 2, value, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
@@ -4294,8 +4294,8 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj _35reg749 = primGenSym(symval);
-Obj val = _35reg749;
+Obj v0x7f1f23f49220 = primGenSym(symval);
+Obj val = v0x7f1f23f49220;
 pushCont(co, 18, clofun2, 2, value, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
@@ -4322,15 +4322,15 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35val750 = __arg1;
+Obj v0x7f1f23f496c0 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg751 = makeCons(_35val750, Nil);
-Obj _35reg752 = makeCons(value, _35reg751);
-Obj _35reg753 = makeCons(val, _35reg752);
-Obj _35reg754 = makeCons(symlet, _35reg753);
+Obj v0x7f1f23f49700 = makeCons(v0x7f1f23f496c0, Nil);
+Obj v0x7f1f23f49720 = makeCons(value, v0x7f1f23f49700);
+Obj v0x7f1f23f49740 = makeCons(val, v0x7f1f23f49720);
+Obj v0x7f1f23f49760 = makeCons(symlet, v0x7f1f23f49740);
 __nargs = 2;
-__arg1 = _35reg754;
+__arg1 = v0x7f1f23f49760;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4338,15 +4338,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label19:
 {
-Obj _35val744 = __arg1;
+Obj v0x7f1f23f58f40 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg745 = makeCons(_35val744, Nil);
-Obj _35reg746 = makeCons(value, _35reg745);
-Obj _35reg747 = makeCons(val, _35reg746);
-Obj _35reg748 = makeCons(symlet, _35reg747);
+Obj v0x7f1f23f58f80 = makeCons(v0x7f1f23f58f40, Nil);
+Obj v0x7f1f23f58fa0 = makeCons(value, v0x7f1f23f58f80);
+Obj v0x7f1f23f58fc0 = makeCons(val, v0x7f1f23f58fa0);
+Obj v0x7f1f23f58fe0 = makeCons(symlet, v0x7f1f23f58fc0);
 __nargs = 2;
-__arg1 = _35reg748;
+__arg1 = v0x7f1f23f58fe0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4354,15 +4354,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label20:
 {
-Obj _35val738 = __arg1;
+Obj v0x7f1f23f586c0 = __arg1;
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg739 = makeCons(_35val738, Nil);
-Obj _35reg740 = makeCons(value, _35reg739);
-Obj _35reg741 = makeCons(val, _35reg740);
-Obj _35reg742 = makeCons(symlet, _35reg741);
+Obj v0x7f1f23f58720 = makeCons(v0x7f1f23f586c0, Nil);
+Obj v0x7f1f23f58760 = makeCons(value, v0x7f1f23f58720);
+Obj v0x7f1f23f58780 = makeCons(val, v0x7f1f23f58760);
+Obj v0x7f1f23f587a0 = makeCons(symlet, v0x7f1f23f58780);
 __nargs = 2;
-__arg1 = _35reg742;
+__arg1 = v0x7f1f23f587a0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4385,14 +4385,14 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj _35val678 = __arg1;
+Obj v0x7f1f23ecc820 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val678) {
-Obj _35reg679 = makeCons(makeCString("no match-help found!"), Nil);
-Obj _35reg680 = makeCons(symerror, _35reg679);
+if (True == v0x7f1f23ecc820) {
+Obj v0x7f1f23eccaa0 = makeCons(makeCString("no match-help found!"), Nil);
+Obj v0x7f1f23eccac0 = makeCons(symerror, v0x7f1f23eccaa0);
 __nargs = 2;
-__arg1 = _35reg680;
+__arg1 = v0x7f1f23eccac0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4411,15 +4411,15 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj _35val681 = __arg1;
+Obj v0x7f1f23eccc00 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val681) {
-Obj _35reg682 = PRIM_CDR(rules);
+if (True == v0x7f1f23eccc00) {
+Obj v0x7f1f23eccdc0 = PRIM_CDR(rules);
 pushCont(co, 28, clofun2, 2, rules, value);
 __nargs = 2;
 __arg0 = globalRef(sympair_63);
-__arg1 = _35reg682;
+__arg1 = v0x7f1f23eccdc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4427,10 +4427,10 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 if (True == False) {
-Obj _35reg714 = PRIM_CAR(rules);
-Obj pat = _35reg714;
-Obj _35reg715 = primGenSym(symcc);
-Obj cc = _35reg715;
+Obj v0x7f1f23e9a5a0 = PRIM_CAR(rules);
+Obj pat = v0x7f1f23e9a5a0;
+Obj v0x7f1f23e9a6a0 = primGenSym(symcc);
+Obj cc = v0x7f1f23e9a6a0;
 pushCont(co, 24, clofun2, 4, pat, rules, value, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35extract_45rule_45action);
@@ -4456,12 +4456,12 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj _35val716 = __arg1;
+Obj v0x7f1f23e9a7c0 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = _35val716;
+Obj action = v0x7f1f23e9a7c0;
 pushCont(co, 25, clofun2, 4, action, rules, value, cc);
 __nargs = 2;
 __arg0 = globalRef(symmacroexpand);
@@ -4475,7 +4475,7 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj _35val717 = __arg1;
+Obj v0x7f1f23e9a960 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4483,7 +4483,7 @@ Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 26, clofun2, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
-__arg1 = _35val717;
+__arg1 = v0x7f1f23e9a960;
 __arg2 = value;
 __arg3 = action;
 co->args[4] = cc;
@@ -4496,18 +4496,18 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35val718 = __arg1;
+Obj v0x7f1f23e9a9e0 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = _35val718;
-Obj _35reg719 = PRIM_CDR(rules);
-Obj _35reg720 = PRIM_CDR(_35reg719);
+Obj curr = v0x7f1f23e9a9e0;
+Obj v0x7f1f23e9ac40 = PRIM_CDR(rules);
+Obj v0x7f1f23e9ac60 = PRIM_CDR(v0x7f1f23e9ac40);
 pushCont(co, 27, clofun2, 2, curr, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
 __arg1 = value;
-__arg2 = _35reg720;
+__arg2 = v0x7f1f23e9ac60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4517,19 +4517,19 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj _35val721 = __arg1;
+Obj v0x7f1f23e9ac80 = __arg1;
 Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = _35val721;
-Obj _35reg722 = makeCons(rest, Nil);
-Obj _35reg723 = makeCons(Nil, _35reg722);
-Obj _35reg724 = makeCons(symlambda, _35reg723);
-Obj _35reg725 = makeCons(curr, Nil);
-Obj _35reg726 = makeCons(_35reg724, _35reg725);
-Obj _35reg727 = makeCons(cc, _35reg726);
-Obj _35reg728 = makeCons(symlet, _35reg727);
+Obj rest = v0x7f1f23e9ac80;
+Obj v0x7f1f23e96100 = makeCons(rest, Nil);
+Obj v0x7f1f23e96120 = makeCons(Nil, v0x7f1f23e96100);
+Obj v0x7f1f23e96140 = makeCons(symlambda, v0x7f1f23e96120);
+Obj v0x7f1f23e96240 = makeCons(curr, Nil);
+Obj v0x7f1f23e96260 = makeCons(v0x7f1f23e96140, v0x7f1f23e96240);
+Obj v0x7f1f23e96280 = makeCons(cc, v0x7f1f23e96260);
+Obj v0x7f1f23e962a0 = makeCons(symlet, v0x7f1f23e96280);
 __nargs = 2;
-__arg1 = _35reg728;
+__arg1 = v0x7f1f23e962a0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4537,15 +4537,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label28:
 {
-Obj _35val683 = __arg1;
+Obj v0x7f1f23eccde0 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val683) {
+if (True == v0x7f1f23eccde0) {
 if (True == True) {
-Obj _35reg684 = PRIM_CAR(rules);
-Obj pat = _35reg684;
-Obj _35reg685 = primGenSym(symcc);
-Obj cc = _35reg685;
+Obj v0x7f1f23eccf20 = PRIM_CAR(rules);
+Obj pat = v0x7f1f23eccf20;
+Obj v0x7f1f23eb1060 = primGenSym(symcc);
+Obj cc = v0x7f1f23eb1060;
 pushCont(co, 33, clofun2, 4, pat, rules, value, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35extract_45rule_45action);
@@ -4568,10 +4568,10 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj _35reg699 = PRIM_CAR(rules);
-Obj pat = _35reg699;
-Obj _35reg700 = primGenSym(symcc);
-Obj cc = _35reg700;
+Obj v0x7f1f23eb1fe0 = PRIM_CAR(rules);
+Obj pat = v0x7f1f23eb1fe0;
+Obj v0x7f1f23e9b0e0 = primGenSym(symcc);
+Obj cc = v0x7f1f23e9b0e0;
 pushCont(co, 29, clofun2, 4, pat, rules, value, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35extract_45rule_45action);
@@ -4597,12 +4597,12 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj _35val701 = __arg1;
+Obj v0x7f1f23e9b220 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = _35val701;
+Obj action = v0x7f1f23e9b220;
 pushCont(co, 30, clofun2, 4, action, rules, value, cc);
 __nargs = 2;
 __arg0 = globalRef(symmacroexpand);
@@ -4616,7 +4616,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj _35val702 = __arg1;
+Obj v0x7f1f23e9bac0 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4624,7 +4624,7 @@ Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 31, clofun2, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
-__arg1 = _35val702;
+__arg1 = v0x7f1f23e9bac0;
 __arg2 = value;
 __arg3 = action;
 co->args[4] = cc;
@@ -4637,18 +4637,18 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj _35val703 = __arg1;
+Obj v0x7f1f23e9bb40 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = _35val703;
-Obj _35reg704 = PRIM_CDR(rules);
-Obj _35reg705 = PRIM_CDR(_35reg704);
+Obj curr = v0x7f1f23e9bb40;
+Obj v0x7f1f23e9bda0 = PRIM_CDR(rules);
+Obj v0x7f1f23e9bdc0 = PRIM_CDR(v0x7f1f23e9bda0);
 pushCont(co, 32, clofun2, 2, curr, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
 __arg1 = value;
-__arg2 = _35reg705;
+__arg2 = v0x7f1f23e9bdc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4658,19 +4658,19 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj _35val706 = __arg1;
+Obj v0x7f1f23e9bde0 = __arg1;
 Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = _35val706;
-Obj _35reg707 = makeCons(rest, Nil);
-Obj _35reg708 = makeCons(Nil, _35reg707);
-Obj _35reg709 = makeCons(symlambda, _35reg708);
-Obj _35reg710 = makeCons(curr, Nil);
-Obj _35reg711 = makeCons(_35reg709, _35reg710);
-Obj _35reg712 = makeCons(cc, _35reg711);
-Obj _35reg713 = makeCons(symlet, _35reg712);
+Obj rest = v0x7f1f23e9bde0;
+Obj v0x7f1f23e9a260 = makeCons(rest, Nil);
+Obj v0x7f1f23e9a280 = makeCons(Nil, v0x7f1f23e9a260);
+Obj v0x7f1f23e9a2a0 = makeCons(symlambda, v0x7f1f23e9a280);
+Obj v0x7f1f23e9a3a0 = makeCons(curr, Nil);
+Obj v0x7f1f23e9a3c0 = makeCons(v0x7f1f23e9a2a0, v0x7f1f23e9a3a0);
+Obj v0x7f1f23e9a3e0 = makeCons(cc, v0x7f1f23e9a3c0);
+Obj v0x7f1f23e9a400 = makeCons(symlet, v0x7f1f23e9a3e0);
 __nargs = 2;
-__arg1 = _35reg713;
+__arg1 = v0x7f1f23e9a400;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4678,12 +4678,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label33:
 {
-Obj _35val686 = __arg1;
+Obj v0x7f1f23eb11a0 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj action = _35val686;
+Obj action = v0x7f1f23eb11a0;
 pushCont(co, 34, clofun2, 4, action, rules, value, cc);
 __nargs = 2;
 __arg0 = globalRef(symmacroexpand);
@@ -4697,7 +4697,7 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj _35val687 = __arg1;
+Obj v0x7f1f23eb1340 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4705,7 +4705,7 @@ Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 35, clofun2, 3, rules, value, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
-__arg1 = _35val687;
+__arg1 = v0x7f1f23eb1340;
 __arg2 = value;
 __arg3 = action;
 co->args[4] = cc;
@@ -4718,18 +4718,18 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj _35val688 = __arg1;
+Obj v0x7f1f23eb13e0 = __arg1;
 Obj rules= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj value= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj curr = _35val688;
-Obj _35reg689 = PRIM_CDR(rules);
-Obj _35reg690 = PRIM_CDR(_35reg689);
+Obj curr = v0x7f1f23eb13e0;
+Obj v0x7f1f23eb16e0 = PRIM_CDR(rules);
+Obj v0x7f1f23eb1700 = PRIM_CDR(v0x7f1f23eb16e0);
 pushCont(co, 36, clofun2, 2, curr, cc);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35match_45helper);
 __arg1 = value;
-__arg2 = _35reg690;
+__arg2 = v0x7f1f23eb1700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4739,19 +4739,19 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj _35val691 = __arg1;
+Obj v0x7f1f23eb1720 = __arg1;
 Obj curr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj rest = _35val691;
-Obj _35reg692 = makeCons(rest, Nil);
-Obj _35reg693 = makeCons(Nil, _35reg692);
-Obj _35reg694 = makeCons(symlambda, _35reg693);
-Obj _35reg695 = makeCons(curr, Nil);
-Obj _35reg696 = makeCons(_35reg694, _35reg695);
-Obj _35reg697 = makeCons(cc, _35reg696);
-Obj _35reg698 = makeCons(symlet, _35reg697);
+Obj rest = v0x7f1f23eb1720;
+Obj v0x7f1f23eb1c00 = makeCons(rest, Nil);
+Obj v0x7f1f23eb1c20 = makeCons(Nil, v0x7f1f23eb1c00);
+Obj v0x7f1f23eb1c40 = makeCons(symlambda, v0x7f1f23eb1c20);
+Obj v0x7f1f23eb1d80 = makeCons(curr, Nil);
+Obj v0x7f1f23eb1da0 = makeCons(v0x7f1f23eb1c40, v0x7f1f23eb1d80);
+Obj v0x7f1f23eb1dc0 = makeCons(cc, v0x7f1f23eb1da0);
+Obj v0x7f1f23eb1de0 = makeCons(symlet, v0x7f1f23eb1dc0);
 __nargs = 2;
-__arg1 = _35reg698;
+__arg1 = v0x7f1f23eb1de0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4761,9 +4761,9 @@ label37:
 {
 Obj rules = __arg1;
 Obj cc = __arg2;
-Obj _35reg651 = PRIM_CDR(rules);
-Obj _35reg652 = PRIM_CAR(_35reg651);
-Obj action = _35reg652;
+Obj v0x7f1f23eddce0 = PRIM_CDR(rules);
+Obj v0x7f1f23eddd00 = PRIM_CAR(v0x7f1f23eddce0);
+Obj action = v0x7f1f23eddd00;
 pushCont(co, 38, clofun2, 2, cc, action);
 __nargs = 2;
 __arg0 = globalRef(sympair_63);
@@ -4777,13 +4777,13 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj _35val653 = __arg1;
+Obj v0x7f1f23edde40 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val653) {
-Obj _35reg654 = PRIM_CAR(action);
-Obj _35reg655 = PRIM_EQ(_35reg654, symwhere);
-if (True == _35reg655) {
+if (True == v0x7f1f23edde40) {
+Obj v0x7f1f23ed5080 = PRIM_CAR(action);
+Obj v0x7f1f23ed50c0 = PRIM_EQ(v0x7f1f23ed5080, symwhere);
+if (True == v0x7f1f23ed50c0) {
 if (True == True) {
 pushCont(co, 43, clofun2, 2, action, cc);
 __nargs = 2;
@@ -4843,10 +4843,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label39:
 {
-Obj _35val670 = __arg1;
+Obj v0x7f1f23ecc160 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 40, clofun2, 2, cc, _35val670);
+pushCont(co, 40, clofun2, 2, cc, v0x7f1f23ecc160);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = action;
@@ -4859,16 +4859,16 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj _35val671 = __arg1;
+Obj v0x7f1f23ecc320 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35val670= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg672 = makeCons(cc, Nil);
-Obj _35reg673 = makeCons(_35reg672, Nil);
-Obj _35reg674 = makeCons(_35val671, _35reg673);
-Obj _35reg675 = makeCons(_35val670, _35reg674);
-Obj _35reg676 = makeCons(symif, _35reg675);
+Obj v0x7f1f23ecc160= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23ecc4e0 = makeCons(cc, Nil);
+Obj v0x7f1f23ecc520 = makeCons(v0x7f1f23ecc4e0, Nil);
+Obj v0x7f1f23ecc540 = makeCons(v0x7f1f23ecc320, v0x7f1f23ecc520);
+Obj v0x7f1f23ecc560 = makeCons(v0x7f1f23ecc160, v0x7f1f23ecc540);
+Obj v0x7f1f23ecc5a0 = makeCons(symif, v0x7f1f23ecc560);
 __nargs = 2;
-__arg1 = _35reg676;
+__arg1 = v0x7f1f23ecc5a0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4876,10 +4876,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label41:
 {
-Obj _35val663 = __arg1;
+Obj v0x7f1f23ed5b00 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 42, clofun2, 2, cc, _35val663);
+pushCont(co, 42, clofun2, 2, cc, v0x7f1f23ed5b00);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = action;
@@ -4892,16 +4892,16 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj _35val664 = __arg1;
+Obj v0x7f1f23ed5c80 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35val663= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg665 = makeCons(cc, Nil);
-Obj _35reg666 = makeCons(_35reg665, Nil);
-Obj _35reg667 = makeCons(_35val664, _35reg666);
-Obj _35reg668 = makeCons(_35val663, _35reg667);
-Obj _35reg669 = makeCons(symif, _35reg668);
+Obj v0x7f1f23ed5b00= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23ed5e60 = makeCons(cc, Nil);
+Obj v0x7f1f23ed5ea0 = makeCons(v0x7f1f23ed5e60, Nil);
+Obj v0x7f1f23ed5ec0 = makeCons(v0x7f1f23ed5c80, v0x7f1f23ed5ea0);
+Obj v0x7f1f23ed5ee0 = makeCons(v0x7f1f23ed5b00, v0x7f1f23ed5ec0);
+Obj v0x7f1f23ed5f00 = makeCons(symif, v0x7f1f23ed5ee0);
 __nargs = 2;
-__arg1 = _35reg669;
+__arg1 = v0x7f1f23ed5f00;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4909,10 +4909,10 @@ goto *jumpTable[co->ctx.pc.label];
 
 label43:
 {
-Obj _35val656 = __arg1;
+Obj v0x7f1f23ed5360 = __arg1;
 Obj action= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 44, clofun2, 2, cc, _35val656);
+pushCont(co, 44, clofun2, 2, cc, v0x7f1f23ed5360);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = action;
@@ -4925,16 +4925,16 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj _35val657 = __arg1;
+Obj v0x7f1f23ed5560 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35val656= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg658 = makeCons(cc, Nil);
-Obj _35reg659 = makeCons(_35reg658, Nil);
-Obj _35reg660 = makeCons(_35val657, _35reg659);
-Obj _35reg661 = makeCons(_35val656, _35reg660);
-Obj _35reg662 = makeCons(symif, _35reg661);
+Obj v0x7f1f23ed5360= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23ed5700 = makeCons(cc, Nil);
+Obj v0x7f1f23ed5740 = makeCons(v0x7f1f23ed5700, Nil);
+Obj v0x7f1f23ed5760 = makeCons(v0x7f1f23ed5560, v0x7f1f23ed5740);
+Obj v0x7f1f23ed57e0 = makeCons(v0x7f1f23ed5360, v0x7f1f23ed5760);
+Obj v0x7f1f23ed5800 = makeCons(symif, v0x7f1f23ed57e0);
 __nargs = 2;
-__arg1 = _35reg662;
+__arg1 = v0x7f1f23ed5800;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -4960,43 +4960,43 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj _35val621 = __arg1;
+Obj v0x7f1f23efe700 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == _35val621) {
-Obj _35reg622 = PRIM_EQ(pat, expr);
-if (True == _35reg622) {
+if (True == v0x7f1f23efe700) {
+Obj v0x7f1f23efe820 = PRIM_EQ(pat, expr);
+if (True == v0x7f1f23efe820) {
 __nargs = 2;
 __arg1 = body;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg623 = makeCons(expr, Nil);
-Obj _35reg624 = makeCons(pat, _35reg623);
-Obj _35reg625 = makeCons(sym_61, _35reg624);
-Obj _35reg626 = makeCons(cc, Nil);
-Obj _35reg627 = makeCons(_35reg626, Nil);
-Obj _35reg628 = makeCons(body, _35reg627);
-Obj _35reg629 = makeCons(_35reg625, _35reg628);
-Obj _35reg630 = makeCons(symif, _35reg629);
+Obj v0x7f1f23efec40 = makeCons(expr, Nil);
+Obj v0x7f1f23efec60 = makeCons(pat, v0x7f1f23efec40);
+Obj v0x7f1f23efec80 = makeCons(sym_61, v0x7f1f23efec60);
+Obj v0x7f1f23ef8200 = makeCons(cc, Nil);
+Obj v0x7f1f23ef8280 = makeCons(v0x7f1f23ef8200, Nil);
+Obj v0x7f1f23ef82a0 = makeCons(body, v0x7f1f23ef8280);
+Obj v0x7f1f23ef82c0 = makeCons(v0x7f1f23efec80, v0x7f1f23ef82a0);
+Obj v0x7f1f23ef82e0 = makeCons(symif, v0x7f1f23ef82c0);
 __nargs = 2;
-__arg1 = _35reg630;
+__arg1 = v0x7f1f23ef82e0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 }
 } else {
-Obj _35reg631 = primIsSymbol(pat);
-if (True == _35reg631) {
-Obj _35reg632 = makeCons(body, Nil);
-Obj _35reg633 = makeCons(expr, _35reg632);
-Obj _35reg634 = makeCons(pat, _35reg633);
-Obj _35reg635 = makeCons(symlet, _35reg634);
+Obj v0x7f1f23ef83e0 = primIsSymbol(pat);
+if (True == v0x7f1f23ef83e0) {
+Obj v0x7f1f23ef8820 = makeCons(body, Nil);
+Obj v0x7f1f23ef8840 = makeCons(expr, v0x7f1f23ef8820);
+Obj v0x7f1f23ef8860 = makeCons(pat, v0x7f1f23ef8840);
+Obj v0x7f1f23ef8880 = makeCons(symlet, v0x7f1f23ef8860);
 __nargs = 2;
-__arg1 = _35reg635;
+__arg1 = v0x7f1f23ef8880;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5016,32 +5016,32 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj _35val636 = __arg1;
+Obj v0x7f1f23ef8980 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == _35val636) {
-Obj _35reg637 = PRIM_CAR(pat);
-Obj _35reg638 = PRIM_EQ(_35reg637, symquote);
-if (True == _35reg638) {
-Obj _35reg639 = makeCons(expr, Nil);
-Obj _35reg640 = makeCons(pat, _35reg639);
-Obj _35reg641 = makeCons(sym_61, _35reg640);
-Obj _35reg642 = makeCons(cc, Nil);
-Obj _35reg643 = makeCons(_35reg642, Nil);
-Obj _35reg644 = makeCons(body, _35reg643);
-Obj _35reg645 = makeCons(_35reg641, _35reg644);
-Obj _35reg646 = makeCons(symif, _35reg645);
+if (True == v0x7f1f23ef8980) {
+Obj v0x7f1f23ef8b60 = PRIM_CAR(pat);
+Obj v0x7f1f23ef8ba0 = PRIM_EQ(v0x7f1f23ef8b60, symquote);
+if (True == v0x7f1f23ef8ba0) {
+Obj v0x7f1f23ef8f80 = makeCons(expr, Nil);
+Obj v0x7f1f23ef8fa0 = makeCons(pat, v0x7f1f23ef8f80);
+Obj v0x7f1f23ef8fc0 = makeCons(sym_61, v0x7f1f23ef8fa0);
+Obj v0x7f1f23edd260 = makeCons(cc, Nil);
+Obj v0x7f1f23edd380 = makeCons(v0x7f1f23edd260, Nil);
+Obj v0x7f1f23edd3a0 = makeCons(body, v0x7f1f23edd380);
+Obj v0x7f1f23edd3c0 = makeCons(v0x7f1f23ef8fc0, v0x7f1f23edd3a0);
+Obj v0x7f1f23edd3e0 = makeCons(symif, v0x7f1f23edd3c0);
 __nargs = 2;
-__arg1 = _35reg646;
+__arg1 = v0x7f1f23edd3e0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg647 = PRIM_CAR(pat);
-Obj _35reg648 = PRIM_EQ(_35reg647, symcons);
-if (True == _35reg648) {
+Obj v0x7f1f23edd580 = PRIM_CAR(pat);
+Obj v0x7f1f23edd5e0 = PRIM_EQ(v0x7f1f23edd580, symcons);
+if (True == v0x7f1f23edd5e0) {
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match_45cons_45expander);
 __arg1 = pat;
@@ -5080,10 +5080,10 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj _35val649 = __arg1;
+Obj v0x7f1f23edd980 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symerror);
-__arg1 = _35val649;
+__arg1 = v0x7f1f23edd980;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5127,12 +5127,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val618 = __arg1;
+Obj v0x7f1f23efe3c0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == _35val618) {
-Obj _35reg619 = primIsSymbol(x);
-Obj _35reg620 = primNot(_35reg619);
-if (True == _35reg620) {
+if (True == v0x7f1f23efe3c0) {
+Obj v0x7f1f23efe5a0 = primIsSymbol(x);
+Obj v0x7f1f23efe5c0 = primNot(v0x7f1f23efe5a0);
+if (True == v0x7f1f23efe5c0) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -5173,12 +5173,12 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj _35val564 = __arg1;
+Obj v0x7f1f23f58560 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj x = _35val564;
+Obj x = v0x7f1f23f58560;
 pushCont(co, 3, clofun3, 4, expr, body, x, cc);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
@@ -5192,17 +5192,17 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj _35val565 = __arg1;
+Obj v0x7f1f23f58660 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj y = _35val565;
-Obj _35reg566 = PRIM_ISCONS(expr);
-if (True == _35reg566) {
-Obj _35reg567 = PRIM_CAR(expr);
-Obj _35reg568 = PRIM_EQ(_35reg567, symcons);
-if (True == _35reg568) {
+Obj y = v0x7f1f23f58660;
+Obj v0x7f1f23f587e0 = PRIM_ISCONS(expr);
+if (True == v0x7f1f23f587e0) {
+Obj v0x7f1f23f58a60 = PRIM_CAR(expr);
+Obj v0x7f1f23f58aa0 = PRIM_EQ(v0x7f1f23f58a60, symcons);
+if (True == v0x7f1f23f58aa0) {
 if (True == True) {
 pushCont(co, 16, clofun3, 5, expr, y, body, x, cc);
 __nargs = 2;
@@ -5214,17 +5214,17 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg572 = makeCons(expr, Nil);
-Obj _35reg573 = makeCons(symcons_63, _35reg572);
-Obj _35reg574 = makeCons(expr, Nil);
-Obj _35reg575 = makeCons(symcar, _35reg574);
-Obj _35reg576 = makeCons(expr, Nil);
-Obj _35reg577 = makeCons(symcdr, _35reg576);
-pushCont(co, 14, clofun3, 4, x, _35reg575, cc, _35reg573);
+Obj v0x7f1f23f492c0 = makeCons(expr, Nil);
+Obj v0x7f1f23f492e0 = makeCons(symcons_63, v0x7f1f23f492c0);
+Obj v0x7f1f23f49660 = makeCons(expr, Nil);
+Obj v0x7f1f23f49680 = makeCons(symcar, v0x7f1f23f49660);
+Obj v0x7f1f23f49960 = makeCons(expr, Nil);
+Obj v0x7f1f23f49980 = makeCons(symcdr, v0x7f1f23f49960);
+pushCont(co, 14, clofun3, 4, x, v0x7f1f23f49680, cc, v0x7f1f23f492e0);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = y;
-__arg2 = _35reg577;
+__arg2 = v0x7f1f23f49980;
 __arg3 = body;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
@@ -5245,17 +5245,17 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg588 = makeCons(expr, Nil);
-Obj _35reg589 = makeCons(symcons_63, _35reg588);
-Obj _35reg590 = makeCons(expr, Nil);
-Obj _35reg591 = makeCons(symcar, _35reg590);
-Obj _35reg592 = makeCons(expr, Nil);
-Obj _35reg593 = makeCons(symcdr, _35reg592);
-pushCont(co, 9, clofun3, 4, x, _35reg591, cc, _35reg589);
+Obj v0x7f1f23f434c0 = makeCons(expr, Nil);
+Obj v0x7f1f23f434e0 = makeCons(symcons_63, v0x7f1f23f434c0);
+Obj v0x7f1f23f43820 = makeCons(expr, Nil);
+Obj v0x7f1f23f43840 = makeCons(symcar, v0x7f1f23f43820);
+Obj v0x7f1f23f43b40 = makeCons(expr, Nil);
+Obj v0x7f1f23f43b60 = makeCons(symcdr, v0x7f1f23f43b40);
+pushCont(co, 9, clofun3, 4, x, v0x7f1f23f43840, cc, v0x7f1f23f434e0);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = y;
-__arg2 = _35reg593;
+__arg2 = v0x7f1f23f43b60;
 __arg3 = body;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
@@ -5277,17 +5277,17 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg604 = makeCons(expr, Nil);
-Obj _35reg605 = makeCons(symcons_63, _35reg604);
-Obj _35reg606 = makeCons(expr, Nil);
-Obj _35reg607 = makeCons(symcar, _35reg606);
-Obj _35reg608 = makeCons(expr, Nil);
-Obj _35reg609 = makeCons(symcdr, _35reg608);
-pushCont(co, 4, clofun3, 4, x, _35reg607, cc, _35reg605);
+Obj v0x7f1f23f3c660 = makeCons(expr, Nil);
+Obj v0x7f1f23f3c680 = makeCons(symcons_63, v0x7f1f23f3c660);
+Obj v0x7f1f23f3c9e0 = makeCons(expr, Nil);
+Obj v0x7f1f23f3ca00 = makeCons(symcar, v0x7f1f23f3c9e0);
+Obj v0x7f1f23f3cce0 = makeCons(expr, Nil);
+Obj v0x7f1f23f3cd00 = makeCons(symcdr, v0x7f1f23f3cce0);
+pushCont(co, 4, clofun3, 4, x, v0x7f1f23f3ca00, cc, v0x7f1f23f3c680);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = y;
-__arg2 = _35reg609;
+__arg2 = v0x7f1f23f3cd00;
 __arg3 = body;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
@@ -5301,17 +5301,17 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35val610 = __arg1;
+Obj v0x7f1f23f3cd80 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg607= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23f3ca00= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg605= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 5, clofun3, 2, cc, _35reg605);
+Obj v0x7f1f23f3c680= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 5, clofun3, 2, cc, v0x7f1f23f3c680);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
-__arg2 = _35reg607;
-__arg3 = _35val610;
+__arg2 = v0x7f1f23f3ca00;
+__arg3 = v0x7f1f23f3cd80;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5322,16 +5322,16 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35val611 = __arg1;
+Obj v0x7f1f23f3cde0 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg605= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg612 = makeCons(cc, Nil);
-Obj _35reg613 = makeCons(_35reg612, Nil);
-Obj _35reg614 = makeCons(_35val611, _35reg613);
-Obj _35reg615 = makeCons(_35reg605, _35reg614);
-Obj _35reg616 = makeCons(symif, _35reg615);
+Obj v0x7f1f23f3c680= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23f3cf80 = makeCons(cc, Nil);
+Obj v0x7f1f23f3cfe0 = makeCons(v0x7f1f23f3cf80, Nil);
+Obj v0x7f1f23efe000 = makeCons(v0x7f1f23f3cde0, v0x7f1f23f3cfe0);
+Obj v0x7f1f23efe020 = makeCons(v0x7f1f23f3c680, v0x7f1f23efe000);
+Obj v0x7f1f23efe040 = makeCons(symif, v0x7f1f23efe020);
 __nargs = 2;
-__arg1 = _35reg616;
+__arg1 = v0x7f1f23efe040;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5339,13 +5339,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label6:
 {
-Obj _35val601 = __arg1;
+Obj v0x7f1f23f43fa0 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = _35val601;
+Obj e1 = v0x7f1f23f43fa0;
 pushCont(co, 7, clofun3, 5, y, body, x, e1, cc);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
@@ -5359,13 +5359,13 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35val602 = __arg1;
+Obj v0x7f1f23f3c0a0 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = _35val602;
+Obj e2 = v0x7f1f23f3c0a0;
 pushCont(co, 8, clofun3, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
@@ -5382,7 +5382,7 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35val603 = __arg1;
+Obj v0x7f1f23f3c2e0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5390,7 +5390,7 @@ __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
 __arg2 = e1;
-__arg3 = _35val603;
+__arg3 = v0x7f1f23f3c2e0;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5401,17 +5401,17 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj _35val594 = __arg1;
+Obj v0x7f1f23f43bc0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg591= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23f43840= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg589= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 10, clofun3, 2, cc, _35reg589);
+Obj v0x7f1f23f434e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 10, clofun3, 2, cc, v0x7f1f23f434e0);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
-__arg2 = _35reg591;
-__arg3 = _35val594;
+__arg2 = v0x7f1f23f43840;
+__arg3 = v0x7f1f23f43bc0;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5422,16 +5422,16 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj _35val595 = __arg1;
+Obj v0x7f1f23f43c00 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg589= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg596 = makeCons(cc, Nil);
-Obj _35reg597 = makeCons(_35reg596, Nil);
-Obj _35reg598 = makeCons(_35val595, _35reg597);
-Obj _35reg599 = makeCons(_35reg589, _35reg598);
-Obj _35reg600 = makeCons(symif, _35reg599);
+Obj v0x7f1f23f434e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23f43dc0 = makeCons(cc, Nil);
+Obj v0x7f1f23f43e20 = makeCons(v0x7f1f23f43dc0, Nil);
+Obj v0x7f1f23f43e40 = makeCons(v0x7f1f23f43c00, v0x7f1f23f43e20);
+Obj v0x7f1f23f43e60 = makeCons(v0x7f1f23f434e0, v0x7f1f23f43e40);
+Obj v0x7f1f23f43e80 = makeCons(symif, v0x7f1f23f43e60);
 __nargs = 2;
-__arg1 = _35reg600;
+__arg1 = v0x7f1f23f43e80;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5439,13 +5439,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label11:
 {
-Obj _35val585 = __arg1;
+Obj v0x7f1f23f49dc0 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = _35val585;
+Obj e1 = v0x7f1f23f49dc0;
 pushCont(co, 12, clofun3, 5, y, body, x, e1, cc);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
@@ -5459,13 +5459,13 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj _35val586 = __arg1;
+Obj v0x7f1f23f49ee0 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = _35val586;
+Obj e2 = v0x7f1f23f49ee0;
 pushCont(co, 13, clofun3, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
@@ -5482,7 +5482,7 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35val587 = __arg1;
+Obj v0x7f1f23f43120 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5490,7 +5490,7 @@ __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
 __arg2 = e1;
-__arg3 = _35val587;
+__arg3 = v0x7f1f23f43120;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5501,17 +5501,17 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj _35val578 = __arg1;
+Obj v0x7f1f23f499e0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg575= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23f49680= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg573= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-pushCont(co, 15, clofun3, 2, cc, _35reg573);
+Obj v0x7f1f23f492e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
+pushCont(co, 15, clofun3, 2, cc, v0x7f1f23f492e0);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
-__arg2 = _35reg575;
-__arg3 = _35val578;
+__arg2 = v0x7f1f23f49680;
+__arg3 = v0x7f1f23f499e0;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5522,16 +5522,16 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj _35val579 = __arg1;
+Obj v0x7f1f23f49a40 = __arg1;
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg573= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg580 = makeCons(cc, Nil);
-Obj _35reg581 = makeCons(_35reg580, Nil);
-Obj _35reg582 = makeCons(_35val579, _35reg581);
-Obj _35reg583 = makeCons(_35reg573, _35reg582);
-Obj _35reg584 = makeCons(symif, _35reg583);
+Obj v0x7f1f23f492e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23f49c00 = makeCons(cc, Nil);
+Obj v0x7f1f23f49c40 = makeCons(v0x7f1f23f49c00, Nil);
+Obj v0x7f1f23f49c60 = makeCons(v0x7f1f23f49a40, v0x7f1f23f49c40);
+Obj v0x7f1f23f49c80 = makeCons(v0x7f1f23f492e0, v0x7f1f23f49c60);
+Obj v0x7f1f23f49ca0 = makeCons(symif, v0x7f1f23f49c80);
 __nargs = 2;
-__arg1 = _35reg584;
+__arg1 = v0x7f1f23f49ca0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5539,13 +5539,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label16:
 {
-Obj _35val569 = __arg1;
+Obj v0x7f1f23f58ba0 = __arg1;
 Obj expr= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e1 = _35val569;
+Obj e1 = v0x7f1f23f58ba0;
 pushCont(co, 17, clofun3, 5, y, body, x, e1, cc);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
@@ -5559,13 +5559,13 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj _35val570 = __arg1;
+Obj v0x7f1f23f58d00 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj e2 = _35val570;
+Obj e2 = v0x7f1f23f58d00;
 pushCont(co, 18, clofun3, 3, x, e1, cc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
@@ -5582,7 +5582,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35val571 = __arg1;
+Obj v0x7f1f23f58f20 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj e1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5590,7 +5590,7 @@ __nargs = 5;
 __arg0 = globalRef(symcora_47init_35match1);
 __arg1 = x;
 __arg2 = e1;
-__arg3 = _35val571;
+__arg3 = v0x7f1f23f58f20;
 co->args[4] = cc;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5602,10 +5602,10 @@ goto *jumpTable[ps.label];
 label19:
 {
 Obj exp = __arg1;
-Obj _35reg562 = PRIM_CDR(exp);
+Obj v0x7f1f23f58260 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rcons1);
-__arg1 = _35reg562;
+__arg1 = v0x7f1f23f58260;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5616,11 +5616,11 @@ goto *jumpTable[ps.label];
 label20:
 {
 Obj pat = __arg1;
-Obj _35reg552 = PRIM_CDR(pat);
+Obj v0x7f1f23f5c580 = PRIM_CDR(pat);
 pushCont(co, 21, clofun3, 1, pat);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = _35reg552;
+__arg1 = v0x7f1f23f5c580;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5630,22 +5630,22 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj _35val553 = __arg1;
+Obj v0x7f1f23f5c5c0 = __arg1;
 Obj pat= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == _35val553) {
-Obj _35reg554 = PRIM_CAR(pat);
+if (True == v0x7f1f23f5c5c0) {
+Obj v0x7f1f23f5c6a0 = PRIM_CAR(pat);
 __nargs = 2;
-__arg1 = _35reg554;
+__arg1 = v0x7f1f23f5c6a0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg555 = PRIM_CAR(pat);
-Obj _35reg556 = PRIM_CDR(pat);
-pushCont(co, 22, clofun3, 1, _35reg555);
+Obj v0x7f1f23f5c9e0 = PRIM_CAR(pat);
+Obj v0x7f1f23f5cd00 = PRIM_CDR(pat);
+pushCont(co, 22, clofun3, 1, v0x7f1f23f5c9e0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rcons1);
-__arg1 = _35reg556;
+__arg1 = v0x7f1f23f5cd00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5656,13 +5656,13 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj _35val557 = __arg1;
-Obj _35reg555= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg558 = makeCons(_35val557, Nil);
-Obj _35reg559 = makeCons(_35reg555, _35reg558);
-Obj _35reg560 = makeCons(symcons, _35reg559);
+Obj v0x7f1f23f5cd20 = __arg1;
+Obj v0x7f1f23f5c9e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f23f5ce00 = makeCons(v0x7f1f23f5cd20, Nil);
+Obj v0x7f1f23f5ce20 = makeCons(v0x7f1f23f5c9e0, v0x7f1f23f5ce00);
+Obj v0x7f1f23f5ce60 = makeCons(symcons, v0x7f1f23f5ce20);
 __nargs = 2;
-__arg1 = _35reg560;
+__arg1 = v0x7f1f23f5ce60;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5671,16 +5671,16 @@ goto *jumpTable[co->ctx.pc.label];
 label23:
 {
 Obj x = __arg1;
-Obj _35reg549 = PRIM_EQ(x, True);
-if (True == _35reg549) {
+Obj v0x7f1f23e9b900 = PRIM_EQ(x, True);
+if (True == v0x7f1f23e9b900) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg550 = PRIM_EQ(x, False);
-if (True == _35reg550) {
+Obj v0x7f1f23f5c020 = PRIM_EQ(x, False);
+if (True == v0x7f1f23f5c020) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -5699,10 +5699,10 @@ goto *jumpTable[co->ctx.pc.label];
 label24:
 {
 Obj exp = __arg1;
-Obj _35reg547 = PRIM_CDR(exp);
+Obj v0x7f1f23e9b680 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45and);
-__arg1 = _35reg547;
+__arg1 = v0x7f1f23e9b680;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5713,28 +5713,28 @@ goto *jumpTable[ps.label];
 label25:
 {
 Obj l = __arg1;
-Obj _35reg535 = PRIM_EQ(Nil, l);
-if (True == _35reg535) {
+Obj v0x7f1f23eb1ac0 = PRIM_EQ(Nil, l);
+if (True == v0x7f1f23eb1ac0) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg536 = PRIM_CAR(l);
-Obj _35reg537 = PRIM_EQ(_35reg536, False);
-if (True == _35reg537) {
+Obj v0x7f1f23eb1c60 = PRIM_CAR(l);
+Obj v0x7f1f23eb1ca0 = PRIM_EQ(v0x7f1f23eb1c60, False);
+if (True == v0x7f1f23eb1ca0) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg538 = PRIM_CDR(l);
+Obj v0x7f1f23eb1e40 = PRIM_CDR(l);
 pushCont(co, 26, clofun3, 1, l);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45and);
-__arg1 = _35reg538;
+__arg1 = v0x7f1f23eb1e40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5746,24 +5746,24 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35val539 = __arg1;
+Obj v0x7f1f23eb1e60 = __arg1;
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj more = _35val539;
-Obj _35reg540 = PRIM_EQ(more, False);
-if (True == _35reg540) {
+Obj more = v0x7f1f23eb1e60;
+Obj v0x7f1f23eb1f80 = PRIM_EQ(more, False);
+if (True == v0x7f1f23eb1f80) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg541 = PRIM_CAR(l);
-Obj _35reg542 = makeCons(False, Nil);
-Obj _35reg543 = makeCons(more, _35reg542);
-Obj _35reg544 = makeCons(_35reg541, _35reg543);
-Obj _35reg545 = makeCons(symif, _35reg544);
+Obj v0x7f1f23e9b1a0 = PRIM_CAR(l);
+Obj v0x7f1f23e9b360 = makeCons(False, Nil);
+Obj v0x7f1f23e9b380 = makeCons(more, v0x7f1f23e9b360);
+Obj v0x7f1f23e9b3a0 = makeCons(v0x7f1f23e9b1a0, v0x7f1f23e9b380);
+Obj v0x7f1f23e9b3c0 = makeCons(symif, v0x7f1f23e9b3a0);
 __nargs = 2;
-__arg1 = _35reg545;
+__arg1 = v0x7f1f23e9b3c0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5773,10 +5773,10 @@ goto *jumpTable[co->ctx.pc.label];
 label27:
 {
 Obj exp = __arg1;
-Obj _35reg533 = PRIM_CDR(exp);
+Obj v0x7f1f23eb1840 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45or);
-__arg1 = _35reg533;
+__arg1 = v0x7f1f23eb1840;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5787,28 +5787,28 @@ goto *jumpTable[ps.label];
 label28:
 {
 Obj l = __arg1;
-Obj _35reg521 = PRIM_EQ(l, Nil);
-if (True == _35reg521) {
+Obj v0x7f1f23eccc80 = PRIM_EQ(l, Nil);
+if (True == v0x7f1f23eccc80) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg522 = PRIM_CAR(l);
-Obj _35reg523 = PRIM_EQ(_35reg522, True);
-if (True == _35reg523) {
+Obj v0x7f1f23ecce20 = PRIM_CAR(l);
+Obj v0x7f1f23ecce60 = PRIM_EQ(v0x7f1f23ecce20, True);
+if (True == v0x7f1f23ecce60) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg524 = PRIM_CDR(l);
+Obj v0x7f1f23eb1000 = PRIM_CDR(l);
 pushCont(co, 29, clofun3, 1, l);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45or);
-__arg1 = _35reg524;
+__arg1 = v0x7f1f23eb1000;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5820,24 +5820,24 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj _35val525 = __arg1;
+Obj v0x7f1f23eb1020 = __arg1;
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj more = _35val525;
-Obj _35reg526 = PRIM_EQ(more, True);
-if (True == _35reg526) {
+Obj more = v0x7f1f23eb1020;
+Obj v0x7f1f23eb1140 = PRIM_EQ(more, True);
+if (True == v0x7f1f23eb1140) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg527 = PRIM_CAR(l);
-Obj _35reg528 = makeCons(more, Nil);
-Obj _35reg529 = makeCons(True, _35reg528);
-Obj _35reg530 = makeCons(_35reg527, _35reg529);
-Obj _35reg531 = makeCons(symif, _35reg530);
+Obj v0x7f1f23eb1360 = PRIM_CAR(l);
+Obj v0x7f1f23eb1520 = makeCons(more, Nil);
+Obj v0x7f1f23eb1540 = makeCons(True, v0x7f1f23eb1520);
+Obj v0x7f1f23eb1560 = makeCons(v0x7f1f23eb1360, v0x7f1f23eb1540);
+Obj v0x7f1f23eb1580 = makeCons(symif, v0x7f1f23eb1560);
 __nargs = 2;
-__arg1 = _35reg531;
+__arg1 = v0x7f1f23eb1580;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5847,13 +5847,13 @@ goto *jumpTable[co->ctx.pc.label];
 label30:
 {
 Obj exp = __arg1;
-Obj _35reg507 = PRIM_CDR(exp);
-Obj _35reg508 = PRIM_EQ(Nil, _35reg507);
-if (True == _35reg508) {
-Obj _35reg509 = makeCons(makeCString("no cond match"), Nil);
-Obj _35reg510 = makeCons(symerror, _35reg509);
+Obj v0x7f1f23ecc080 = PRIM_CDR(exp);
+Obj v0x7f1f23ecc0a0 = PRIM_EQ(Nil, v0x7f1f23ecc080);
+if (True == v0x7f1f23ecc0a0) {
+Obj v0x7f1f23ecc240 = makeCons(makeCString("no cond match"), Nil);
+Obj v0x7f1f23ecc260 = makeCons(symerror, v0x7f1f23ecc240);
 __nargs = 2;
-__arg1 = _35reg510;
+__arg1 = v0x7f1f23ecc260;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5872,11 +5872,11 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj _35val511 = __arg1;
+Obj v0x7f1f23ecc360 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj curr = _35val511;
-Obj _35reg512 = PRIM_CAR(curr);
-pushCont(co, 32, clofun3, 2, exp, _35reg512);
+Obj curr = v0x7f1f23ecc360;
+Obj v0x7f1f23ecc580 = PRIM_CAR(curr);
+pushCont(co, 32, clofun3, 2, exp, v0x7f1f23ecc580);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
 __arg1 = curr;
@@ -5889,10 +5889,10 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj _35val513 = __arg1;
+Obj v0x7f1f23ecc700 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg512= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 33, clofun3, 2, _35val513, _35reg512);
+Obj v0x7f1f23ecc580= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 33, clofun3, 2, v0x7f1f23ecc700, v0x7f1f23ecc580);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
 __arg1 = exp;
@@ -5905,16 +5905,16 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj _35val514 = __arg1;
-Obj _35val513= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg512= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg515 = makeCons(symcond, _35val514);
-Obj _35reg516 = makeCons(_35reg515, Nil);
-Obj _35reg517 = makeCons(_35val513, _35reg516);
-Obj _35reg518 = makeCons(_35reg512, _35reg517);
-Obj _35reg519 = makeCons(symif, _35reg518);
+Obj v0x7f1f23ecc940 = __arg1;
+Obj v0x7f1f23ecc700= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f23ecc580= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23ecc960 = makeCons(symcond, v0x7f1f23ecc940);
+Obj v0x7f1f23ecc9a0 = makeCons(v0x7f1f23ecc960, Nil);
+Obj v0x7f1f23ecc9c0 = makeCons(v0x7f1f23ecc700, v0x7f1f23ecc9a0);
+Obj v0x7f1f23ecc9e0 = makeCons(v0x7f1f23ecc580, v0x7f1f23ecc9c0);
+Obj v0x7f1f23ecca00 = makeCons(symif, v0x7f1f23ecc9e0);
 __nargs = 2;
-__arg1 = _35reg519;
+__arg1 = v0x7f1f23ecca00;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -5923,10 +5923,10 @@ goto *jumpTable[co->ctx.pc.label];
 label34:
 {
 Obj exp = __arg1;
-Obj _35reg505 = PRIM_CDR(exp);
+Obj v0x7f1f23ed5d60 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45let);
-__arg1 = _35reg505;
+__arg1 = v0x7f1f23ed5d60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5937,11 +5937,11 @@ goto *jumpTable[ps.label];
 label35:
 {
 Obj exp = __arg1;
-Obj _35reg493 = PRIM_CDR(exp);
+Obj v0x7f1f23eddee0 = PRIM_CDR(exp);
 pushCont(co, 36, clofun3, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symnull_63);
-__arg1 = _35reg493;
+__arg1 = v0x7f1f23eddee0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5951,18 +5951,18 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj _35val494 = __arg1;
+Obj v0x7f1f23eddf40 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == _35val494) {
-Obj _35reg495 = PRIM_CAR(exp);
+if (True == v0x7f1f23eddf40) {
+Obj v0x7f1f23ed5000 = PRIM_CAR(exp);
 __nargs = 2;
-__arg1 = _35reg495;
+__arg1 = v0x7f1f23ed5000;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg496 = PRIM_CAR(exp);
-pushCont(co, 37, clofun3, 2, exp, _35reg496);
+Obj v0x7f1f23ed5280 = PRIM_CAR(exp);
+pushCont(co, 37, clofun3, 2, exp, v0x7f1f23ed5280);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
 __arg1 = exp;
@@ -5976,10 +5976,10 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj _35val497 = __arg1;
+Obj v0x7f1f23ed5400 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg496= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 38, clofun3, 2, _35val497, _35reg496);
+Obj v0x7f1f23ed5280= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 38, clofun3, 2, v0x7f1f23ed5400, v0x7f1f23ed5280);
 __nargs = 2;
 __arg0 = globalRef(symcddr);
 __arg1 = exp;
@@ -5992,13 +5992,13 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj _35val498 = __arg1;
-Obj _35val497= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg496= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 39, clofun3, 2, _35val497, _35reg496);
+Obj v0x7f1f23ed59e0 = __arg1;
+Obj v0x7f1f23ed5400= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f23ed5280= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 39, clofun3, 2, v0x7f1f23ed5400, v0x7f1f23ed5280);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35rewrite_45let);
-__arg1 = _35val498;
+__arg1 = v0x7f1f23ed59e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6008,15 +6008,15 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj _35val499 = __arg1;
-Obj _35val497= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg496= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg500 = makeCons(_35val499, Nil);
-Obj _35reg501 = makeCons(_35val497, _35reg500);
-Obj _35reg502 = makeCons(_35reg496, _35reg501);
-Obj _35reg503 = makeCons(symlet, _35reg502);
+Obj v0x7f1f23ed5a00 = __arg1;
+Obj v0x7f1f23ed5400= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f23ed5280= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23ed5a40 = makeCons(v0x7f1f23ed5a00, Nil);
+Obj v0x7f1f23ed5a60 = makeCons(v0x7f1f23ed5400, v0x7f1f23ed5a40);
+Obj v0x7f1f23ed5a80 = makeCons(v0x7f1f23ed5280, v0x7f1f23ed5a60);
+Obj v0x7f1f23ed5aa0 = makeCons(symlet, v0x7f1f23ed5a80);
 __nargs = 2;
-__arg1 = _35reg503;
+__arg1 = v0x7f1f23ed5aa0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6025,10 +6025,10 @@ goto *jumpTable[co->ctx.pc.label];
 label40:
 {
 Obj x = __arg1;
-Obj _35reg490 = PRIM_ISCONS(x);
-Obj _35reg491 = primNot(_35reg490);
+Obj v0x7f1f23eddbc0 = PRIM_ISCONS(x);
+Obj v0x7f1f23eddbe0 = primNot(v0x7f1f23eddbc0);
 __nargs = 2;
-__arg1 = _35reg491;
+__arg1 = v0x7f1f23eddbe0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6038,22 +6038,22 @@ label41:
 {
 Obj x = __arg1;
 Obj l = __arg2;
-Obj _35reg485 = PRIM_ISCONS(l);
-if (True == _35reg485) {
-Obj _35reg486 = PRIM_CAR(l);
-Obj _35reg487 = PRIM_EQ(_35reg486, x);
-if (True == _35reg487) {
+Obj v0x7f1f23edd5a0 = PRIM_ISCONS(l);
+if (True == v0x7f1f23edd5a0) {
+Obj v0x7f1f23edd740 = PRIM_CAR(l);
+Obj v0x7f1f23edd780 = PRIM_EQ(v0x7f1f23edd740, x);
+if (True == v0x7f1f23edd780) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg488 = PRIM_CDR(l);
+Obj v0x7f1f23edd900 = PRIM_CDR(l);
 __nargs = 3;
 __arg0 = globalRef(symelem_63);
 __arg1 = x;
-__arg2 = _35reg488;
+__arg2 = v0x7f1f23edd900;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6085,9 +6085,9 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj _35val475 = __arg1;
+Obj v0x7f1f23ef8de0 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 44, clofun3, 2, exp, _35val475);
+pushCont(co, 44, clofun3, 2, exp, v0x7f1f23ef8de0);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = exp;
@@ -6100,10 +6100,10 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj _35val476 = __arg1;
+Obj v0x7f1f23edd0c0 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35val475= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 45, clofun3, 2, _35val476, _35val475);
+Obj v0x7f1f23ef8de0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 45, clofun3, 2, v0x7f1f23edd0c0, v0x7f1f23ef8de0);
 __nargs = 2;
 __arg0 = globalRef(symcadddr);
 __arg1 = exp;
@@ -6116,17 +6116,17 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj _35val477 = __arg1;
-Obj _35val476= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35val475= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg478 = makeCons(_35val477, Nil);
-Obj _35reg479 = makeCons(_35val476, _35reg478);
-Obj _35reg480 = makeCons(symlambda, _35reg479);
-Obj _35reg481 = makeCons(_35reg480, Nil);
-Obj _35reg482 = makeCons(_35val475, _35reg481);
-Obj _35reg483 = makeCons(symdef, _35reg482);
+Obj v0x7f1f23edd240 = __arg1;
+Obj v0x7f1f23edd0c0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f23ef8de0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23edd280 = makeCons(v0x7f1f23edd240, Nil);
+Obj v0x7f1f23edd2a0 = makeCons(v0x7f1f23edd0c0, v0x7f1f23edd280);
+Obj v0x7f1f23edd2c0 = makeCons(symlambda, v0x7f1f23edd2a0);
+Obj v0x7f1f23edd300 = makeCons(v0x7f1f23edd2c0, Nil);
+Obj v0x7f1f23edd320 = makeCons(v0x7f1f23ef8de0, v0x7f1f23edd300);
+Obj v0x7f1f23edd340 = makeCons(symdef, v0x7f1f23edd320);
 __nargs = 2;
-__arg1 = _35reg483;
+__arg1 = v0x7f1f23edd340;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun3) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6135,10 +6135,10 @@ goto *jumpTable[co->ctx.pc.label];
 label46:
 {
 Obj exp = __arg1;
-Obj _35reg473 = PRIM_CDR(exp);
+Obj v0x7f1f23ef8a60 = PRIM_CDR(exp);
 __nargs = 2;
 __arg0 = globalRef(symrcons);
-__arg1 = _35reg473;
+__arg1 = v0x7f1f23ef8a60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6162,11 +6162,11 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj _35val461 = __arg1;
+Obj v0x7f1f23ef8160 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg462 = makeCons(_35val461, Nil);
-Obj _35reg463 = makeCons(symquote, _35reg462);
-pushCont(co, 49, clofun3, 2, exp, _35reg463);
+Obj v0x7f1f23ef81a0 = makeCons(v0x7f1f23ef8160, Nil);
+Obj v0x7f1f23ef81c0 = makeCons(symquote, v0x7f1f23ef81a0);
+pushCont(co, 49, clofun3, 2, exp, v0x7f1f23ef81c0);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = exp;
@@ -6179,10 +6179,10 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj _35val464 = __arg1;
+Obj v0x7f1f23ef84e0 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg463= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 0, clofun4, 2, _35val464, _35reg463);
+Obj v0x7f1f23ef81c0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 0, clofun4, 2, v0x7f1f23ef84e0, v0x7f1f23ef81c0);
 __nargs = 2;
 __arg0 = globalRef(symcdddr);
 __arg1 = exp;
@@ -6215,16 +6215,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val465 = __arg1;
-Obj _35val464= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg463= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg466 = makeCons(_35val464, _35val465);
-Obj _35reg467 = makeCons(symlambda, _35reg466);
-Obj _35reg468 = makeCons(_35reg467, Nil);
-Obj _35reg469 = makeCons(_35reg463, _35reg468);
-Obj _35reg470 = makeCons(symcora_47init_35add_45to_45_42macros_42, _35reg469);
+Obj v0x7f1f23ef85c0 = __arg1;
+Obj v0x7f1f23ef84e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f23ef81c0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f23ef85e0 = makeCons(v0x7f1f23ef84e0, v0x7f1f23ef85c0);
+Obj v0x7f1f23ef8600 = makeCons(symlambda, v0x7f1f23ef85e0);
+Obj v0x7f1f23ef8640 = makeCons(v0x7f1f23ef8600, Nil);
+Obj v0x7f1f23ef8660 = makeCons(v0x7f1f23ef81c0, v0x7f1f23ef8640);
+Obj v0x7f1f23ef8680 = makeCons(symcora_47init_35add_45to_45_42macros_42, v0x7f1f23ef8660);
 __nargs = 2;
-__arg1 = _35reg470;
+__arg1 = v0x7f1f23ef8680;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6233,21 +6233,21 @@ goto *jumpTable[co->ctx.pc.label];
 label1:
 {
 Obj exp = __arg1;
-Obj _35reg443 = PRIM_ISCONS(exp);
-if (True == _35reg443) {
-Obj _35reg444 = PRIM_CAR(exp);
-Obj _35reg445 = PRIM_EQ(_35reg444, globalRef(sym_42protect_45symbol_42));
-if (True == _35reg445) {
-Obj _35reg446 = PRIM_CDR(exp);
+Obj v0x7f1f23f3c920 = PRIM_ISCONS(exp);
+if (True == v0x7f1f23f3c920) {
+Obj v0x7f1f23f3cac0 = PRIM_CAR(exp);
+Obj v0x7f1f23f3cb00 = PRIM_EQ(v0x7f1f23f3cac0, globalRef(sym_42protect_45symbol_42));
+if (True == v0x7f1f23f3cb00) {
+Obj v0x7f1f23f3cbc0 = PRIM_CDR(exp);
 __nargs = 2;
-__arg1 = _35reg446;
+__arg1 = v0x7f1f23f3cbc0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg447 = PRIM_CAR(exp);
-Obj _35reg448 = PRIM_EQ(_35reg447, symlambda);
-if (True == _35reg448) {
+Obj v0x7f1f23f3cd60 = PRIM_CAR(exp);
+Obj v0x7f1f23f3cda0 = PRIM_EQ(v0x7f1f23f3cd60, symlambda);
+if (True == v0x7f1f23f3cda0) {
 pushCont(co, 4, clofun4, 1, exp);
 __nargs = 2;
 __arg0 = globalRef(symcadr);
@@ -6258,9 +6258,9 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg455 = PRIM_CAR(exp);
-Obj _35reg456 = PRIM_EQ(_35reg455, symquote);
-if (True == _35reg456) {
+Obj v0x7f1f23efe420 = PRIM_CAR(exp);
+Obj v0x7f1f23efe460 = PRIM_EQ(v0x7f1f23efe420, symquote);
+if (True == v0x7f1f23efe460) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -6290,11 +6290,11 @@ goto *jumpTable[co->ctx.pc.label];
 
 label2:
 {
-Obj _35val458 = __arg1;
+Obj v0x7f1f23efe8a0 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = makeNative(3, clofun4, 1, 1, exp);
-__arg1 = _35val458;
+__arg1 = v0x7f1f23efe8a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6305,8 +6305,8 @@ goto *jumpTable[ps.label];
 label3:
 {
 Obj exp1 = __arg1;
-Obj _35reg457 = PRIM_EQ(exp1, closureRef(co, 0));
-if (True == _35reg457) {
+Obj v0x7f1f23efe660 = PRIM_EQ(exp1, closureRef(co, 0));
+if (True == v0x7f1f23efe660) {
 __nargs = 3;
 __arg0 = globalRef(symmap);
 __arg1 = globalRef(symcora_47init_35macroexpand_45boot);
@@ -6330,9 +6330,9 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35val449 = __arg1;
+Obj v0x7f1f23f3cfc0 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 5, clofun4, 1, _35val449);
+pushCont(co, 5, clofun4, 1, v0x7f1f23f3cfc0);
 __nargs = 2;
 __arg0 = globalRef(symcaddr);
 __arg1 = exp;
@@ -6345,12 +6345,12 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35val450 = __arg1;
-Obj _35val449= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 6, clofun4, 1, _35val449);
+Obj v0x7f1f23efe1e0 = __arg1;
+Obj v0x7f1f23f3cfc0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+pushCont(co, 6, clofun4, 1, v0x7f1f23f3cfc0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35macroexpand_45boot);
-__arg1 = _35val450;
+__arg1 = v0x7f1f23efe1e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6360,13 +6360,13 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj _35val451 = __arg1;
-Obj _35val449= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg452 = makeCons(_35val451, Nil);
-Obj _35reg453 = makeCons(_35val449, _35reg452);
-Obj _35reg454 = makeCons(symlambda, _35reg453);
+Obj v0x7f1f23efe200 = __arg1;
+Obj v0x7f1f23f3cfc0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f23efe240 = makeCons(v0x7f1f23efe200, Nil);
+Obj v0x7f1f23efe260 = makeCons(v0x7f1f23f3cfc0, v0x7f1f23efe240);
+Obj v0x7f1f23efe280 = makeCons(symlambda, v0x7f1f23efe260);
 __nargs = 2;
-__arg1 = _35reg454;
+__arg1 = v0x7f1f23efe280;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6390,18 +6390,18 @@ label8:
 {
 Obj exp = __arg1;
 Obj macros = __arg2;
-Obj _35reg429 = PRIM_EQ(Nil, macros);
-if (True == _35reg429) {
+Obj v0x7f1f23f43680 = PRIM_EQ(Nil, macros);
+if (True == v0x7f1f23f43680) {
 __nargs = 2;
 __arg1 = exp;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg440 = PRIM_CAR(macros);
+Obj v0x7f1f23f3c4a0 = PRIM_CAR(macros);
 __nargs = 2;
 __arg0 = makeNative(9, clofun4, 1, 2, exp, macros);
-__arg1 = _35reg440;
+__arg1 = v0x7f1f23f3c4a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6413,16 +6413,16 @@ goto *jumpTable[ps.label];
 label9:
 {
 Obj item = __arg1;
-Obj _35reg430 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg430) {
-Obj _35reg431 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg432 = PRIM_CAR(item);
-Obj _35reg433 = PRIM_EQ(_35reg431, _35reg432);
-if (True == _35reg433) {
+Obj v0x7f1f23f43880 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23f43880) {
+Obj v0x7f1f23f43a20 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23f43b00 = PRIM_CAR(item);
+Obj v0x7f1f23f43b20 = PRIM_EQ(v0x7f1f23f43a20, v0x7f1f23f43b00);
+if (True == v0x7f1f23f43b20) {
 if (True == True) {
-Obj _35reg434 = PRIM_CDR(item);
+Obj v0x7f1f23f43c60 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = _35reg434;
+__arg0 = v0x7f1f23f43c60;
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6430,11 +6430,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg435 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f23f43e00 = PRIM_CDR(closureRef(co, 1));
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35macroexpand1_45h);
 __arg1 = closureRef(co, 0);
-__arg2 = _35reg435;
+__arg2 = v0x7f1f23f43e00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6443,9 +6443,9 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj _35reg436 = PRIM_CDR(item);
+Obj v0x7f1f23f43f40 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = _35reg436;
+__arg0 = v0x7f1f23f43f40;
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6453,11 +6453,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg437 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f23f3c0e0 = PRIM_CDR(closureRef(co, 1));
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35macroexpand1_45h);
 __arg1 = closureRef(co, 0);
-__arg2 = _35reg437;
+__arg2 = v0x7f1f23f3c0e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6467,9 +6467,9 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj _35reg438 = PRIM_CDR(item);
+Obj v0x7f1f23f3c220 = PRIM_CDR(item);
 __nargs = 2;
-__arg0 = _35reg438;
+__arg0 = v0x7f1f23f3c220;
 __arg1 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6477,11 +6477,11 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg439 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f23f3c3c0 = PRIM_CDR(closureRef(co, 1));
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35macroexpand1_45h);
 __arg1 = closureRef(co, 0);
-__arg2 = _35reg439;
+__arg2 = v0x7f1f23f3c3c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6495,11 +6495,11 @@ label10:
 {
 Obj n = __arg1;
 Obj v = __arg2;
-Obj _35reg425 = makeCons(n, v);
-Obj _35reg426 = makeCons(_35reg425, globalRef(sym_42macros_42));
-Obj _35reg427 = primSet(co, sym_42macros_42, _35reg426);
+Obj v0x7f1f23f433a0 = makeCons(n, v);
+Obj v0x7f1f23f433e0 = makeCons(v0x7f1f23f433a0, globalRef(sym_42macros_42));
+Obj v0x7f1f23f43400 = primSet(co, sym_42macros_42, v0x7f1f23f433e0);
 __nargs = 2;
-__arg1 = _35reg427;
+__arg1 = v0x7f1f23f43400;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6526,13 +6526,13 @@ label12:
 Obj res = __arg1;
 Obj f = __arg2;
 Obj l = __arg3;
-Obj _35reg415 = PRIM_ISCONS(l);
-if (True == _35reg415) {
-Obj _35reg416 = PRIM_CAR(l);
+Obj v0x7f1f23f49620 = PRIM_ISCONS(l);
+if (True == v0x7f1f23f49620) {
+Obj v0x7f1f23f498c0 = PRIM_CAR(l);
 pushCont(co, 13, clofun4, 3, res, l, f);
 __nargs = 2;
 __arg0 = f;
-__arg1 = _35reg416;
+__arg1 = v0x7f1f23f498c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6552,17 +6552,17 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35val417 = __arg1;
+Obj v0x7f1f23f498e0 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj l= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg418 = makeCons(_35val417, res);
-Obj _35reg419 = PRIM_CDR(l);
+Obj v0x7f1f23f49920 = makeCons(v0x7f1f23f498e0, res);
+Obj v0x7f1f23f49a20 = PRIM_CDR(l);
 __nargs = 4;
 __arg0 = globalRef(symmap_45h);
-__arg1 = _35reg418;
+__arg1 = v0x7f1f23f49920;
 __arg2 = f;
-__arg3 = _35reg419;
+__arg3 = v0x7f1f23f49a20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6574,15 +6574,15 @@ label14:
 {
 Obj res = __arg1;
 Obj l = __arg2;
-Obj _35reg408 = PRIM_ISCONS(l);
-if (True == _35reg408) {
-Obj _35reg409 = PRIM_CAR(l);
-Obj _35reg410 = makeCons(_35reg409, res);
-Obj _35reg411 = PRIM_CDR(l);
+Obj v0x7f1f23f58ec0 = PRIM_ISCONS(l);
+if (True == v0x7f1f23f58ec0) {
+Obj v0x7f1f23f490c0 = PRIM_CAR(l);
+Obj v0x7f1f23f49100 = makeCons(v0x7f1f23f490c0, res);
+Obj v0x7f1f23f491e0 = PRIM_CDR(l);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35reverse_45h);
-__arg1 = _35reg410;
-__arg2 = _35reg411;
+__arg1 = v0x7f1f23f49100;
+__arg2 = v0x7f1f23f491e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6600,9 +6600,9 @@ goto *jumpTable[co->ctx.pc.label];
 label15:
 {
 Obj x = __arg1;
-Obj _35reg406 = PRIM_ISCONS(x);
+Obj v0x7f1f23f58c40 = PRIM_ISCONS(x);
 __nargs = 2;
-__arg1 = _35reg406;
+__arg1 = v0x7f1f23f58c40;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6611,14 +6611,14 @@ goto *jumpTable[co->ctx.pc.label];
 label16:
 {
 Obj exp = __arg1;
-Obj _35reg398 = PRIM_ISCONS(exp);
-if (True == _35reg398) {
-Obj _35reg399 = PRIM_CAR(exp);
-Obj _35reg400 = PRIM_CDR(exp);
-pushCont(co, 17, clofun4, 1, _35reg399);
+Obj v0x7f1f23f584e0 = PRIM_ISCONS(exp);
+if (True == v0x7f1f23f584e0) {
+Obj v0x7f1f23f58740 = PRIM_CAR(exp);
+Obj v0x7f1f23f58960 = PRIM_CDR(exp);
+pushCont(co, 17, clofun4, 1, v0x7f1f23f58740);
 __nargs = 2;
 __arg0 = globalRef(symrcons);
-__arg1 = _35reg400;
+__arg1 = v0x7f1f23f58960;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6635,13 +6635,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label17:
 {
-Obj _35val401 = __arg1;
-Obj _35reg399= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg402 = makeCons(_35val401, Nil);
-Obj _35reg403 = makeCons(_35reg399, _35reg402);
-Obj _35reg404 = makeCons(symcons, _35reg403);
+Obj v0x7f1f23f58980 = __arg1;
+Obj v0x7f1f23f58740= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f23f589e0 = makeCons(v0x7f1f23f58980, Nil);
+Obj v0x7f1f23f58a00 = makeCons(v0x7f1f23f58740, v0x7f1f23f589e0);
+Obj v0x7f1f23f58a20 = makeCons(symcons, v0x7f1f23f58a00);
 __nargs = 2;
-__arg1 = _35reg404;
+__arg1 = v0x7f1f23f58a20;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6650,11 +6650,11 @@ goto *jumpTable[co->ctx.pc.label];
 label18:
 {
 Obj x = __arg1;
-Obj _35reg394 = PRIM_CDR(x);
-Obj _35reg395 = PRIM_CDR(_35reg394);
-Obj _35reg396 = PRIM_CDR(_35reg395);
+Obj v0x7f1f23f581e0 = PRIM_CDR(x);
+Obj v0x7f1f23f58200 = PRIM_CDR(v0x7f1f23f581e0);
+Obj v0x7f1f23f58220 = PRIM_CDR(v0x7f1f23f58200);
 __nargs = 2;
-__arg1 = _35reg396;
+__arg1 = v0x7f1f23f58220;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6663,12 +6663,12 @@ goto *jumpTable[co->ctx.pc.label];
 label19:
 {
 Obj x = __arg1;
-Obj _35reg389 = PRIM_CDR(x);
-Obj _35reg390 = PRIM_CDR(_35reg389);
-Obj _35reg391 = PRIM_CDR(_35reg390);
-Obj _35reg392 = PRIM_CAR(_35reg391);
+Obj v0x7f1f23f5cd40 = PRIM_CDR(x);
+Obj v0x7f1f23f5cd60 = PRIM_CDR(v0x7f1f23f5cd40);
+Obj v0x7f1f23f5cd80 = PRIM_CDR(v0x7f1f23f5cd60);
+Obj v0x7f1f23f5cda0 = PRIM_CAR(v0x7f1f23f5cd80);
 __nargs = 2;
-__arg1 = _35reg392;
+__arg1 = v0x7f1f23f5cda0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6677,11 +6677,11 @@ goto *jumpTable[co->ctx.pc.label];
 label20:
 {
 Obj x = __arg1;
-Obj _35reg385 = PRIM_CDR(x);
-Obj _35reg386 = PRIM_CDR(_35reg385);
-Obj _35reg387 = PRIM_CAR(_35reg386);
+Obj v0x7f1f23f5c7a0 = PRIM_CDR(x);
+Obj v0x7f1f23f5c7c0 = PRIM_CDR(v0x7f1f23f5c7a0);
+Obj v0x7f1f23f5c7e0 = PRIM_CAR(v0x7f1f23f5c7c0);
 __nargs = 2;
-__arg1 = _35reg387;
+__arg1 = v0x7f1f23f5c7e0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6690,10 +6690,10 @@ goto *jumpTable[co->ctx.pc.label];
 label21:
 {
 Obj x = __arg1;
-Obj _35reg382 = PRIM_CDR(x);
-Obj _35reg383 = PRIM_CDR(_35reg382);
+Obj v0x7f1f23f5c2c0 = PRIM_CDR(x);
+Obj v0x7f1f23f5c340 = PRIM_CDR(v0x7f1f23f5c2c0);
 __nargs = 2;
-__arg1 = _35reg383;
+__arg1 = v0x7f1f23f5c340;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6702,10 +6702,10 @@ goto *jumpTable[co->ctx.pc.label];
 label22:
 {
 Obj x = __arg1;
-Obj _35reg379 = PRIM_CAR(x);
-Obj _35reg380 = PRIM_CDR(_35reg379);
+Obj v0x7f1f23ed5780 = PRIM_CAR(x);
+Obj v0x7f1f23ed57a0 = PRIM_CDR(v0x7f1f23ed5780);
 __nargs = 2;
-__arg1 = _35reg380;
+__arg1 = v0x7f1f23ed57a0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6714,10 +6714,10 @@ goto *jumpTable[co->ctx.pc.label];
 label23:
 {
 Obj x = __arg1;
-Obj _35reg376 = PRIM_CAR(x);
-Obj _35reg377 = PRIM_CAR(_35reg376);
+Obj v0x7f1f23ed54a0 = PRIM_CAR(x);
+Obj v0x7f1f23ed54c0 = PRIM_CAR(v0x7f1f23ed54a0);
 __nargs = 2;
-__arg1 = _35reg377;
+__arg1 = v0x7f1f23ed54c0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6726,10 +6726,10 @@ goto *jumpTable[co->ctx.pc.label];
 label24:
 {
 Obj x = __arg1;
-Obj _35reg373 = PRIM_CDR(x);
-Obj _35reg374 = PRIM_CAR(_35reg373);
+Obj v0x7f1f23ed51c0 = PRIM_CDR(x);
+Obj v0x7f1f23ed51e0 = PRIM_CAR(v0x7f1f23ed51c0);
 __nargs = 2;
-__arg1 = _35reg374;
+__arg1 = v0x7f1f23ed51e0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6738,9 +6738,9 @@ goto *jumpTable[co->ctx.pc.label];
 label25:
 {
 Obj x = __arg1;
-Obj _35reg371 = PRIM_EQ(x, Nil);
+Obj v0x7f1f23eddf00 = PRIM_EQ(x, Nil);
 __nargs = 2;
-__arg1 = _35reg371;
+__arg1 = v0x7f1f23eddf00;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun4) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];

--- a/lib/hash-h.c
+++ b/lib/hash-h.c
@@ -17,11 +17,12 @@ hashToNumberHelp(Obj key) {
 
   switch (tag(key)) {
   case TAG_SYMBOL:
-    {
-      const char* str = symbolStr(key);
-      int sum = hashForString(str);
-      return makeNumber(sum);
-    }
+	  {
+		  char str[256];
+		  symbolStr(key, str, 256);
+		  int sum = hashForString(str);
+		  return makeNumber(sum);
+	  }
 
   case TAG_IMMEDIATE_CONST:
     if (key == True) {

--- a/lib/os.c
+++ b/lib/os.c
@@ -29,7 +29,8 @@ static void
 popenFn(struct Cora *co) {
   Obj cmd = co->args[1];
   Obj mode = co->args[2];
-  char* type = symbolStr(mode);
+  char type[256];
+  symbolStr(mode, type, 256);
 
   strBuf cmdStr = cmdListStr(cmd);
   FILE* f = popen(toCStr(cmdStr), type);

--- a/lib/toc.c
+++ b/lib/toc.c
@@ -330,7 +330,7 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj _35val1641 = __arg1;
+Obj v0x7f1f24138720 = __arg1;
 PUSH_CONT_0(co, 2, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35import);
@@ -344,7 +344,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj _35val1642 = __arg1;
+Obj v0x7f1f24138820 = __arg1;
 PUSH_CONT_0(co, 3, clofun0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35import);
@@ -358,120 +358,120 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj _35val1643 = __arg1;
-Obj _35reg1644 = primSet(co, symcora_47lib_47toc_35_42ns_45export_42, Nil);
-Obj _35reg1659 = primSet(co, symcora_47lib_47toc_35assq, makeNative(40, clofun9, 2, 0));
-Obj _35reg1665 = primSet(co, symcora_47lib_47toc_35foldl, makeNative(36, clofun9, 3, 0));
-Obj _35reg1675 = primSet(co, symcora_47lib_47toc_35pos_45in_45list0, makeNative(32, clofun9, 3, 0));
-Obj _35reg1676 = primSet(co, symcora_47lib_47toc_35index, makeNative(31, clofun9, 2, 0));
-Obj _35reg1683 = primSet(co, symcora_47lib_47toc_35exist_45in_45env, makeNative(27, clofun9, 2, 0));
-Obj _35reg1684 = makeCons(makeCString("primSet"), Nil);
-Obj _35reg1685 = makeCons(MAKE_NUMBER(2), _35reg1684);
-Obj _35reg1686 = makeCons(symset, _35reg1685);
-Obj _35reg1687 = makeCons(makeCString("PRIM_CAR"), Nil);
-Obj _35reg1688 = makeCons(MAKE_NUMBER(1), _35reg1687);
-Obj _35reg1689 = makeCons(symcar, _35reg1688);
-Obj _35reg1690 = makeCons(makeCString("PRIM_CDR"), Nil);
-Obj _35reg1691 = makeCons(MAKE_NUMBER(1), _35reg1690);
-Obj _35reg1692 = makeCons(symcdr, _35reg1691);
-Obj _35reg1693 = makeCons(makeCString("makeCons"), Nil);
-Obj _35reg1694 = makeCons(MAKE_NUMBER(2), _35reg1693);
-Obj _35reg1695 = makeCons(symcons, _35reg1694);
-Obj _35reg1696 = makeCons(makeCString("PRIM_ISCONS"), Nil);
-Obj _35reg1697 = makeCons(MAKE_NUMBER(1), _35reg1696);
-Obj _35reg1698 = makeCons(symcons_63, _35reg1697);
-Obj _35reg1699 = makeCons(makeCString("PRIM_ADD"), Nil);
-Obj _35reg1700 = makeCons(MAKE_NUMBER(2), _35reg1699);
-Obj _35reg1701 = makeCons(sym_43, _35reg1700);
-Obj _35reg1702 = makeCons(makeCString("PRIM_SUB"), Nil);
-Obj _35reg1703 = makeCons(MAKE_NUMBER(2), _35reg1702);
-Obj _35reg1704 = makeCons(sym_45, _35reg1703);
-Obj _35reg1705 = makeCons(makeCString("PRIM_MUL"), Nil);
-Obj _35reg1706 = makeCons(MAKE_NUMBER(2), _35reg1705);
-Obj _35reg1707 = makeCons(sym_42, _35reg1706);
-Obj _35reg1708 = makeCons(makeCString("primDiv"), Nil);
-Obj _35reg1709 = makeCons(MAKE_NUMBER(2), _35reg1708);
-Obj _35reg1710 = makeCons(sym_47, _35reg1709);
-Obj _35reg1711 = makeCons(makeCString("PRIM_EQ"), Nil);
-Obj _35reg1712 = makeCons(MAKE_NUMBER(2), _35reg1711);
-Obj _35reg1713 = makeCons(sym_61, _35reg1712);
-Obj _35reg1714 = makeCons(makeCString("PRIM_GT"), Nil);
-Obj _35reg1715 = makeCons(MAKE_NUMBER(2), _35reg1714);
-Obj _35reg1716 = makeCons(sym_62, _35reg1715);
-Obj _35reg1717 = makeCons(makeCString("PRIM_LT"), Nil);
-Obj _35reg1718 = makeCons(MAKE_NUMBER(2), _35reg1717);
-Obj _35reg1719 = makeCons(sym_60, _35reg1718);
-Obj _35reg1720 = makeCons(makeCString("primGenSym"), Nil);
-Obj _35reg1721 = makeCons(MAKE_NUMBER(1), _35reg1720);
-Obj _35reg1722 = makeCons(symgensym, _35reg1721);
-Obj _35reg1723 = makeCons(makeCString("primIsSymbol"), Nil);
-Obj _35reg1724 = makeCons(MAKE_NUMBER(1), _35reg1723);
-Obj _35reg1725 = makeCons(symsymbol_63, _35reg1724);
-Obj _35reg1726 = makeCons(makeCString("primNot"), Nil);
-Obj _35reg1727 = makeCons(MAKE_NUMBER(1), _35reg1726);
-Obj _35reg1728 = makeCons(symnot, _35reg1727);
-Obj _35reg1729 = makeCons(makeCString("primIsNumber"), Nil);
-Obj _35reg1730 = makeCons(MAKE_NUMBER(1), _35reg1729);
-Obj _35reg1731 = makeCons(syminteger_63, _35reg1730);
-Obj _35reg1732 = makeCons(makeCString("primIsString"), Nil);
-Obj _35reg1733 = makeCons(MAKE_NUMBER(1), _35reg1732);
-Obj _35reg1734 = makeCons(symstring_63, _35reg1733);
-Obj _35reg1735 = makeCons(_35reg1734, Nil);
-Obj _35reg1736 = makeCons(_35reg1731, _35reg1735);
-Obj _35reg1737 = makeCons(_35reg1728, _35reg1736);
-Obj _35reg1738 = makeCons(_35reg1725, _35reg1737);
-Obj _35reg1739 = makeCons(_35reg1722, _35reg1738);
-Obj _35reg1740 = makeCons(_35reg1719, _35reg1739);
-Obj _35reg1741 = makeCons(_35reg1716, _35reg1740);
-Obj _35reg1742 = makeCons(_35reg1713, _35reg1741);
-Obj _35reg1743 = makeCons(_35reg1710, _35reg1742);
-Obj _35reg1744 = makeCons(_35reg1707, _35reg1743);
-Obj _35reg1745 = makeCons(_35reg1704, _35reg1744);
-Obj _35reg1746 = makeCons(_35reg1701, _35reg1745);
-Obj _35reg1747 = makeCons(_35reg1698, _35reg1746);
-Obj _35reg1748 = makeCons(_35reg1695, _35reg1747);
-Obj _35reg1749 = makeCons(_35reg1692, _35reg1748);
-Obj _35reg1750 = makeCons(_35reg1689, _35reg1749);
-Obj _35reg1751 = makeCons(_35reg1686, _35reg1750);
-Obj _35reg1752 = primSet(co, symcora_47lib_47toc_35_42builtin_45prims_42, _35reg1751);
-Obj _35reg1756 = primSet(co, symcora_47lib_47toc_35builtin_63, makeNative(24, clofun9, 1, 0));
-Obj _35reg1759 = primSet(co, symcora_47lib_47toc_35builtin_45_62name, makeNative(21, clofun9, 1, 0));
-Obj _35reg1762 = primSet(co, symcora_47lib_47toc_35builtin_45_62args, makeNative(18, clofun9, 1, 0));
-Obj _35reg1767 = primSet(co, symcora_47lib_47toc_35temp_45list, makeNative(15, clofun9, 2, 0));
-Obj _35reg1773 = primSet(co, symcora_47lib_47toc_35var_45with_45ns, makeNative(10, clofun9, 2, 0));
-Obj _35reg1785 = primSet(co, symcora_47lib_47toc_35lookup_45var, makeNative(0, clofun9, 3, 0));
-Obj _35reg2021 = primSet(co, symcora_47lib_47toc_35parse, makeNative(9, clofun8, 5, 0));
-Obj _35reg2032 = primSet(co, symcora_47lib_47toc_35union, makeNative(3, clofun8, 2, 0));
-Obj _35reg2043 = primSet(co, symcora_47lib_47toc_35diff, makeNative(47, clofun7, 2, 0));
-Obj _35reg2094 = primSet(co, symcora_47lib_47toc_35convert_45protect_63, makeNative(40, clofun7, 1, 0));
-Obj _35reg2269 = primSet(co, symcora_47lib_47toc_35free_45vars, makeNative(17, clofun7, 1, 0));
-Obj _35reg2342 = primSet(co, symcora_47lib_47toc_35closure_45convert, makeNative(2, clofun7, 2, 0));
-Obj _35reg2345 = primSet(co, symcora_47lib_47toc_35id, makeNative(1, clofun7, 1, 0));
-Obj _35reg2482 = primSet(co, symcora_47lib_47toc_35tailify, makeNative(33, clofun6, 2, 0));
-Obj _35reg2529 = primSet(co, symcora_47lib_47toc_35tailify_45list, makeNative(23, clofun6, 3, 0));
-Obj _35reg2608 = primSet(co, symcora_47lib_47toc_35explicit_45stack, makeNative(5, clofun6, 2, 0));
-Obj _35reg2706 = primSet(co, symcora_47lib_47toc_35collect_45lambda, makeNative(35, clofun5, 2, 0));
-Obj _35reg2714 = primSet(co, symcora_47lib_47toc_35append_45result, makeNative(31, clofun5, 2, 0));
-Obj _35reg2721 = primSet(co, symcora_47lib_47toc_35wrap_45var, makeNative(29, clofun5, 2, 0));
-Obj _35reg2741 = primSet(co, symcora_47lib_47toc_35generate_45call_45list, makeNative(15, clofun5, 4, 0));
-Obj _35reg2746 = primSet(co, symcora_47lib_47toc_35add_45symbol_45to_45list, makeNative(12, clofun5, 2, 0));
-Obj _35reg3019 = primSet(co, symcora_47lib_47toc_35generate_45inst, makeNative(28, clofun3, 4, 0));
-Obj _35reg3058 = primSet(co, symcora_47lib_47toc_35generate_45cont, makeNative(4, clofun3, 3, 0));
-Obj _35reg3067 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list_45h, makeNative(48, clofun2, 5, 0));
-Obj _35reg3068 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list, makeNative(47, clofun2, 4, 0));
-Obj _35reg3069 = primSet(co, symcora_47lib_47toc_35_42mod_45num_42, MAKE_NUMBER(50));
-Obj _35reg3073 = primSet(co, symcora_47lib_47toc_35generate_45group_45name, makeNative(45, clofun2, 3, 0));
-Obj _35reg3077 = primSet(co, symcora_47lib_47toc_35code_45gen_45func_45declare, makeNative(41, clofun2, 3, 0));
-Obj _35reg3085 = primSet(co, symcora_47lib_47toc_35local_45from_45params, makeNative(34, clofun2, 3, 0));
-Obj _35reg3090 = primSet(co, symcora_47lib_47toc_35local_45from_45cont, makeNative(29, clofun2, 3, 0));
-Obj _35reg3097 = primSet(co, symcora_47lib_47toc_35generate_45call_45args_45reverse, makeNative(25, clofun2, 4, 0));
-Obj _35reg3160 = primSet(co, symcora_47lib_47toc_35code_45gen_45toplevel, makeNative(13, clofun2, 3, 0));
-Obj _35reg3161 = primSet(co, symcora_47lib_47toc_35parse_45pass, makeNative(12, clofun2, 2, 0));
-Obj _35reg3162 = primSet(co, symcora_47lib_47toc_35closure_45convert_45pass, makeNative(11, clofun2, 1, 0));
-Obj _35reg3163 = primSet(co, symcora_47lib_47toc_35tailify_45pass, makeNative(10, clofun2, 1, 0));
-Obj _35reg3164 = primSet(co, symcora_47lib_47toc_35explicit_45stack_45pass, makeNative(9, clofun2, 1, 0));
-Obj _35reg3174 = primSet(co, symcora_47lib_47toc_35collect_45lambda_45pass, makeNative(3, clofun2, 1, 0));
-Obj _35reg3181 = primSet(co, symcora_47lib_47toc_35rewrite_45_45_62macro, makeNative(0, clofun2, 2, 0));
+Obj v0x7f1f24138920 = __arg1;
+Obj v0x7f1f24138a40 = primSet(co, symcora_47lib_47toc_35_42ns_45export_42, Nil);
+Obj v0x7f1f24135f40 = primSet(co, symcora_47lib_47toc_35assq, makeNative(40, clofun9, 2, 0));
+Obj v0x7f1f24133a20 = primSet(co, symcora_47lib_47toc_35foldl, makeNative(36, clofun9, 3, 0));
+Obj v0x7f1f2412fb20 = primSet(co, symcora_47lib_47toc_35pos_45in_45list0, makeNative(32, clofun9, 3, 0));
+Obj v0x7f1f2412fd60 = primSet(co, symcora_47lib_47toc_35index, makeNative(31, clofun9, 2, 0));
+Obj v0x7f1f2412cbc0 = primSet(co, symcora_47lib_47toc_35exist_45in_45env, makeNative(27, clofun9, 2, 0));
+Obj v0x7f1f24128000 = makeCons(makeCString("primSet"), Nil);
+Obj v0x7f1f24128020 = makeCons(MAKE_NUMBER(2), v0x7f1f24128000);
+Obj v0x7f1f24128040 = makeCons(symset, v0x7f1f24128020);
+Obj v0x7f1f241283a0 = makeCons(makeCString("PRIM_CAR"), Nil);
+Obj v0x7f1f241283c0 = makeCons(MAKE_NUMBER(1), v0x7f1f241283a0);
+Obj v0x7f1f241283e0 = makeCons(symcar, v0x7f1f241283c0);
+Obj v0x7f1f24128780 = makeCons(makeCString("PRIM_CDR"), Nil);
+Obj v0x7f1f241287a0 = makeCons(MAKE_NUMBER(1), v0x7f1f24128780);
+Obj v0x7f1f241287c0 = makeCons(symcdr, v0x7f1f241287a0);
+Obj v0x7f1f24128b20 = makeCons(makeCString("makeCons"), Nil);
+Obj v0x7f1f24128b40 = makeCons(MAKE_NUMBER(2), v0x7f1f24128b20);
+Obj v0x7f1f24128b60 = makeCons(symcons, v0x7f1f24128b40);
+Obj v0x7f1f24128f00 = makeCons(makeCString("PRIM_ISCONS"), Nil);
+Obj v0x7f1f24128f20 = makeCons(MAKE_NUMBER(1), v0x7f1f24128f00);
+Obj v0x7f1f24128f40 = makeCons(symcons_63, v0x7f1f24128f20);
+Obj v0x7f1f240f9280 = makeCons(makeCString("PRIM_ADD"), Nil);
+Obj v0x7f1f240f92a0 = makeCons(MAKE_NUMBER(2), v0x7f1f240f9280);
+Obj v0x7f1f240f92c0 = makeCons(sym_43, v0x7f1f240f92a0);
+Obj v0x7f1f240f9600 = makeCons(makeCString("PRIM_SUB"), Nil);
+Obj v0x7f1f240f9660 = makeCons(MAKE_NUMBER(2), v0x7f1f240f9600);
+Obj v0x7f1f240f9680 = makeCons(sym_45, v0x7f1f240f9660);
+Obj v0x7f1f240f99e0 = makeCons(makeCString("PRIM_MUL"), Nil);
+Obj v0x7f1f240f9a00 = makeCons(MAKE_NUMBER(2), v0x7f1f240f99e0);
+Obj v0x7f1f240f9a20 = makeCons(sym_42, v0x7f1f240f9a00);
+Obj v0x7f1f240f9d40 = makeCons(makeCString("primDiv"), Nil);
+Obj v0x7f1f240f9d60 = makeCons(MAKE_NUMBER(2), v0x7f1f240f9d40);
+Obj v0x7f1f240f9d80 = makeCons(sym_47, v0x7f1f240f9d60);
+Obj v0x7f1f240f80a0 = makeCons(makeCString("PRIM_EQ"), Nil);
+Obj v0x7f1f240f80c0 = makeCons(MAKE_NUMBER(2), v0x7f1f240f80a0);
+Obj v0x7f1f240f80e0 = makeCons(sym_61, v0x7f1f240f80c0);
+Obj v0x7f1f240f8400 = makeCons(makeCString("PRIM_GT"), Nil);
+Obj v0x7f1f240f8420 = makeCons(MAKE_NUMBER(2), v0x7f1f240f8400);
+Obj v0x7f1f240f8440 = makeCons(sym_62, v0x7f1f240f8420);
+Obj v0x7f1f240f8760 = makeCons(makeCString("PRIM_LT"), Nil);
+Obj v0x7f1f240f8780 = makeCons(MAKE_NUMBER(2), v0x7f1f240f8760);
+Obj v0x7f1f240f87a0 = makeCons(sym_60, v0x7f1f240f8780);
+Obj v0x7f1f240f8ac0 = makeCons(makeCString("primGenSym"), Nil);
+Obj v0x7f1f240f8ae0 = makeCons(MAKE_NUMBER(1), v0x7f1f240f8ac0);
+Obj v0x7f1f240f8b00 = makeCons(symgensym, v0x7f1f240f8ae0);
+Obj v0x7f1f240f8e20 = makeCons(makeCString("primIsSymbol"), Nil);
+Obj v0x7f1f240f8e40 = makeCons(MAKE_NUMBER(1), v0x7f1f240f8e20);
+Obj v0x7f1f240f8e60 = makeCons(symsymbol_63, v0x7f1f240f8e40);
+Obj v0x7f1f240f6180 = makeCons(makeCString("primNot"), Nil);
+Obj v0x7f1f240f61a0 = makeCons(MAKE_NUMBER(1), v0x7f1f240f6180);
+Obj v0x7f1f240f61c0 = makeCons(symnot, v0x7f1f240f61a0);
+Obj v0x7f1f240f64e0 = makeCons(makeCString("primIsNumber"), Nil);
+Obj v0x7f1f240f6500 = makeCons(MAKE_NUMBER(1), v0x7f1f240f64e0);
+Obj v0x7f1f240f6520 = makeCons(syminteger_63, v0x7f1f240f6500);
+Obj v0x7f1f240f6840 = makeCons(makeCString("primIsString"), Nil);
+Obj v0x7f1f240f6860 = makeCons(MAKE_NUMBER(1), v0x7f1f240f6840);
+Obj v0x7f1f240f6880 = makeCons(symstring_63, v0x7f1f240f6860);
+Obj v0x7f1f240f68c0 = makeCons(v0x7f1f240f6880, Nil);
+Obj v0x7f1f240f68e0 = makeCons(v0x7f1f240f6520, v0x7f1f240f68c0);
+Obj v0x7f1f240f6900 = makeCons(v0x7f1f240f61c0, v0x7f1f240f68e0);
+Obj v0x7f1f240f6920 = makeCons(v0x7f1f240f8e60, v0x7f1f240f6900);
+Obj v0x7f1f240f6940 = makeCons(v0x7f1f240f8b00, v0x7f1f240f6920);
+Obj v0x7f1f240f6960 = makeCons(v0x7f1f240f87a0, v0x7f1f240f6940);
+Obj v0x7f1f240f6980 = makeCons(v0x7f1f240f8440, v0x7f1f240f6960);
+Obj v0x7f1f240f69a0 = makeCons(v0x7f1f240f80e0, v0x7f1f240f6980);
+Obj v0x7f1f240f69c0 = makeCons(v0x7f1f240f9d80, v0x7f1f240f69a0);
+Obj v0x7f1f240f69e0 = makeCons(v0x7f1f240f9a20, v0x7f1f240f69c0);
+Obj v0x7f1f240f6a00 = makeCons(v0x7f1f240f9680, v0x7f1f240f69e0);
+Obj v0x7f1f240f6a20 = makeCons(v0x7f1f240f92c0, v0x7f1f240f6a00);
+Obj v0x7f1f240f6a40 = makeCons(v0x7f1f24128f40, v0x7f1f240f6a20);
+Obj v0x7f1f240f6a60 = makeCons(v0x7f1f24128b60, v0x7f1f240f6a40);
+Obj v0x7f1f240f6a80 = makeCons(v0x7f1f241287c0, v0x7f1f240f6a60);
+Obj v0x7f1f240f6aa0 = makeCons(v0x7f1f241283e0, v0x7f1f240f6a80);
+Obj v0x7f1f240f6ac0 = makeCons(v0x7f1f24128040, v0x7f1f240f6aa0);
+Obj v0x7f1f240f6ae0 = primSet(co, symcora_47lib_47toc_35_42builtin_45prims_42, v0x7f1f240f6ac0);
+Obj v0x7f1f240f6ea0 = primSet(co, symcora_47lib_47toc_35builtin_63, makeNative(24, clofun9, 1, 0));
+Obj v0x7f1f240722c0 = primSet(co, symcora_47lib_47toc_35builtin_45_62name, makeNative(21, clofun9, 1, 0));
+Obj v0x7f1f240726e0 = primSet(co, symcora_47lib_47toc_35builtin_45_62args, makeNative(18, clofun9, 1, 0));
+Obj v0x7f1f24072f80 = primSet(co, symcora_47lib_47toc_35temp_45list, makeNative(15, clofun9, 2, 0));
+Obj v0x7f1f2406b620 = primSet(co, symcora_47lib_47toc_35var_45with_45ns, makeNative(10, clofun9, 2, 0));
+Obj v0x7f1f240697e0 = primSet(co, symcora_47lib_47toc_35lookup_45var, makeNative(0, clofun9, 3, 0));
+Obj v0x7f1f24069c60 = primSet(co, symcora_47lib_47toc_35parse, makeNative(9, clofun8, 5, 0));
+Obj v0x7f1f2404d0c0 = primSet(co, symcora_47lib_47toc_35union, makeNative(3, clofun8, 2, 0));
+Obj v0x7f1f240481c0 = primSet(co, symcora_47lib_47toc_35diff, makeNative(47, clofun7, 2, 0));
+Obj v0x7f1f24146b60 = primSet(co, symcora_47lib_47toc_35convert_45protect_63, makeNative(40, clofun7, 1, 0));
+Obj v0x7f1f2404da40 = primSet(co, symcora_47lib_47toc_35free_45vars, makeNative(17, clofun7, 1, 0));
+Obj v0x7f1f2415b560 = primSet(co, symcora_47lib_47toc_35closure_45convert, makeNative(2, clofun7, 2, 0));
+Obj v0x7f1f2415bc20 = primSet(co, symcora_47lib_47toc_35id, makeNative(1, clofun7, 1, 0));
+Obj v0x7f1f240725a0 = primSet(co, symcora_47lib_47toc_35tailify, makeNative(33, clofun6, 2, 0));
+Obj v0x7f1f2404d9c0 = primSet(co, symcora_47lib_47toc_35tailify_45list, makeNative(23, clofun6, 3, 0));
+Obj v0x7f1f24024cc0 = primSet(co, symcora_47lib_47toc_35explicit_45stack, makeNative(5, clofun6, 2, 0));
+Obj v0x7f1f2413ff80 = primSet(co, symcora_47lib_47toc_35collect_45lambda, makeNative(35, clofun5, 2, 0));
+Obj v0x7f1f24138ec0 = primSet(co, symcora_47lib_47toc_35append_45result, makeNative(31, clofun5, 2, 0));
+Obj v0x7f1f241359e0 = primSet(co, symcora_47lib_47toc_35wrap_45var, makeNative(29, clofun5, 2, 0));
+Obj v0x7f1f2412c900 = primSet(co, symcora_47lib_47toc_35generate_45call_45list, makeNative(15, clofun5, 4, 0));
+Obj v0x7f1f24128160 = primSet(co, symcora_47lib_47toc_35add_45symbol_45to_45list, makeNative(12, clofun5, 2, 0));
+Obj v0x7f1f241334e0 = primSet(co, symcora_47lib_47toc_35generate_45inst, makeNative(28, clofun3, 4, 0));
+Obj v0x7f1f240f8f40 = primSet(co, symcora_47lib_47toc_35generate_45cont, makeNative(4, clofun3, 3, 0));
+Obj v0x7f1f24072ee0 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list_45h, makeNative(48, clofun2, 5, 0));
+Obj v0x7f1f2406b300 = primSet(co, symcora_47lib_47toc_35generate_45inst_45list, makeNative(47, clofun2, 4, 0));
+Obj v0x7f1f2406b4e0 = primSet(co, symcora_47lib_47toc_35_42mod_45num_42, MAKE_NUMBER(50));
+Obj v0x7f1f2406bd80 = primSet(co, symcora_47lib_47toc_35generate_45group_45name, makeNative(45, clofun2, 3, 0));
+Obj v0x7f1f24069820 = primSet(co, symcora_47lib_47toc_35code_45gen_45func_45declare, makeNative(41, clofun2, 3, 0));
+Obj v0x7f1f2404fb40 = primSet(co, symcora_47lib_47toc_35local_45from_45params, makeNative(34, clofun2, 3, 0));
+Obj v0x7f1f2404d560 = primSet(co, symcora_47lib_47toc_35local_45from_45cont, makeNative(29, clofun2, 3, 0));
+Obj v0x7f1f24048840 = primSet(co, symcora_47lib_47toc_35generate_45call_45args_45reverse, makeNative(25, clofun2, 4, 0));
+Obj v0x7f1f240222a0 = primSet(co, symcora_47lib_47toc_35code_45gen_45toplevel, makeNative(13, clofun2, 3, 0));
+Obj v0x7f1f24022520 = primSet(co, symcora_47lib_47toc_35parse_45pass, makeNative(12, clofun2, 2, 0));
+Obj v0x7f1f24022780 = primSet(co, symcora_47lib_47toc_35closure_45convert_45pass, makeNative(11, clofun2, 1, 0));
+Obj v0x7f1f240229e0 = primSet(co, symcora_47lib_47toc_35tailify_45pass, makeNative(10, clofun2, 1, 0));
+Obj v0x7f1f24022c60 = primSet(co, symcora_47lib_47toc_35explicit_45stack_45pass, makeNative(9, clofun2, 1, 0));
+Obj v0x7f1f2401f9e0 = primSet(co, symcora_47lib_47toc_35collect_45lambda_45pass, makeNative(3, clofun2, 1, 0));
+Obj v0x7f1f240176e0 = primSet(co, symcora_47lib_47toc_35rewrite_45_45_62macro, makeNative(0, clofun2, 2, 0));
 PUSH_CONT_0(co, 4, clofun0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35add_45to_45_42macros_42);
@@ -486,21 +486,21 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35val3184 = __arg1;
-Obj _35reg3190 = primSet(co, symcora_47lib_47toc_35compile, makeNative(41, clofun1, 2, 0));
-Obj _35reg3196 = primSet(co, symcora_47lib_47toc_35for_45each, makeNative(37, clofun1, 2, 0));
-Obj _35reg3203 = primSet(co, symcora_47lib_47toc_35generate_45jumptable, makeNative(33, clofun1, 3, 0));
-Obj _35reg3224 = primSet(co, symcora_47lib_47toc_35generate_45toplevel_45group, makeNative(11, clofun1, 3, 0));
-Obj _35reg3239 = primSet(co, symcora_47lib_47toc_35group_45by_45mod_45h, makeNative(5, clofun1, 4, 0));
-Obj _35reg3250 = primSet(co, symcora_47lib_47toc_35generate_45entry, makeNative(42, clofun0, 2, 0));
-Obj _35reg3261 = primSet(co, symcora_47lib_47toc_35generate_45c, makeNative(29, clofun0, 3, 0));
-Obj _35reg3302 = primSet(co, symcora_47lib_47toc_35handle_45import_45eagerly, makeNative(22, clofun0, 1, 0));
-Obj _35reg3343 = primSet(co, symcora_47lib_47toc_35split_45type_45and_45code, makeNative(15, clofun0, 4, 0));
-Obj _35reg3344 = primSet(co, symcora_47lib_47infer_35_42typecheck_42, False);
-Obj _35reg3347 = primSet(co, symcora_47lib_47toc_35preprocess, makeNative(12, clofun0, 1, 0));
-Obj _35reg3356 = primSet(co, symcora_47lib_47toc_35compile_45to_45c, makeNative(5, clofun0, 2, 0));
+Obj v0x7f1f24017b40 = __arg1;
+Obj v0x7f1f240131c0 = primSet(co, symcora_47lib_47toc_35compile, makeNative(41, clofun1, 2, 0));
+Obj v0x7f1f24013de0 = primSet(co, symcora_47lib_47toc_35for_45each, makeNative(37, clofun1, 2, 0));
+Obj v0x7f1f23f5c820 = primSet(co, symcora_47lib_47toc_35generate_45jumptable, makeNative(33, clofun1, 3, 0));
+Obj v0x7f1f23f49580 = primSet(co, symcora_47lib_47toc_35generate_45toplevel_45group, makeNative(11, clofun1, 3, 0));
+Obj v0x7f1f23f3c060 = primSet(co, symcora_47lib_47toc_35group_45by_45mod_45h, makeNative(5, clofun1, 4, 0));
+Obj v0x7f1f23f3cf60 = primSet(co, symcora_47lib_47toc_35generate_45entry, makeNative(42, clofun0, 2, 0));
+Obj v0x7f1f23ef8120 = primSet(co, symcora_47lib_47toc_35generate_45c, makeNative(29, clofun0, 3, 0));
+Obj v0x7f1f24154060 = primSet(co, symcora_47lib_47toc_35handle_45import_45eagerly, makeNative(22, clofun0, 1, 0));
+Obj v0x7f1f241336e0 = primSet(co, symcora_47lib_47toc_35split_45type_45and_45code, makeNative(15, clofun0, 4, 0));
+Obj v0x7f1f24133900 = primSet(co, symcora_47lib_47infer_35_42typecheck_42, False);
+Obj v0x7f1f24133f60 = primSet(co, symcora_47lib_47toc_35preprocess, makeNative(12, clofun0, 1, 0));
+Obj v0x7f1f2412c120 = primSet(co, symcora_47lib_47toc_35compile_45to_45c, makeNative(5, clofun0, 2, 0));
 __nargs = 2;
-__arg1 = _35reg3356;
+__arg1 = v0x7f1f2412c120;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun0) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -510,9 +510,9 @@ label5:
 {
 Obj from = __arg1;
 Obj to = __arg2;
-Obj _35reg3348 = primGenSym(symcollect);
-Obj globals = _35reg3348;
-Obj _35reg3349 = primSet(co, globals, Nil);
+Obj v0x7f1f2412f360 = primGenSym(symcollect);
+Obj globals = v0x7f1f2412f360;
+Obj v0x7f1f2412f4e0 = primSet(co, globals, Nil);
 pushCont(co, 6, clofun0, 3, from, to, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35compile);
@@ -526,11 +526,11 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj _35val3350 = __arg1;
+Obj v0x7f1f2412f800 = __arg1;
 Obj from= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 7, clofun0, 3, _35val3350, to, globals);
+pushCont(co, 7, clofun0, 3, v0x7f1f2412f800, to, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35preprocess);
 __arg1 = from;
@@ -543,14 +543,14 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35val3351 = __arg1;
-Obj _35val3350= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f2412fb80 = __arg1;
+Obj v0x7f1f2412f800= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 8, clofun0, 3, _35val3350, to, globals);
+pushCont(co, 8, clofun0, 3, v0x7f1f2412f800, to, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35macroexpand);
-__arg1 = _35val3351;
+__arg1 = v0x7f1f2412fb80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -560,14 +560,14 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35val3352 = __arg1;
-Obj _35val3350= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f2412fba0 = __arg1;
+Obj v0x7f1f2412f800= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 9, clofun0, 2, to, globals);
 __nargs = 2;
-__arg0 = _35val3350;
-__arg1 = _35val3352;
+__arg0 = v0x7f1f2412f800;
+__arg1 = v0x7f1f2412fba0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -577,10 +577,10 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj _35val3353 = __arg1;
+Obj v0x7f1f2412fbc0 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj bc = _35val3353;
+Obj bc = v0x7f1f2412fbc0;
 pushCont(co, 10, clofun0, 2, bc, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35open_45output_45file);
@@ -594,10 +594,10 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj _35val3354 = __arg1;
+Obj v0x7f1f2412fdc0 = __arg1;
 Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj stream = _35val3354;
+Obj stream = v0x7f1f2412fdc0;
 pushCont(co, 11, clofun0, 1, stream);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45c);
@@ -613,7 +613,7 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj _35val3355 = __arg1;
+Obj v0x7f1f2412ffc0 = __arg1;
 Obj stream= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35close_45output_45file);
@@ -641,8 +641,8 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35val3345 = __arg1;
-Obj sexp = _35val3345;
+Obj v0x7f1f24133ce0 = __arg1;
+Obj sexp = v0x7f1f24133ce0;
 pushCont(co, 14, clofun0, 1, sexp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
@@ -656,7 +656,7 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj _35val3346 = __arg1;
+Obj v0x7f1f24133ee0 = __arg1;
 Obj sexp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg1 = sexp;
@@ -667,16 +667,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj _35p1633 = __arg1;
-Obj _35p1634 = __arg2;
-Obj _35p1635 = __arg3;
-Obj _35p1636 = co->args[4];
-Obj _35cc1637 = makeNative(18, clofun0, 0, 4, _35p1633, _35p1634, _35p1635, _35p1636);
-Obj _35reg3340 = PRIM_EQ(Nil, _35p1633);
-if (True == _35reg3340) {
-Obj type = _35p1634;
-Obj code = _35p1635;
-Obj k = _35p1636;
+Obj v0x7f1f2414d0c0 = __arg1;
+Obj v0x7f1f2414d0e0 = __arg2;
+Obj v0x7f1f2414d100 = __arg3;
+Obj v0x7f1f2414d120 = co->args[4];
+Obj v0x7f1f2414d280 = makeNative(18, clofun0, 0, 4, v0x7f1f2414d0c0, v0x7f1f2414d0e0, v0x7f1f2414d100, v0x7f1f2414d120);
+Obj v0x7f1f24135f60 = PRIM_EQ(Nil, v0x7f1f2414d0c0);
+if (True == v0x7f1f24135f60) {
+Obj type = v0x7f1f2414d0e0;
+Obj code = v0x7f1f2414d100;
+Obj k = v0x7f1f2414d120;
 pushCont(co, 16, clofun0, 2, code, k);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
@@ -688,7 +688,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1637;
+__arg0 = v0x7f1f2414d280;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -699,10 +699,10 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35val3341 = __arg1;
+Obj v0x7f1f24133300 = __arg1;
 Obj code= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 17, clofun0, 2, k, _35val3341);
+pushCont(co, 17, clofun0, 2, k, v0x7f1f24133300);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
 __arg1 = code;
@@ -715,13 +715,13 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj _35val3342 = __arg1;
+Obj v0x7f1f241334c0 = __arg1;
 Obj k= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35val3341= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f24133300= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 3;
 __arg0 = k;
-__arg1 = _35val3341;
-__arg2 = _35val3342;
+__arg1 = v0x7f1f24133300;
+__arg2 = v0x7f1f241334c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -731,30 +731,30 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35cc1638 = makeNative(19, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg3329 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg3329) {
-Obj _35reg3330 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3331 = PRIM_ISCONS(_35reg3330);
-if (True == _35reg3331) {
-Obj _35reg3332 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3333 = PRIM_CAR(_35reg3332);
-Obj _35reg3334 = PRIM_EQ(sym_58type, _35reg3333);
-if (True == _35reg3334) {
-Obj _35reg3335 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3336 = PRIM_CDR(_35reg3335);
-Obj exp = _35reg3336;
-Obj _35reg3337 = PRIM_CDR(closureRef(co, 0));
-Obj more = _35reg3337;
+Obj v0x7f1f2414d540 = makeNative(19, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj v0x7f1f241384a0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f241384a0) {
+Obj v0x7f1f24138780 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f241387a0 = PRIM_ISCONS(v0x7f1f24138780);
+if (True == v0x7f1f241387a0) {
+Obj v0x7f1f24138d00 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f24138d20 = PRIM_CAR(v0x7f1f24138d00);
+Obj v0x7f1f24138d80 = PRIM_EQ(sym_58type, v0x7f1f24138d20);
+if (True == v0x7f1f24138d80) {
+Obj v0x7f1f241350a0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f241350c0 = PRIM_CDR(v0x7f1f241350a0);
+Obj exp = v0x7f1f241350c0;
+Obj v0x7f1f24135280 = PRIM_CDR(closureRef(co, 0));
+Obj more = v0x7f1f24135280;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj _35reg3338 = makeCons(symbegin, exp);
-Obj _35reg3339 = makeCons(_35reg3338, type);
+Obj v0x7f1f24135a00 = makeCons(symbegin, exp);
+Obj v0x7f1f24135a80 = makeCons(v0x7f1f24135a00, type);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
 __arg1 = more;
-__arg2 = _35reg3339;
+__arg2 = v0x7f1f24135a80;
 __arg3 = code;
 co->args[4] = k;
 co->ctx.frees = __arg0;
@@ -764,7 +764,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1638;
+__arg0 = v0x7f1f2414d540;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -773,7 +773,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1638;
+__arg0 = v0x7f1f2414d540;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -782,7 +782,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1638;
+__arg0 = v0x7f1f2414d540;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -793,30 +793,30 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj _35cc1639 = makeNative(20, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg3318 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg3318) {
-Obj _35reg3319 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3320 = PRIM_ISCONS(_35reg3319);
-if (True == _35reg3320) {
-Obj _35reg3321 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3322 = PRIM_CAR(_35reg3321);
-Obj _35reg3323 = PRIM_EQ(sym_58declare, _35reg3322);
-if (True == _35reg3323) {
-Obj _35reg3324 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3325 = PRIM_CDR(_35reg3324);
-Obj exp = _35reg3325;
-Obj _35reg3326 = PRIM_CDR(closureRef(co, 0));
-Obj more = _35reg3326;
+Obj v0x7f1f2414d900 = makeNative(20, clofun0, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj v0x7f1f24146e20 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24146e20) {
+Obj v0x7f1f24146fe0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2413f0c0 = PRIM_ISCONS(v0x7f1f24146fe0);
+if (True == v0x7f1f2413f0c0) {
+Obj v0x7f1f2413f4c0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2413f4e0 = PRIM_CAR(v0x7f1f2413f4c0);
+Obj v0x7f1f2413f500 = PRIM_EQ(sym_58declare, v0x7f1f2413f4e0);
+if (True == v0x7f1f2413f500) {
+Obj v0x7f1f2413f880 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2413f8a0 = PRIM_CDR(v0x7f1f2413f880);
+Obj exp = v0x7f1f2413f8a0;
+Obj v0x7f1f2413fac0 = PRIM_CDR(closureRef(co, 0));
+Obj more = v0x7f1f2413fac0;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj _35reg3327 = makeCons(symdeclare, exp);
-Obj _35reg3328 = makeCons(_35reg3327, type);
+Obj v0x7f1f2413ff20 = makeCons(symdeclare, exp);
+Obj v0x7f1f2413ff60 = makeCons(v0x7f1f2413ff20, type);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
 __arg1 = more;
-__arg2 = _35reg3328;
+__arg2 = v0x7f1f2413ff60;
 __arg3 = code;
 co->args[4] = k;
 co->ctx.frees = __arg0;
@@ -826,7 +826,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1639;
+__arg0 = v0x7f1f2414d900;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -835,7 +835,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1639;
+__arg0 = v0x7f1f2414d900;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -844,7 +844,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1639;
+__arg0 = v0x7f1f2414d900;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -855,33 +855,33 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj _35cc1640 = makeNative(21, clofun0, 0, 0);
-Obj _35reg3303 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg3303) {
-Obj _35reg3304 = PRIM_CAR(closureRef(co, 0));
-Obj exp = _35reg3304;
-Obj _35reg3305 = PRIM_CDR(closureRef(co, 0));
-Obj more = _35reg3305;
+Obj v0x7f1f2414dc60 = makeNative(21, clofun0, 0, 0);
+Obj v0x7f1f24154ca0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24154ca0) {
+Obj v0x7f1f24154f80 = PRIM_CAR(closureRef(co, 0));
+Obj exp = v0x7f1f24154f80;
+Obj v0x7f1f2414d180 = PRIM_CDR(closureRef(co, 0));
+Obj more = v0x7f1f2414d180;
 Obj type = closureRef(co, 1);
 Obj code = closureRef(co, 2);
 Obj k = closureRef(co, 3);
-Obj _35reg3306 = makeCons(exp, Nil);
-Obj _35reg3307 = makeCons(symbackquote, _35reg3306);
-Obj _35reg3308 = makeCons(_35reg3307, Nil);
-Obj _35reg3309 = makeCons(symmacroexpand, _35reg3308);
-Obj _35reg3310 = makeCons(symtvar, Nil);
-Obj _35reg3311 = makeCons(Nil, Nil);
-Obj _35reg3312 = makeCons(Nil, _35reg3311);
-Obj _35reg3313 = makeCons(_35reg3310, _35reg3312);
-Obj _35reg3314 = makeCons(_35reg3309, _35reg3313);
-Obj _35reg3315 = makeCons(symcora_47lib_47infer_35check_45type, _35reg3314);
-Obj _35reg3316 = makeCons(_35reg3315, type);
-Obj _35reg3317 = makeCons(exp, code);
+Obj v0x7f1f2414de40 = makeCons(exp, Nil);
+Obj v0x7f1f2414dee0 = makeCons(symbackquote, v0x7f1f2414de40);
+Obj v0x7f1f24146000 = makeCons(v0x7f1f2414dee0, Nil);
+Obj v0x7f1f24146020 = makeCons(symmacroexpand, v0x7f1f24146000);
+Obj v0x7f1f241462a0 = makeCons(symtvar, Nil);
+Obj v0x7f1f241466a0 = makeCons(Nil, Nil);
+Obj v0x7f1f241466c0 = makeCons(Nil, v0x7f1f241466a0);
+Obj v0x7f1f241466e0 = makeCons(v0x7f1f241462a0, v0x7f1f241466c0);
+Obj v0x7f1f24146700 = makeCons(v0x7f1f24146020, v0x7f1f241466e0);
+Obj v0x7f1f24146780 = makeCons(symcora_47lib_47infer_35check_45type, v0x7f1f24146700);
+Obj v0x7f1f241467c0 = makeCons(v0x7f1f24146780, type);
+Obj v0x7f1f24146a40 = makeCons(exp, code);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35split_45type_45and_45code);
 __arg1 = more;
-__arg2 = _35reg3316;
-__arg3 = _35reg3317;
+__arg2 = v0x7f1f241467c0;
+__arg3 = v0x7f1f24146a40;
 co->args[4] = k;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -890,7 +890,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1640;
+__arg0 = v0x7f1f2414dc60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -913,22 +913,22 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj _35p1627 = __arg1;
-Obj _35cc1628 = makeNative(23, clofun0, 0, 1, _35p1627);
-Obj _35reg3293 = PRIM_ISCONS(_35p1627);
-if (True == _35reg3293) {
-Obj _35reg3294 = PRIM_CAR(_35p1627);
-Obj _35reg3295 = PRIM_EQ(symdefine_45library, _35reg3294);
-if (True == _35reg3295) {
-Obj _35reg3296 = PRIM_CDR(_35p1627);
-Obj _35reg3297 = PRIM_ISCONS(_35reg3296);
-if (True == _35reg3297) {
-Obj _35reg3298 = PRIM_CDR(_35p1627);
-Obj _35reg3299 = PRIM_CAR(_35reg3298);
-Obj __ = _35reg3299;
-Obj _35reg3300 = PRIM_CDR(_35p1627);
-Obj _35reg3301 = PRIM_CDR(_35reg3300);
-Obj remain = _35reg3301;
+Obj v0x7f1f24154320 = __arg1;
+Obj v0x7f1f241543e0 = makeNative(23, clofun0, 0, 1, v0x7f1f24154320);
+Obj v0x7f1f24161640 = PRIM_ISCONS(v0x7f1f24154320);
+if (True == v0x7f1f24161640) {
+Obj v0x7f1f24161a00 = PRIM_CAR(v0x7f1f24154320);
+Obj v0x7f1f24161a40 = PRIM_EQ(symdefine_45library, v0x7f1f24161a00);
+if (True == v0x7f1f24161a40) {
+Obj v0x7f1f24161fa0 = PRIM_CDR(v0x7f1f24154320);
+Obj v0x7f1f2415b060 = PRIM_ISCONS(v0x7f1f24161fa0);
+if (True == v0x7f1f2415b060) {
+Obj v0x7f1f2415b480 = PRIM_CDR(v0x7f1f24154320);
+Obj v0x7f1f2415b4a0 = PRIM_CAR(v0x7f1f2415b480);
+Obj __ = v0x7f1f2415b4a0;
+Obj v0x7f1f2415b9c0 = PRIM_CDR(v0x7f1f24154320);
+Obj v0x7f1f2415ba40 = PRIM_CDR(v0x7f1f2415b9c0);
+Obj remain = v0x7f1f2415ba40;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = remain;
@@ -939,7 +939,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1628;
+__arg0 = v0x7f1f241543e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -948,7 +948,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1628;
+__arg0 = v0x7f1f241543e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -957,7 +957,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1628;
+__arg0 = v0x7f1f241543e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -968,14 +968,14 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj _35cc1629 = makeNative(24, clofun0, 0, 1, closureRef(co, 0));
-Obj _35reg3289 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg3289) {
-Obj _35reg3290 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3291 = PRIM_EQ(symbegin, _35reg3290);
-if (True == _35reg3291) {
-Obj _35reg3292 = PRIM_CDR(closureRef(co, 0));
-Obj remain = _35reg3292;
+Obj v0x7f1f241546a0 = makeNative(24, clofun0, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23ed53e0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23ed53e0) {
+Obj v0x7f1f23ed55a0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23ed55c0 = PRIM_EQ(symbegin, v0x7f1f23ed55a0);
+if (True == v0x7f1f23ed55c0) {
+Obj v0x7f1f23ed56c0 = PRIM_CDR(closureRef(co, 0));
+Obj remain = v0x7f1f23ed56c0;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = remain;
@@ -986,7 +986,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1629;
+__arg0 = v0x7f1f241546a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -995,7 +995,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1629;
+__arg0 = v0x7f1f241546a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1006,21 +1006,21 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj _35cc1630 = makeNative(25, clofun0, 0, 1, closureRef(co, 0));
-Obj _35reg3280 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg3280) {
-Obj _35reg3281 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3282 = PRIM_ISCONS(_35reg3281);
-if (True == _35reg3282) {
-Obj _35reg3283 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3284 = PRIM_CAR(_35reg3283);
-Obj _35reg3285 = PRIM_EQ(symexport, _35reg3284);
-if (True == _35reg3285) {
-Obj _35reg3286 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3287 = PRIM_CDR(_35reg3286);
-Obj more = _35reg3287;
-Obj _35reg3288 = PRIM_CDR(closureRef(co, 0));
-Obj remain = _35reg3288;
+Obj v0x7f1f24154820 = makeNative(25, clofun0, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23edd9a0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23edd9a0) {
+Obj v0x7f1f23eddb40 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23eddb60 = PRIM_ISCONS(v0x7f1f23eddb40);
+if (True == v0x7f1f23eddb60) {
+Obj v0x7f1f23edddc0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23eddde0 = PRIM_CAR(v0x7f1f23edddc0);
+Obj v0x7f1f23edde00 = PRIM_EQ(symexport, v0x7f1f23eddde0);
+if (True == v0x7f1f23edde00) {
+Obj v0x7f1f23eddfa0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23eddfc0 = PRIM_CDR(v0x7f1f23eddfa0);
+Obj more = v0x7f1f23eddfc0;
+Obj v0x7f1f23ed50c0 = PRIM_CDR(closureRef(co, 0));
+Obj remain = v0x7f1f23ed50c0;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
 __arg1 = remain;
@@ -1031,7 +1031,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1630;
+__arg0 = v0x7f1f24154820;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1040,7 +1040,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1630;
+__arg0 = v0x7f1f24154820;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1049,7 +1049,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1630;
+__arg0 = v0x7f1f24154820;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1060,31 +1060,31 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj _35cc1631 = makeNative(27, clofun0, 0, 1, closureRef(co, 0));
-Obj _35reg3262 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg3262) {
-Obj _35reg3263 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3264 = PRIM_ISCONS(_35reg3263);
-if (True == _35reg3264) {
-Obj _35reg3265 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3266 = PRIM_CAR(_35reg3265);
-Obj _35reg3267 = PRIM_EQ(symimport, _35reg3266);
-if (True == _35reg3267) {
-Obj _35reg3268 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3269 = PRIM_CDR(_35reg3268);
-Obj _35reg3270 = PRIM_ISCONS(_35reg3269);
-if (True == _35reg3270) {
-Obj _35reg3271 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3272 = PRIM_CDR(_35reg3271);
-Obj _35reg3273 = PRIM_CAR(_35reg3272);
-Obj pkg = _35reg3273;
-Obj _35reg3274 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg3275 = PRIM_CDR(_35reg3274);
-Obj _35reg3276 = PRIM_CDR(_35reg3275);
-Obj _35reg3277 = PRIM_EQ(Nil, _35reg3276);
-if (True == _35reg3277) {
-Obj _35reg3278 = PRIM_CDR(closureRef(co, 0));
-Obj remain = _35reg3278;
+Obj v0x7f1f24154a40 = makeNative(27, clofun0, 0, 1, closureRef(co, 0));
+Obj v0x7f1f23ef86c0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23ef86c0) {
+Obj v0x7f1f23ef8860 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23ef8880 = PRIM_ISCONS(v0x7f1f23ef8860);
+if (True == v0x7f1f23ef8880) {
+Obj v0x7f1f23ef8ae0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23ef8b00 = PRIM_CAR(v0x7f1f23ef8ae0);
+Obj v0x7f1f23ef8b20 = PRIM_EQ(symimport, v0x7f1f23ef8b00);
+if (True == v0x7f1f23ef8b20) {
+Obj v0x7f1f23ef8d60 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23ef8d80 = PRIM_CDR(v0x7f1f23ef8d60);
+Obj v0x7f1f23ef8da0 = PRIM_ISCONS(v0x7f1f23ef8d80);
+if (True == v0x7f1f23ef8da0) {
+Obj v0x7f1f23ef8fe0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23edd000 = PRIM_CDR(v0x7f1f23ef8fe0);
+Obj v0x7f1f23edd020 = PRIM_CAR(v0x7f1f23edd000);
+Obj pkg = v0x7f1f23edd020;
+Obj v0x7f1f23edd320 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23edd340 = PRIM_CDR(v0x7f1f23edd320);
+Obj v0x7f1f23edd360 = PRIM_CDR(v0x7f1f23edd340);
+Obj v0x7f1f23edd380 = PRIM_EQ(Nil, v0x7f1f23edd360);
+if (True == v0x7f1f23edd380) {
+Obj v0x7f1f23edd480 = PRIM_CDR(closureRef(co, 0));
+Obj remain = v0x7f1f23edd480;
 pushCont(co, 26, clofun0, 1, remain);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35import);
@@ -1096,7 +1096,7 @@ if (ps.func != clofun0) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1631;
+__arg0 = v0x7f1f24154a40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1105,7 +1105,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1631;
+__arg0 = v0x7f1f24154a40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1114,7 +1114,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1631;
+__arg0 = v0x7f1f24154a40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1123,7 +1123,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1631;
+__arg0 = v0x7f1f24154a40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1132,7 +1132,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1631;
+__arg0 = v0x7f1f24154a40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1143,7 +1143,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35val3279 = __arg1;
+Obj v0x7f1f23edd580 = __arg1;
 Obj remain= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35handle_45import_45eagerly);
@@ -1157,7 +1157,7 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj _35cc1632 = makeNative(28, clofun0, 0, 0);
+Obj v0x7f1f24154d40 = makeNative(28, clofun0, 0, 0);
 Obj __ = closureRef(co, 0);
 __nargs = 2;
 __arg1 = Nil;
@@ -1199,11 +1199,11 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj _35val3251 = __arg1;
+Obj v0x7f1f23efe200 = __arg1;
 Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj groups = _35val3251;
+Obj groups = v0x7f1f23efe200;
 pushCont(co, 31, clofun0, 3, globals, to, groups);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35caar);
@@ -1217,11 +1217,11 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj _35val3252 = __arg1;
+Obj v0x7f1f23efe300 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj maxid = _35val3252;
+Obj maxid = v0x7f1f23efe300;
 pushCont(co, 32, clofun0, 4, globals, to, maxid, groups);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -1236,7 +1236,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj _35val3253 = __arg1;
+Obj v0x7f1f23efe420 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1255,7 +1255,7 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj _35val3254 = __arg1;
+Obj v0x7f1f23efe540 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1274,7 +1274,7 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj _35val3257 = __arg1;
+Obj v0x7f1f23efe960 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1293,7 +1293,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj _35val3258 = __arg1;
+Obj v0x7f1f23efea80 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1311,7 +1311,7 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj _35val3259 = __arg1;
+Obj v0x7f1f23efec40 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1319,7 +1319,7 @@ pushCont(co, 37, clofun0, 3, to, maxid, groups);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45entry);
 __arg1 = to;
-__arg2 = _35val3259;
+__arg2 = v0x7f1f23efec40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1329,7 +1329,7 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj _35val3260 = __arg1;
+Obj v0x7f1f23efec60 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj groups= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1375,12 +1375,12 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj _35val3255 = __arg1;
+Obj v0x7f1f23efe820 = __arg1;
 PUSH_CONT_0(co, 41, clofun0);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35code_45gen_45func_45declare);
 __arg1 = closureRef(co, 1);
-__arg2 = _35val3255;
+__arg2 = v0x7f1f23efe820;
 __arg3 = closureRef(co, 0);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1391,7 +1391,7 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj _35val3256 = __arg1;
+Obj v0x7f1f23efe860 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 1);
@@ -1421,7 +1421,7 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj _35val3242 = __arg1;
+Obj v0x7f1f23f3c600 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 44, clofun0, 2, globals, to);
@@ -1438,7 +1438,7 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj _35val3243 = __arg1;
+Obj v0x7f1f23f3c720 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 45, clofun0, 1, to);
@@ -1455,7 +1455,7 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj _35val3249 = __arg1;
+Obj v0x7f1f23f3ce80 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -1485,7 +1485,7 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj _35val3244 = __arg1;
+Obj v0x7f1f23f3c960 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 48, clofun0, 1, sym);
 __nargs = 3;
@@ -1501,7 +1501,7 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj _35val3245 = __arg1;
+Obj v0x7f1f23f3ca80 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 49, clofun0, 1, sym);
 __nargs = 3;
@@ -1517,7 +1517,7 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj _35val3246 = __arg1;
+Obj v0x7f1f23f3cba0 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 0, clofun1);
 __nargs = 2;
@@ -1552,12 +1552,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val3247 = __arg1;
+Obj v0x7f1f23f3cd60 = __arg1;
 PUSH_CONT_0(co, 1, clofun1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
-__arg2 = _35val3247;
+__arg2 = v0x7f1f23f3cd60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1567,7 +1567,7 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj _35val3248 = __arg1;
+Obj v0x7f1f23f3cd80 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
@@ -1596,7 +1596,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj _35val3240 = __arg1;
+Obj v0x7f1f23f3c3e0 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 4, clofun1);
 __nargs = 3;
@@ -1612,7 +1612,7 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35val3241 = __arg1;
+Obj v0x7f1f23f3c500 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 0);
@@ -1626,16 +1626,16 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35p1621 = __arg1;
-Obj _35p1622 = __arg2;
-Obj _35p1623 = __arg3;
-Obj _35p1624 = co->args[4];
-Obj _35cc1625 = makeNative(8, clofun1, 0, 4, _35p1621, _35p1622, _35p1623, _35p1624);
-Obj res = _35p1621;
-Obj idx = _35p1622;
-Obj acc = _35p1623;
-Obj _35reg3234 = PRIM_EQ(Nil, _35p1624);
-if (True == _35reg3234) {
+Obj v0x7f1f2415b620 = __arg1;
+Obj v0x7f1f2415b640 = __arg2;
+Obj v0x7f1f2415b660 = __arg3;
+Obj v0x7f1f2415b680 = co->args[4];
+Obj v0x7f1f2415b820 = makeNative(8, clofun1, 0, 4, v0x7f1f2415b620, v0x7f1f2415b640, v0x7f1f2415b660, v0x7f1f2415b680);
+Obj res = v0x7f1f2415b620;
+Obj idx = v0x7f1f2415b640;
+Obj acc = v0x7f1f2415b660;
+Obj v0x7f1f23f43bc0 = PRIM_EQ(Nil, v0x7f1f2415b680);
+if (True == v0x7f1f23f43bc0) {
 pushCont(co, 6, clofun1, 2, acc, res);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
@@ -1647,7 +1647,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1625;
+__arg0 = v0x7f1f2415b820;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1658,11 +1658,11 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj _35val3235 = __arg1;
+Obj v0x7f1f23f43e00 = __arg1;
 Obj acc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg3236 = primNot(_35val3235);
-if (True == _35reg3236) {
+Obj v0x7f1f23f43e20 = primNot(v0x7f1f23f43e00);
+if (True == v0x7f1f23f43e20) {
 pushCont(co, 7, clofun1, 1, res);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
@@ -1686,12 +1686,12 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35val3237 = __arg1;
+Obj v0x7f1f23f43f80 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg3238 = makeCons(_35val3237, res);
+Obj v0x7f1f23f43fc0 = makeCons(v0x7f1f23f43f80, res);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
-__arg1 = _35reg3238;
+__arg1 = v0x7f1f23f43fc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1701,18 +1701,18 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35cc1626 = makeNative(10, clofun1, 0, 0);
+Obj v0x7f1f2415bc60 = makeNative(10, clofun1, 0, 0);
 Obj res = closureRef(co, 0);
 Obj idx = closureRef(co, 1);
 Obj acc = closureRef(co, 2);
-Obj _35reg3225 = PRIM_ISCONS(closureRef(co, 3));
-if (True == _35reg3225) {
-Obj _35reg3226 = PRIM_CAR(closureRef(co, 3));
-Obj bc = _35reg3226;
-Obj _35reg3227 = PRIM_CDR(closureRef(co, 3));
-Obj more = _35reg3227;
-Obj _35reg3228 = PRIM_EQ(idx, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
-if (True == _35reg3228) {
+Obj v0x7f1f23f49aa0 = PRIM_ISCONS(closureRef(co, 3));
+if (True == v0x7f1f23f49aa0) {
+Obj v0x7f1f23f49ba0 = PRIM_CAR(closureRef(co, 3));
+Obj bc = v0x7f1f23f49ba0;
+Obj v0x7f1f23f49cc0 = PRIM_CDR(closureRef(co, 3));
+Obj more = v0x7f1f23f49cc0;
+Obj v0x7f1f23f43320 = PRIM_EQ(idx, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
+if (True == v0x7f1f23f43320) {
 pushCont(co, 9, clofun1, 3, res, bc, more);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
@@ -1723,13 +1723,13 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg3232 = PRIM_ADD(idx, MAKE_NUMBER(1));
-Obj _35reg3233 = makeCons(bc, acc);
+Obj v0x7f1f23f43840 = PRIM_ADD(idx, MAKE_NUMBER(1));
+Obj v0x7f1f23f43940 = makeCons(bc, acc);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
 __arg1 = res;
-__arg2 = _35reg3232;
-__arg3 = _35reg3233;
+__arg2 = v0x7f1f23f43840;
+__arg3 = v0x7f1f23f43940;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1739,7 +1739,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1626;
+__arg0 = v0x7f1f2415bc60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1750,18 +1750,18 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj _35val3229 = __arg1;
+Obj v0x7f1f23f43520 = __arg1;
 Obj res= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj bc= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg3230 = makeCons(_35val3229, res);
-Obj _35reg3231 = makeCons(bc, more);
+Obj v0x7f1f23f43560 = makeCons(v0x7f1f23f43520, res);
+Obj v0x7f1f23f436a0 = makeCons(bc, more);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35group_45by_45mod_45h);
-__arg1 = _35reg3230;
+__arg1 = v0x7f1f23f43560;
 __arg2 = MAKE_NUMBER(0);
 __arg3 = Nil;
-co->args[4] = _35reg3231;
+co->args[4] = v0x7f1f23f436a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1799,7 +1799,7 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj _35val3204 = __arg1;
+Obj v0x7f1f23f5cba0 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1807,7 +1807,7 @@ pushCont(co, 13, clofun1, 3, maxid, group, to);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35code_45gen_45func_45declare);
 __arg1 = to;
-__arg2 = _35val3204;
+__arg2 = v0x7f1f23f5cba0;
 __arg3 = maxid;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -1818,7 +1818,7 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35val3205 = __arg1;
+Obj v0x7f1f23f5cc20 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1836,7 +1836,7 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj _35val3206 = __arg1;
+Obj v0x7f1f23f5cd40 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1854,7 +1854,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj _35val3207 = __arg1;
+Obj v0x7f1f23f5cec0 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1872,7 +1872,7 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35val3208 = __arg1;
+Obj v0x7f1f23f5cfe0 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1890,7 +1890,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj _35val3209 = __arg1;
+Obj v0x7f1f23f58160 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1908,7 +1908,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35val3210 = __arg1;
+Obj v0x7f1f23f58280 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1926,7 +1926,7 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj _35val3211 = __arg1;
+Obj v0x7f1f23f583a0 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1944,7 +1944,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj _35val3212 = __arg1;
+Obj v0x7f1f23f58540 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1961,7 +1961,7 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj _35val3213 = __arg1;
+Obj v0x7f1f23f587a0 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1970,7 +1970,7 @@ __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45jumptable);
 __arg1 = to;
 __arg2 = MAKE_NUMBER(0);
-__arg3 = _35val3213;
+__arg3 = v0x7f1f23f587a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -1980,7 +1980,7 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj _35val3214 = __arg1;
+Obj v0x7f1f23f587c0 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -1998,7 +1998,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj _35val3215 = __arg1;
+Obj v0x7f1f23f588e0 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2016,7 +2016,7 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj _35val3216 = __arg1;
+Obj v0x7f1f23f58a00 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj group= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2034,7 +2034,7 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj _35val3217 = __arg1;
+Obj v0x7f1f23f58d00 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 26, clofun1, 1, to);
 __nargs = 3;
@@ -2050,7 +2050,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35val3218 = __arg1;
+Obj v0x7f1f23f58e40 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 27, clofun1, 1, to);
 __nargs = 3;
@@ -2066,7 +2066,7 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj _35val3219 = __arg1;
+Obj v0x7f1f23f58f80 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 28, clofun1, 1, to);
 __nargs = 3;
@@ -2082,7 +2082,7 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj _35val3220 = __arg1;
+Obj v0x7f1f23f490c0 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 29, clofun1, 1, to);
 __nargs = 3;
@@ -2098,7 +2098,7 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj _35val3221 = __arg1;
+Obj v0x7f1f23f49200 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 30, clofun1, 1, to);
 __nargs = 3;
@@ -2114,7 +2114,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj _35val3222 = __arg1;
+Obj v0x7f1f23f49340 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 31, clofun1, 1, to);
 __nargs = 3;
@@ -2130,7 +2130,7 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj _35val3223 = __arg1;
+Obj v0x7f1f23f49480 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2163,8 +2163,8 @@ label33:
 Obj to = __arg1;
 Obj i = __arg2;
 Obj n = __arg3;
-Obj _35reg3197 = PRIM_EQ(i, MAKE_NUMBER(0));
-if (True == _35reg3197) {
+Obj v0x7f1f23f5c080 = PRIM_EQ(i, MAKE_NUMBER(0));
+if (True == v0x7f1f23f5c080) {
 pushCont(co, 36, clofun1, 2, to, n);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2176,8 +2176,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg3199 = PRIM_LT(i, n);
-if (True == _35reg3199) {
+Obj v0x7f1f23f5c3e0 = PRIM_LT(i, n);
+if (True == v0x7f1f23f5c3e0) {
 pushCont(co, 34, clofun1, 3, i, to, n);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2200,7 +2200,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label34:
 {
-Obj _35val3200 = __arg1;
+Obj v0x7f1f23f5c500 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2218,15 +2218,15 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj _35val3201 = __arg1;
+Obj v0x7f1f23f5c620 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg3202 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj v0x7f1f23f5c7e0 = PRIM_ADD(i, MAKE_NUMBER(1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45jumptable);
 __arg1 = to;
-__arg2 = _35reg3202;
+__arg2 = v0x7f1f23f5c7e0;
 __arg3 = n;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2237,7 +2237,7 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj _35val3198 = __arg1;
+Obj v0x7f1f23f5c1c0 = __arg1;
 Obj to= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj n= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -2254,12 +2254,12 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj _35p1617 = __arg1;
-Obj _35p1618 = __arg2;
-Obj _35cc1619 = makeNative(38, clofun1, 0, 2, _35p1617, _35p1618);
-Obj fn = _35p1617;
-Obj _35reg3195 = PRIM_EQ(Nil, _35p1618);
-if (True == _35reg3195) {
+Obj v0x7f1f24161ac0 = __arg1;
+Obj v0x7f1f24161b00 = __arg2;
+Obj v0x7f1f24161be0 = makeNative(38, clofun1, 0, 2, v0x7f1f24161ac0, v0x7f1f24161b00);
+Obj fn = v0x7f1f24161ac0;
+Obj v0x7f1f24013d40 = PRIM_EQ(Nil, v0x7f1f24161b00);
+if (True == v0x7f1f24013d40) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2267,7 +2267,7 @@ if (co->ctx.pc.func != clofun1) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1619;
+__arg0 = v0x7f1f24161be0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2278,14 +2278,14 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj _35cc1620 = makeNative(40, clofun1, 0, 0);
+Obj v0x7f1f24161ec0 = makeNative(40, clofun1, 0, 0);
 Obj fn = closureRef(co, 0);
-Obj _35reg3191 = PRIM_ISCONS(closureRef(co, 1));
-if (True == _35reg3191) {
-Obj _35reg3192 = PRIM_CAR(closureRef(co, 1));
-Obj x = _35reg3192;
-Obj _35reg3193 = PRIM_CDR(closureRef(co, 1));
-Obj y = _35reg3193;
+Obj v0x7f1f240136a0 = PRIM_ISCONS(closureRef(co, 1));
+if (True == v0x7f1f240136a0) {
+Obj v0x7f1f240137a0 = PRIM_CAR(closureRef(co, 1));
+Obj x = v0x7f1f240137a0;
+Obj v0x7f1f24013920 = PRIM_CDR(closureRef(co, 1));
+Obj y = v0x7f1f24013920;
 pushCont(co, 39, clofun1, 2, fn, y);
 __nargs = 2;
 __arg0 = fn;
@@ -2297,7 +2297,7 @@ if (ps.func != clofun1) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1620;
+__arg0 = v0x7f1f24161ec0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2308,7 +2308,7 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj _35val3194 = __arg1;
+Obj v0x7f1f24013a40 = __arg1;
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 3;
@@ -2351,11 +2351,11 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj _35val3185 = __arg1;
+Obj v0x7f1f24013100 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 43, clofun1);
 __nargs = 2;
-__arg0 = _35val3185;
+__arg0 = v0x7f1f24013100;
 __arg1 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2366,11 +2366,11 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj _35val3186 = __arg1;
+Obj v0x7f1f24013140 = __arg1;
 PUSH_CONT_0(co, 44, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert_45pass);
-__arg1 = _35val3186;
+__arg1 = v0x7f1f24013140;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2380,11 +2380,11 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj _35val3187 = __arg1;
+Obj v0x7f1f24013160 = __arg1;
 PUSH_CONT_0(co, 45, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify_45pass);
-__arg1 = _35val3187;
+__arg1 = v0x7f1f24013160;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2394,11 +2394,11 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj _35val3188 = __arg1;
+Obj v0x7f1f24013180 = __arg1;
 PUSH_CONT_0(co, 46, clofun1);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack_45pass);
-__arg1 = _35val3188;
+__arg1 = v0x7f1f24013180;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2408,10 +2408,10 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj _35val3189 = __arg1;
+Obj v0x7f1f240131a0 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35collect_45lambda_45pass);
-__arg1 = _35val3189;
+__arg1 = v0x7f1f240131a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2435,9 +2435,9 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj _35val3182 = __arg1;
+Obj v0x7f1f24017960 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj obj = _35val3182;
+Obj obj = v0x7f1f24017960;
 pushCont(co, 49, clofun1, 1, obj);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35cddr);
@@ -2451,9 +2451,9 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj _35val3183 = __arg1;
+Obj v0x7f1f24017a60 = __arg1;
 Obj obj= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj fns = _35val3183;
+Obj fns = v0x7f1f24017a60;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35rewrite_45_45_62macro);
 __arg1 = obj;
@@ -2487,12 +2487,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35p1613 = __arg1;
-Obj _35p1614 = __arg2;
-Obj _35cc1615 = makeNative(1, clofun2, 0, 2, _35p1613, _35p1614);
-Obj obj = _35p1613;
-Obj _35reg3180 = PRIM_EQ(Nil, _35p1614);
-if (True == _35reg3180) {
+Obj v0x7f1f24161240 = __arg1;
+Obj v0x7f1f241612c0 = __arg2;
+Obj v0x7f1f241613e0 = makeNative(1, clofun2, 0, 2, v0x7f1f24161240, v0x7f1f241612c0);
+Obj obj = v0x7f1f24161240;
+Obj v0x7f1f24017640 = PRIM_EQ(Nil, v0x7f1f241612c0);
+if (True == v0x7f1f24017640) {
 __nargs = 2;
 __arg1 = obj;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -2500,7 +2500,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1615;
+__arg0 = v0x7f1f241613e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2511,19 +2511,19 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj _35cc1616 = makeNative(2, clofun2, 0, 0);
+Obj v0x7f1f241616a0 = makeNative(2, clofun2, 0, 0);
 Obj obj = closureRef(co, 0);
-Obj _35reg3175 = PRIM_ISCONS(closureRef(co, 1));
-if (True == _35reg3175) {
-Obj _35reg3176 = PRIM_CAR(closureRef(co, 1));
-Obj hd = _35reg3176;
-Obj _35reg3177 = PRIM_CDR(closureRef(co, 1));
-Obj more = _35reg3177;
-Obj _35reg3178 = makeCons(obj, Nil);
-Obj _35reg3179 = makeCons(hd, _35reg3178);
+Obj v0x7f1f2401fea0 = PRIM_ISCONS(closureRef(co, 1));
+if (True == v0x7f1f2401fea0) {
+Obj v0x7f1f2401ffa0 = PRIM_CAR(closureRef(co, 1));
+Obj hd = v0x7f1f2401ffa0;
+Obj v0x7f1f240170a0 = PRIM_CDR(closureRef(co, 1));
+Obj more = v0x7f1f240170a0;
+Obj v0x7f1f240173e0 = makeCons(obj, Nil);
+Obj v0x7f1f24017400 = makeCons(hd, v0x7f1f240173e0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35rewrite_45_45_62macro);
-__arg1 = _35reg3179;
+__arg1 = v0x7f1f24017400;
 __arg2 = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2532,7 +2532,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1616;
+__arg0 = v0x7f1f241616a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2569,9 +2569,9 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35val3165 = __arg1;
+Obj v0x7f1f24022f20 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v = _35val3165;
+Obj v = v0x7f1f24022f20;
 pushCont(co, 5, clofun2, 2, exp, v);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35vector_45set_33);
@@ -2587,7 +2587,7 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35val3166 = __arg1;
+Obj v0x7f1f2401f060 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 6, clofun2, 2, exp, v);
@@ -2605,7 +2605,7 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj _35val3167 = __arg1;
+Obj v0x7f1f2401f220 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 7, clofun2, 1, v);
@@ -2622,18 +2622,18 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35val3168 = __arg1;
+Obj v0x7f1f2401f340 = __arg1;
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj e1 = _35val3168;
-Obj _35reg3169 = makeCons(e1, Nil);
-Obj _35reg3170 = makeCons(Nil, _35reg3169);
-Obj _35reg3171 = makeCons(Nil, _35reg3170);
-Obj _35reg3172 = makeCons(symlambda, _35reg3171);
+Obj e1 = v0x7f1f2401f340;
+Obj v0x7f1f2401f7e0 = makeCons(e1, Nil);
+Obj v0x7f1f2401f800 = makeCons(Nil, v0x7f1f2401f7e0);
+Obj v0x7f1f2401f820 = makeCons(Nil, v0x7f1f2401f800);
+Obj v0x7f1f2401f8e0 = makeCons(symlambda, v0x7f1f2401f820);
 pushCont(co, 8, clofun2, 1, v);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = _35reg3172;
+__arg2 = v0x7f1f2401f8e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2643,7 +2643,7 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35val3173 = __arg1;
+Obj v0x7f1f2401f900 = __arg1;
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -2718,76 +2718,76 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35p1608 = __arg1;
-Obj _35p1609 = __arg2;
-Obj _35p1610 = __arg3;
-Obj _35cc1611 = makeNative(21, clofun2, 0, 3, _35p1608, _35p1609, _35p1610);
-Obj w = _35p1608;
-Obj _35reg3100 = PRIM_ISCONS(_35p1609);
-if (True == _35reg3100) {
-Obj _35reg3101 = PRIM_CAR(_35p1609);
-Obj label = _35reg3101;
-Obj _35reg3102 = PRIM_CDR(_35p1609);
-Obj _35reg3103 = PRIM_ISCONS(_35reg3102);
-if (True == _35reg3103) {
-Obj _35reg3104 = PRIM_CDR(_35p1609);
-Obj _35reg3105 = PRIM_CAR(_35reg3104);
-Obj _35reg3106 = PRIM_ISCONS(_35reg3105);
-if (True == _35reg3106) {
-Obj _35reg3107 = PRIM_CDR(_35p1609);
-Obj _35reg3108 = PRIM_CAR(_35reg3107);
-Obj _35reg3109 = PRIM_CAR(_35reg3108);
-Obj _35reg3110 = PRIM_EQ(symlambda, _35reg3109);
-if (True == _35reg3110) {
-Obj _35reg3111 = PRIM_CDR(_35p1609);
-Obj _35reg3112 = PRIM_CAR(_35reg3111);
-Obj _35reg3113 = PRIM_CDR(_35reg3112);
-Obj _35reg3114 = PRIM_ISCONS(_35reg3113);
-if (True == _35reg3114) {
-Obj _35reg3115 = PRIM_CDR(_35p1609);
-Obj _35reg3116 = PRIM_CAR(_35reg3115);
-Obj _35reg3117 = PRIM_CDR(_35reg3116);
-Obj _35reg3118 = PRIM_CAR(_35reg3117);
-Obj params = _35reg3118;
-Obj _35reg3119 = PRIM_CDR(_35p1609);
-Obj _35reg3120 = PRIM_CAR(_35reg3119);
-Obj _35reg3121 = PRIM_CDR(_35reg3120);
-Obj _35reg3122 = PRIM_CDR(_35reg3121);
-Obj _35reg3123 = PRIM_ISCONS(_35reg3122);
-if (True == _35reg3123) {
-Obj _35reg3124 = PRIM_CDR(_35p1609);
-Obj _35reg3125 = PRIM_CAR(_35reg3124);
-Obj _35reg3126 = PRIM_CDR(_35reg3125);
-Obj _35reg3127 = PRIM_CDR(_35reg3126);
-Obj _35reg3128 = PRIM_CAR(_35reg3127);
-Obj actives = _35reg3128;
-Obj _35reg3129 = PRIM_CDR(_35p1609);
-Obj _35reg3130 = PRIM_CAR(_35reg3129);
-Obj _35reg3131 = PRIM_CDR(_35reg3130);
-Obj _35reg3132 = PRIM_CDR(_35reg3131);
-Obj _35reg3133 = PRIM_CDR(_35reg3132);
-Obj _35reg3134 = PRIM_ISCONS(_35reg3133);
-if (True == _35reg3134) {
-Obj _35reg3135 = PRIM_CDR(_35p1609);
-Obj _35reg3136 = PRIM_CAR(_35reg3135);
-Obj _35reg3137 = PRIM_CDR(_35reg3136);
-Obj _35reg3138 = PRIM_CDR(_35reg3137);
-Obj _35reg3139 = PRIM_CDR(_35reg3138);
-Obj _35reg3140 = PRIM_CAR(_35reg3139);
-Obj body = _35reg3140;
-Obj _35reg3141 = PRIM_CDR(_35p1609);
-Obj _35reg3142 = PRIM_CAR(_35reg3141);
-Obj _35reg3143 = PRIM_CDR(_35reg3142);
-Obj _35reg3144 = PRIM_CDR(_35reg3143);
-Obj _35reg3145 = PRIM_CDR(_35reg3144);
-Obj _35reg3146 = PRIM_CDR(_35reg3145);
-Obj _35reg3147 = PRIM_EQ(Nil, _35reg3146);
-if (True == _35reg3147) {
-Obj _35reg3148 = PRIM_CDR(_35p1609);
-Obj _35reg3149 = PRIM_CDR(_35reg3148);
-Obj _35reg3150 = PRIM_EQ(Nil, _35reg3149);
-if (True == _35reg3150) {
-Obj maxid = _35p1610;
+Obj v0x7f1f241544c0 = __arg1;
+Obj v0x7f1f241544e0 = __arg2;
+Obj v0x7f1f24154520 = __arg3;
+Obj v0x7f1f24154680 = makeNative(21, clofun2, 0, 3, v0x7f1f241544c0, v0x7f1f241544e0, v0x7f1f24154520);
+Obj w = v0x7f1f241544c0;
+Obj v0x7f1f24043300 = PRIM_ISCONS(v0x7f1f241544e0);
+if (True == v0x7f1f24043300) {
+Obj v0x7f1f240434c0 = PRIM_CAR(v0x7f1f241544e0);
+Obj label = v0x7f1f240434c0;
+Obj v0x7f1f240436e0 = PRIM_CDR(v0x7f1f241544e0);
+Obj v0x7f1f24043700 = PRIM_ISCONS(v0x7f1f240436e0);
+if (True == v0x7f1f24043700) {
+Obj v0x7f1f24043ac0 = PRIM_CDR(v0x7f1f241544e0);
+Obj v0x7f1f24043b00 = PRIM_CAR(v0x7f1f24043ac0);
+Obj v0x7f1f24043b40 = PRIM_ISCONS(v0x7f1f24043b00);
+if (True == v0x7f1f24043b40) {
+Obj v0x7f1f24043fe0 = PRIM_CDR(v0x7f1f241544e0);
+Obj v0x7f1f2403d000 = PRIM_CAR(v0x7f1f24043fe0);
+Obj v0x7f1f2403d020 = PRIM_CAR(v0x7f1f2403d000);
+Obj v0x7f1f2403d040 = PRIM_EQ(symlambda, v0x7f1f2403d020);
+if (True == v0x7f1f2403d040) {
+Obj v0x7f1f2403d4a0 = PRIM_CDR(v0x7f1f241544e0);
+Obj v0x7f1f2403d4c0 = PRIM_CAR(v0x7f1f2403d4a0);
+Obj v0x7f1f2403d4e0 = PRIM_CDR(v0x7f1f2403d4c0);
+Obj v0x7f1f2403d500 = PRIM_ISCONS(v0x7f1f2403d4e0);
+if (True == v0x7f1f2403d500) {
+Obj v0x7f1f2403d980 = PRIM_CDR(v0x7f1f241544e0);
+Obj v0x7f1f2403d9a0 = PRIM_CAR(v0x7f1f2403d980);
+Obj v0x7f1f2403d9c0 = PRIM_CDR(v0x7f1f2403d9a0);
+Obj v0x7f1f2403d9e0 = PRIM_CAR(v0x7f1f2403d9c0);
+Obj params = v0x7f1f2403d9e0;
+Obj v0x7f1f2403df60 = PRIM_CDR(v0x7f1f241544e0);
+Obj v0x7f1f2403df80 = PRIM_CAR(v0x7f1f2403df60);
+Obj v0x7f1f2403dfa0 = PRIM_CDR(v0x7f1f2403df80);
+Obj v0x7f1f2403dfc0 = PRIM_CDR(v0x7f1f2403dfa0);
+Obj v0x7f1f2403dfe0 = PRIM_ISCONS(v0x7f1f2403dfc0);
+if (True == v0x7f1f2403dfe0) {
+Obj v0x7f1f240355e0 = PRIM_CDR(v0x7f1f241544e0);
+Obj v0x7f1f24035620 = PRIM_CAR(v0x7f1f240355e0);
+Obj v0x7f1f24035640 = PRIM_CDR(v0x7f1f24035620);
+Obj v0x7f1f24035660 = PRIM_CDR(v0x7f1f24035640);
+Obj v0x7f1f24035680 = PRIM_CAR(v0x7f1f24035660);
+Obj actives = v0x7f1f24035680;
+Obj v0x7f1f24035d00 = PRIM_CDR(v0x7f1f241544e0);
+Obj v0x7f1f24035d20 = PRIM_CAR(v0x7f1f24035d00);
+Obj v0x7f1f24035d40 = PRIM_CDR(v0x7f1f24035d20);
+Obj v0x7f1f24035d80 = PRIM_CDR(v0x7f1f24035d40);
+Obj v0x7f1f24035da0 = PRIM_CDR(v0x7f1f24035d80);
+Obj v0x7f1f24035dc0 = PRIM_ISCONS(v0x7f1f24035da0);
+if (True == v0x7f1f24035dc0) {
+Obj v0x7f1f24033280 = PRIM_CDR(v0x7f1f241544e0);
+Obj v0x7f1f240332c0 = PRIM_CAR(v0x7f1f24033280);
+Obj v0x7f1f24033340 = PRIM_CDR(v0x7f1f240332c0);
+Obj v0x7f1f24033360 = PRIM_CDR(v0x7f1f24033340);
+Obj v0x7f1f24033380 = PRIM_CDR(v0x7f1f24033360);
+Obj v0x7f1f240333a0 = PRIM_CAR(v0x7f1f24033380);
+Obj body = v0x7f1f240333a0;
+Obj v0x7f1f240339e0 = PRIM_CDR(v0x7f1f241544e0);
+Obj v0x7f1f24033a00 = PRIM_CAR(v0x7f1f240339e0);
+Obj v0x7f1f24033a60 = PRIM_CDR(v0x7f1f24033a00);
+Obj v0x7f1f24033a80 = PRIM_CDR(v0x7f1f24033a60);
+Obj v0x7f1f24033aa0 = PRIM_CDR(v0x7f1f24033a80);
+Obj v0x7f1f24033ac0 = PRIM_CDR(v0x7f1f24033aa0);
+Obj v0x7f1f24033ae0 = PRIM_EQ(Nil, v0x7f1f24033ac0);
+if (True == v0x7f1f24033ae0) {
+Obj v0x7f1f24033e00 = PRIM_CDR(v0x7f1f241544e0);
+Obj v0x7f1f24033e20 = PRIM_CDR(v0x7f1f24033e00);
+Obj v0x7f1f24033ea0 = PRIM_EQ(Nil, v0x7f1f24033e20);
+if (True == v0x7f1f24033ea0) {
+Obj maxid = v0x7f1f24154520;
 pushCont(co, 14, clofun2, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -2800,7 +2800,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1611;
+__arg0 = v0x7f1f24154680;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2809,7 +2809,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1611;
+__arg0 = v0x7f1f24154680;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2818,7 +2818,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1611;
+__arg0 = v0x7f1f24154680;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2827,7 +2827,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1611;
+__arg0 = v0x7f1f24154680;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2836,7 +2836,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1611;
+__arg0 = v0x7f1f24154680;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2845,7 +2845,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1611;
+__arg0 = v0x7f1f24154680;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2854,7 +2854,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1611;
+__arg0 = v0x7f1f24154680;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2863,7 +2863,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1611;
+__arg0 = v0x7f1f24154680;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2872,7 +2872,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1611;
+__arg0 = v0x7f1f24154680;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2883,18 +2883,18 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj _35val3151 = __arg1;
+Obj v0x7f1f24024060 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj _35reg3152 = PRIM_SUB(maxid, label);
+Obj v0x7f1f240243e0 = PRIM_SUB(maxid, label);
 pushCont(co, 15, clofun2, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = _35reg3152;
+__arg1 = v0x7f1f240243e0;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -2905,7 +2905,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj _35val3153 = __arg1;
+Obj v0x7f1f24024420 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2916,7 +2916,7 @@ pushCont(co, 16, clofun2, 6, actives, maxid, label, params, body, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = _35val3153;
+__arg2 = v0x7f1f24024420;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -2926,7 +2926,7 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35val3154 = __arg1;
+Obj v0x7f1f24024440 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2947,7 +2947,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj _35val3155 = __arg1;
+Obj v0x7f1f24024560 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2970,7 +2970,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35val3156 = __arg1;
+Obj v0x7f1f240247c0 = __arg1;
 Obj actives= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -2993,17 +2993,17 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj _35val3157 = __arg1;
+Obj v0x7f1f24024920 = __arg1;
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj _35reg3158 = makeCons(maxid, label);
+Obj v0x7f1f24024ba0 = makeCons(maxid, label);
 pushCont(co, 20, clofun2, 1, w);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
-__arg1 = _35reg3158;
+__arg1 = v0x7f1f24024ba0;
 __arg2 = params;
 __arg3 = w;
 co->args[4] = body;
@@ -3016,7 +3016,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj _35val3159 = __arg1;
+Obj v0x7f1f24024c60 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3031,7 +3031,7 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj _35cc1612 = makeNative(24, clofun2, 0, 0);
+Obj v0x7f1f24154c60 = makeNative(24, clofun2, 0, 0);
 Obj w = closureRef(co, 0);
 Obj other = closureRef(co, 1);
 Obj maxid = closureRef(co, 2);
@@ -3048,7 +3048,7 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj _35val3098 = __arg1;
+Obj v0x7f1f24048f40 = __arg1;
 Obj other= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 23, clofun2);
 __nargs = 2;
@@ -3063,7 +3063,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj _35val3099 = __arg1;
+Obj v0x7f1f240430e0 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47io_35display);
 __arg1 = makeCString("\n");
@@ -3088,16 +3088,16 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj _35p1602 = __arg1;
-Obj _35p1603 = __arg2;
-Obj _35p1604 = __arg3;
-Obj _35p1605 = co->args[4];
-Obj _35cc1606 = makeNative(26, clofun2, 0, 4, _35p1602, _35p1603, _35p1604, _35p1605);
-Obj fn = _35p1602;
-Obj w = _35p1603;
-Obj idx = _35p1604;
-Obj _35reg3096 = PRIM_EQ(Nil, _35p1605);
-if (True == _35reg3096) {
+Obj v0x7f1f2415baa0 = __arg1;
+Obj v0x7f1f2415bac0 = __arg2;
+Obj v0x7f1f2415bae0 = __arg3;
+Obj v0x7f1f2415bb20 = co->args[4];
+Obj v0x7f1f2415bd00 = makeNative(26, clofun2, 0, 4, v0x7f1f2415baa0, v0x7f1f2415bac0, v0x7f1f2415bae0, v0x7f1f2415bb20);
+Obj fn = v0x7f1f2415baa0;
+Obj w = v0x7f1f2415bac0;
+Obj idx = v0x7f1f2415bae0;
+Obj v0x7f1f24048760 = PRIM_EQ(Nil, v0x7f1f2415bb20);
+if (True == v0x7f1f24048760) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -3105,7 +3105,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1606;
+__arg0 = v0x7f1f2415bd00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3116,16 +3116,16 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35cc1607 = makeNative(28, clofun2, 0, 0);
+Obj v0x7f1f24154000 = makeNative(28, clofun2, 0, 0);
 Obj fn = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj idx = closureRef(co, 2);
-Obj _35reg3091 = PRIM_ISCONS(closureRef(co, 3));
-if (True == _35reg3091) {
-Obj _35reg3092 = PRIM_CAR(closureRef(co, 3));
-Obj a = _35reg3092;
-Obj _35reg3093 = PRIM_CDR(closureRef(co, 3));
-Obj b = _35reg3093;
+Obj v0x7f1f2404dc80 = PRIM_ISCONS(closureRef(co, 3));
+if (True == v0x7f1f2404dc80) {
+Obj v0x7f1f2404dde0 = PRIM_CAR(closureRef(co, 3));
+Obj a = v0x7f1f2404dde0;
+Obj v0x7f1f2404df40 = PRIM_CDR(closureRef(co, 3));
+Obj b = v0x7f1f2404df40;
 pushCont(co, 27, clofun2, 4, idx, fn, w, b);
 __nargs = 4;
 __arg0 = fn;
@@ -3139,7 +3139,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1607;
+__arg0 = v0x7f1f24154000;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3150,17 +3150,17 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj _35val3094 = __arg1;
+Obj v0x7f1f24048120 = __arg1;
 Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj _35reg3095 = PRIM_ADD(idx, MAKE_NUMBER(1));
+Obj v0x7f1f24048380 = PRIM_ADD(idx, MAKE_NUMBER(1));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45args_45reverse);
 __arg1 = fn;
 __arg2 = w;
-__arg3 = _35reg3095;
+__arg3 = v0x7f1f24048380;
 co->args[4] = b;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3200,7 +3200,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj _35val3086 = __arg1;
+Obj v0x7f1f2404fee0 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3220,7 +3220,7 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj _35val3087 = __arg1;
+Obj v0x7f1f2404d180 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 32, clofun2, 2, i, w);
@@ -3237,7 +3237,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj _35val3088 = __arg1;
+Obj v0x7f1f2404d2e0 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 33, clofun2, 1, w);
@@ -3254,7 +3254,7 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj _35val3089 = __arg1;
+Obj v0x7f1f2404d440 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3286,7 +3286,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj _35val3078 = __arg1;
+Obj v0x7f1f24069c20 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3306,11 +3306,11 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj _35val3079 = __arg1;
+Obj v0x7f1f24069e80 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg3080 = PRIM_LT(i, MAKE_NUMBER(4));
-if (True == _35reg3080) {
+Obj v0x7f1f24069fe0 = PRIM_LT(i, MAKE_NUMBER(4));
+if (True == v0x7f1f24069fe0) {
 pushCont(co, 39, clofun2, 2, i, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3337,7 +3337,7 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj _35val3083 = __arg1;
+Obj v0x7f1f2404f6a0 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 38, clofun2, 1, w);
@@ -3354,7 +3354,7 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj _35val3084 = __arg1;
+Obj v0x7f1f2404f8a0 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3369,7 +3369,7 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj _35val3081 = __arg1;
+Obj v0x7f1f2404f200 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 40, clofun2, 1, w);
@@ -3386,7 +3386,7 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj _35val3082 = __arg1;
+Obj v0x7f1f2404f380 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3418,7 +3418,7 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj _35val3074 = __arg1;
+Obj v0x7f1f240691e0 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj maxid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3437,7 +3437,7 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj _35val3075 = __arg1;
+Obj v0x7f1f240694e0 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 44, clofun2, 1, w);
 __nargs = 3;
@@ -3453,7 +3453,7 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj _35val3076 = __arg1;
+Obj v0x7f1f24069640 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3471,9 +3471,9 @@ label45:
 Obj w = __arg1;
 Obj label = __arg2;
 Obj maxid = __arg3;
-Obj _35reg3070 = PRIM_SUB(maxid, label);
-Obj _35reg3071 = primDiv(_35reg3070, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
-Obj gid = _35reg3071;
+Obj v0x7f1f2406b9e0 = PRIM_SUB(maxid, label);
+Obj v0x7f1f2406ba20 = primDiv(v0x7f1f2406b9e0, globalRef(symcora_47lib_47toc_35_42mod_45num_42));
+Obj gid = v0x7f1f2406ba20;
 pushCont(co, 46, clofun2, 2, w, gid);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3488,7 +3488,7 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj _35val3072 = __arg1;
+Obj v0x7f1f2406bc60 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj gid= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 3;
@@ -3524,18 +3524,18 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj _35p1595 = __arg1;
-Obj _35p1596 = __arg2;
-Obj _35p1597 = __arg3;
-Obj _35p1598 = co->args[4];
-Obj _35p1599 = co->args[5];
-Obj _35cc1600 = makeNative(49, clofun2, 0, 5, _35p1595, _35p1596, _35p1597, _35p1598, _35p1599);
-Obj self = _35p1595;
-Obj env = _35p1596;
-Obj fn = _35p1597;
-Obj w = _35p1598;
-Obj _35reg3066 = PRIM_EQ(Nil, _35p1599);
-if (True == _35reg3066) {
+Obj v0x7f1f24161c40 = __arg1;
+Obj v0x7f1f24161ce0 = __arg2;
+Obj v0x7f1f24161d00 = __arg3;
+Obj v0x7f1f24161d20 = co->args[4];
+Obj v0x7f1f24161d40 = co->args[5];
+Obj v0x7f1f24161f40 = makeNative(49, clofun2, 0, 5, v0x7f1f24161c40, v0x7f1f24161ce0, v0x7f1f24161d00, v0x7f1f24161d20, v0x7f1f24161d40);
+Obj self = v0x7f1f24161c40;
+Obj env = v0x7f1f24161ce0;
+Obj fn = v0x7f1f24161d00;
+Obj w = v0x7f1f24161d20;
+Obj v0x7f1f24072e20 = PRIM_EQ(Nil, v0x7f1f24161d40);
+if (True == v0x7f1f24072e20) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -3543,7 +3543,7 @@ if (co->ctx.pc.func != clofun2) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1600;
+__arg0 = v0x7f1f24161f40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3554,17 +3554,17 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj _35cc1601 = makeNative(3, clofun3, 0, 0);
+Obj v0x7f1f2415b340 = makeNative(3, clofun3, 0, 0);
 Obj self = closureRef(co, 0);
 Obj env = closureRef(co, 1);
 Obj fn = closureRef(co, 2);
 Obj w = closureRef(co, 3);
-Obj _35reg3059 = PRIM_ISCONS(closureRef(co, 4));
-if (True == _35reg3059) {
-Obj _35reg3060 = PRIM_CAR(closureRef(co, 4));
-Obj a = _35reg3060;
-Obj _35reg3061 = PRIM_CDR(closureRef(co, 4));
-Obj b = _35reg3061;
+Obj v0x7f1f240f6820 = PRIM_ISCONS(closureRef(co, 4));
+if (True == v0x7f1f240f6820) {
+Obj v0x7f1f240f6c60 = PRIM_CAR(closureRef(co, 4));
+Obj a = v0x7f1f240f6c60;
+Obj v0x7f1f240f6da0 = PRIM_CDR(closureRef(co, 4));
+Obj b = v0x7f1f240f6da0;
 pushCont(co, 0, clofun3, 5, self, env, fn, w, b);
 __nargs = 5;
 __arg0 = fn;
@@ -3579,7 +3579,7 @@ if (ps.func != clofun2) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1601;
+__arg0 = v0x7f1f2415b340;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3610,7 +3610,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val3062 = __arg1;
+Obj v0x7f1f240720a0 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3629,14 +3629,14 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj _35val3063 = __arg1;
+Obj v0x7f1f240723c0 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj _35reg3064 = primNot(_35val3063);
-if (True == _35reg3064) {
+Obj v0x7f1f240723e0 = primNot(v0x7f1f240723c0);
+if (True == v0x7f1f240723e0) {
 pushCont(co, 2, clofun3, 5, self, env, fn, w, b);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3666,7 +3666,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj _35val3065 = __arg1;
+Obj v0x7f1f24072600 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fn= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3700,28 +3700,28 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35p1591 = __arg1;
-Obj _35p1592 = __arg2;
-Obj _35p1593 = __arg3;
-Obj _35cc1594 = makeNative(27, clofun3, 0, 0);
-Obj self = _35p1591;
-Obj w = _35p1592;
-Obj _35reg3020 = PRIM_ISCONS(_35p1593);
-if (True == _35reg3020) {
-Obj _35reg3021 = PRIM_CAR(_35p1593);
-Obj _35reg3022 = PRIM_EQ(sym_37continuation, _35reg3021);
-if (True == _35reg3022) {
-Obj _35reg3023 = PRIM_CDR(_35p1593);
-Obj _35reg3024 = PRIM_ISCONS(_35reg3023);
-if (True == _35reg3024) {
-Obj _35reg3025 = PRIM_CDR(_35p1593);
-Obj _35reg3026 = PRIM_CAR(_35reg3025);
-Obj label = _35reg3026;
-Obj _35reg3027 = PRIM_CDR(_35p1593);
-Obj _35reg3028 = PRIM_CDR(_35reg3027);
-Obj stacks = _35reg3028;
-Obj _35reg3029 = PRIM_EQ(stacks, Nil);
-if (True == _35reg3029) {
+Obj v0x7f1f24161460 = __arg1;
+Obj v0x7f1f24161480 = __arg2;
+Obj v0x7f1f241614a0 = __arg3;
+Obj v0x7f1f24161620 = makeNative(27, clofun3, 0, 0);
+Obj self = v0x7f1f24161460;
+Obj w = v0x7f1f24161480;
+Obj v0x7f1f24133c00 = PRIM_ISCONS(v0x7f1f241614a0);
+if (True == v0x7f1f24133c00) {
+Obj v0x7f1f24133fc0 = PRIM_CAR(v0x7f1f241614a0);
+Obj v0x7f1f24133fe0 = PRIM_EQ(sym_37continuation, v0x7f1f24133fc0);
+if (True == v0x7f1f24133fe0) {
+Obj v0x7f1f2412f300 = PRIM_CDR(v0x7f1f241614a0);
+Obj v0x7f1f2412f320 = PRIM_ISCONS(v0x7f1f2412f300);
+if (True == v0x7f1f2412f320) {
+Obj v0x7f1f2412f540 = PRIM_CDR(v0x7f1f241614a0);
+Obj v0x7f1f2412f560 = PRIM_CAR(v0x7f1f2412f540);
+Obj label = v0x7f1f2412f560;
+Obj v0x7f1f2412f860 = PRIM_CDR(v0x7f1f241614a0);
+Obj v0x7f1f2412f880 = PRIM_CDR(v0x7f1f2412f860);
+Obj stacks = v0x7f1f2412f880;
+Obj v0x7f1f2412faa0 = PRIM_EQ(stacks, Nil);
+if (True == v0x7f1f2412faa0) {
 pushCont(co, 16, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3746,7 +3746,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1594;
+__arg0 = v0x7f1f24161620;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3755,7 +3755,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1594;
+__arg0 = v0x7f1f24161620;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3764,7 +3764,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1594;
+__arg0 = v0x7f1f24161620;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3775,17 +3775,17 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35val3044 = __arg1;
+Obj v0x7f1f24128e20 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj _35reg3045 = PRIM_CAR(self);
-Obj _35reg3046 = PRIM_SUB(_35reg3045, label);
+Obj v0x7f1f240f93e0 = PRIM_CAR(self);
+Obj v0x7f1f240f9440 = PRIM_SUB(v0x7f1f240f93e0, label);
 pushCont(co, 6, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = _35reg3046;
+__arg1 = v0x7f1f240f9440;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -3796,7 +3796,7 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj _35val3047 = __arg1;
+Obj v0x7f1f240f9500 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3805,7 +3805,7 @@ pushCont(co, 7, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = _35val3047;
+__arg2 = v0x7f1f240f9500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3815,7 +3815,7 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35val3048 = __arg1;
+Obj v0x7f1f240f9520 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3834,18 +3834,18 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35val3049 = __arg1;
+Obj v0x7f1f240f97e0 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj _35reg3050 = PRIM_CAR(self);
+Obj v0x7f1f240f9b40 = PRIM_CAR(self);
 pushCont(co, 9, clofun3, 3, self, stacks, w);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = w;
 __arg2 = label;
-__arg3 = _35reg3050;
+__arg3 = v0x7f1f240f9b40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3855,12 +3855,12 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj _35val3051 = __arg1;
+Obj v0x7f1f240f9b80 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg3052 = PRIM_EQ(stacks, Nil);
-if (True == _35reg3052) {
+Obj v0x7f1f240f9ce0 = PRIM_EQ(stacks, Nil);
+if (True == v0x7f1f240f9ce0) {
 Nil;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3887,7 +3887,7 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj _35val3053 = __arg1;
+Obj v0x7f1f240f8160 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3904,7 +3904,7 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj _35val3054 = __arg1;
+Obj v0x7f1f240f8500 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3912,7 +3912,7 @@ pushCont(co, 12, clofun3, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = _35val3054;
+__arg2 = v0x7f1f240f8500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -3922,7 +3922,7 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj _35val3055 = __arg1;
+Obj v0x7f1f240f8520 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -3940,7 +3940,7 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35val3057 = __arg1;
+Obj v0x7f1f240f8be0 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -3970,7 +3970,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj _35val3056 = __arg1;
+Obj v0x7f1f240f88a0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -3987,17 +3987,17 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35val3030 = __arg1;
+Obj v0x7f1f2412fc60 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj _35reg3031 = PRIM_CAR(self);
-Obj _35reg3032 = PRIM_SUB(_35reg3031, label);
+Obj v0x7f1f2412c1e0 = PRIM_CAR(self);
+Obj v0x7f1f2412c2a0 = PRIM_SUB(v0x7f1f2412c1e0, label);
 pushCont(co, 17, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = _35reg3032;
+__arg1 = v0x7f1f2412c2a0;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -4008,7 +4008,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj _35val3033 = __arg1;
+Obj v0x7f1f2412c2e0 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4017,7 +4017,7 @@ pushCont(co, 18, clofun3, 4, label, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = _35val3033;
+__arg2 = v0x7f1f2412c2e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4027,7 +4027,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35val3034 = __arg1;
+Obj v0x7f1f2412c300 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4046,18 +4046,18 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj _35val3035 = __arg1;
+Obj v0x7f1f2412c860 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj _35reg3036 = PRIM_CAR(self);
+Obj v0x7f1f2412cba0 = PRIM_CAR(self);
 pushCont(co, 20, clofun3, 3, self, stacks, w);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = w;
 __arg2 = label;
-__arg3 = _35reg3036;
+__arg3 = v0x7f1f2412cba0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4067,12 +4067,12 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj _35val3037 = __arg1;
+Obj v0x7f1f2412cbe0 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg3038 = PRIM_EQ(stacks, Nil);
-if (True == _35reg3038) {
+Obj v0x7f1f2412cda0 = PRIM_EQ(stacks, Nil);
+if (True == v0x7f1f2412cda0) {
 Nil;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4099,7 +4099,7 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj _35val3039 = __arg1;
+Obj v0x7f1f24128200 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4116,7 +4116,7 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj _35val3040 = __arg1;
+Obj v0x7f1f24128560 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4124,7 +4124,7 @@ pushCont(co, 23, clofun3, 3, self, stacks, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = w;
-__arg2 = _35val3040;
+__arg2 = v0x7f1f24128560;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4134,7 +4134,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj _35val3041 = __arg1;
+Obj v0x7f1f24128580 = __arg1;
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj stacks= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4152,7 +4152,7 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj _35val3043 = __arg1;
+Obj v0x7f1f24128bc0 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4182,7 +4182,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35val3042 = __arg1;
+Obj v0x7f1f24128940 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -4215,8 +4215,8 @@ Obj self = __arg1;
 Obj env = __arg2;
 Obj w = __arg3;
 Obj x1 = co->args[4];
-Obj _35reg2747 = primIsSymbol(x1);
-if (True == _35reg2747) {
+Obj v0x7f1f24128600 = primIsSymbol(x1);
+if (True == v0x7f1f24128600) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
 __arg1 = w;
@@ -4227,22 +4227,22 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35cc1578 = makeNative(31, clofun3, 0, 4, self, env, x1, w);
-Obj _35reg3007 = PRIM_ISCONS(x1);
-if (True == _35reg3007) {
-Obj _35reg3008 = PRIM_CAR(x1);
-Obj _35reg3009 = PRIM_EQ(sym_37global, _35reg3008);
-if (True == _35reg3009) {
-Obj _35reg3010 = PRIM_CDR(x1);
-Obj _35reg3011 = PRIM_ISCONS(_35reg3010);
-if (True == _35reg3011) {
-Obj _35reg3012 = PRIM_CDR(x1);
-Obj _35reg3013 = PRIM_CAR(_35reg3012);
-Obj x = _35reg3013;
-Obj _35reg3014 = PRIM_CDR(x1);
-Obj _35reg3015 = PRIM_CDR(_35reg3014);
-Obj _35reg3016 = PRIM_EQ(Nil, _35reg3015);
-if (True == _35reg3016) {
+Obj v0x7f1f2415b580 = makeNative(31, clofun3, 0, 4, self, env, x1, w);
+Obj v0x7f1f24138de0 = PRIM_ISCONS(x1);
+if (True == v0x7f1f24138de0) {
+Obj v0x7f1f24135160 = PRIM_CAR(x1);
+Obj v0x7f1f24135180 = PRIM_EQ(sym_37global, v0x7f1f24135160);
+if (True == v0x7f1f24135180) {
+Obj v0x7f1f24135360 = PRIM_CDR(x1);
+Obj v0x7f1f24135400 = PRIM_ISCONS(v0x7f1f24135360);
+if (True == v0x7f1f24135400) {
+Obj v0x7f1f24135640 = PRIM_CDR(x1);
+Obj v0x7f1f24135660 = PRIM_CAR(v0x7f1f24135640);
+Obj x = v0x7f1f24135660;
+Obj v0x7f1f24135c80 = PRIM_CDR(x1);
+Obj v0x7f1f24135ca0 = PRIM_CDR(v0x7f1f24135c80);
+Obj v0x7f1f24135cc0 = PRIM_EQ(Nil, v0x7f1f24135ca0);
+if (True == v0x7f1f24135cc0) {
 pushCont(co, 29, clofun3, 2, x, w);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4255,7 +4255,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1578;
+__arg0 = v0x7f1f2415b580;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4264,7 +4264,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1578;
+__arg0 = v0x7f1f2415b580;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4273,7 +4273,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1578;
+__arg0 = v0x7f1f2415b580;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4282,7 +4282,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1578;
+__arg0 = v0x7f1f2415b580;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4294,7 +4294,7 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj _35val3017 = __arg1;
+Obj v0x7f1f24135e60 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 30, clofun3, 1, w);
@@ -4311,7 +4311,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj _35val3018 = __arg1;
+Obj v0x7f1f24133000 = __arg1;
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4326,22 +4326,22 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj _35cc1579 = makeNative(34, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg2995 = PRIM_ISCONS(closureRef(co, 2));
-if (True == _35reg2995) {
-Obj _35reg2996 = PRIM_CAR(closureRef(co, 2));
-Obj _35reg2997 = PRIM_EQ(sym_37closure_45ref, _35reg2996);
-if (True == _35reg2997) {
-Obj _35reg2998 = PRIM_CDR(closureRef(co, 2));
-Obj _35reg2999 = PRIM_ISCONS(_35reg2998);
-if (True == _35reg2999) {
-Obj _35reg3000 = PRIM_CDR(closureRef(co, 2));
-Obj _35reg3001 = PRIM_CAR(_35reg3000);
-Obj idx = _35reg3001;
-Obj _35reg3002 = PRIM_CDR(closureRef(co, 2));
-Obj _35reg3003 = PRIM_CDR(_35reg3002);
-Obj _35reg3004 = PRIM_EQ(Nil, _35reg3003);
-if (True == _35reg3004) {
+Obj v0x7f1f2415b700 = makeNative(34, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj v0x7f1f2413f620 = PRIM_ISCONS(closureRef(co, 2));
+if (True == v0x7f1f2413f620) {
+Obj v0x7f1f2413f980 = PRIM_CAR(closureRef(co, 2));
+Obj v0x7f1f2413f9a0 = PRIM_EQ(sym_37closure_45ref, v0x7f1f2413f980);
+if (True == v0x7f1f2413f9a0) {
+Obj v0x7f1f2413fc40 = PRIM_CDR(closureRef(co, 2));
+Obj v0x7f1f2413fca0 = PRIM_ISCONS(v0x7f1f2413fc40);
+if (True == v0x7f1f2413fca0) {
+Obj v0x7f1f2413fec0 = PRIM_CDR(closureRef(co, 2));
+Obj v0x7f1f2413fee0 = PRIM_CAR(v0x7f1f2413fec0);
+Obj idx = v0x7f1f2413fee0;
+Obj v0x7f1f24138340 = PRIM_CDR(closureRef(co, 2));
+Obj v0x7f1f24138360 = PRIM_CDR(v0x7f1f24138340);
+Obj v0x7f1f24138380 = PRIM_EQ(Nil, v0x7f1f24138360);
+if (True == v0x7f1f24138380) {
 pushCont(co, 32, clofun3, 1, idx);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4354,7 +4354,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1579;
+__arg0 = v0x7f1f2415b700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4363,7 +4363,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1579;
+__arg0 = v0x7f1f2415b700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4372,7 +4372,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1579;
+__arg0 = v0x7f1f2415b700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4381,7 +4381,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1579;
+__arg0 = v0x7f1f2415b700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4392,7 +4392,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj _35val3005 = __arg1;
+Obj v0x7f1f24138520 = __arg1;
 Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 33, clofun3);
 __nargs = 3;
@@ -4408,7 +4408,7 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj _35val3006 = __arg1;
+Obj v0x7f1f241386c0 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4422,22 +4422,22 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj _35cc1580 = makeNative(37, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg2983 = PRIM_ISCONS(closureRef(co, 2));
-if (True == _35reg2983) {
-Obj _35reg2984 = PRIM_CAR(closureRef(co, 2));
-Obj _35reg2985 = PRIM_EQ(sym_37stack_45ref, _35reg2984);
-if (True == _35reg2985) {
-Obj _35reg2986 = PRIM_CDR(closureRef(co, 2));
-Obj _35reg2987 = PRIM_ISCONS(_35reg2986);
-if (True == _35reg2987) {
-Obj _35reg2988 = PRIM_CDR(closureRef(co, 2));
-Obj _35reg2989 = PRIM_CAR(_35reg2988);
-Obj idx = _35reg2989;
-Obj _35reg2990 = PRIM_CDR(closureRef(co, 2));
-Obj _35reg2991 = PRIM_CDR(_35reg2990);
-Obj _35reg2992 = PRIM_EQ(Nil, _35reg2991);
-if (True == _35reg2992) {
+Obj v0x7f1f2415b860 = makeNative(37, clofun3, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj v0x7f1f2414de60 = PRIM_ISCONS(closureRef(co, 2));
+if (True == v0x7f1f2414de60) {
+Obj v0x7f1f24146200 = PRIM_CAR(closureRef(co, 2));
+Obj v0x7f1f24146220 = PRIM_EQ(sym_37stack_45ref, v0x7f1f24146200);
+if (True == v0x7f1f24146220) {
+Obj v0x7f1f24146560 = PRIM_CDR(closureRef(co, 2));
+Obj v0x7f1f241465a0 = PRIM_ISCONS(v0x7f1f24146560);
+if (True == v0x7f1f241465a0) {
+Obj v0x7f1f241467e0 = PRIM_CDR(closureRef(co, 2));
+Obj v0x7f1f24146880 = PRIM_CAR(v0x7f1f241467e0);
+Obj idx = v0x7f1f24146880;
+Obj v0x7f1f24146c60 = PRIM_CDR(closureRef(co, 2));
+Obj v0x7f1f24146c80 = PRIM_CDR(v0x7f1f24146c60);
+Obj v0x7f1f24146ca0 = PRIM_EQ(Nil, v0x7f1f24146c80);
+if (True == v0x7f1f24146ca0) {
 pushCont(co, 35, clofun3, 1, idx);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4450,7 +4450,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1580;
+__arg0 = v0x7f1f2415b860;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4459,7 +4459,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1580;
+__arg0 = v0x7f1f2415b860;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4468,7 +4468,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1580;
+__arg0 = v0x7f1f2415b860;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4477,7 +4477,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1580;
+__arg0 = v0x7f1f2415b860;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4488,7 +4488,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj _35val2993 = __arg1;
+Obj v0x7f1f24146ee0 = __arg1;
 Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 36, clofun3);
 __nargs = 3;
@@ -4504,7 +4504,7 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj _35val2994 = __arg1;
+Obj v0x7f1f2413f080 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4518,24 +4518,24 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj _35cc1581 = makeNative(45, clofun3, 0, 4, closureRef(co, 2), closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
-Obj _35reg2961 = PRIM_ISCONS(closureRef(co, 2));
-if (True == _35reg2961) {
-Obj _35reg2962 = PRIM_CAR(closureRef(co, 2));
-Obj _35reg2963 = PRIM_EQ(sym_37const, _35reg2962);
-if (True == _35reg2963) {
-Obj _35reg2964 = PRIM_CDR(closureRef(co, 2));
-Obj _35reg2965 = PRIM_ISCONS(_35reg2964);
-if (True == _35reg2965) {
-Obj _35reg2966 = PRIM_CDR(closureRef(co, 2));
-Obj _35reg2967 = PRIM_CAR(_35reg2966);
-Obj x = _35reg2967;
-Obj _35reg2968 = PRIM_CDR(closureRef(co, 2));
-Obj _35reg2969 = PRIM_CDR(_35reg2968);
-Obj _35reg2970 = PRIM_EQ(Nil, _35reg2969);
-if (True == _35reg2970) {
-Obj _35reg2971 = primIsSymbol(x);
-if (True == _35reg2971) {
+Obj v0x7f1f2415ba20 = makeNative(45, clofun3, 0, 4, closureRef(co, 2), closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
+Obj v0x7f1f23f43040 = PRIM_ISCONS(closureRef(co, 2));
+if (True == v0x7f1f23f43040) {
+Obj v0x7f1f23f43200 = PRIM_CAR(closureRef(co, 2));
+Obj v0x7f1f23f43220 = PRIM_EQ(sym_37const, v0x7f1f23f43200);
+if (True == v0x7f1f23f43220) {
+Obj v0x7f1f24161360 = PRIM_CDR(closureRef(co, 2));
+Obj v0x7f1f241613a0 = PRIM_ISCONS(v0x7f1f24161360);
+if (True == v0x7f1f241613a0) {
+Obj v0x7f1f24161920 = PRIM_CDR(closureRef(co, 2));
+Obj v0x7f1f24161940 = PRIM_CAR(v0x7f1f24161920);
+Obj x = v0x7f1f24161940;
+Obj v0x7f1f24161fc0 = PRIM_CDR(closureRef(co, 2));
+Obj v0x7f1f24161fe0 = PRIM_CDR(v0x7f1f24161fc0);
+Obj v0x7f1f2415b040 = PRIM_EQ(Nil, v0x7f1f24161fe0);
+if (True == v0x7f1f2415b040) {
+Obj v0x7f1f2415b1e0 = primIsSymbol(x);
+if (True == v0x7f1f2415b1e0) {
 pushCont(co, 44, clofun3, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4559,7 +4559,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1581;
+__arg0 = v0x7f1f2415ba20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4568,7 +4568,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1581;
+__arg0 = v0x7f1f2415ba20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4577,7 +4577,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1581;
+__arg0 = v0x7f1f2415ba20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4586,7 +4586,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1581;
+__arg0 = v0x7f1f2415ba20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4597,9 +4597,9 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj _35val2973 = __arg1;
+Obj v0x7f1f2415ba00 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == _35val2973) {
+if (True == v0x7f1f2415ba00) {
 pushCont(co, 42, clofun3, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4611,8 +4611,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2976 = primIsString(x);
-if (True == _35reg2976) {
+Obj v0x7f1f24154360 = primIsString(x);
+if (True == v0x7f1f24154360) {
 pushCont(co, 39, clofun3, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4624,8 +4624,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2980 = PRIM_EQ(x, Nil);
-if (True == _35reg2980) {
+Obj v0x7f1f24154f40 = PRIM_EQ(x, Nil);
+if (True == v0x7f1f24154f40) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4636,8 +4636,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2981 = PRIM_EQ(x, True);
-if (True == _35reg2981) {
+Obj v0x7f1f2414d260 = PRIM_EQ(x, True);
+if (True == v0x7f1f2414d260) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4648,8 +4648,8 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2982 = PRIM_EQ(x, False);
-if (True == _35reg2982) {
+Obj v0x7f1f2414d680 = PRIM_EQ(x, False);
+if (True == v0x7f1f2414d680) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4677,7 +4677,7 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj _35val2977 = __arg1;
+Obj v0x7f1f241546c0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 40, clofun3);
 __nargs = 2;
@@ -4692,12 +4692,12 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj _35val2978 = __arg1;
+Obj v0x7f1f24154a00 = __arg1;
 PUSH_CONT_0(co, 41, clofun3);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
-__arg2 = _35val2978;
+__arg2 = v0x7f1f24154a00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4707,7 +4707,7 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj _35val2979 = __arg1;
+Obj v0x7f1f24154aa0 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4721,7 +4721,7 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj _35val2974 = __arg1;
+Obj v0x7f1f2415be00 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 43, clofun3);
 __nargs = 3;
@@ -4737,7 +4737,7 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj _35val2975 = __arg1;
+Obj v0x7f1f2415bfc0 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -4751,7 +4751,7 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj _35val2972 = __arg1;
+Obj v0x7f1f2415b520 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45sym);
@@ -4766,42 +4766,42 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj _35cc1582 = makeNative(6, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg2922 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2922) {
-Obj _35reg2923 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2924 = PRIM_EQ(symlet, _35reg2923);
-if (True == _35reg2924) {
-Obj _35reg2925 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2926 = PRIM_ISCONS(_35reg2925);
-if (True == _35reg2926) {
-Obj _35reg2927 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2928 = PRIM_CAR(_35reg2927);
-Obj a = _35reg2928;
-Obj _35reg2929 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2930 = PRIM_CDR(_35reg2929);
-Obj _35reg2931 = PRIM_ISCONS(_35reg2930);
-if (True == _35reg2931) {
-Obj _35reg2932 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2933 = PRIM_CDR(_35reg2932);
-Obj _35reg2934 = PRIM_CAR(_35reg2933);
-Obj b = _35reg2934;
-Obj _35reg2935 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2936 = PRIM_CDR(_35reg2935);
-Obj _35reg2937 = PRIM_CDR(_35reg2936);
-Obj _35reg2938 = PRIM_ISCONS(_35reg2937);
-if (True == _35reg2938) {
-Obj _35reg2939 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2940 = PRIM_CDR(_35reg2939);
-Obj _35reg2941 = PRIM_CDR(_35reg2940);
-Obj _35reg2942 = PRIM_CAR(_35reg2941);
-Obj c = _35reg2942;
-Obj _35reg2943 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2944 = PRIM_CDR(_35reg2943);
-Obj _35reg2945 = PRIM_CDR(_35reg2944);
-Obj _35reg2946 = PRIM_CDR(_35reg2945);
-Obj _35reg2947 = PRIM_EQ(Nil, _35reg2946);
-if (True == _35reg2947) {
+Obj v0x7f1f2415bbe0 = makeNative(6, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj v0x7f1f23f5c6a0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f23f5c6a0) {
+Obj v0x7f1f23f5c860 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f23f5c880 = PRIM_EQ(symlet, v0x7f1f23f5c860);
+if (True == v0x7f1f23f5c880) {
+Obj v0x7f1f23f5ca20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f5ca40 = PRIM_ISCONS(v0x7f1f23f5ca20);
+if (True == v0x7f1f23f5ca40) {
+Obj v0x7f1f23f5cbe0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f5cc00 = PRIM_CAR(v0x7f1f23f5cbe0);
+Obj a = v0x7f1f23f5cc00;
+Obj v0x7f1f23f5ce40 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f5ce60 = PRIM_CDR(v0x7f1f23f5ce40);
+Obj v0x7f1f23f5ce80 = PRIM_ISCONS(v0x7f1f23f5ce60);
+if (True == v0x7f1f23f5ce80) {
+Obj v0x7f1f23f580c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f580e0 = PRIM_CDR(v0x7f1f23f580c0);
+Obj v0x7f1f23f58100 = PRIM_CAR(v0x7f1f23f580e0);
+Obj b = v0x7f1f23f58100;
+Obj v0x7f1f23f583e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f58400 = PRIM_CDR(v0x7f1f23f583e0);
+Obj v0x7f1f23f58420 = PRIM_CDR(v0x7f1f23f58400);
+Obj v0x7f1f23f58440 = PRIM_ISCONS(v0x7f1f23f58420);
+if (True == v0x7f1f23f58440) {
+Obj v0x7f1f23f58720 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f58740 = PRIM_CDR(v0x7f1f23f58720);
+Obj v0x7f1f23f58760 = PRIM_CDR(v0x7f1f23f58740);
+Obj v0x7f1f23f58780 = PRIM_CAR(v0x7f1f23f58760);
+Obj c = v0x7f1f23f58780;
+Obj v0x7f1f23f58b20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f23f58b40 = PRIM_CDR(v0x7f1f23f58b20);
+Obj v0x7f1f23f58b60 = PRIM_CDR(v0x7f1f23f58b40);
+Obj v0x7f1f23f58b80 = PRIM_CDR(v0x7f1f23f58b60);
+Obj v0x7f1f23f58ba0 = PRIM_EQ(Nil, v0x7f1f23f58b80);
+if (True == v0x7f1f23f58ba0) {
 pushCont(co, 46, clofun3, 3, b, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35index);
@@ -4814,7 +4814,7 @@ if (ps.func != clofun3) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1582;
+__arg0 = v0x7f1f2415bbe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4823,7 +4823,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1582;
+__arg0 = v0x7f1f2415bbe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4832,7 +4832,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1582;
+__arg0 = v0x7f1f2415bbe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4841,7 +4841,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1582;
+__arg0 = v0x7f1f2415bbe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4850,7 +4850,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1582;
+__arg0 = v0x7f1f2415bbe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4859,7 +4859,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1582;
+__arg0 = v0x7f1f2415bbe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -4870,13 +4870,13 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj _35val2948 = __arg1;
+Obj v0x7f1f23f58cc0 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj idx = _35val2948;
-Obj _35reg2949 = PRIM_LT(idx, MAKE_NUMBER(0));
-if (True == _35reg2949) {
+Obj idx = v0x7f1f23f58cc0;
+Obj v0x7f1f23f58e20 = PRIM_LT(idx, MAKE_NUMBER(0));
+if (True == v0x7f1f23f58e20) {
 pushCont(co, 1, clofun4, 3, b, a, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -4904,7 +4904,7 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj _35val2956 = __arg1;
+Obj v0x7f1f23f496c0 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4922,7 +4922,7 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj _35val2957 = __arg1;
+Obj v0x7f1f23f497e0 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -4942,7 +4942,7 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj _35val2958 = __arg1;
+Obj v0x7f1f23f49940 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 0, clofun4, 2, a, c);
@@ -4979,14 +4979,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2959 = __arg1;
+Obj v0x7f1f23f49a60 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2960 = makeCons(a, closureRef(co, 2));
+Obj v0x7f1f23f49c00 = makeCons(a, closureRef(co, 2));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
-__arg2 = _35reg2960;
+__arg2 = v0x7f1f23f49c00;
 __arg3 = closureRef(co, 3);
 co->args[4] = c;
 co->ctx.frees = __arg0;
@@ -4998,7 +4998,7 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj _35val2950 = __arg1;
+Obj v0x7f1f23f58f00 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5016,7 +5016,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj _35val2951 = __arg1;
+Obj v0x7f1f23f49020 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5034,7 +5034,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj _35val2952 = __arg1;
+Obj v0x7f1f23f49140 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5054,7 +5054,7 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35val2953 = __arg1;
+Obj v0x7f1f23f492a0 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 5, clofun4, 2, a, c);
@@ -5071,14 +5071,14 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35val2954 = __arg1;
+Obj v0x7f1f23f493c0 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2955 = makeCons(a, closureRef(co, 2));
+Obj v0x7f1f23f49560 = makeCons(a, closureRef(co, 2));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
-__arg2 = _35reg2955;
+__arg2 = v0x7f1f23f49560;
 __arg3 = closureRef(co, 3);
 co->args[4] = c;
 co->ctx.frees = __arg0;
@@ -5090,31 +5090,31 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj _35cc1583 = makeNative(13, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg2898 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2898) {
-Obj _35reg2899 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2900 = PRIM_ISCONS(_35reg2899);
-if (True == _35reg2900) {
-Obj _35reg2901 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2902 = PRIM_CAR(_35reg2901);
-Obj _35reg2903 = PRIM_EQ(sym_37builtin, _35reg2902);
-if (True == _35reg2903) {
-Obj _35reg2904 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2905 = PRIM_CDR(_35reg2904);
-Obj _35reg2906 = PRIM_ISCONS(_35reg2905);
-if (True == _35reg2906) {
-Obj _35reg2907 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2908 = PRIM_CDR(_35reg2907);
-Obj _35reg2909 = PRIM_CAR(_35reg2908);
-Obj f = _35reg2909;
-Obj _35reg2910 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2911 = PRIM_CDR(_35reg2910);
-Obj _35reg2912 = PRIM_CDR(_35reg2911);
-Obj _35reg2913 = PRIM_EQ(Nil, _35reg2912);
-if (True == _35reg2913) {
-Obj _35reg2914 = PRIM_CDR(closureRef(co, 0));
-Obj args = _35reg2914;
+Obj v0x7f1f2415bea0 = makeNative(13, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj v0x7f1f24017c20 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24017c20) {
+Obj v0x7f1f24017dc0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f24017de0 = PRIM_ISCONS(v0x7f1f24017dc0);
+if (True == v0x7f1f24017de0) {
+Obj v0x7f1f24013040 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f24013060 = PRIM_CAR(v0x7f1f24013040);
+Obj v0x7f1f24013080 = PRIM_EQ(sym_37builtin, v0x7f1f24013060);
+if (True == v0x7f1f24013080) {
+Obj v0x7f1f240132c0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f240132e0 = PRIM_CDR(v0x7f1f240132c0);
+Obj v0x7f1f24013300 = PRIM_ISCONS(v0x7f1f240132e0);
+if (True == v0x7f1f24013300) {
+Obj v0x7f1f24013540 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f24013560 = PRIM_CDR(v0x7f1f24013540);
+Obj v0x7f1f24013580 = PRIM_CAR(v0x7f1f24013560);
+Obj f = v0x7f1f24013580;
+Obj v0x7f1f24013880 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f240138a0 = PRIM_CDR(v0x7f1f24013880);
+Obj v0x7f1f240138c0 = PRIM_CDR(v0x7f1f240138a0);
+Obj v0x7f1f240138e0 = PRIM_EQ(Nil, v0x7f1f240138c0);
+if (True == v0x7f1f240138e0) {
+Obj v0x7f1f240139e0 = PRIM_CDR(closureRef(co, 0));
+Obj args = v0x7f1f240139e0;
 pushCont(co, 7, clofun4, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35builtin_45_62name);
@@ -5126,7 +5126,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1583;
+__arg0 = v0x7f1f2415bea0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5135,7 +5135,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1583;
+__arg0 = v0x7f1f2415bea0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5144,7 +5144,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1583;
+__arg0 = v0x7f1f2415bea0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5153,7 +5153,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1583;
+__arg0 = v0x7f1f2415bea0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5162,7 +5162,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1583;
+__arg0 = v0x7f1f2415bea0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5173,14 +5173,14 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35val2915 = __arg1;
+Obj v0x7f1f24013ba0 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 8, clofun4, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
-__arg2 = _35val2915;
+__arg2 = v0x7f1f24013ba0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5190,11 +5190,11 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35val2916 = __arg1;
+Obj v0x7f1f24013bc0 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2917 = PRIM_EQ(f, symset);
-if (True == _35reg2917) {
+Obj v0x7f1f24013d20 = PRIM_EQ(f, symset);
+if (True == v0x7f1f24013d20) {
 pushCont(co, 11, clofun4, 1, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5221,7 +5221,7 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj _35val2920 = __arg1;
+Obj v0x7f1f23f5c100 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 10, clofun4);
 __nargs = 5;
@@ -5239,7 +5239,7 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj _35val2921 = __arg1;
+Obj v0x7f1f23f5c260 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5253,7 +5253,7 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj _35val2918 = __arg1;
+Obj v0x7f1f24013e00 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 12, clofun4);
 __nargs = 5;
@@ -5271,7 +5271,7 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj _35val2919 = __arg1;
+Obj v0x7f1f24013f60 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5285,42 +5285,42 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35cc1584 = makeNative(20, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg2866 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2866) {
-Obj _35reg2867 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2868 = PRIM_EQ(symif, _35reg2867);
-if (True == _35reg2868) {
-Obj _35reg2869 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2870 = PRIM_ISCONS(_35reg2869);
-if (True == _35reg2870) {
-Obj _35reg2871 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2872 = PRIM_CAR(_35reg2871);
-Obj a = _35reg2872;
-Obj _35reg2873 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2874 = PRIM_CDR(_35reg2873);
-Obj _35reg2875 = PRIM_ISCONS(_35reg2874);
-if (True == _35reg2875) {
-Obj _35reg2876 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2877 = PRIM_CDR(_35reg2876);
-Obj _35reg2878 = PRIM_CAR(_35reg2877);
-Obj b = _35reg2878;
-Obj _35reg2879 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2880 = PRIM_CDR(_35reg2879);
-Obj _35reg2881 = PRIM_CDR(_35reg2880);
-Obj _35reg2882 = PRIM_ISCONS(_35reg2881);
-if (True == _35reg2882) {
-Obj _35reg2883 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2884 = PRIM_CDR(_35reg2883);
-Obj _35reg2885 = PRIM_CDR(_35reg2884);
-Obj _35reg2886 = PRIM_CAR(_35reg2885);
-Obj c = _35reg2886;
-Obj _35reg2887 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2888 = PRIM_CDR(_35reg2887);
-Obj _35reg2889 = PRIM_CDR(_35reg2888);
-Obj _35reg2890 = PRIM_CDR(_35reg2889);
-Obj _35reg2891 = PRIM_EQ(Nil, _35reg2890);
-if (True == _35reg2891) {
+Obj v0x7f1f241540a0 = makeNative(20, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj v0x7f1f24033260 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24033260) {
+Obj v0x7f1f240334a0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f240334c0 = PRIM_EQ(symif, v0x7f1f240334a0);
+if (True == v0x7f1f240334c0) {
+Obj v0x7f1f24033680 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240336e0 = PRIM_ISCONS(v0x7f1f24033680);
+if (True == v0x7f1f240336e0) {
+Obj v0x7f1f240338c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240338e0 = PRIM_CAR(v0x7f1f240338c0);
+Obj a = v0x7f1f240338e0;
+Obj v0x7f1f24033b60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24033b80 = PRIM_CDR(v0x7f1f24033b60);
+Obj v0x7f1f24033ba0 = PRIM_ISCONS(v0x7f1f24033b80);
+if (True == v0x7f1f24033ba0) {
+Obj v0x7f1f24033e40 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24033e60 = PRIM_CDR(v0x7f1f24033e40);
+Obj v0x7f1f24033e80 = PRIM_CAR(v0x7f1f24033e60);
+Obj b = v0x7f1f24033e80;
+Obj v0x7f1f240241c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240241e0 = PRIM_CDR(v0x7f1f240241c0);
+Obj v0x7f1f24024200 = PRIM_CDR(v0x7f1f240241e0);
+Obj v0x7f1f24024220 = PRIM_ISCONS(v0x7f1f24024200);
+if (True == v0x7f1f24024220) {
+Obj v0x7f1f24024580 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240245c0 = PRIM_CDR(v0x7f1f24024580);
+Obj v0x7f1f24024640 = PRIM_CDR(v0x7f1f240245c0);
+Obj v0x7f1f24024660 = PRIM_CAR(v0x7f1f24024640);
+Obj c = v0x7f1f24024660;
+Obj v0x7f1f24024a00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24024a40 = PRIM_CDR(v0x7f1f24024a00);
+Obj v0x7f1f24024a60 = PRIM_CDR(v0x7f1f24024a40);
+Obj v0x7f1f24024a80 = PRIM_CDR(v0x7f1f24024a60);
+Obj v0x7f1f24024aa0 = PRIM_EQ(Nil, v0x7f1f24024a80);
+if (True == v0x7f1f24024aa0) {
 pushCont(co, 14, clofun4, 3, a, b, c);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5333,7 +5333,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1584;
+__arg0 = v0x7f1f241540a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5342,7 +5342,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1584;
+__arg0 = v0x7f1f241540a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5351,7 +5351,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1584;
+__arg0 = v0x7f1f241540a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5360,7 +5360,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1584;
+__arg0 = v0x7f1f241540a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5369,7 +5369,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1584;
+__arg0 = v0x7f1f241540a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5378,7 +5378,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1584;
+__arg0 = v0x7f1f241540a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5389,7 +5389,7 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj _35val2892 = __arg1;
+Obj v0x7f1f24024bc0 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5409,7 +5409,7 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj _35val2893 = __arg1;
+Obj v0x7f1f24024d60 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 16, clofun4, 2, b, c);
@@ -5426,7 +5426,7 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35val2894 = __arg1;
+Obj v0x7f1f24024e80 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 17, clofun4, 1, c);
@@ -5445,7 +5445,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj _35val2895 = __arg1;
+Obj v0x7f1f24024fe0 = __arg1;
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 18, clofun4, 1, c);
 __nargs = 3;
@@ -5461,7 +5461,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35val2896 = __arg1;
+Obj v0x7f1f24022100 = __arg1;
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 19, clofun4);
 __nargs = 5;
@@ -5479,7 +5479,7 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj _35val2897 = __arg1;
+Obj v0x7f1f24022280 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5493,30 +5493,30 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj _35cc1585 = makeNative(34, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg2833 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2833) {
-Obj _35reg2834 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2835 = PRIM_EQ(sym_37closure, _35reg2834);
-if (True == _35reg2835) {
-Obj _35reg2836 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2837 = PRIM_ISCONS(_35reg2836);
-if (True == _35reg2837) {
-Obj _35reg2838 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2839 = PRIM_CAR(_35reg2838);
-Obj label = _35reg2839;
-Obj _35reg2840 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2841 = PRIM_CDR(_35reg2840);
-Obj _35reg2842 = PRIM_ISCONS(_35reg2841);
-if (True == _35reg2842) {
-Obj _35reg2843 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2844 = PRIM_CDR(_35reg2843);
-Obj _35reg2845 = PRIM_CAR(_35reg2844);
-Obj nargs = _35reg2845;
-Obj _35reg2846 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2847 = PRIM_CDR(_35reg2846);
-Obj _35reg2848 = PRIM_CDR(_35reg2847);
-Obj frees = _35reg2848;
+Obj v0x7f1f24154380 = makeNative(34, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj v0x7f1f24043520 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24043520) {
+Obj v0x7f1f240437c0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f240437e0 = PRIM_EQ(sym_37closure, v0x7f1f240437c0);
+if (True == v0x7f1f240437e0) {
+Obj v0x7f1f24043980 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24043a20 = PRIM_ISCONS(v0x7f1f24043980);
+if (True == v0x7f1f24043a20) {
+Obj v0x7f1f24043c00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24043c20 = PRIM_CAR(v0x7f1f24043c00);
+Obj label = v0x7f1f24043c20;
+Obj v0x7f1f24043f60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24043f80 = PRIM_CDR(v0x7f1f24043f60);
+Obj v0x7f1f24043fa0 = PRIM_ISCONS(v0x7f1f24043f80);
+if (True == v0x7f1f24043fa0) {
+Obj v0x7f1f2403d2a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2403d2c0 = PRIM_CDR(v0x7f1f2403d2a0);
+Obj v0x7f1f2403d2e0 = PRIM_CAR(v0x7f1f2403d2c0);
+Obj nargs = v0x7f1f2403d2e0;
+Obj v0x7f1f2403d580 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2403d5a0 = PRIM_CDR(v0x7f1f2403d580);
+Obj v0x7f1f2403d620 = PRIM_CDR(v0x7f1f2403d5a0);
+Obj frees = v0x7f1f2403d620;
 pushCont(co, 21, clofun4, 3, label, nargs, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5529,7 +5529,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1585;
+__arg0 = v0x7f1f24154380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5538,7 +5538,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1585;
+__arg0 = v0x7f1f24154380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5547,7 +5547,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1585;
+__arg0 = v0x7f1f24154380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5556,7 +5556,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1585;
+__arg0 = v0x7f1f24154380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5567,16 +5567,16 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj _35val2849 = __arg1;
+Obj v0x7f1f2403d7c0 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg2850 = PRIM_CAR(closureRef(co, 1));
-Obj _35reg2851 = PRIM_SUB(_35reg2850, label);
+Obj v0x7f1f2403db80 = PRIM_CAR(closureRef(co, 1));
+Obj v0x7f1f2403dbc0 = PRIM_SUB(v0x7f1f2403db80, label);
 pushCont(co, 22, clofun4, 3, label, nargs, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47hash_45h_35mod);
-__arg1 = _35reg2851;
+__arg1 = v0x7f1f2403dbc0;
 __arg2 = globalRef(symcora_47lib_47toc_35_42mod_45num_42);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -5587,7 +5587,7 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj _35val2852 = __arg1;
+Obj v0x7f1f2403dc00 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5595,7 +5595,7 @@ pushCont(co, 23, clofun4, 3, label, nargs, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = closureRef(co, 3);
-__arg2 = _35val2852;
+__arg2 = v0x7f1f2403dc00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5605,7 +5605,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj _35val2853 = __arg1;
+Obj v0x7f1f2403dc20 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -5623,17 +5623,17 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj _35val2854 = __arg1;
+Obj v0x7f1f2403dde0 = __arg1;
 Obj label= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg2855 = PRIM_CAR(closureRef(co, 1));
+Obj v0x7f1f24035000 = PRIM_CAR(closureRef(co, 1));
 pushCont(co, 25, clofun4, 2, nargs, frees);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = closureRef(co, 3);
 __arg2 = label;
-__arg3 = _35reg2855;
+__arg3 = v0x7f1f24035000;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5643,7 +5643,7 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj _35val2856 = __arg1;
+Obj v0x7f1f24035060 = __arg1;
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 26, clofun4, 2, nargs, frees);
@@ -5660,7 +5660,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35val2857 = __arg1;
+Obj v0x7f1f24035200 = __arg1;
 Obj nargs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 27, clofun4, 1, frees);
@@ -5677,7 +5677,7 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj _35val2858 = __arg1;
+Obj v0x7f1f240353a0 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 28, clofun4, 1, frees);
 __nargs = 3;
@@ -5693,7 +5693,7 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj _35val2859 = __arg1;
+Obj v0x7f1f240354e0 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 29, clofun4, 1, frees);
 __nargs = 2;
@@ -5708,13 +5708,13 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj _35val2860 = __arg1;
+Obj v0x7f1f24035740 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 30, clofun4, 1, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = closureRef(co, 3);
-__arg2 = _35val2860;
+__arg2 = v0x7f1f24035740;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5724,7 +5724,7 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj _35val2861 = __arg1;
+Obj v0x7f1f24035760 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 31, clofun4, 1, frees);
 __nargs = 2;
@@ -5739,10 +5739,10 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj _35val2862 = __arg1;
+Obj v0x7f1f240359c0 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg2863 = primNot(_35val2862);
-if (True == _35reg2863) {
+Obj v0x7f1f240359e0 = primNot(v0x7f1f240359c0);
+if (True == v0x7f1f240359e0) {
 pushCont(co, 32, clofun4, 1, frees);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5769,7 +5769,7 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj _35val2864 = __arg1;
+Obj v0x7f1f24035b80 = __arg1;
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 33, clofun4);
 __nargs = 5;
@@ -5787,7 +5787,7 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj _35val2865 = __arg1;
+Obj v0x7f1f24035d60 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -5801,31 +5801,31 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj _35cc1586 = makeNative(37, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
-Obj _35reg2814 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2814) {
-Obj _35reg2815 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2816 = PRIM_EQ(symdo, _35reg2815);
-if (True == _35reg2816) {
-Obj _35reg2817 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2818 = PRIM_ISCONS(_35reg2817);
-if (True == _35reg2818) {
-Obj _35reg2819 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2820 = PRIM_CAR(_35reg2819);
-Obj a = _35reg2820;
-Obj _35reg2821 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2822 = PRIM_CDR(_35reg2821);
-Obj _35reg2823 = PRIM_ISCONS(_35reg2822);
-if (True == _35reg2823) {
-Obj _35reg2824 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2825 = PRIM_CDR(_35reg2824);
-Obj _35reg2826 = PRIM_CAR(_35reg2825);
-Obj b = _35reg2826;
-Obj _35reg2827 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2828 = PRIM_CDR(_35reg2827);
-Obj _35reg2829 = PRIM_CDR(_35reg2828);
-Obj _35reg2830 = PRIM_EQ(Nil, _35reg2829);
-if (True == _35reg2830) {
+Obj v0x7f1f241545c0 = makeNative(37, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
+Obj v0x7f1f2404dae0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2404dae0) {
+Obj v0x7f1f2404dce0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2404dd00 = PRIM_EQ(symdo, v0x7f1f2404dce0);
+if (True == v0x7f1f2404dd00) {
+Obj v0x7f1f2404dec0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2404dee0 = PRIM_ISCONS(v0x7f1f2404dec0);
+if (True == v0x7f1f2404dee0) {
+Obj v0x7f1f240480c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24048100 = PRIM_CAR(v0x7f1f240480c0);
+Obj a = v0x7f1f24048100;
+Obj v0x7f1f240483e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24048420 = PRIM_CDR(v0x7f1f240483e0);
+Obj v0x7f1f24048440 = PRIM_ISCONS(v0x7f1f24048420);
+if (True == v0x7f1f24048440) {
+Obj v0x7f1f24048700 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24048720 = PRIM_CDR(v0x7f1f24048700);
+Obj v0x7f1f24048740 = PRIM_CAR(v0x7f1f24048720);
+Obj b = v0x7f1f24048740;
+Obj v0x7f1f24048b00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24048b20 = PRIM_CDR(v0x7f1f24048b00);
+Obj v0x7f1f24048b40 = PRIM_CDR(v0x7f1f24048b20);
+Obj v0x7f1f24048ba0 = PRIM_EQ(Nil, v0x7f1f24048b40);
+if (True == v0x7f1f24048ba0) {
 pushCont(co, 35, clofun4, 1, b);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -5840,7 +5840,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1586;
+__arg0 = v0x7f1f241545c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5849,7 +5849,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1586;
+__arg0 = v0x7f1f241545c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5858,7 +5858,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1586;
+__arg0 = v0x7f1f241545c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5867,7 +5867,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1586;
+__arg0 = v0x7f1f241545c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5876,7 +5876,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1586;
+__arg0 = v0x7f1f241545c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5887,7 +5887,7 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj _35val2831 = __arg1;
+Obj v0x7f1f24048d60 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 36, clofun4, 1, b);
 __nargs = 3;
@@ -5903,7 +5903,7 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj _35val2832 = __arg1;
+Obj v0x7f1f24048f00 = __arg1;
 Obj b= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -5920,22 +5920,22 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj _35cc1587 = makeNative(46, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
-Obj _35reg2794 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2794) {
-Obj _35reg2795 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2796 = PRIM_EQ(symreturn, _35reg2795);
-if (True == _35reg2796) {
-Obj _35reg2797 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2798 = PRIM_ISCONS(_35reg2797);
-if (True == _35reg2798) {
-Obj _35reg2799 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2800 = PRIM_CAR(_35reg2799);
-Obj x = _35reg2800;
-Obj _35reg2801 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2802 = PRIM_CDR(_35reg2801);
-Obj _35reg2803 = PRIM_EQ(Nil, _35reg2802);
-if (True == _35reg2803) {
+Obj v0x7f1f24154780 = makeNative(46, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 2), closureRef(co, 1), closureRef(co, 3));
+Obj v0x7f1f24069940 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24069940) {
+Obj v0x7f1f24069c80 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f24069d20 = PRIM_EQ(symreturn, v0x7f1f24069c80);
+if (True == v0x7f1f24069d20) {
+Obj v0x7f1f24069ee0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24069f00 = PRIM_ISCONS(v0x7f1f24069ee0);
+if (True == v0x7f1f24069f00) {
+Obj v0x7f1f2404f100 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2404f140 = PRIM_CAR(v0x7f1f2404f100);
+Obj x = v0x7f1f2404f140;
+Obj v0x7f1f2404f440 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2404f460 = PRIM_CDR(v0x7f1f2404f440);
+Obj v0x7f1f2404f480 = PRIM_EQ(Nil, v0x7f1f2404f460);
+if (True == v0x7f1f2404f480) {
 pushCont(co, 38, clofun4, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -5948,7 +5948,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1587;
+__arg0 = v0x7f1f24154780;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5957,7 +5957,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1587;
+__arg0 = v0x7f1f24154780;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5966,7 +5966,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1587;
+__arg0 = v0x7f1f24154780;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5975,7 +5975,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1587;
+__arg0 = v0x7f1f24154780;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -5986,7 +5986,7 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj _35val2804 = __arg1;
+Obj v0x7f1f2404f640 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 39, clofun4, 1, x);
 __nargs = 3;
@@ -6002,7 +6002,7 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj _35val2805 = __arg1;
+Obj v0x7f1f2404f800 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 40, clofun4);
 __nargs = 5;
@@ -6020,7 +6020,7 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj _35val2806 = __arg1;
+Obj v0x7f1f2404fb60 = __arg1;
 PUSH_CONT_0(co, 41, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6035,7 +6035,7 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj _35val2807 = __arg1;
+Obj v0x7f1f2404fca0 = __arg1;
 PUSH_CONT_0(co, 42, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6050,7 +6050,7 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj _35val2808 = __arg1;
+Obj v0x7f1f2404fe80 = __arg1;
 PUSH_CONT_0(co, 43, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6065,15 +6065,15 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj _35val2809 = __arg1;
-Obj _35reg2810 = PRIM_CDR(closureRef(co, 2));
-Obj _35reg2811 = PRIM_CAR(closureRef(co, 2));
+Obj v0x7f1f2404d000 = __arg1;
+Obj v0x7f1f2404d2a0 = PRIM_CDR(closureRef(co, 2));
+Obj v0x7f1f2404d380 = PRIM_CAR(closureRef(co, 2));
 PUSH_CONT_0(co, 44, clofun4);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = closureRef(co, 3);
-__arg2 = _35reg2810;
-__arg3 = _35reg2811;
+__arg2 = v0x7f1f2404d2a0;
+__arg3 = v0x7f1f2404d380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6083,7 +6083,7 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj _35val2812 = __arg1;
+Obj v0x7f1f2404d3a0 = __arg1;
 PUSH_CONT_0(co, 45, clofun4);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6098,7 +6098,7 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj _35val2813 = __arg1;
+Obj v0x7f1f2404d4c0 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 3);
@@ -6112,22 +6112,22 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj _35cc1588 = makeNative(47, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
-Obj _35reg2784 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2784) {
-Obj _35reg2785 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2786 = PRIM_EQ(symtailcall, _35reg2785);
-if (True == _35reg2786) {
-Obj _35reg2787 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2788 = PRIM_ISCONS(_35reg2787);
-if (True == _35reg2788) {
-Obj _35reg2789 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2790 = PRIM_CAR(_35reg2789);
-Obj exp = _35reg2790;
-Obj _35reg2791 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2792 = PRIM_CDR(_35reg2791);
-Obj _35reg2793 = PRIM_EQ(Nil, _35reg2792);
-if (True == _35reg2793) {
+Obj v0x7f1f24154900 = makeNative(47, clofun4, 0, 4, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3));
+Obj v0x7f1f2406b6c0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2406b6c0) {
+Obj v0x7f1f2406b960 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2406b980 = PRIM_EQ(symtailcall, v0x7f1f2406b960);
+if (True == v0x7f1f2406b980) {
+Obj v0x7f1f2406bc00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2406bc20 = PRIM_ISCONS(v0x7f1f2406bc00);
+if (True == v0x7f1f2406bc20) {
+Obj v0x7f1f2406bf20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2406bf60 = PRIM_CAR(v0x7f1f2406bf20);
+Obj exp = v0x7f1f2406bf60;
+Obj v0x7f1f24069320 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240693a0 = PRIM_CDR(v0x7f1f24069320);
+Obj v0x7f1f240693c0 = PRIM_EQ(Nil, v0x7f1f240693a0);
+if (True == v0x7f1f240693c0) {
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
 __arg1 = closureRef(co, 1);
@@ -6141,7 +6141,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1588;
+__arg0 = v0x7f1f24154900;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6150,7 +6150,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1588;
+__arg0 = v0x7f1f24154900;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6159,7 +6159,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1588;
+__arg0 = v0x7f1f24154900;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6168,7 +6168,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1588;
+__arg0 = v0x7f1f24154900;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6179,31 +6179,31 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj _35cc1589 = makeNative(49, clofun4, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
-Obj _35reg2766 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2766) {
-Obj _35reg2767 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2768 = PRIM_EQ(symcall, _35reg2767);
-if (True == _35reg2768) {
-Obj _35reg2769 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2770 = PRIM_ISCONS(_35reg2769);
-if (True == _35reg2770) {
-Obj _35reg2771 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2772 = PRIM_CAR(_35reg2771);
-Obj exp = _35reg2772;
-Obj _35reg2773 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2774 = PRIM_CDR(_35reg2773);
-Obj _35reg2775 = PRIM_ISCONS(_35reg2774);
-if (True == _35reg2775) {
-Obj _35reg2776 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2777 = PRIM_CDR(_35reg2776);
-Obj _35reg2778 = PRIM_CAR(_35reg2777);
-Obj cont = _35reg2778;
-Obj _35reg2779 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2780 = PRIM_CDR(_35reg2779);
-Obj _35reg2781 = PRIM_CDR(_35reg2780);
-Obj _35reg2782 = PRIM_EQ(Nil, _35reg2781);
-if (True == _35reg2782) {
+Obj v0x7f1f24154a60 = makeNative(49, clofun4, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 3));
+Obj v0x7f1f240f6740 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f240f6740) {
+Obj v0x7f1f240f6c00 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f240f6c20 = PRIM_EQ(symcall, v0x7f1f240f6c00);
+if (True == v0x7f1f240f6c20) {
+Obj v0x7f1f240f6f40 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f6f60 = PRIM_ISCONS(v0x7f1f240f6f40);
+if (True == v0x7f1f240f6f60) {
+Obj v0x7f1f240721a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240721c0 = PRIM_CAR(v0x7f1f240721a0);
+Obj exp = v0x7f1f240721c0;
+Obj v0x7f1f24072480 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240724a0 = PRIM_CDR(v0x7f1f24072480);
+Obj v0x7f1f240724e0 = PRIM_ISCONS(v0x7f1f240724a0);
+if (True == v0x7f1f240724e0) {
+Obj v0x7f1f24072860 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24072880 = PRIM_CDR(v0x7f1f24072860);
+Obj v0x7f1f240728a0 = PRIM_CAR(v0x7f1f24072880);
+Obj cont = v0x7f1f240728a0;
+Obj v0x7f1f24072cc0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24072d00 = PRIM_CDR(v0x7f1f24072cc0);
+Obj v0x7f1f24072d20 = PRIM_CDR(v0x7f1f24072d00);
+Obj v0x7f1f24072d60 = PRIM_EQ(Nil, v0x7f1f24072d20);
+if (True == v0x7f1f24072d60) {
 pushCont(co, 48, clofun4, 1, exp);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45cont);
@@ -6217,7 +6217,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1589;
+__arg0 = v0x7f1f24154a60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6226,7 +6226,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1589;
+__arg0 = v0x7f1f24154a60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6235,7 +6235,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1589;
+__arg0 = v0x7f1f24154a60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6244,7 +6244,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1589;
+__arg0 = v0x7f1f24154a60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6253,7 +6253,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1589;
+__arg0 = v0x7f1f24154a60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6264,7 +6264,7 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj _35val2783 = __arg1;
+Obj v0x7f1f24072f40 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45inst);
@@ -6281,13 +6281,13 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj _35cc1590 = makeNative(11, clofun5, 0, 0);
-Obj _35reg2748 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2748) {
-Obj _35reg2749 = PRIM_CAR(closureRef(co, 0));
-Obj f = _35reg2749;
-Obj _35reg2750 = PRIM_CDR(closureRef(co, 0));
-Obj args = _35reg2750;
+Obj v0x7f1f24154c80 = makeNative(11, clofun5, 0, 0);
+Obj v0x7f1f240f9580 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f240f9580) {
+Obj v0x7f1f240f9800 = PRIM_CAR(closureRef(co, 0));
+Obj f = v0x7f1f240f9800;
+Obj v0x7f1f240f9920 = PRIM_CDR(closureRef(co, 0));
+Obj args = v0x7f1f240f9920;
 pushCont(co, 0, clofun5, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6300,7 +6300,7 @@ if (ps.func != clofun4) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1590;
+__arg0 = v0x7f1f24154c80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6331,7 +6331,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2751 = __arg1;
+Obj v0x7f1f240f9b60 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 1, clofun5, 2, f, args);
@@ -6347,15 +6347,15 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj _35val2752 = __arg1;
+Obj v0x7f1f240f9fa0 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2753 = PRIM_ADD(MAKE_NUMBER(1), _35val2752);
+Obj v0x7f1f240f9fc0 = PRIM_ADD(MAKE_NUMBER(1), v0x7f1f240f9fa0);
 pushCont(co, 2, clofun5, 2, f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45num);
 __arg1 = closureRef(co, 2);
-__arg2 = _35reg2753;
+__arg2 = v0x7f1f240f9fc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6365,7 +6365,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj _35val2754 = __arg1;
+Obj v0x7f1f240f9fe0 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 pushCont(co, 3, clofun5, 2, f, args);
@@ -6382,17 +6382,17 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj _35val2755 = __arg1;
+Obj v0x7f1f240f8180 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2756 = makeCons(f, args);
+Obj v0x7f1f240f8560 = makeCons(f, args);
 PUSH_CONT_0(co, 4, clofun5);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
 __arg1 = closureRef(co, 1);
 __arg2 = closureRef(co, 2);
 __arg3 = MAKE_NUMBER(0);
-co->args[4] = _35reg2756;
+co->args[4] = v0x7f1f240f8560;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6402,7 +6402,7 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35val2757 = __arg1;
+Obj v0x7f1f240f8580 = __arg1;
 PUSH_CONT_0(co, 5, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6417,7 +6417,7 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35val2758 = __arg1;
+Obj v0x7f1f240f86a0 = __arg1;
 PUSH_CONT_0(co, 6, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6432,7 +6432,7 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj _35val2759 = __arg1;
+Obj v0x7f1f240f89e0 = __arg1;
 PUSH_CONT_0(co, 7, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6447,7 +6447,7 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35val2760 = __arg1;
+Obj v0x7f1f240f8bc0 = __arg1;
 PUSH_CONT_0(co, 8, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6462,15 +6462,15 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35val2761 = __arg1;
-Obj _35reg2762 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2763 = PRIM_CAR(closureRef(co, 1));
+Obj v0x7f1f240f8d60 = __arg1;
+Obj v0x7f1f240f8fa0 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f240f60e0 = PRIM_CAR(closureRef(co, 1));
 PUSH_CONT_0(co, 9, clofun5);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45group_45name);
 __arg1 = closureRef(co, 2);
-__arg2 = _35reg2762;
-__arg3 = _35reg2763;
+__arg2 = v0x7f1f240f8fa0;
+__arg3 = v0x7f1f240f60e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6480,7 +6480,7 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj _35val2764 = __arg1;
+Obj v0x7f1f240f6100 = __arg1;
 PUSH_CONT_0(co, 10, clofun5);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6495,7 +6495,7 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj _35val2765 = __arg1;
+Obj v0x7f1f240f63a0 = __arg1;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
 __arg1 = closureRef(co, 2);
@@ -6536,10 +6536,10 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35val2742 = __arg1;
+Obj v0x7f1f2412cc80 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj val = _35val2742;
+Obj val = v0x7f1f2412cc80;
 pushCont(co, 14, clofun5, 3, sym, val, globals);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
@@ -6554,21 +6554,21 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj _35val2743 = __arg1;
+Obj v0x7f1f2412cde0 = __arg1;
 Obj sym= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == _35val2743) {
+if (True == v0x7f1f2412cde0) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg2744 = makeCons(sym, val);
-Obj _35reg2745 = primSet(co, globals, _35reg2744);
+Obj v0x7f1f24128120 = makeCons(sym, val);
+Obj v0x7f1f24128140 = primSet(co, globals, v0x7f1f24128120);
 __nargs = 2;
-__arg1 = _35reg2745;
+__arg1 = v0x7f1f24128140;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6577,16 +6577,16 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj _35p1572 = __arg1;
-Obj _35p1573 = __arg2;
-Obj _35p1574 = __arg3;
-Obj _35p1575 = co->args[4];
-Obj _35cc1576 = makeNative(16, clofun5, 0, 4, _35p1572, _35p1573, _35p1574, _35p1575);
-Obj self = _35p1572;
-Obj w = _35p1573;
-Obj i = _35p1574;
-Obj _35reg2740 = PRIM_EQ(Nil, _35p1575);
-if (True == _35reg2740) {
+Obj v0x7f1f24161c60 = __arg1;
+Obj v0x7f1f24161c80 = __arg2;
+Obj v0x7f1f24161ca0 = __arg3;
+Obj v0x7f1f24161cc0 = co->args[4];
+Obj v0x7f1f24161e20 = makeNative(16, clofun5, 0, 4, v0x7f1f24161c60, v0x7f1f24161c80, v0x7f1f24161ca0, v0x7f1f24161cc0);
+Obj self = v0x7f1f24161c60;
+Obj w = v0x7f1f24161c80;
+Obj i = v0x7f1f24161ca0;
+Obj v0x7f1f2412c820 = PRIM_EQ(Nil, v0x7f1f24161cc0);
+if (True == v0x7f1f2412c820) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -6594,7 +6594,7 @@ if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1576;
+__arg0 = v0x7f1f24161e20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6605,19 +6605,19 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35cc1577 = makeNative(28, clofun5, 0, 0);
+Obj v0x7f1f2415b0e0 = makeNative(28, clofun5, 0, 0);
 Obj self = closureRef(co, 0);
 Obj w = closureRef(co, 1);
 Obj i = closureRef(co, 2);
-Obj _35reg2722 = PRIM_ISCONS(closureRef(co, 3));
-if (True == _35reg2722) {
-Obj _35reg2723 = PRIM_CAR(closureRef(co, 3));
-Obj x = _35reg2723;
-Obj _35reg2724 = PRIM_CDR(closureRef(co, 3));
-Obj more = _35reg2724;
-Obj _35reg2725 = PRIM_GT(i, MAKE_NUMBER(3));
-Obj _35reg2726 = primNot(_35reg2725);
-if (True == _35reg2726) {
+Obj v0x7f1f24133100 = PRIM_ISCONS(closureRef(co, 3));
+if (True == v0x7f1f24133100) {
+Obj v0x7f1f24133260 = PRIM_CAR(closureRef(co, 3));
+Obj x = v0x7f1f24133260;
+Obj v0x7f1f24133400 = PRIM_CDR(closureRef(co, 3));
+Obj more = v0x7f1f24133400;
+Obj v0x7f1f241337a0 = PRIM_GT(i, MAKE_NUMBER(3));
+Obj v0x7f1f241337c0 = primNot(v0x7f1f241337a0);
+if (True == v0x7f1f241337c0) {
 pushCont(co, 23, clofun5, 5, x, i, self, w, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_47internal_35generate_45str);
@@ -6642,7 +6642,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1577;
+__arg0 = v0x7f1f2415b0e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6653,7 +6653,7 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj _35val2733 = __arg1;
+Obj v0x7f1f2412f500 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6673,7 +6673,7 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35val2734 = __arg1;
+Obj v0x7f1f2412f720 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6693,7 +6693,7 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj _35val2735 = __arg1;
+Obj v0x7f1f2412f820 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6713,7 +6713,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj _35val2736 = __arg1;
+Obj v0x7f1f2412f9c0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6735,7 +6735,7 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj _35val2737 = __arg1;
+Obj v0x7f1f2412fc00 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6754,17 +6754,17 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj _35val2738 = __arg1;
+Obj v0x7f1f2412fde0 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj _35reg2739 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj v0x7f1f2412c040 = PRIM_ADD(i, MAKE_NUMBER(1));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
 __arg1 = self;
 __arg2 = w;
-__arg3 = _35reg2739;
+__arg3 = v0x7f1f2412c040;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6775,7 +6775,7 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj _35val2727 = __arg1;
+Obj v0x7f1f241339a0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6795,7 +6795,7 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj _35val2728 = __arg1;
+Obj v0x7f1f24133aa0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6815,7 +6815,7 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj _35val2729 = __arg1;
+Obj v0x7f1f24133ca0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6837,7 +6837,7 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35val2730 = __arg1;
+Obj v0x7f1f24133f20 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -6856,17 +6856,17 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj _35val2731 = __arg1;
+Obj v0x7f1f2412f080 = __arg1;
 Obj i= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj self= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj w= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj _35reg2732 = PRIM_ADD(i, MAKE_NUMBER(1));
+Obj v0x7f1f2412f380 = PRIM_ADD(i, MAKE_NUMBER(1));
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35generate_45call_45list);
 __arg1 = self;
 __arg2 = w;
-__arg3 = _35reg2732;
+__arg3 = v0x7f1f2412f380;
 co->args[4] = more;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -6891,8 +6891,8 @@ label29:
 {
 Obj x = __arg1;
 Obj k = __arg2;
-Obj _35reg2715 = primGenSym(symreg);
-Obj tmp = _35reg2715;
+Obj v0x7f1f24135240 = primGenSym(symreg);
+Obj tmp = v0x7f1f24135240;
 pushCont(co, 30, clofun5, 2, x, tmp);
 __nargs = 2;
 __arg0 = k;
@@ -6906,15 +6906,15 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj _35val2716 = __arg1;
+Obj v0x7f1f24135900 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2717 = makeCons(_35val2716, Nil);
-Obj _35reg2718 = makeCons(x, _35reg2717);
-Obj _35reg2719 = makeCons(tmp, _35reg2718);
-Obj _35reg2720 = makeCons(symlet, _35reg2719);
+Obj v0x7f1f24135940 = makeCons(v0x7f1f24135900, Nil);
+Obj v0x7f1f24135960 = makeCons(x, v0x7f1f24135940);
+Obj v0x7f1f24135980 = makeCons(tmp, v0x7f1f24135960);
+Obj v0x7f1f241359a0 = makeCons(symlet, v0x7f1f24135980);
 __nargs = 2;
-__arg1 = _35reg2720;
+__arg1 = v0x7f1f241359a0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -6938,10 +6938,10 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj _35val2707 = __arg1;
+Obj v0x7f1f241383c0 = __arg1;
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj idx = _35val2707;
+Obj idx = v0x7f1f241383c0;
 pushCont(co, 33, clofun5, 3, val, idx, v);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -6956,22 +6956,22 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj _35val2708 = __arg1;
+Obj v0x7f1f241385a0 = __arg1;
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj idx= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj cur = _35val2708;
-Obj _35reg2709 = makeCons(val, Nil);
-Obj _35reg2710 = makeCons(idx, _35reg2709);
-Obj _35reg2711 = makeCons(_35reg2710, cur);
-Obj cur1 = _35reg2711;
-Obj _35reg2712 = PRIM_ADD(idx, MAKE_NUMBER(1));
+Obj cur = v0x7f1f241385a0;
+Obj v0x7f1f24138980 = makeCons(val, Nil);
+Obj v0x7f1f241389a0 = makeCons(idx, v0x7f1f24138980);
+Obj v0x7f1f241389e0 = makeCons(v0x7f1f241389a0, cur);
+Obj cur1 = v0x7f1f241389e0;
+Obj v0x7f1f24138d40 = PRIM_ADD(idx, MAKE_NUMBER(1));
 pushCont(co, 34, clofun5, 2, v, cur1);
 __nargs = 4;
 __arg0 = globalRef(symcora_47init_35vector_45set_33);
 __arg1 = v;
 __arg2 = MAKE_NUMBER(0);
-__arg3 = _35reg2712;
+__arg3 = v0x7f1f24138d40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -6981,7 +6981,7 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj _35val2713 = __arg1;
+Obj v0x7f1f24138d60 = __arg1;
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cur1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 4;
@@ -6998,60 +6998,60 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj _35p1567 = __arg1;
-Obj _35p1568 = __arg2;
-Obj _35cc1569 = makeNative(1, clofun6, 0, 2, _35p1567, _35p1568);
-Obj v = _35p1567;
-Obj _35reg2610 = PRIM_ISCONS(_35p1568);
-if (True == _35reg2610) {
-Obj _35reg2611 = PRIM_CAR(_35p1568);
-Obj clo_45or_45cont = _35reg2611;
-Obj _35reg2612 = PRIM_CDR(_35p1568);
-Obj _35reg2613 = PRIM_ISCONS(_35reg2612);
-if (True == _35reg2613) {
-Obj _35reg2614 = PRIM_CDR(_35p1568);
-Obj _35reg2615 = PRIM_CAR(_35reg2614);
-Obj _35reg2616 = PRIM_ISCONS(_35reg2615);
-if (True == _35reg2616) {
-Obj _35reg2617 = PRIM_CDR(_35p1568);
-Obj _35reg2618 = PRIM_CAR(_35reg2617);
-Obj _35reg2619 = PRIM_CAR(_35reg2618);
-Obj _35reg2620 = PRIM_EQ(symlambda, _35reg2619);
-if (True == _35reg2620) {
-Obj _35reg2621 = PRIM_CDR(_35p1568);
-Obj _35reg2622 = PRIM_CAR(_35reg2621);
-Obj _35reg2623 = PRIM_CDR(_35reg2622);
-Obj _35reg2624 = PRIM_ISCONS(_35reg2623);
-if (True == _35reg2624) {
-Obj _35reg2625 = PRIM_CDR(_35p1568);
-Obj _35reg2626 = PRIM_CAR(_35reg2625);
-Obj _35reg2627 = PRIM_CDR(_35reg2626);
-Obj _35reg2628 = PRIM_CAR(_35reg2627);
-Obj params = _35reg2628;
-Obj _35reg2629 = PRIM_CDR(_35p1568);
-Obj _35reg2630 = PRIM_CAR(_35reg2629);
-Obj _35reg2631 = PRIM_CDR(_35reg2630);
-Obj _35reg2632 = PRIM_CDR(_35reg2631);
-Obj _35reg2633 = PRIM_ISCONS(_35reg2632);
-if (True == _35reg2633) {
-Obj _35reg2634 = PRIM_CDR(_35p1568);
-Obj _35reg2635 = PRIM_CAR(_35reg2634);
-Obj _35reg2636 = PRIM_CDR(_35reg2635);
-Obj _35reg2637 = PRIM_CDR(_35reg2636);
-Obj _35reg2638 = PRIM_CAR(_35reg2637);
-Obj body = _35reg2638;
-Obj _35reg2639 = PRIM_CDR(_35p1568);
-Obj _35reg2640 = PRIM_CAR(_35reg2639);
-Obj _35reg2641 = PRIM_CDR(_35reg2640);
-Obj _35reg2642 = PRIM_CDR(_35reg2641);
-Obj _35reg2643 = PRIM_CDR(_35reg2642);
-Obj _35reg2644 = PRIM_EQ(Nil, _35reg2643);
-if (True == _35reg2644) {
-Obj _35reg2645 = PRIM_CDR(_35p1568);
-Obj _35reg2646 = PRIM_CDR(_35reg2645);
-Obj fvs = _35reg2646;
-Obj _35reg2647 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == _35reg2647) {
+Obj v0x7f1f24161140 = __arg1;
+Obj v0x7f1f24161160 = __arg2;
+Obj v0x7f1f24161260 = makeNative(1, clofun6, 0, 2, v0x7f1f24161140, v0x7f1f24161160);
+Obj v = v0x7f1f24161140;
+Obj v0x7f1f240225a0 = PRIM_ISCONS(v0x7f1f24161160);
+if (True == v0x7f1f240225a0) {
+Obj v0x7f1f240226a0 = PRIM_CAR(v0x7f1f24161160);
+Obj clo_45or_45cont = v0x7f1f240226a0;
+Obj v0x7f1f24022840 = PRIM_CDR(v0x7f1f24161160);
+Obj v0x7f1f24022860 = PRIM_ISCONS(v0x7f1f24022840);
+if (True == v0x7f1f24022860) {
+Obj v0x7f1f24022aa0 = PRIM_CDR(v0x7f1f24161160);
+Obj v0x7f1f24022ac0 = PRIM_CAR(v0x7f1f24022aa0);
+Obj v0x7f1f24022ae0 = PRIM_ISCONS(v0x7f1f24022ac0);
+if (True == v0x7f1f24022ae0) {
+Obj v0x7f1f24022de0 = PRIM_CDR(v0x7f1f24161160);
+Obj v0x7f1f24022e00 = PRIM_CAR(v0x7f1f24022de0);
+Obj v0x7f1f24022e20 = PRIM_CAR(v0x7f1f24022e00);
+Obj v0x7f1f24022e40 = PRIM_EQ(symlambda, v0x7f1f24022e20);
+if (True == v0x7f1f24022e40) {
+Obj v0x7f1f2401f120 = PRIM_CDR(v0x7f1f24161160);
+Obj v0x7f1f2401f140 = PRIM_CAR(v0x7f1f2401f120);
+Obj v0x7f1f2401f160 = PRIM_CDR(v0x7f1f2401f140);
+Obj v0x7f1f2401f180 = PRIM_ISCONS(v0x7f1f2401f160);
+if (True == v0x7f1f2401f180) {
+Obj v0x7f1f2401f460 = PRIM_CDR(v0x7f1f24161160);
+Obj v0x7f1f2401f480 = PRIM_CAR(v0x7f1f2401f460);
+Obj v0x7f1f2401f4a0 = PRIM_CDR(v0x7f1f2401f480);
+Obj v0x7f1f2401f4c0 = PRIM_CAR(v0x7f1f2401f4a0);
+Obj params = v0x7f1f2401f4c0;
+Obj v0x7f1f2401f840 = PRIM_CDR(v0x7f1f24161160);
+Obj v0x7f1f2401f860 = PRIM_CAR(v0x7f1f2401f840);
+Obj v0x7f1f2401f880 = PRIM_CDR(v0x7f1f2401f860);
+Obj v0x7f1f2401f8a0 = PRIM_CDR(v0x7f1f2401f880);
+Obj v0x7f1f2401f8c0 = PRIM_ISCONS(v0x7f1f2401f8a0);
+if (True == v0x7f1f2401f8c0) {
+Obj v0x7f1f2401fc40 = PRIM_CDR(v0x7f1f24161160);
+Obj v0x7f1f2401fc60 = PRIM_CAR(v0x7f1f2401fc40);
+Obj v0x7f1f2401fc80 = PRIM_CDR(v0x7f1f2401fc60);
+Obj v0x7f1f2401fca0 = PRIM_CDR(v0x7f1f2401fc80);
+Obj v0x7f1f2401fcc0 = PRIM_CAR(v0x7f1f2401fca0);
+Obj body = v0x7f1f2401fcc0;
+Obj v0x7f1f24017100 = PRIM_CDR(v0x7f1f24161160);
+Obj v0x7f1f24017120 = PRIM_CAR(v0x7f1f24017100);
+Obj v0x7f1f24017140 = PRIM_CDR(v0x7f1f24017120);
+Obj v0x7f1f24017160 = PRIM_CDR(v0x7f1f24017140);
+Obj v0x7f1f24017180 = PRIM_CDR(v0x7f1f24017160);
+Obj v0x7f1f240171a0 = PRIM_EQ(Nil, v0x7f1f24017180);
+if (True == v0x7f1f240171a0) {
+Obj v0x7f1f24017340 = PRIM_CDR(v0x7f1f24161160);
+Obj v0x7f1f24017360 = PRIM_CDR(v0x7f1f24017340);
+Obj fvs = v0x7f1f24017360;
+Obj v0x7f1f240174c0 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == v0x7f1f240174c0) {
 if (True == True) {
 pushCont(co, 46, clofun5, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
@@ -7065,7 +7065,7 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1569;
+__arg0 = v0x7f1f24161260;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7073,8 +7073,8 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj _35reg2667 = PRIM_EQ(clo_45or_45cont, sym_37continuation);
-if (True == _35reg2667) {
+Obj v0x7f1f2415bec0 = PRIM_EQ(clo_45or_45cont, sym_37continuation);
+if (True == v0x7f1f2415bec0) {
 if (True == True) {
 pushCont(co, 41, clofun5, 4, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
@@ -7088,7 +7088,7 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1569;
+__arg0 = v0x7f1f24161260;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7109,7 +7109,7 @@ if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1569;
+__arg0 = v0x7f1f24161260;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7120,7 +7120,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1569;
+__arg0 = v0x7f1f24161260;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7129,7 +7129,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1569;
+__arg0 = v0x7f1f24161260;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7138,7 +7138,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1569;
+__arg0 = v0x7f1f24161260;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7147,7 +7147,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1569;
+__arg0 = v0x7f1f24161260;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7156,7 +7156,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1569;
+__arg0 = v0x7f1f24161260;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7165,7 +7165,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1569;
+__arg0 = v0x7f1f24161260;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7174,7 +7174,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1569;
+__arg0 = v0x7f1f24161260;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7185,12 +7185,12 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj _35val2687 = __arg1;
+Obj v0x7f1f241461c0 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body1 = _35val2687;
+Obj body1 = v0x7f1f241461c0;
 pushCont(co, 37, clofun5, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -7205,39 +7205,39 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj _35val2688 = __arg1;
+Obj v0x7f1f24146320 = __arg1;
 Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj cur = _35val2688;
-Obj _35reg2689 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == _35reg2689) {
-Obj _35reg2690 = makeCons(body1, Nil);
-Obj _35reg2691 = makeCons(Nil, _35reg2690);
-Obj _35reg2692 = makeCons(params, _35reg2691);
-Obj _35reg2693 = makeCons(symlambda, _35reg2692);
+Obj cur = v0x7f1f24146320;
+Obj v0x7f1f24146580 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == v0x7f1f24146580) {
+Obj v0x7f1f24146ba0 = makeCons(body1, Nil);
+Obj v0x7f1f24146bc0 = makeCons(Nil, v0x7f1f24146ba0);
+Obj v0x7f1f24146be0 = makeCons(params, v0x7f1f24146bc0);
+Obj v0x7f1f24146c00 = makeCons(symlambda, v0x7f1f24146be0);
 pushCont(co, 39, clofun5, 4, params, fvs, cur, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = _35reg2693;
+__arg2 = v0x7f1f24146c00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2699 = makeCons(body1, Nil);
-Obj _35reg2700 = makeCons(fvs, _35reg2699);
-Obj _35reg2701 = makeCons(params, _35reg2700);
-Obj _35reg2702 = makeCons(symlambda, _35reg2701);
+Obj v0x7f1f2413f6a0 = makeCons(body1, Nil);
+Obj v0x7f1f2413f6c0 = makeCons(fvs, v0x7f1f2413f6a0);
+Obj v0x7f1f2413f700 = makeCons(params, v0x7f1f2413f6c0);
+Obj v0x7f1f2413f720 = makeCons(symlambda, v0x7f1f2413f700);
 pushCont(co, 38, clofun5, 3, cur, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = _35reg2702;
+__arg2 = v0x7f1f2413f720;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7248,14 +7248,14 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj _35val2703 = __arg1;
+Obj v0x7f1f2413f740 = __arg1;
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg2704 = makeCons(cur, fvs);
-Obj _35reg2705 = makeCons(clo_45or_45cont, _35reg2704);
+Obj v0x7f1f2413fa00 = makeCons(cur, fvs);
+Obj v0x7f1f2413fa20 = makeCons(clo_45or_45cont, v0x7f1f2413fa00);
 __nargs = 2;
-__arg1 = _35reg2705;
+__arg1 = v0x7f1f2413fa20;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7263,7 +7263,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label39:
 {
-Obj _35val2694 = __arg1;
+Obj v0x7f1f24146c20 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7281,15 +7281,15 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj _35val2695 = __arg1;
+Obj v0x7f1f2413f0a0 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg2696 = makeCons(_35val2695, fvs);
-Obj _35reg2697 = makeCons(cur, _35reg2696);
-Obj _35reg2698 = makeCons(clo_45or_45cont, _35reg2697);
+Obj v0x7f1f2413f0e0 = makeCons(v0x7f1f2413f0a0, fvs);
+Obj v0x7f1f2413f100 = makeCons(cur, v0x7f1f2413f0e0);
+Obj v0x7f1f2413f120 = makeCons(clo_45or_45cont, v0x7f1f2413f100);
 __nargs = 2;
-__arg1 = _35reg2698;
+__arg1 = v0x7f1f2413f120;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7297,12 +7297,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label41:
 {
-Obj _35val2668 = __arg1;
+Obj v0x7f1f24154080 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body1 = _35val2668;
+Obj body1 = v0x7f1f24154080;
 pushCont(co, 42, clofun5, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -7317,39 +7317,39 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj _35val2669 = __arg1;
+Obj v0x7f1f241542e0 = __arg1;
 Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj cur = _35val2669;
-Obj _35reg2670 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == _35reg2670) {
-Obj _35reg2671 = makeCons(body1, Nil);
-Obj _35reg2672 = makeCons(Nil, _35reg2671);
-Obj _35reg2673 = makeCons(params, _35reg2672);
-Obj _35reg2674 = makeCons(symlambda, _35reg2673);
+Obj cur = v0x7f1f241542e0;
+Obj v0x7f1f24154580 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == v0x7f1f24154580) {
+Obj v0x7f1f24154d80 = makeCons(body1, Nil);
+Obj v0x7f1f24154da0 = makeCons(Nil, v0x7f1f24154d80);
+Obj v0x7f1f24154e80 = makeCons(params, v0x7f1f24154da0);
+Obj v0x7f1f24154ea0 = makeCons(symlambda, v0x7f1f24154e80);
 pushCont(co, 44, clofun5, 4, params, fvs, cur, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = _35reg2674;
+__arg2 = v0x7f1f24154ea0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2680 = makeCons(body1, Nil);
-Obj _35reg2681 = makeCons(fvs, _35reg2680);
-Obj _35reg2682 = makeCons(params, _35reg2681);
-Obj _35reg2683 = makeCons(symlambda, _35reg2682);
+Obj v0x7f1f2414dc20 = makeCons(body1, Nil);
+Obj v0x7f1f2414dc40 = makeCons(fvs, v0x7f1f2414dc20);
+Obj v0x7f1f2414dca0 = makeCons(params, v0x7f1f2414dc40);
+Obj v0x7f1f2414dcc0 = makeCons(symlambda, v0x7f1f2414dca0);
 pushCont(co, 43, clofun5, 3, cur, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = _35reg2683;
+__arg2 = v0x7f1f2414dcc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7360,14 +7360,14 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj _35val2684 = __arg1;
+Obj v0x7f1f2414dce0 = __arg1;
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg2685 = makeCons(cur, fvs);
-Obj _35reg2686 = makeCons(clo_45or_45cont, _35reg2685);
+Obj v0x7f1f2414de80 = makeCons(cur, fvs);
+Obj v0x7f1f2414dec0 = makeCons(clo_45or_45cont, v0x7f1f2414de80);
 __nargs = 2;
-__arg1 = _35reg2686;
+__arg1 = v0x7f1f2414dec0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7375,7 +7375,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label44:
 {
-Obj _35val2675 = __arg1;
+Obj v0x7f1f24154ee0 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7393,15 +7393,15 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj _35val2676 = __arg1;
+Obj v0x7f1f2414d340 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg2677 = makeCons(_35val2676, fvs);
-Obj _35reg2678 = makeCons(cur, _35reg2677);
-Obj _35reg2679 = makeCons(clo_45or_45cont, _35reg2678);
+Obj v0x7f1f2414d3e0 = makeCons(v0x7f1f2414d340, fvs);
+Obj v0x7f1f2414d440 = makeCons(cur, v0x7f1f2414d3e0);
+Obj v0x7f1f2414d460 = makeCons(clo_45or_45cont, v0x7f1f2414d440);
 __nargs = 2;
-__arg1 = _35reg2679;
+__arg1 = v0x7f1f2414d460;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7409,12 +7409,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label46:
 {
-Obj _35val2648 = __arg1;
+Obj v0x7f1f240175e0 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj body1 = _35val2648;
+Obj body1 = v0x7f1f240175e0;
 pushCont(co, 47, clofun5, 5, body1, params, v, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35vector_45ref);
@@ -7429,39 +7429,39 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj _35val2649 = __arg1;
+Obj v0x7f1f24017700 = __arg1;
 Obj body1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj cur = _35val2649;
-Obj _35reg2650 = PRIM_EQ(clo_45or_45cont, sym_37closure);
-if (True == _35reg2650) {
-Obj _35reg2651 = makeCons(body1, Nil);
-Obj _35reg2652 = makeCons(Nil, _35reg2651);
-Obj _35reg2653 = makeCons(params, _35reg2652);
-Obj _35reg2654 = makeCons(symlambda, _35reg2653);
+Obj cur = v0x7f1f24017700;
+Obj v0x7f1f24017820 = PRIM_EQ(clo_45or_45cont, sym_37closure);
+if (True == v0x7f1f24017820) {
+Obj v0x7f1f241613c0 = makeCons(body1, Nil);
+Obj v0x7f1f24161400 = makeCons(Nil, v0x7f1f241613c0);
+Obj v0x7f1f24161440 = makeCons(params, v0x7f1f24161400);
+Obj v0x7f1f241614c0 = makeCons(symlambda, v0x7f1f24161440);
 pushCont(co, 49, clofun5, 4, params, fvs, cur, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = _35reg2654;
+__arg2 = v0x7f1f241614c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
 if (ps.func != clofun5) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2660 = makeCons(body1, Nil);
-Obj _35reg2661 = makeCons(fvs, _35reg2660);
-Obj _35reg2662 = makeCons(params, _35reg2661);
-Obj _35reg2663 = makeCons(symlambda, _35reg2662);
+Obj v0x7f1f2415b5e0 = makeCons(body1, Nil);
+Obj v0x7f1f2415b6a0 = makeCons(fvs, v0x7f1f2415b5e0);
+Obj v0x7f1f2415b6e0 = makeCons(params, v0x7f1f2415b6a0);
+Obj v0x7f1f2415b720 = makeCons(symlambda, v0x7f1f2415b6e0);
 pushCont(co, 48, clofun5, 3, cur, fvs, clo_45or_45cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35append_45result);
 __arg1 = v;
-__arg2 = _35reg2663;
+__arg2 = v0x7f1f2415b720;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7472,14 +7472,14 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj _35val2664 = __arg1;
+Obj v0x7f1f2415b760 = __arg1;
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg2665 = makeCons(cur, fvs);
-Obj _35reg2666 = makeCons(clo_45or_45cont, _35reg2665);
+Obj v0x7f1f2415ba80 = makeCons(cur, fvs);
+Obj v0x7f1f2415bb60 = makeCons(clo_45or_45cont, v0x7f1f2415ba80);
 __nargs = 2;
-__arg1 = _35reg2666;
+__arg1 = v0x7f1f2415bb60;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun5) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7487,7 +7487,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label49:
 {
-Obj _35val2655 = __arg1;
+Obj v0x7f1f241614e0 = __arg1;
 Obj params= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -7525,15 +7525,15 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35val2656 = __arg1;
+Obj v0x7f1f24161b80 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cur= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj clo_45or_45cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg2657 = makeCons(_35val2656, fvs);
-Obj _35reg2658 = makeCons(cur, _35reg2657);
-Obj _35reg2659 = makeCons(clo_45or_45cont, _35reg2658);
+Obj v0x7f1f24161c00 = makeCons(v0x7f1f24161b80, fvs);
+Obj v0x7f1f24161c20 = makeCons(cur, v0x7f1f24161c00);
+Obj v0x7f1f24161d80 = makeCons(clo_45or_45cont, v0x7f1f24161c20);
 __nargs = 2;
-__arg1 = _35reg2659;
+__arg1 = v0x7f1f24161d80;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7541,11 +7541,11 @@ goto *jumpTable[co->ctx.pc.label];
 
 label1:
 {
-Obj _35cc1570 = makeNative(3, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f241617e0 = makeNative(3, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj v = closureRef(co, 0);
 Obj f_45args = closureRef(co, 1);
-Obj _35reg2609 = PRIM_ISCONS(f_45args);
-if (True == _35reg2609) {
+Obj v0x7f1f24022220 = PRIM_ISCONS(f_45args);
+if (True == v0x7f1f24022220) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = makeNative(2, clofun6, 1, 1, v);
@@ -7557,7 +7557,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1570;
+__arg0 = v0x7f1f241617e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7582,7 +7582,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj _35cc1571 = makeNative(4, clofun6, 0, 0);
+Obj v0x7f1f24161980 = makeNative(4, clofun6, 0, 0);
 Obj v = closureRef(co, 0);
 Obj x = closureRef(co, 1);
 __nargs = 2;
@@ -7606,12 +7606,12 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35p1559 = __arg1;
-Obj _35p1560 = __arg2;
-Obj _35cc1561 = makeNative(7, clofun6, 0, 2, _35p1559, _35p1560);
-Obj __ = _35p1559;
-Obj x = _35p1560;
-pushCont(co, 6, clofun6, 2, x, _35cc1561);
+Obj v0x7f1f24154140 = __arg1;
+Obj v0x7f1f24154160 = __arg2;
+Obj v0x7f1f24154240 = makeNative(7, clofun6, 0, 2, v0x7f1f24154140, v0x7f1f24154160);
+Obj __ = v0x7f1f24154140;
+Obj x = v0x7f1f24154160;
+pushCont(co, 6, clofun6, 2, x, v0x7f1f24154240);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -7624,10 +7624,10 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj _35val2607 = __arg1;
+Obj v0x7f1f24024c20 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35cc1561= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val2607) {
+Obj v0x7f1f24154240= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == v0x7f1f24024c20) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -7635,7 +7635,7 @@ if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1561;
+__arg0 = v0x7f1f24154240;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7646,11 +7646,11 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35cc1562 = makeNative(8, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f241543c0 = makeNative(8, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj _35reg2606 = primIsSymbol(var);
-if (True == _35reg2606) {
+Obj v0x7f1f24024a20 = primIsSymbol(var);
+if (True == v0x7f1f24024a20) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -7658,7 +7658,7 @@ if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1562;
+__arg0 = v0x7f1f241543c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7669,32 +7669,32 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35cc1563 = makeNative(10, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f24154540 = makeNative(10, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2585 = PRIM_ISCONS(closureRef(co, 1));
-if (True == _35reg2585) {
-Obj _35reg2586 = PRIM_CAR(closureRef(co, 1));
-Obj _35reg2587 = PRIM_EQ(symlambda, _35reg2586);
-if (True == _35reg2587) {
-Obj _35reg2588 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2589 = PRIM_ISCONS(_35reg2588);
-if (True == _35reg2589) {
-Obj _35reg2590 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2591 = PRIM_CAR(_35reg2590);
-Obj args = _35reg2591;
-Obj _35reg2592 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2593 = PRIM_CDR(_35reg2592);
-Obj _35reg2594 = PRIM_ISCONS(_35reg2593);
-if (True == _35reg2594) {
-Obj _35reg2595 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2596 = PRIM_CDR(_35reg2595);
-Obj _35reg2597 = PRIM_CAR(_35reg2596);
-Obj body = _35reg2597;
-Obj _35reg2598 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2599 = PRIM_CDR(_35reg2598);
-Obj _35reg2600 = PRIM_CDR(_35reg2599);
-Obj _35reg2601 = PRIM_EQ(Nil, _35reg2600);
-if (True == _35reg2601) {
+Obj v0x7f1f240334e0 = PRIM_ISCONS(closureRef(co, 1));
+if (True == v0x7f1f240334e0) {
+Obj v0x7f1f240336a0 = PRIM_CAR(closureRef(co, 1));
+Obj v0x7f1f240336c0 = PRIM_EQ(symlambda, v0x7f1f240336a0);
+if (True == v0x7f1f240336c0) {
+Obj v0x7f1f24033860 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24033880 = PRIM_ISCONS(v0x7f1f24033860);
+if (True == v0x7f1f24033880) {
+Obj v0x7f1f24033a20 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24033a40 = PRIM_CAR(v0x7f1f24033a20);
+Obj args = v0x7f1f24033a40;
+Obj v0x7f1f24033c80 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24033ca0 = PRIM_CDR(v0x7f1f24033c80);
+Obj v0x7f1f24033cc0 = PRIM_ISCONS(v0x7f1f24033ca0);
+if (True == v0x7f1f24033cc0) {
+Obj v0x7f1f24033f00 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24033f20 = PRIM_CDR(v0x7f1f24033f00);
+Obj v0x7f1f24033f40 = PRIM_CAR(v0x7f1f24033f20);
+Obj body = v0x7f1f24033f40;
+Obj v0x7f1f24024240 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24024260 = PRIM_CDR(v0x7f1f24024240);
+Obj v0x7f1f24024280 = PRIM_CDR(v0x7f1f24024260);
+Obj v0x7f1f240242a0 = PRIM_EQ(Nil, v0x7f1f24024280);
+if (True == v0x7f1f240242a0) {
 pushCont(co, 9, clofun6, 1, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -7707,7 +7707,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1563;
+__arg0 = v0x7f1f24154540;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7716,7 +7716,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1563;
+__arg0 = v0x7f1f24154540;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7725,7 +7725,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1563;
+__arg0 = v0x7f1f24154540;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7734,7 +7734,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1563;
+__arg0 = v0x7f1f24154540;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7743,7 +7743,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1563;
+__arg0 = v0x7f1f24154540;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7754,13 +7754,13 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj _35val2602 = __arg1;
+Obj v0x7f1f240245a0 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg2603 = makeCons(_35val2602, Nil);
-Obj _35reg2604 = makeCons(args, _35reg2603);
-Obj _35reg2605 = makeCons(symlambda, _35reg2604);
+Obj v0x7f1f240245e0 = makeCons(v0x7f1f240245a0, Nil);
+Obj v0x7f1f24024600 = makeCons(args, v0x7f1f240245e0);
+Obj v0x7f1f24024620 = makeCons(symlambda, v0x7f1f24024600);
 __nargs = 2;
-__arg1 = _35reg2605;
+__arg1 = v0x7f1f24024620;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7768,32 +7768,32 @@ goto *jumpTable[co->ctx.pc.label];
 
 label10:
 {
-Obj _35cc1564 = makeNative(16, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f24154840 = makeNative(16, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2558 = PRIM_ISCONS(closureRef(co, 1));
-if (True == _35reg2558) {
-Obj _35reg2559 = PRIM_CAR(closureRef(co, 1));
-Obj _35reg2560 = PRIM_EQ(symcontinuation, _35reg2559);
-if (True == _35reg2560) {
-Obj _35reg2561 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2562 = PRIM_ISCONS(_35reg2561);
-if (True == _35reg2562) {
-Obj _35reg2563 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2564 = PRIM_CAR(_35reg2563);
-Obj val = _35reg2564;
-Obj _35reg2565 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2566 = PRIM_CDR(_35reg2565);
-Obj _35reg2567 = PRIM_ISCONS(_35reg2566);
-if (True == _35reg2567) {
-Obj _35reg2568 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2569 = PRIM_CDR(_35reg2568);
-Obj _35reg2570 = PRIM_CAR(_35reg2569);
-Obj body = _35reg2570;
-Obj _35reg2571 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2572 = PRIM_CDR(_35reg2571);
-Obj _35reg2573 = PRIM_CDR(_35reg2572);
-Obj _35reg2574 = PRIM_EQ(Nil, _35reg2573);
-if (True == _35reg2574) {
+Obj v0x7f1f2403d220 = PRIM_ISCONS(closureRef(co, 1));
+if (True == v0x7f1f2403d220) {
+Obj v0x7f1f2403d3e0 = PRIM_CAR(closureRef(co, 1));
+Obj v0x7f1f2403d400 = PRIM_EQ(symcontinuation, v0x7f1f2403d3e0);
+if (True == v0x7f1f2403d400) {
+Obj v0x7f1f2403d5c0 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f2403d5e0 = PRIM_ISCONS(v0x7f1f2403d5c0);
+if (True == v0x7f1f2403d5e0) {
+Obj v0x7f1f2403d820 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f2403d840 = PRIM_CAR(v0x7f1f2403d820);
+Obj val = v0x7f1f2403d840;
+Obj v0x7f1f2403da80 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f2403daa0 = PRIM_CDR(v0x7f1f2403da80);
+Obj v0x7f1f2403dac0 = PRIM_ISCONS(v0x7f1f2403daa0);
+if (True == v0x7f1f2403dac0) {
+Obj v0x7f1f2403dd60 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f2403dd80 = PRIM_CDR(v0x7f1f2403dd60);
+Obj v0x7f1f2403dda0 = PRIM_CAR(v0x7f1f2403dd80);
+Obj body = v0x7f1f2403dda0;
+Obj v0x7f1f24035120 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24035140 = PRIM_CDR(v0x7f1f24035120);
+Obj v0x7f1f24035160 = PRIM_CDR(v0x7f1f24035140);
+Obj v0x7f1f24035180 = PRIM_EQ(Nil, v0x7f1f24035160);
+if (True == v0x7f1f24035180) {
 pushCont(co, 11, clofun6, 3, fvs, body, val);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
@@ -7805,7 +7805,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1564;
+__arg0 = v0x7f1f24154840;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7814,7 +7814,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1564;
+__arg0 = v0x7f1f24154840;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7823,7 +7823,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1564;
+__arg0 = v0x7f1f24154840;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7832,7 +7832,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1564;
+__arg0 = v0x7f1f24154840;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7841,7 +7841,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1564;
+__arg0 = v0x7f1f24154840;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7852,14 +7852,14 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj _35val2575 = __arg1;
+Obj v0x7f1f24035380 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 12, clofun6, 3, fvs, body, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = _35val2575;
+__arg1 = v0x7f1f24035380;
 __arg2 = val;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7870,11 +7870,11 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj _35val2576 = __arg1;
+Obj v0x7f1f240353c0 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs1 = _35val2576;
+Obj fvs1 = v0x7f1f240353c0;
 pushCont(co, 13, clofun6, 3, fvs1, body, val);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -7888,14 +7888,14 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35val2577 = __arg1;
+Obj v0x7f1f240355c0 = __arg1;
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 14, clofun6, 3, fvs1, body, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = _35val2577;
+__arg1 = v0x7f1f240355c0;
 __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -7906,11 +7906,11 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj _35val2578 = __arg1;
+Obj v0x7f1f24035600 = __arg1;
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs2 = _35val2578;
+Obj fvs2 = v0x7f1f24035600;
 pushCont(co, 15, clofun6, 2, val, fvs2);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -7925,16 +7925,16 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj _35val2579 = __arg1;
+Obj v0x7f1f24035ae0 = __arg1;
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2580 = makeCons(_35val2579, Nil);
-Obj _35reg2581 = makeCons(val, _35reg2580);
-Obj _35reg2582 = makeCons(symlambda, _35reg2581);
-Obj _35reg2583 = makeCons(_35reg2582, fvs2);
-Obj _35reg2584 = makeCons(sym_37continuation, _35reg2583);
+Obj v0x7f1f24035b20 = makeCons(v0x7f1f24035ae0, Nil);
+Obj v0x7f1f24035b40 = makeCons(val, v0x7f1f24035b20);
+Obj v0x7f1f24035b60 = makeCons(symlambda, v0x7f1f24035b40);
+Obj v0x7f1f24035ba0 = makeCons(v0x7f1f24035b60, fvs2);
+Obj v0x7f1f24035bc0 = makeCons(sym_37continuation, v0x7f1f24035ba0);
 __nargs = 2;
-__arg1 = _35reg2584;
+__arg1 = v0x7f1f24035bc0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -7942,32 +7942,32 @@ goto *jumpTable[co->ctx.pc.label];
 
 label16:
 {
-Obj _35cc1565 = makeNative(20, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f24154b40 = makeNative(20, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2535 = PRIM_ISCONS(closureRef(co, 1));
-if (True == _35reg2535) {
-Obj _35reg2536 = PRIM_CAR(closureRef(co, 1));
-Obj _35reg2537 = PRIM_EQ(symcall, _35reg2536);
-if (True == _35reg2537) {
-Obj _35reg2538 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2539 = PRIM_ISCONS(_35reg2538);
-if (True == _35reg2539) {
-Obj _35reg2540 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2541 = PRIM_CAR(_35reg2540);
-Obj exp = _35reg2541;
-Obj _35reg2542 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2543 = PRIM_CDR(_35reg2542);
-Obj _35reg2544 = PRIM_ISCONS(_35reg2543);
-if (True == _35reg2544) {
-Obj _35reg2545 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2546 = PRIM_CDR(_35reg2545);
-Obj _35reg2547 = PRIM_CAR(_35reg2546);
-Obj cont = _35reg2547;
-Obj _35reg2548 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2549 = PRIM_CDR(_35reg2548);
-Obj _35reg2550 = PRIM_CDR(_35reg2549);
-Obj _35reg2551 = PRIM_EQ(Nil, _35reg2550);
-if (True == _35reg2551) {
+Obj v0x7f1f240487a0 = PRIM_ISCONS(closureRef(co, 1));
+if (True == v0x7f1f240487a0) {
+Obj v0x7f1f24048980 = PRIM_CAR(closureRef(co, 1));
+Obj v0x7f1f240489e0 = PRIM_EQ(symcall, v0x7f1f24048980);
+if (True == v0x7f1f240489e0) {
+Obj v0x7f1f24048bc0 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24048be0 = PRIM_ISCONS(v0x7f1f24048bc0);
+if (True == v0x7f1f24048be0) {
+Obj v0x7f1f24048da0 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24048dc0 = PRIM_CAR(v0x7f1f24048da0);
+Obj exp = v0x7f1f24048dc0;
+Obj v0x7f1f24043080 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f240430a0 = PRIM_CDR(v0x7f1f24043080);
+Obj v0x7f1f240430c0 = PRIM_ISCONS(v0x7f1f240430a0);
+if (True == v0x7f1f240430c0) {
+Obj v0x7f1f24043340 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24043360 = PRIM_CDR(v0x7f1f24043340);
+Obj v0x7f1f24043380 = PRIM_CAR(v0x7f1f24043360);
+Obj cont = v0x7f1f24043380;
+Obj v0x7f1f24043740 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24043760 = PRIM_CDR(v0x7f1f24043740);
+Obj v0x7f1f24043780 = PRIM_CDR(v0x7f1f24043760);
+Obj v0x7f1f240437a0 = PRIM_EQ(Nil, v0x7f1f24043780);
+if (True == v0x7f1f240437a0) {
 pushCont(co, 17, clofun6, 3, exp, fvs, cont);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -7979,7 +7979,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1565;
+__arg0 = v0x7f1f24154b40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7988,7 +7988,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1565;
+__arg0 = v0x7f1f24154b40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -7997,7 +7997,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1565;
+__arg0 = v0x7f1f24154b40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8006,7 +8006,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1565;
+__arg0 = v0x7f1f24154b40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8015,7 +8015,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1565;
+__arg0 = v0x7f1f24154b40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8026,14 +8026,14 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj _35val2552 = __arg1;
+Obj v0x7f1f24043ae0 = __arg1;
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 pushCont(co, 18, clofun6, 2, fvs, cont);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = _35val2552;
+__arg1 = v0x7f1f24043ae0;
 __arg2 = exp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8044,10 +8044,10 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35val2553 = __arg1;
+Obj v0x7f1f24043b20 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj cont= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 19, clofun6, 1, _35val2553);
+pushCont(co, 19, clofun6, 1, v0x7f1f24043b20);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
 __arg1 = fvs;
@@ -8061,13 +8061,13 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj _35val2554 = __arg1;
-Obj _35val2553= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg2555 = makeCons(_35val2554, Nil);
-Obj _35reg2556 = makeCons(_35val2553, _35reg2555);
-Obj _35reg2557 = makeCons(symcall, _35reg2556);
+Obj v0x7f1f24043cc0 = __arg1;
+Obj v0x7f1f24043b20= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f24043d80 = makeCons(v0x7f1f24043cc0, Nil);
+Obj v0x7f1f24043da0 = makeCons(v0x7f1f24043b20, v0x7f1f24043d80);
+Obj v0x7f1f24043dc0 = makeCons(symcall, v0x7f1f24043da0);
 __nargs = 2;
-__arg1 = _35reg2557;
+__arg1 = v0x7f1f24043dc0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8075,14 +8075,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label20:
 {
-Obj _35cc1566 = makeNative(22, clofun6, 0, 0);
+Obj v0x7f1f24154e40 = makeNative(22, clofun6, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj _35reg2530 = PRIM_ISCONS(closureRef(co, 1));
-if (True == _35reg2530) {
-Obj _35reg2531 = PRIM_CAR(closureRef(co, 1));
-Obj f = _35reg2531;
-Obj _35reg2532 = PRIM_CDR(closureRef(co, 1));
-Obj args = _35reg2532;
+Obj v0x7f1f240480a0 = PRIM_ISCONS(closureRef(co, 1));
+if (True == v0x7f1f240480a0) {
+Obj v0x7f1f24048200 = PRIM_CAR(closureRef(co, 1));
+Obj f = v0x7f1f24048200;
+Obj v0x7f1f24048320 = PRIM_CDR(closureRef(co, 1));
+Obj args = v0x7f1f24048320;
 pushCont(co, 21, clofun6, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35explicit_45stack);
@@ -8094,7 +8094,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1566;
+__arg0 = v0x7f1f24154e40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8105,14 +8105,14 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj _35val2533 = __arg1;
+Obj v0x7f1f240484a0 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2534 = makeCons(f, args);
+Obj v0x7f1f240485c0 = makeCons(f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = _35val2533;
-__arg2 = _35reg2534;
+__arg1 = v0x7f1f240484a0;
+__arg2 = v0x7f1f240485c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8134,14 +8134,14 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj _35p1554 = __arg1;
-Obj _35p1555 = __arg2;
-Obj _35p1556 = __arg3;
-Obj _35cc1557 = makeNative(30, clofun6, 0, 3, _35p1554, _35p1555, _35p1556);
-Obj _35reg2487 = PRIM_EQ(Nil, _35p1554);
-if (True == _35reg2487) {
-Obj ls = _35p1555;
-Obj next = _35p1556;
+Obj v0x7f1f2415b920 = __arg1;
+Obj v0x7f1f2415b940 = __arg2;
+Obj v0x7f1f2415b960 = __arg3;
+Obj v0x7f1f2415ba60 = makeNative(30, clofun6, 0, 3, v0x7f1f2415b920, v0x7f1f2415b940, v0x7f1f2415b960);
+Obj v0x7f1f2406b3e0 = PRIM_EQ(Nil, v0x7f1f2415b920);
+if (True == v0x7f1f2406b3e0) {
+Obj ls = v0x7f1f2415b940;
+Obj next = v0x7f1f2415b960;
 pushCont(co, 24, clofun6, 1, next);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35reverse);
@@ -8153,7 +8153,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1557;
+__arg0 = v0x7f1f2415ba60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8164,14 +8164,14 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj _35val2488 = __arg1;
+Obj v0x7f1f2406b6a0 = __arg1;
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj exp = _35val2488;
-Obj _35reg2489 = PRIM_CAR(exp);
+Obj exp = v0x7f1f2406b6a0;
+Obj v0x7f1f2406b920 = PRIM_CAR(exp);
 pushCont(co, 25, clofun6, 2, next, exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35pair_63);
-__arg1 = _35reg2489;
+__arg1 = v0x7f1f2406b920;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8181,10 +8181,10 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj _35val2490 = __arg1;
+Obj v0x7f1f2406b940 = __arg1;
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val2490) {
+if (True == v0x7f1f2406b940) {
 pushCont(co, 27, clofun6, 2, next, exp);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35caar);
@@ -8206,20 +8206,20 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2517 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
-if (True == _35reg2517) {
-Obj _35reg2518 = makeCons(exp, Nil);
-Obj _35reg2519 = makeCons(symtailcall, _35reg2518);
+Obj v0x7f1f2404fd80 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
+if (True == v0x7f1f2404fd80) {
+Obj v0x7f1f2404ff40 = makeCons(exp, Nil);
+Obj v0x7f1f2404ff60 = makeCons(symtailcall, v0x7f1f2404ff40);
 __nargs = 2;
-__arg1 = _35reg2519;
+__arg1 = v0x7f1f2404ff60;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg2520 = primGenSym(symval);
-Obj val = _35reg2520;
-Obj _35reg2521 = makeCons(val, Nil);
-pushCont(co, 26, clofun6, 2, _35reg2521, exp);
+Obj v0x7f1f2404d080 = primGenSym(symval);
+Obj val = v0x7f1f2404d080;
+Obj v0x7f1f2404d5c0 = makeCons(val, Nil);
+pushCont(co, 26, clofun6, 2, v0x7f1f2404d5c0, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
@@ -8235,17 +8235,17 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35val2522 = __arg1;
-Obj _35reg2521= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f2404d7c0 = __arg1;
+Obj v0x7f1f2404d5c0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2523 = makeCons(_35val2522, Nil);
-Obj _35reg2524 = makeCons(_35reg2521, _35reg2523);
-Obj _35reg2525 = makeCons(symcontinuation, _35reg2524);
-Obj _35reg2526 = makeCons(_35reg2525, Nil);
-Obj _35reg2527 = makeCons(exp, _35reg2526);
-Obj _35reg2528 = makeCons(symcall, _35reg2527);
+Obj v0x7f1f2404d800 = makeCons(v0x7f1f2404d7c0, Nil);
+Obj v0x7f1f2404d820 = makeCons(v0x7f1f2404d5c0, v0x7f1f2404d800);
+Obj v0x7f1f2404d840 = makeCons(symcontinuation, v0x7f1f2404d820);
+Obj v0x7f1f2404d880 = makeCons(v0x7f1f2404d840, Nil);
+Obj v0x7f1f2404d8a0 = makeCons(exp, v0x7f1f2404d880);
+Obj v0x7f1f2404d8c0 = makeCons(symcall, v0x7f1f2404d8a0);
 __nargs = 2;
-__arg1 = _35reg2528;
+__arg1 = v0x7f1f2404d8c0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8253,11 +8253,11 @@ goto *jumpTable[co->ctx.pc.label];
 
 label27:
 {
-Obj _35val2491 = __arg1;
+Obj v0x7f1f2406bb60 = __arg1;
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2492 = PRIM_EQ(_35val2491, sym_37builtin);
-if (True == _35reg2492) {
+Obj v0x7f1f2406bbc0 = PRIM_EQ(v0x7f1f2406bb60, sym_37builtin);
+if (True == v0x7f1f2406bbc0) {
 if (True == True) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35wrap_45var);
@@ -8269,20 +8269,20 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2493 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
-if (True == _35reg2493) {
-Obj _35reg2494 = makeCons(exp, Nil);
-Obj _35reg2495 = makeCons(symtailcall, _35reg2494);
+Obj v0x7f1f2406bde0 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
+if (True == v0x7f1f2406bde0) {
+Obj v0x7f1f240690e0 = makeCons(exp, Nil);
+Obj v0x7f1f24069100 = makeCons(symtailcall, v0x7f1f240690e0);
 __nargs = 2;
-__arg1 = _35reg2495;
+__arg1 = v0x7f1f24069100;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg2496 = primGenSym(symval);
-Obj val = _35reg2496;
-Obj _35reg2497 = makeCons(val, Nil);
-pushCont(co, 29, clofun6, 2, _35reg2497, exp);
+Obj v0x7f1f24069200 = primGenSym(symval);
+Obj val = v0x7f1f24069200;
+Obj v0x7f1f240698e0 = makeCons(val, Nil);
+pushCont(co, 29, clofun6, 2, v0x7f1f240698e0, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
@@ -8305,20 +8305,20 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg2505 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
-if (True == _35reg2505) {
-Obj _35reg2506 = makeCons(exp, Nil);
-Obj _35reg2507 = makeCons(symtailcall, _35reg2506);
+Obj v0x7f1f24069e60 = PRIM_EQ(next, globalRef(symcora_47lib_47toc_35id));
+if (True == v0x7f1f24069e60) {
+Obj v0x7f1f2404f000 = makeCons(exp, Nil);
+Obj v0x7f1f2404f020 = makeCons(symtailcall, v0x7f1f2404f000);
 __nargs = 2;
-__arg1 = _35reg2507;
+__arg1 = v0x7f1f2404f020;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg2508 = primGenSym(symval);
-Obj val = _35reg2508;
-Obj _35reg2509 = makeCons(val, Nil);
-pushCont(co, 28, clofun6, 2, _35reg2509, exp);
+Obj v0x7f1f2404f160 = primGenSym(symval);
+Obj val = v0x7f1f2404f160;
+Obj v0x7f1f2404f700 = makeCons(val, Nil);
+pushCont(co, 28, clofun6, 2, v0x7f1f2404f700, exp);
 __nargs = 2;
 __arg0 = next;
 __arg1 = val;
@@ -8334,17 +8334,17 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj _35val2510 = __arg1;
-Obj _35reg2509= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f2404f940 = __arg1;
+Obj v0x7f1f2404f700= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2511 = makeCons(_35val2510, Nil);
-Obj _35reg2512 = makeCons(_35reg2509, _35reg2511);
-Obj _35reg2513 = makeCons(symcontinuation, _35reg2512);
-Obj _35reg2514 = makeCons(_35reg2513, Nil);
-Obj _35reg2515 = makeCons(exp, _35reg2514);
-Obj _35reg2516 = makeCons(symcall, _35reg2515);
+Obj v0x7f1f2404f980 = makeCons(v0x7f1f2404f940, Nil);
+Obj v0x7f1f2404f9a0 = makeCons(v0x7f1f2404f700, v0x7f1f2404f980);
+Obj v0x7f1f2404f9c0 = makeCons(symcontinuation, v0x7f1f2404f9a0);
+Obj v0x7f1f2404faa0 = makeCons(v0x7f1f2404f9c0, Nil);
+Obj v0x7f1f2404fac0 = makeCons(exp, v0x7f1f2404faa0);
+Obj v0x7f1f2404fae0 = makeCons(symcall, v0x7f1f2404fac0);
 __nargs = 2;
-__arg1 = _35reg2516;
+__arg1 = v0x7f1f2404fae0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8352,17 +8352,17 @@ goto *jumpTable[co->ctx.pc.label];
 
 label29:
 {
-Obj _35val2498 = __arg1;
-Obj _35reg2497= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f24069aa0 = __arg1;
+Obj v0x7f1f240698e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj exp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2499 = makeCons(_35val2498, Nil);
-Obj _35reg2500 = makeCons(_35reg2497, _35reg2499);
-Obj _35reg2501 = makeCons(symcontinuation, _35reg2500);
-Obj _35reg2502 = makeCons(_35reg2501, Nil);
-Obj _35reg2503 = makeCons(exp, _35reg2502);
-Obj _35reg2504 = makeCons(symcall, _35reg2503);
+Obj v0x7f1f24069ae0 = makeCons(v0x7f1f24069aa0, Nil);
+Obj v0x7f1f24069b00 = makeCons(v0x7f1f240698e0, v0x7f1f24069ae0);
+Obj v0x7f1f24069b20 = makeCons(symcontinuation, v0x7f1f24069b00);
+Obj v0x7f1f24069b60 = makeCons(v0x7f1f24069b20, Nil);
+Obj v0x7f1f24069b80 = makeCons(exp, v0x7f1f24069b60);
+Obj v0x7f1f24069be0 = makeCons(symcall, v0x7f1f24069b80);
 __nargs = 2;
-__arg1 = _35reg2504;
+__arg1 = v0x7f1f24069be0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8370,13 +8370,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label30:
 {
-Obj _35cc1558 = makeNative(32, clofun6, 0, 0);
-Obj _35reg2483 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2483) {
-Obj _35reg2484 = PRIM_CAR(closureRef(co, 0));
-Obj hd = _35reg2484;
-Obj _35reg2485 = PRIM_CDR(closureRef(co, 0));
-Obj tl = _35reg2485;
+Obj v0x7f1f2415bcc0 = makeNative(32, clofun6, 0, 0);
+Obj v0x7f1f24072aa0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24072aa0) {
+Obj v0x7f1f24072ba0 = PRIM_CAR(closureRef(co, 0));
+Obj hd = v0x7f1f24072ba0;
+Obj v0x7f1f24072ce0 = PRIM_CDR(closureRef(co, 0));
+Obj tl = v0x7f1f24072ce0;
 Obj ls = closureRef(co, 1);
 Obj next = closureRef(co, 2);
 __nargs = 3;
@@ -8390,7 +8390,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1558;
+__arg0 = v0x7f1f2415bcc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8402,11 +8402,11 @@ goto *jumpTable[ps.label];
 label31:
 {
 Obj hd1 = __arg1;
-Obj _35reg2486 = makeCons(hd1, closureRef(co, 1));
+Obj v0x7f1f2406b160 = makeCons(hd1, closureRef(co, 1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify_45list);
 __arg1 = closureRef(co, 0);
-__arg2 = _35reg2486;
+__arg2 = v0x7f1f2406b160;
 __arg3 = closureRef(co, 2);
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -8429,13 +8429,13 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj _35p1545 = __arg1;
-Obj _35p1546 = __arg2;
-Obj _35cc1547 = makeNative(35, clofun6, 0, 2, _35p1545, _35p1546);
-Obj x = _35p1545;
-Obj next = _35p1546;
-Obj _35reg2480 = primIsSymbol(x);
-if (True == _35reg2480) {
+Obj v0x7f1f24161280 = __arg1;
+Obj v0x7f1f241612a0 = __arg2;
+Obj v0x7f1f24161380 = makeNative(35, clofun6, 0, 2, v0x7f1f24161280, v0x7f1f241612a0);
+Obj x = v0x7f1f24161280;
+Obj next = v0x7f1f241612a0;
+Obj v0x7f1f240f6f80 = primIsSymbol(x);
+if (True == v0x7f1f240f6f80) {
 if (True == True) {
 __nargs = 2;
 __arg0 = next;
@@ -8447,7 +8447,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1547;
+__arg0 = v0x7f1f24161380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8455,7 +8455,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 34, clofun6, 3, next, x, _35cc1547);
+pushCont(co, 34, clofun6, 3, next, x, v0x7f1f24161380);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -8469,11 +8469,11 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj _35val2481 = __arg1;
+Obj v0x7f1f24072240 = __arg1;
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35cc1547= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == _35val2481) {
+Obj v0x7f1f24161380= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == v0x7f1f24072240) {
 if (True == True) {
 __nargs = 2;
 __arg0 = next;
@@ -8485,7 +8485,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1547;
+__arg0 = v0x7f1f24161380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8504,7 +8504,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1547;
+__arg0 = v0x7f1f24161380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8516,10 +8516,10 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj _35cc1548 = makeNative(37, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f24161520 = makeNative(37, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj x = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
-pushCont(co, 36, clofun6, 2, x, _35cc1548);
+pushCont(co, 36, clofun6, 2, x, v0x7f1f24161520);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -8532,10 +8532,10 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj _35val2479 = __arg1;
+Obj v0x7f1f240f6bc0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35cc1548= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val2479) {
+Obj v0x7f1f24161520= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == v0x7f1f240f6bc0) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -8543,7 +8543,7 @@ if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1548;
+__arg0 = v0x7f1f24161520;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8554,42 +8554,42 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj _35cc1549 = makeNative(41, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2447 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2447) {
-Obj _35reg2448 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2449 = PRIM_EQ(symif, _35reg2448);
-if (True == _35reg2449) {
-Obj _35reg2450 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2451 = PRIM_ISCONS(_35reg2450);
-if (True == _35reg2451) {
-Obj _35reg2452 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2453 = PRIM_CAR(_35reg2452);
-Obj a = _35reg2453;
-Obj _35reg2454 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2455 = PRIM_CDR(_35reg2454);
-Obj _35reg2456 = PRIM_ISCONS(_35reg2455);
-if (True == _35reg2456) {
-Obj _35reg2457 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2458 = PRIM_CDR(_35reg2457);
-Obj _35reg2459 = PRIM_CAR(_35reg2458);
-Obj b = _35reg2459;
-Obj _35reg2460 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2461 = PRIM_CDR(_35reg2460);
-Obj _35reg2462 = PRIM_CDR(_35reg2461);
-Obj _35reg2463 = PRIM_ISCONS(_35reg2462);
-if (True == _35reg2463) {
-Obj _35reg2464 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2465 = PRIM_CDR(_35reg2464);
-Obj _35reg2466 = PRIM_CDR(_35reg2465);
-Obj _35reg2467 = PRIM_CAR(_35reg2466);
-Obj c = _35reg2467;
-Obj _35reg2468 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2469 = PRIM_CDR(_35reg2468);
-Obj _35reg2470 = PRIM_CDR(_35reg2469);
-Obj _35reg2471 = PRIM_CDR(_35reg2470);
-Obj _35reg2472 = PRIM_EQ(Nil, _35reg2471);
-if (True == _35reg2472) {
+Obj v0x7f1f24161700 = makeNative(41, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f241289a0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f241289a0) {
+Obj v0x7f1f24128ca0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f24128cc0 = PRIM_EQ(symif, v0x7f1f24128ca0);
+if (True == v0x7f1f24128cc0) {
+Obj v0x7f1f24128f80 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24128fa0 = PRIM_ISCONS(v0x7f1f24128f80);
+if (True == v0x7f1f24128fa0) {
+Obj v0x7f1f240f9200 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f9220 = PRIM_CAR(v0x7f1f240f9200);
+Obj a = v0x7f1f240f9220;
+Obj v0x7f1f240f95c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f95e0 = PRIM_CDR(v0x7f1f240f95c0);
+Obj v0x7f1f240f96a0 = PRIM_ISCONS(v0x7f1f240f95e0);
+if (True == v0x7f1f240f96a0) {
+Obj v0x7f1f240f9980 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f99a0 = PRIM_CDR(v0x7f1f240f9980);
+Obj v0x7f1f240f99c0 = PRIM_CAR(v0x7f1f240f99a0);
+Obj b = v0x7f1f240f99c0;
+Obj v0x7f1f240f9de0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f9e80 = PRIM_CDR(v0x7f1f240f9de0);
+Obj v0x7f1f240f9ea0 = PRIM_CDR(v0x7f1f240f9e80);
+Obj v0x7f1f240f9ec0 = PRIM_ISCONS(v0x7f1f240f9ea0);
+if (True == v0x7f1f240f9ec0) {
+Obj v0x7f1f240f82e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f8300 = PRIM_CDR(v0x7f1f240f82e0);
+Obj v0x7f1f240f8320 = PRIM_CDR(v0x7f1f240f8300);
+Obj v0x7f1f240f8360 = PRIM_CAR(v0x7f1f240f8320);
+Obj c = v0x7f1f240f8360;
+Obj v0x7f1f240f88c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f88e0 = PRIM_CDR(v0x7f1f240f88c0);
+Obj v0x7f1f240f8900 = PRIM_CDR(v0x7f1f240f88e0);
+Obj v0x7f1f240f8980 = PRIM_CDR(v0x7f1f240f8900);
+Obj v0x7f1f240f89a0 = PRIM_EQ(Nil, v0x7f1f240f8980);
+if (True == v0x7f1f240f89a0) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
@@ -8602,7 +8602,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1549;
+__arg0 = v0x7f1f24161700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8611,7 +8611,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1549;
+__arg0 = v0x7f1f24161700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8620,7 +8620,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1549;
+__arg0 = v0x7f1f24161700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8629,7 +8629,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1549;
+__arg0 = v0x7f1f24161700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8638,7 +8638,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1549;
+__arg0 = v0x7f1f24161700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8647,7 +8647,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1549;
+__arg0 = v0x7f1f24161700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8673,9 +8673,9 @@ goto *jumpTable[ps.label];
 
 label39:
 {
-Obj _35val2473 = __arg1;
+Obj v0x7f1f240f8f80 = __arg1;
 Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-pushCont(co, 40, clofun6, 2, _35val2473, ra);
+pushCont(co, 40, clofun6, 2, v0x7f1f240f8f80, ra);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
 __arg1 = closureRef(co, 1);
@@ -8689,15 +8689,15 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj _35val2474 = __arg1;
-Obj _35val2473= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f240f61e0 = __arg1;
+Obj v0x7f1f240f8f80= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2475 = makeCons(_35val2474, Nil);
-Obj _35reg2476 = makeCons(_35val2473, _35reg2475);
-Obj _35reg2477 = makeCons(ra, _35reg2476);
-Obj _35reg2478 = makeCons(symif, _35reg2477);
+Obj v0x7f1f240f6240 = makeCons(v0x7f1f240f61e0, Nil);
+Obj v0x7f1f240f6260 = makeCons(v0x7f1f240f8f80, v0x7f1f240f6240);
+Obj v0x7f1f240f6280 = makeCons(ra, v0x7f1f240f6260);
+Obj v0x7f1f240f6300 = makeCons(symif, v0x7f1f240f6280);
 __nargs = 2;
-__arg1 = _35reg2478;
+__arg1 = v0x7f1f240f6300;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8705,31 +8705,31 @@ goto *jumpTable[co->ctx.pc.label];
 
 label41:
 {
-Obj _35cc1550 = makeNative(44, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2425 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2425) {
-Obj _35reg2426 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2427 = PRIM_EQ(symdo, _35reg2426);
-if (True == _35reg2427) {
-Obj _35reg2428 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2429 = PRIM_ISCONS(_35reg2428);
-if (True == _35reg2429) {
-Obj _35reg2430 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2431 = PRIM_CAR(_35reg2430);
-Obj a = _35reg2431;
-Obj _35reg2432 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2433 = PRIM_CDR(_35reg2432);
-Obj _35reg2434 = PRIM_ISCONS(_35reg2433);
-if (True == _35reg2434) {
-Obj _35reg2435 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2436 = PRIM_CDR(_35reg2435);
-Obj _35reg2437 = PRIM_CAR(_35reg2436);
-Obj b = _35reg2437;
-Obj _35reg2438 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2439 = PRIM_CDR(_35reg2438);
-Obj _35reg2440 = PRIM_CDR(_35reg2439);
-Obj _35reg2441 = PRIM_EQ(Nil, _35reg2440);
-if (True == _35reg2441) {
+Obj v0x7f1f24161ae0 = makeNative(44, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f2412f420 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2412f420) {
+Obj v0x7f1f2412f620 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2412f6a0 = PRIM_EQ(symdo, v0x7f1f2412f620);
+if (True == v0x7f1f2412f6a0) {
+Obj v0x7f1f2412f8a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2412f8c0 = PRIM_ISCONS(v0x7f1f2412f8a0);
+if (True == v0x7f1f2412f8c0) {
+Obj v0x7f1f2412fb40 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2412fb60 = PRIM_CAR(v0x7f1f2412fb40);
+Obj a = v0x7f1f2412fb60;
+Obj v0x7f1f2412fe60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2412fe80 = PRIM_CDR(v0x7f1f2412fe60);
+Obj v0x7f1f2412fea0 = PRIM_ISCONS(v0x7f1f2412fe80);
+if (True == v0x7f1f2412fea0) {
+Obj v0x7f1f2412c200 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2412c220 = PRIM_CDR(v0x7f1f2412c200);
+Obj v0x7f1f2412c240 = PRIM_CAR(v0x7f1f2412c220);
+Obj b = v0x7f1f2412c240;
+Obj v0x7f1f2412c9a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2412c9c0 = PRIM_CDR(v0x7f1f2412c9a0);
+Obj v0x7f1f2412c9e0 = PRIM_CDR(v0x7f1f2412c9c0);
+Obj v0x7f1f2412ca00 = PRIM_EQ(Nil, v0x7f1f2412c9e0);
+if (True == v0x7f1f2412ca00) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
@@ -8742,7 +8742,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1550;
+__arg0 = v0x7f1f24161ae0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8751,7 +8751,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1550;
+__arg0 = v0x7f1f24161ae0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8760,7 +8760,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1550;
+__arg0 = v0x7f1f24161ae0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8769,7 +8769,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1550;
+__arg0 = v0x7f1f24161ae0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8778,7 +8778,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1550;
+__arg0 = v0x7f1f24161ae0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8790,8 +8790,8 @@ goto *jumpTable[ps.label];
 label42:
 {
 Obj ra = __arg1;
-Obj _35reg2442 = primIsSymbol(ra);
-if (True == _35reg2442) {
+Obj v0x7f1f2412cd20 = primIsSymbol(ra);
+if (True == v0x7f1f2412cd20) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
 __arg1 = closureRef(co, 0);
@@ -8817,13 +8817,13 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj _35val2443 = __arg1;
+Obj v0x7f1f24128340 = __arg1;
 Obj ra= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg2444 = makeCons(_35val2443, Nil);
-Obj _35reg2445 = makeCons(ra, _35reg2444);
-Obj _35reg2446 = makeCons(symdo, _35reg2445);
+Obj v0x7f1f24128380 = makeCons(v0x7f1f24128340, Nil);
+Obj v0x7f1f24128400 = makeCons(ra, v0x7f1f24128380);
+Obj v0x7f1f24128480 = makeCons(symdo, v0x7f1f24128400);
 __nargs = 2;
-__arg1 = _35reg2446;
+__arg1 = v0x7f1f24128480;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8831,42 +8831,42 @@ goto *jumpTable[co->ctx.pc.label];
 
 label44:
 {
-Obj _35cc1551 = makeNative(47, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2394 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2394) {
-Obj _35reg2395 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2396 = PRIM_EQ(symlet, _35reg2395);
-if (True == _35reg2396) {
-Obj _35reg2397 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2398 = PRIM_ISCONS(_35reg2397);
-if (True == _35reg2398) {
-Obj _35reg2399 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2400 = PRIM_CAR(_35reg2399);
-Obj a = _35reg2400;
-Obj _35reg2401 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2402 = PRIM_CDR(_35reg2401);
-Obj _35reg2403 = PRIM_ISCONS(_35reg2402);
-if (True == _35reg2403) {
-Obj _35reg2404 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2405 = PRIM_CDR(_35reg2404);
-Obj _35reg2406 = PRIM_CAR(_35reg2405);
-Obj b = _35reg2406;
-Obj _35reg2407 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2408 = PRIM_CDR(_35reg2407);
-Obj _35reg2409 = PRIM_CDR(_35reg2408);
-Obj _35reg2410 = PRIM_ISCONS(_35reg2409);
-if (True == _35reg2410) {
-Obj _35reg2411 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2412 = PRIM_CDR(_35reg2411);
-Obj _35reg2413 = PRIM_CDR(_35reg2412);
-Obj _35reg2414 = PRIM_CAR(_35reg2413);
-Obj c = _35reg2414;
-Obj _35reg2415 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2416 = PRIM_CDR(_35reg2415);
-Obj _35reg2417 = PRIM_CDR(_35reg2416);
-Obj _35reg2418 = PRIM_CDR(_35reg2417);
-Obj _35reg2419 = PRIM_EQ(Nil, _35reg2418);
-if (True == _35reg2419) {
+Obj v0x7f1f24161dc0 = makeNative(47, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f24138960 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24138960) {
+Obj v0x7f1f24138b40 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f24138b60 = PRIM_EQ(symlet, v0x7f1f24138b40);
+if (True == v0x7f1f24138b60) {
+Obj v0x7f1f24138e00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24138e20 = PRIM_ISCONS(v0x7f1f24138e00);
+if (True == v0x7f1f24138e20) {
+Obj v0x7f1f241350e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24135120 = PRIM_CAR(v0x7f1f241350e0);
+Obj a = v0x7f1f24135120;
+Obj v0x7f1f241353a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f241353c0 = PRIM_CDR(v0x7f1f241353a0);
+Obj v0x7f1f241353e0 = PRIM_ISCONS(v0x7f1f241353c0);
+if (True == v0x7f1f241353e0) {
+Obj v0x7f1f24135720 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24135740 = PRIM_CDR(v0x7f1f24135720);
+Obj v0x7f1f24135840 = PRIM_CAR(v0x7f1f24135740);
+Obj b = v0x7f1f24135840;
+Obj v0x7f1f24135c00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24135c20 = PRIM_CDR(v0x7f1f24135c00);
+Obj v0x7f1f24135c40 = PRIM_CDR(v0x7f1f24135c20);
+Obj v0x7f1f24135c60 = PRIM_ISCONS(v0x7f1f24135c40);
+if (True == v0x7f1f24135c60) {
+Obj v0x7f1f24133040 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24133060 = PRIM_CDR(v0x7f1f24133040);
+Obj v0x7f1f24133080 = PRIM_CDR(v0x7f1f24133060);
+Obj v0x7f1f241330a0 = PRIM_CAR(v0x7f1f24133080);
+Obj c = v0x7f1f241330a0;
+Obj v0x7f1f24133560 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24133580 = PRIM_CDR(v0x7f1f24133560);
+Obj v0x7f1f24133660 = PRIM_CDR(v0x7f1f24133580);
+Obj v0x7f1f24133680 = PRIM_CDR(v0x7f1f24133660);
+Obj v0x7f1f241336a0 = PRIM_EQ(Nil, v0x7f1f24133680);
+if (True == v0x7f1f241336a0) {
 Obj next = closureRef(co, 1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify);
@@ -8879,7 +8879,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1551;
+__arg0 = v0x7f1f24161dc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8888,7 +8888,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1551;
+__arg0 = v0x7f1f24161dc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8897,7 +8897,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1551;
+__arg0 = v0x7f1f24161dc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8906,7 +8906,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1551;
+__arg0 = v0x7f1f24161dc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8915,7 +8915,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1551;
+__arg0 = v0x7f1f24161dc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8924,7 +8924,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1551;
+__arg0 = v0x7f1f24161dc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -8950,14 +8950,14 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj _35val2420 = __arg1;
+Obj v0x7f1f24133d80 = __arg1;
 Obj rb= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg2421 = makeCons(_35val2420, Nil);
-Obj _35reg2422 = makeCons(rb, _35reg2421);
-Obj _35reg2423 = makeCons(closureRef(co, 0), _35reg2422);
-Obj _35reg2424 = makeCons(symlet, _35reg2423);
+Obj v0x7f1f24133dc0 = makeCons(v0x7f1f24133d80, Nil);
+Obj v0x7f1f24133de0 = makeCons(rb, v0x7f1f24133dc0);
+Obj v0x7f1f24133e60 = makeCons(closureRef(co, 0), v0x7f1f24133de0);
+Obj v0x7f1f24133e80 = makeCons(symlet, v0x7f1f24133e60);
 __nargs = 2;
-__arg1 = _35reg2424;
+__arg1 = v0x7f1f24133e80;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun6) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -8965,56 +8965,56 @@ goto *jumpTable[co->ctx.pc.label];
 
 label47:
 {
-Obj _35cc1552 = makeNative(49, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2350 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2350) {
-Obj _35reg2351 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2352 = PRIM_EQ(sym_37closure, _35reg2351);
-if (True == _35reg2352) {
-Obj _35reg2353 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2354 = PRIM_ISCONS(_35reg2353);
-if (True == _35reg2354) {
-Obj _35reg2355 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2356 = PRIM_CAR(_35reg2355);
-Obj _35reg2357 = PRIM_ISCONS(_35reg2356);
-if (True == _35reg2357) {
-Obj _35reg2358 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2359 = PRIM_CAR(_35reg2358);
-Obj _35reg2360 = PRIM_CAR(_35reg2359);
-Obj _35reg2361 = PRIM_EQ(symlambda, _35reg2360);
-if (True == _35reg2361) {
-Obj _35reg2362 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2363 = PRIM_CAR(_35reg2362);
-Obj _35reg2364 = PRIM_CDR(_35reg2363);
-Obj _35reg2365 = PRIM_ISCONS(_35reg2364);
-if (True == _35reg2365) {
-Obj _35reg2366 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2367 = PRIM_CAR(_35reg2366);
-Obj _35reg2368 = PRIM_CDR(_35reg2367);
-Obj _35reg2369 = PRIM_CAR(_35reg2368);
-Obj args = _35reg2369;
-Obj _35reg2370 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2371 = PRIM_CAR(_35reg2370);
-Obj _35reg2372 = PRIM_CDR(_35reg2371);
-Obj _35reg2373 = PRIM_CDR(_35reg2372);
-Obj _35reg2374 = PRIM_ISCONS(_35reg2373);
-if (True == _35reg2374) {
-Obj _35reg2375 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2376 = PRIM_CAR(_35reg2375);
-Obj _35reg2377 = PRIM_CDR(_35reg2376);
-Obj _35reg2378 = PRIM_CDR(_35reg2377);
-Obj _35reg2379 = PRIM_CAR(_35reg2378);
-Obj body = _35reg2379;
-Obj _35reg2380 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2381 = PRIM_CAR(_35reg2380);
-Obj _35reg2382 = PRIM_CDR(_35reg2381);
-Obj _35reg2383 = PRIM_CDR(_35reg2382);
-Obj _35reg2384 = PRIM_CDR(_35reg2383);
-Obj _35reg2385 = PRIM_EQ(Nil, _35reg2384);
-if (True == _35reg2385) {
-Obj _35reg2386 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2387 = PRIM_CDR(_35reg2386);
-Obj frees = _35reg2387;
+Obj v0x7f1f2415b160 = makeNative(49, clofun6, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f2414d200 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2414d200) {
+Obj v0x7f1f2414d480 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2414d4a0 = PRIM_EQ(sym_37closure, v0x7f1f2414d480);
+if (True == v0x7f1f2414d4a0) {
+Obj v0x7f1f2414d760 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2414d780 = PRIM_ISCONS(v0x7f1f2414d760);
+if (True == v0x7f1f2414d780) {
+Obj v0x7f1f2414dae0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2414db00 = PRIM_CAR(v0x7f1f2414dae0);
+Obj v0x7f1f2414db20 = PRIM_ISCONS(v0x7f1f2414db00);
+if (True == v0x7f1f2414db20) {
+Obj v0x7f1f2414df00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2414df40 = PRIM_CAR(v0x7f1f2414df00);
+Obj v0x7f1f2414df80 = PRIM_CAR(v0x7f1f2414df40);
+Obj v0x7f1f2414dfa0 = PRIM_EQ(symlambda, v0x7f1f2414df80);
+if (True == v0x7f1f2414dfa0) {
+Obj v0x7f1f24146360 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24146400 = PRIM_CAR(v0x7f1f24146360);
+Obj v0x7f1f24146420 = PRIM_CDR(v0x7f1f24146400);
+Obj v0x7f1f24146440 = PRIM_ISCONS(v0x7f1f24146420);
+if (True == v0x7f1f24146440) {
+Obj v0x7f1f24146800 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24146820 = PRIM_CAR(v0x7f1f24146800);
+Obj v0x7f1f24146840 = PRIM_CDR(v0x7f1f24146820);
+Obj v0x7f1f24146860 = PRIM_CAR(v0x7f1f24146840);
+Obj args = v0x7f1f24146860;
+Obj v0x7f1f24146d40 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24146d60 = PRIM_CAR(v0x7f1f24146d40);
+Obj v0x7f1f24146d80 = PRIM_CDR(v0x7f1f24146d60);
+Obj v0x7f1f24146da0 = PRIM_CDR(v0x7f1f24146d80);
+Obj v0x7f1f24146dc0 = PRIM_ISCONS(v0x7f1f24146da0);
+if (True == v0x7f1f24146dc0) {
+Obj v0x7f1f2413f1c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2413f1e0 = PRIM_CAR(v0x7f1f2413f1c0);
+Obj v0x7f1f2413f200 = PRIM_CDR(v0x7f1f2413f1e0);
+Obj v0x7f1f2413f220 = PRIM_CDR(v0x7f1f2413f200);
+Obj v0x7f1f2413f240 = PRIM_CAR(v0x7f1f2413f220);
+Obj body = v0x7f1f2413f240;
+Obj v0x7f1f2413f760 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2413f780 = PRIM_CAR(v0x7f1f2413f760);
+Obj v0x7f1f2413f7a0 = PRIM_CDR(v0x7f1f2413f780);
+Obj v0x7f1f2413f7c0 = PRIM_CDR(v0x7f1f2413f7a0);
+Obj v0x7f1f2413f800 = PRIM_CDR(v0x7f1f2413f7c0);
+Obj v0x7f1f2413f820 = PRIM_EQ(Nil, v0x7f1f2413f800);
+if (True == v0x7f1f2413f820) {
+Obj v0x7f1f2413f9c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2413f9e0 = PRIM_CDR(v0x7f1f2413f9c0);
+Obj frees = v0x7f1f2413f9e0;
 Obj next = closureRef(co, 1);
 pushCont(co, 48, clofun6, 3, args, frees, next);
 __nargs = 3;
@@ -9028,7 +9028,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1552;
+__arg0 = v0x7f1f2415b160;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9037,7 +9037,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1552;
+__arg0 = v0x7f1f2415b160;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9046,7 +9046,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1552;
+__arg0 = v0x7f1f2415b160;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9055,7 +9055,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1552;
+__arg0 = v0x7f1f2415b160;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9064,7 +9064,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1552;
+__arg0 = v0x7f1f2415b160;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9073,7 +9073,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1552;
+__arg0 = v0x7f1f2415b160;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9082,7 +9082,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1552;
+__arg0 = v0x7f1f2415b160;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9091,7 +9091,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1552;
+__arg0 = v0x7f1f2415b160;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9102,18 +9102,18 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj _35val2388 = __arg1;
+Obj v0x7f1f241380e0 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj frees= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj next= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg2389 = makeCons(_35val2388, Nil);
-Obj _35reg2390 = makeCons(args, _35reg2389);
-Obj _35reg2391 = makeCons(symlambda, _35reg2390);
-Obj _35reg2392 = makeCons(_35reg2391, frees);
-Obj _35reg2393 = makeCons(sym_37closure, _35reg2392);
+Obj v0x7f1f24138120 = makeCons(v0x7f1f241380e0, Nil);
+Obj v0x7f1f24138140 = makeCons(args, v0x7f1f24138120);
+Obj v0x7f1f24138160 = makeCons(symlambda, v0x7f1f24138140);
+Obj v0x7f1f241381a0 = makeCons(v0x7f1f24138160, frees);
+Obj v0x7f1f241381c0 = makeCons(sym_37closure, v0x7f1f241381a0);
 __nargs = 2;
 __arg0 = next;
-__arg1 = _35reg2393;
+__arg1 = v0x7f1f241381c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9123,18 +9123,18 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj _35cc1553 = makeNative(0, clofun7, 0, 0);
-Obj _35reg2346 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2346) {
-Obj _35reg2347 = PRIM_CAR(closureRef(co, 0));
-Obj f = _35reg2347;
-Obj _35reg2348 = PRIM_CDR(closureRef(co, 0));
-Obj args = _35reg2348;
+Obj v0x7f1f2415b600 = makeNative(0, clofun7, 0, 0);
+Obj v0x7f1f24154880 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24154880) {
+Obj v0x7f1f24154a20 = PRIM_CAR(closureRef(co, 0));
+Obj f = v0x7f1f24154a20;
+Obj v0x7f1f24154bc0 = PRIM_CDR(closureRef(co, 0));
+Obj args = v0x7f1f24154bc0;
 Obj next = closureRef(co, 1);
-Obj _35reg2349 = makeCons(f, args);
+Obj v0x7f1f24154f20 = makeCons(f, args);
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35tailify_45list);
-__arg1 = _35reg2349;
+__arg1 = v0x7f1f24154f20;
 __arg2 = Nil;
 __arg3 = next;
 co->ctx.frees = __arg0;
@@ -9144,7 +9144,7 @@ if (ps.func != clofun6) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1553;
+__arg0 = v0x7f1f2415b600;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9188,10 +9188,10 @@ goto *jumpTable[ps.label];
 label1:
 {
 Obj x = __arg1;
-Obj _35reg2343 = makeCons(x, Nil);
-Obj _35reg2344 = makeCons(symreturn, _35reg2343);
+Obj v0x7f1f2415bba0 = makeCons(x, Nil);
+Obj v0x7f1f2415bc00 = makeCons(symreturn, v0x7f1f2415bba0);
 __nargs = 2;
-__arg1 = _35reg2344;
+__arg1 = v0x7f1f2415bc00;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -9199,12 +9199,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label2:
 {
-Obj _35p1538 = __arg1;
-Obj _35p1539 = __arg2;
-Obj _35cc1540 = makeNative(4, clofun7, 0, 2, _35p1538, _35p1539);
-Obj __ = _35p1538;
-Obj x = _35p1539;
-pushCont(co, 3, clofun7, 2, x, _35cc1540);
+Obj v0x7f1f2414d4c0 = __arg1;
+Obj v0x7f1f2414d4e0 = __arg2;
+Obj v0x7f1f2414d5a0 = makeNative(4, clofun7, 0, 2, v0x7f1f2414d4c0, v0x7f1f2414d4e0);
+Obj __ = v0x7f1f2414d4c0;
+Obj x = v0x7f1f2414d4e0;
+pushCont(co, 3, clofun7, 2, x, v0x7f1f2414d5a0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -9217,10 +9217,10 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj _35val2341 = __arg1;
+Obj v0x7f1f2415b440 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35cc1540= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val2341) {
+Obj v0x7f1f2414d5a0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == v0x7f1f2415b440) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -9228,7 +9228,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1540;
+__arg0 = v0x7f1f2414d5a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9239,11 +9239,11 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35cc1541 = makeNative(6, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f2414d700 = makeNative(6, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
 Obj var = closureRef(co, 1);
-Obj _35reg2336 = primIsSymbol(var);
-if (True == _35reg2336) {
+Obj v0x7f1f241618c0 = primIsSymbol(var);
+if (True == v0x7f1f241618c0) {
 pushCont(co, 5, clofun7, 1, var);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35index);
@@ -9256,7 +9256,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1541;
+__arg0 = v0x7f1f2414d700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9267,21 +9267,21 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35val2337 = __arg1;
+Obj v0x7f1f24161a20 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj pos = _35val2337;
-Obj _35reg2338 = PRIM_EQ(MAKE_NUMBER(-1), pos);
-if (True == _35reg2338) {
+Obj pos = v0x7f1f24161a20;
+Obj v0x7f1f24161d60 = PRIM_EQ(MAKE_NUMBER(-1), pos);
+if (True == v0x7f1f24161d60) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
-Obj _35reg2339 = makeCons(pos, Nil);
-Obj _35reg2340 = makeCons(sym_37closure_45ref, _35reg2339);
+Obj v0x7f1f2415b000 = makeCons(pos, Nil);
+Obj v0x7f1f2415b020 = makeCons(sym_37closure_45ref, v0x7f1f2415b000);
 __nargs = 2;
-__arg1 = _35reg2340;
+__arg1 = v0x7f1f2415b020;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -9290,39 +9290,39 @@ goto *jumpTable[co->ctx.pc.label];
 
 label6:
 {
-Obj _35cc1542 = makeNative(11, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f2414d880 = makeNative(11, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2307 = PRIM_ISCONS(closureRef(co, 1));
-if (True == _35reg2307) {
-Obj _35reg2308 = PRIM_CAR(closureRef(co, 1));
-Obj _35reg2309 = PRIM_EQ(symlambda, _35reg2308);
-if (True == _35reg2309) {
-Obj _35reg2310 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2311 = PRIM_ISCONS(_35reg2310);
-if (True == _35reg2311) {
-Obj _35reg2312 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2313 = PRIM_CAR(_35reg2312);
-Obj args = _35reg2313;
-Obj _35reg2314 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2315 = PRIM_CDR(_35reg2314);
-Obj _35reg2316 = PRIM_ISCONS(_35reg2315);
-if (True == _35reg2316) {
-Obj _35reg2317 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2318 = PRIM_CDR(_35reg2317);
-Obj _35reg2319 = PRIM_CAR(_35reg2318);
-Obj body = _35reg2319;
-Obj _35reg2320 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2321 = PRIM_CDR(_35reg2320);
-Obj _35reg2322 = PRIM_CDR(_35reg2321);
-Obj _35reg2323 = PRIM_EQ(Nil, _35reg2322);
-if (True == _35reg2323) {
-Obj _35reg2324 = makeCons(body, Nil);
-Obj _35reg2325 = makeCons(args, _35reg2324);
-Obj _35reg2326 = makeCons(symlambda, _35reg2325);
+Obj v0x7f1f2403dae0 = PRIM_ISCONS(closureRef(co, 1));
+if (True == v0x7f1f2403dae0) {
+Obj v0x7f1f2403dca0 = PRIM_CAR(closureRef(co, 1));
+Obj v0x7f1f2403dcc0 = PRIM_EQ(symlambda, v0x7f1f2403dca0);
+if (True == v0x7f1f2403dcc0) {
+Obj v0x7f1f2403de60 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f2403de80 = PRIM_ISCONS(v0x7f1f2403de60);
+if (True == v0x7f1f2403de80) {
+Obj v0x7f1f24035020 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24035040 = PRIM_CAR(v0x7f1f24035020);
+Obj args = v0x7f1f24035040;
+Obj v0x7f1f24035280 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f240352a0 = PRIM_CDR(v0x7f1f24035280);
+Obj v0x7f1f240352c0 = PRIM_ISCONS(v0x7f1f240352a0);
+if (True == v0x7f1f240352c0) {
+Obj v0x7f1f24035500 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24035520 = PRIM_CDR(v0x7f1f24035500);
+Obj v0x7f1f24035540 = PRIM_CAR(v0x7f1f24035520);
+Obj body = v0x7f1f24035540;
+Obj v0x7f1f24035840 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24035860 = PRIM_CDR(v0x7f1f24035840);
+Obj v0x7f1f24035880 = PRIM_CDR(v0x7f1f24035860);
+Obj v0x7f1f240358a0 = PRIM_EQ(Nil, v0x7f1f24035880);
+if (True == v0x7f1f240358a0) {
+Obj v0x7f1f24035be0 = makeCons(body, Nil);
+Obj v0x7f1f24035c00 = makeCons(args, v0x7f1f24035be0);
+Obj v0x7f1f24035c20 = makeCons(symlambda, v0x7f1f24035c00);
 pushCont(co, 7, clofun7, 3, body, args, fvs);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = _35reg2326;
+__arg1 = v0x7f1f24035c20;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9330,16 +9330,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1542;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1542;
+__arg0 = v0x7f1f2414d880;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9348,7 +9339,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1542;
+__arg0 = v0x7f1f2414d880;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9357,7 +9348,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1542;
+__arg0 = v0x7f1f2414d880;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9366,7 +9357,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1542;
+__arg0 = v0x7f1f2414d880;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = v0x7f1f2414d880;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9377,11 +9377,11 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35val2327 = __arg1;
+Obj v0x7f1f24035c40 = __arg1;
 Obj body= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj fvs1 = _35val2327;
+Obj fvs1 = v0x7f1f24035c40;
 pushCont(co, 8, clofun7, 3, args, fvs, fvs1);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
@@ -9396,14 +9396,14 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35val2328 = __arg1;
+Obj v0x7f1f240330a0 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-Obj _35reg2329 = makeCons(_35val2328, Nil);
-Obj _35reg2330 = makeCons(args, _35reg2329);
-Obj _35reg2331 = makeCons(symlambda, _35reg2330);
-pushCont(co, 9, clofun7, 2, fvs1, _35reg2331);
+Obj v0x7f1f240330e0 = makeCons(v0x7f1f240330a0, Nil);
+Obj v0x7f1f24033100 = makeCons(args, v0x7f1f240330e0);
+Obj v0x7f1f24033120 = makeCons(symlambda, v0x7f1f24033100);
+pushCont(co, 9, clofun7, 2, fvs1, v0x7f1f24033120);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
 __arg1 = fvs;
@@ -9416,13 +9416,13 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj _35val2332 = __arg1;
+Obj v0x7f1f240332a0 = __arg1;
 Obj fvs1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg2331= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 10, clofun7, 1, _35reg2331);
+Obj v0x7f1f24033120= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 10, clofun7, 1, v0x7f1f24033120);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = _35val2332;
+__arg1 = v0x7f1f240332a0;
 __arg2 = fvs1;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -9433,12 +9433,12 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj _35val2333 = __arg1;
-Obj _35reg2331= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg2334 = makeCons(_35reg2331, _35val2333);
-Obj _35reg2335 = makeCons(sym_37closure, _35reg2334);
+Obj v0x7f1f240332e0 = __arg1;
+Obj v0x7f1f24033120= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f24033300 = makeCons(v0x7f1f24033120, v0x7f1f240332e0);
+Obj v0x7f1f24033320 = makeCons(sym_37closure, v0x7f1f24033300);
 __nargs = 2;
-__arg1 = _35reg2335;
+__arg1 = v0x7f1f24033320;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -9446,43 +9446,43 @@ goto *jumpTable[co->ctx.pc.label];
 
 label11:
 {
-Obj _35cc1543 = makeNative(14, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f2414db40 = makeNative(14, clofun7, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj fvs = closureRef(co, 0);
-Obj _35reg2275 = PRIM_ISCONS(closureRef(co, 1));
-if (True == _35reg2275) {
-Obj _35reg2276 = PRIM_CAR(closureRef(co, 1));
-Obj _35reg2277 = PRIM_EQ(symlet, _35reg2276);
-if (True == _35reg2277) {
-Obj _35reg2278 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2279 = PRIM_ISCONS(_35reg2278);
-if (True == _35reg2279) {
-Obj _35reg2280 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2281 = PRIM_CAR(_35reg2280);
-Obj a = _35reg2281;
-Obj _35reg2282 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2283 = PRIM_CDR(_35reg2282);
-Obj _35reg2284 = PRIM_ISCONS(_35reg2283);
-if (True == _35reg2284) {
-Obj _35reg2285 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2286 = PRIM_CDR(_35reg2285);
-Obj _35reg2287 = PRIM_CAR(_35reg2286);
-Obj b = _35reg2287;
-Obj _35reg2288 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2289 = PRIM_CDR(_35reg2288);
-Obj _35reg2290 = PRIM_CDR(_35reg2289);
-Obj _35reg2291 = PRIM_ISCONS(_35reg2290);
-if (True == _35reg2291) {
-Obj _35reg2292 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2293 = PRIM_CDR(_35reg2292);
-Obj _35reg2294 = PRIM_CDR(_35reg2293);
-Obj _35reg2295 = PRIM_CAR(_35reg2294);
-Obj c = _35reg2295;
-Obj _35reg2296 = PRIM_CDR(closureRef(co, 1));
-Obj _35reg2297 = PRIM_CDR(_35reg2296);
-Obj _35reg2298 = PRIM_CDR(_35reg2297);
-Obj _35reg2299 = PRIM_CDR(_35reg2298);
-Obj _35reg2300 = PRIM_EQ(Nil, _35reg2299);
-if (True == _35reg2300) {
+Obj v0x7f1f240486c0 = PRIM_ISCONS(closureRef(co, 1));
+if (True == v0x7f1f240486c0) {
+Obj v0x7f1f24048e20 = PRIM_CAR(closureRef(co, 1));
+Obj v0x7f1f24048e40 = PRIM_EQ(symlet, v0x7f1f24048e20);
+if (True == v0x7f1f24048e40) {
+Obj v0x7f1f24048fe0 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24043000 = PRIM_ISCONS(v0x7f1f24048fe0);
+if (True == v0x7f1f24043000) {
+Obj v0x7f1f240431a0 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f240431c0 = PRIM_CAR(v0x7f1f240431a0);
+Obj a = v0x7f1f240431c0;
+Obj v0x7f1f24043400 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24043420 = PRIM_CDR(v0x7f1f24043400);
+Obj v0x7f1f24043440 = PRIM_ISCONS(v0x7f1f24043420);
+if (True == v0x7f1f24043440) {
+Obj v0x7f1f24043680 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f240436a0 = PRIM_CDR(v0x7f1f24043680);
+Obj v0x7f1f240436c0 = PRIM_CAR(v0x7f1f240436a0);
+Obj b = v0x7f1f240436c0;
+Obj v0x7f1f240439a0 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f240439c0 = PRIM_CDR(v0x7f1f240439a0);
+Obj v0x7f1f240439e0 = PRIM_CDR(v0x7f1f240439c0);
+Obj v0x7f1f24043a00 = PRIM_ISCONS(v0x7f1f240439e0);
+if (True == v0x7f1f24043a00) {
+Obj v0x7f1f24043ce0 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f24043d00 = PRIM_CDR(v0x7f1f24043ce0);
+Obj v0x7f1f24043d20 = PRIM_CDR(v0x7f1f24043d00);
+Obj v0x7f1f24043d40 = PRIM_CAR(v0x7f1f24043d20);
+Obj c = v0x7f1f24043d40;
+Obj v0x7f1f2403d0e0 = PRIM_CDR(closureRef(co, 1));
+Obj v0x7f1f2403d100 = PRIM_CDR(v0x7f1f2403d0e0);
+Obj v0x7f1f2403d120 = PRIM_CDR(v0x7f1f2403d100);
+Obj v0x7f1f2403d140 = PRIM_CDR(v0x7f1f2403d120);
+Obj v0x7f1f2403d160 = PRIM_EQ(Nil, v0x7f1f2403d140);
+if (True == v0x7f1f2403d160) {
 pushCont(co, 12, clofun7, 3, fvs, c, a);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
@@ -9495,7 +9495,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1543;
+__arg0 = v0x7f1f2414db40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9504,7 +9504,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1543;
+__arg0 = v0x7f1f2414db40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9513,7 +9513,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1543;
+__arg0 = v0x7f1f2414db40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9522,7 +9522,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1543;
+__arg0 = v0x7f1f2414db40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9531,7 +9531,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1543;
+__arg0 = v0x7f1f2414db40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9540,7 +9540,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1543;
+__arg0 = v0x7f1f2414db40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9551,11 +9551,11 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj _35val2301 = __arg1;
+Obj v0x7f1f2403d460 = __arg1;
 Obj fvs= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-pushCont(co, 13, clofun7, 2, _35val2301, a);
+pushCont(co, 13, clofun7, 2, v0x7f1f2403d460, a);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
 __arg1 = fvs;
@@ -9569,15 +9569,15 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35val2302 = __arg1;
-Obj _35val2301= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f2403d600 = __arg1;
+Obj v0x7f1f2403d460= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2303 = makeCons(_35val2302, Nil);
-Obj _35reg2304 = makeCons(_35val2301, _35reg2303);
-Obj _35reg2305 = makeCons(a, _35reg2304);
-Obj _35reg2306 = makeCons(symlet, _35reg2305);
+Obj v0x7f1f2403d640 = makeCons(v0x7f1f2403d600, Nil);
+Obj v0x7f1f2403d660 = makeCons(v0x7f1f2403d460, v0x7f1f2403d640);
+Obj v0x7f1f2403d680 = makeCons(a, v0x7f1f2403d660);
+Obj v0x7f1f2403d6a0 = makeCons(symlet, v0x7f1f2403d680);
 __nargs = 2;
-__arg1 = _35reg2306;
+__arg1 = v0x7f1f2403d6a0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -9585,14 +9585,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label14:
 {
-Obj _35cc1544 = makeNative(16, clofun7, 0, 0);
+Obj v0x7f1f2414dea0 = makeNative(16, clofun7, 0, 0);
 Obj fvs = closureRef(co, 0);
-Obj _35reg2270 = PRIM_ISCONS(closureRef(co, 1));
-if (True == _35reg2270) {
-Obj _35reg2271 = PRIM_CAR(closureRef(co, 1));
-Obj f = _35reg2271;
-Obj _35reg2272 = PRIM_CDR(closureRef(co, 1));
-Obj args = _35reg2272;
+Obj v0x7f1f24048060 = PRIM_ISCONS(closureRef(co, 1));
+if (True == v0x7f1f24048060) {
+Obj v0x7f1f24048180 = PRIM_CAR(closureRef(co, 1));
+Obj f = v0x7f1f24048180;
+Obj v0x7f1f240482a0 = PRIM_CDR(closureRef(co, 1));
+Obj args = v0x7f1f240482a0;
 pushCont(co, 15, clofun7, 2, f, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35closure_45convert);
@@ -9604,7 +9604,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1544;
+__arg0 = v0x7f1f2414dea0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9615,14 +9615,14 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj _35val2273 = __arg1;
+Obj v0x7f1f24048400 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2274 = makeCons(f, args);
+Obj v0x7f1f24048500 = makeCons(f, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = _35val2273;
-__arg2 = _35reg2274;
+__arg1 = v0x7f1f24048400;
+__arg2 = v0x7f1f24048500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9644,10 +9644,10 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj _35p1525 = __arg1;
-Obj _35cc1526 = makeNative(19, clofun7, 0, 1, _35p1525);
-Obj x = _35p1525;
-pushCont(co, 18, clofun7, 1, _35cc1526);
+Obj v0x7f1f2415bb40 = __arg1;
+Obj v0x7f1f2415bbc0 = makeNative(19, clofun7, 0, 1, v0x7f1f2415bb40);
+Obj x = v0x7f1f2415bb40;
+pushCont(co, 18, clofun7, 1, v0x7f1f2415bbc0);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35convert_45protect_63);
 __arg1 = x;
@@ -9660,9 +9660,9 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35val2268 = __arg1;
-Obj _35cc1526= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == _35val2268) {
+Obj v0x7f1f2404d9a0 = __arg1;
+Obj v0x7f1f2415bbc0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+if (True == v0x7f1f2404d9a0) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -9670,7 +9670,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1526;
+__arg0 = v0x7f1f2415bbc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9681,19 +9681,19 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj _35cc1527 = makeNative(20, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f2415bca0 = makeNative(20, clofun7, 0, 1, closureRef(co, 0));
 Obj x = closureRef(co, 0);
-Obj _35reg2266 = primIsSymbol(x);
-if (True == _35reg2266) {
-Obj _35reg2267 = makeCons(x, Nil);
+Obj v0x7f1f2404d6a0 = primIsSymbol(x);
+if (True == v0x7f1f2404d6a0) {
+Obj v0x7f1f2404d7a0 = makeCons(x, Nil);
 __nargs = 2;
-__arg1 = _35reg2267;
+__arg1 = v0x7f1f2404d7a0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1527;
+__arg0 = v0x7f1f2415bca0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9704,31 +9704,31 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj _35cc1528 = makeNative(22, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2248 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2248) {
-Obj _35reg2249 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2250 = PRIM_EQ(symlambda, _35reg2249);
-if (True == _35reg2250) {
-Obj _35reg2251 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2252 = PRIM_ISCONS(_35reg2251);
-if (True == _35reg2252) {
-Obj _35reg2253 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2254 = PRIM_CAR(_35reg2253);
-Obj args = _35reg2254;
-Obj _35reg2255 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2256 = PRIM_CDR(_35reg2255);
-Obj _35reg2257 = PRIM_ISCONS(_35reg2256);
-if (True == _35reg2257) {
-Obj _35reg2258 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2259 = PRIM_CDR(_35reg2258);
-Obj _35reg2260 = PRIM_CAR(_35reg2259);
-Obj body = _35reg2260;
-Obj _35reg2261 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2262 = PRIM_CDR(_35reg2261);
-Obj _35reg2263 = PRIM_CDR(_35reg2262);
-Obj _35reg2264 = PRIM_EQ(Nil, _35reg2263);
-if (True == _35reg2264) {
+Obj v0x7f1f2415bd80 = makeNative(22, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f2404f120 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2404f120) {
+Obj v0x7f1f2404f320 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2404f340 = PRIM_EQ(symlambda, v0x7f1f2404f320);
+if (True == v0x7f1f2404f340) {
+Obj v0x7f1f2404f520 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2404f540 = PRIM_ISCONS(v0x7f1f2404f520);
+if (True == v0x7f1f2404f540) {
+Obj v0x7f1f2404f720 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2404f740 = PRIM_CAR(v0x7f1f2404f720);
+Obj args = v0x7f1f2404f740;
+Obj v0x7f1f2404fa40 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2404fa60 = PRIM_CDR(v0x7f1f2404fa40);
+Obj v0x7f1f2404fa80 = PRIM_ISCONS(v0x7f1f2404fa60);
+if (True == v0x7f1f2404fa80) {
+Obj v0x7f1f2404fd00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2404fd40 = PRIM_CDR(v0x7f1f2404fd00);
+Obj v0x7f1f2404fd60 = PRIM_CAR(v0x7f1f2404fd40);
+Obj body = v0x7f1f2404fd60;
+Obj v0x7f1f2404d0a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2404d0e0 = PRIM_CDR(v0x7f1f2404d0a0);
+Obj v0x7f1f2404d100 = PRIM_CDR(v0x7f1f2404d0e0);
+Obj v0x7f1f2404d120 = PRIM_EQ(Nil, v0x7f1f2404d100);
+if (True == v0x7f1f2404d120) {
 pushCont(co, 21, clofun7, 1, args);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
@@ -9740,7 +9740,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1528;
+__arg0 = v0x7f1f2415bd80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9749,7 +9749,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1528;
+__arg0 = v0x7f1f2415bd80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9758,7 +9758,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1528;
+__arg0 = v0x7f1f2415bd80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9767,7 +9767,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1528;
+__arg0 = v0x7f1f2415bd80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9776,7 +9776,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1528;
+__arg0 = v0x7f1f2415bd80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9787,11 +9787,11 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj _35val2265 = __arg1;
+Obj v0x7f1f2404d280 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = _35val2265;
+__arg1 = v0x7f1f2404d280;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -9802,50 +9802,50 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj _35cc1529 = makeNative(24, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2218 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2218) {
-Obj _35reg2219 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2220 = PRIM_EQ(symif, _35reg2219);
-if (True == _35reg2220) {
-Obj _35reg2221 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2222 = PRIM_ISCONS(_35reg2221);
-if (True == _35reg2222) {
-Obj _35reg2223 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2224 = PRIM_CAR(_35reg2223);
-Obj x = _35reg2224;
-Obj _35reg2225 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2226 = PRIM_CDR(_35reg2225);
-Obj _35reg2227 = PRIM_ISCONS(_35reg2226);
-if (True == _35reg2227) {
-Obj _35reg2228 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2229 = PRIM_CDR(_35reg2228);
-Obj _35reg2230 = PRIM_CAR(_35reg2229);
-Obj y = _35reg2230;
-Obj _35reg2231 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2232 = PRIM_CDR(_35reg2231);
-Obj _35reg2233 = PRIM_CDR(_35reg2232);
-Obj _35reg2234 = PRIM_ISCONS(_35reg2233);
-if (True == _35reg2234) {
-Obj _35reg2235 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2236 = PRIM_CDR(_35reg2235);
-Obj _35reg2237 = PRIM_CDR(_35reg2236);
-Obj _35reg2238 = PRIM_CAR(_35reg2237);
-Obj z = _35reg2238;
-Obj _35reg2239 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2240 = PRIM_CDR(_35reg2239);
-Obj _35reg2241 = PRIM_CDR(_35reg2240);
-Obj _35reg2242 = PRIM_CDR(_35reg2241);
-Obj _35reg2243 = PRIM_EQ(Nil, _35reg2242);
-if (True == _35reg2243) {
-Obj _35reg2244 = makeCons(z, Nil);
-Obj _35reg2245 = makeCons(y, _35reg2244);
-Obj _35reg2246 = makeCons(x, _35reg2245);
+Obj v0x7f1f2415bfe0 = makeNative(24, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f24072dc0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24072dc0) {
+Obj v0x7f1f2406b040 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2406b060 = PRIM_EQ(symif, v0x7f1f2406b040);
+if (True == v0x7f1f2406b060) {
+Obj v0x7f1f2406b260 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2406b280 = PRIM_ISCONS(v0x7f1f2406b260);
+if (True == v0x7f1f2406b280) {
+Obj v0x7f1f2406b440 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2406b4c0 = PRIM_CAR(v0x7f1f2406b440);
+Obj x = v0x7f1f2406b4c0;
+Obj v0x7f1f2406b7a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2406b7c0 = PRIM_CDR(v0x7f1f2406b7a0);
+Obj v0x7f1f2406b820 = PRIM_ISCONS(v0x7f1f2406b7c0);
+if (True == v0x7f1f2406b820) {
+Obj v0x7f1f2406ba60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2406baa0 = PRIM_CDR(v0x7f1f2406ba60);
+Obj v0x7f1f2406bac0 = PRIM_CAR(v0x7f1f2406baa0);
+Obj y = v0x7f1f2406bac0;
+Obj v0x7f1f2406be00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2406be20 = PRIM_CDR(v0x7f1f2406be00);
+Obj v0x7f1f2406be40 = PRIM_CDR(v0x7f1f2406be20);
+Obj v0x7f1f2406be60 = PRIM_ISCONS(v0x7f1f2406be40);
+if (True == v0x7f1f2406be60) {
+Obj v0x7f1f24069220 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24069280 = PRIM_CDR(v0x7f1f24069220);
+Obj v0x7f1f240692a0 = PRIM_CDR(v0x7f1f24069280);
+Obj v0x7f1f240692c0 = PRIM_CAR(v0x7f1f240692a0);
+Obj z = v0x7f1f240692c0;
+Obj v0x7f1f24069740 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24069760 = PRIM_CDR(v0x7f1f24069740);
+Obj v0x7f1f24069780 = PRIM_CDR(v0x7f1f24069760);
+Obj v0x7f1f240697c0 = PRIM_CDR(v0x7f1f24069780);
+Obj v0x7f1f24069800 = PRIM_EQ(Nil, v0x7f1f240697c0);
+if (True == v0x7f1f24069800) {
+Obj v0x7f1f24069ca0 = makeCons(z, Nil);
+Obj v0x7f1f24069cc0 = makeCons(y, v0x7f1f24069ca0);
+Obj v0x7f1f24069ce0 = makeCons(x, v0x7f1f24069cc0);
 PUSH_CONT_0(co, 23, clofun7);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = _35reg2246;
+__arg2 = v0x7f1f24069ce0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9853,16 +9853,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1529;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1529;
+__arg0 = v0x7f1f2415bfe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9871,7 +9862,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1529;
+__arg0 = v0x7f1f2415bfe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9880,7 +9871,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1529;
+__arg0 = v0x7f1f2415bfe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9889,7 +9880,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1529;
+__arg0 = v0x7f1f2415bfe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9898,7 +9889,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1529;
+__arg0 = v0x7f1f2415bfe0;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = v0x7f1f2415bfe0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9909,12 +9909,12 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj _35val2247 = __arg1;
+Obj v0x7f1f24069d00 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = globalRef(symcora_47lib_47toc_35union);
 __arg2 = Nil;
-__arg3 = _35val2247;
+__arg3 = v0x7f1f24069d00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9924,38 +9924,38 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj _35cc1530 = makeNative(26, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2198 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2198) {
-Obj _35reg2199 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2200 = PRIM_EQ(symdo, _35reg2199);
-if (True == _35reg2200) {
-Obj _35reg2201 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2202 = PRIM_ISCONS(_35reg2201);
-if (True == _35reg2202) {
-Obj _35reg2203 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2204 = PRIM_CAR(_35reg2203);
-Obj x = _35reg2204;
-Obj _35reg2205 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2206 = PRIM_CDR(_35reg2205);
-Obj _35reg2207 = PRIM_ISCONS(_35reg2206);
-if (True == _35reg2207) {
-Obj _35reg2208 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2209 = PRIM_CDR(_35reg2208);
-Obj _35reg2210 = PRIM_CAR(_35reg2209);
-Obj y = _35reg2210;
-Obj _35reg2211 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2212 = PRIM_CDR(_35reg2211);
-Obj _35reg2213 = PRIM_CDR(_35reg2212);
-Obj _35reg2214 = PRIM_EQ(Nil, _35reg2213);
-if (True == _35reg2214) {
-Obj _35reg2215 = makeCons(y, Nil);
-Obj _35reg2216 = makeCons(x, _35reg2215);
+Obj v0x7f1f241542c0 = makeNative(26, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f240f6200 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f240f6200) {
+Obj v0x7f1f240f6420 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f240f6440 = PRIM_EQ(symdo, v0x7f1f240f6420);
+if (True == v0x7f1f240f6440) {
+Obj v0x7f1f240f66c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f66e0 = PRIM_ISCONS(v0x7f1f240f66c0);
+if (True == v0x7f1f240f66e0) {
+Obj v0x7f1f240f6b20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f6b40 = PRIM_CAR(v0x7f1f240f6b20);
+Obj x = v0x7f1f240f6b40;
+Obj v0x7f1f240f6e20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f6ec0 = PRIM_CDR(v0x7f1f240f6e20);
+Obj v0x7f1f240f6ee0 = PRIM_ISCONS(v0x7f1f240f6ec0);
+if (True == v0x7f1f240f6ee0) {
+Obj v0x7f1f24072140 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24072160 = PRIM_CDR(v0x7f1f24072140);
+Obj v0x7f1f24072180 = PRIM_CAR(v0x7f1f24072160);
+Obj y = v0x7f1f24072180;
+Obj v0x7f1f24072500 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24072540 = PRIM_CDR(v0x7f1f24072500);
+Obj v0x7f1f24072560 = PRIM_CDR(v0x7f1f24072540);
+Obj v0x7f1f24072580 = PRIM_EQ(Nil, v0x7f1f24072560);
+if (True == v0x7f1f24072580) {
+Obj v0x7f1f24072980 = makeCons(y, Nil);
+Obj v0x7f1f240729a0 = makeCons(x, v0x7f1f24072980);
 PUSH_CONT_0(co, 25, clofun7);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = _35reg2216;
+__arg2 = v0x7f1f240729a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9963,16 +9963,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1530;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1530;
+__arg0 = v0x7f1f241542c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9981,7 +9972,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1530;
+__arg0 = v0x7f1f241542c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9990,7 +9981,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1530;
+__arg0 = v0x7f1f241542c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -9999,7 +9990,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1530;
+__arg0 = v0x7f1f241542c0;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = v0x7f1f241542c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10010,12 +10010,12 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj _35val2217 = __arg1;
+Obj v0x7f1f240729c0 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = globalRef(symcora_47lib_47toc_35union);
 __arg2 = Nil;
-__arg3 = _35val2217;
+__arg3 = v0x7f1f240729c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10025,42 +10025,42 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35cc1531 = makeNative(30, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2168 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2168) {
-Obj _35reg2169 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2170 = PRIM_EQ(symlet, _35reg2169);
-if (True == _35reg2170) {
-Obj _35reg2171 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2172 = PRIM_ISCONS(_35reg2171);
-if (True == _35reg2172) {
-Obj _35reg2173 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2174 = PRIM_CAR(_35reg2173);
-Obj a = _35reg2174;
-Obj _35reg2175 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2176 = PRIM_CDR(_35reg2175);
-Obj _35reg2177 = PRIM_ISCONS(_35reg2176);
-if (True == _35reg2177) {
-Obj _35reg2178 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2179 = PRIM_CDR(_35reg2178);
-Obj _35reg2180 = PRIM_CAR(_35reg2179);
-Obj b = _35reg2180;
-Obj _35reg2181 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2182 = PRIM_CDR(_35reg2181);
-Obj _35reg2183 = PRIM_CDR(_35reg2182);
-Obj _35reg2184 = PRIM_ISCONS(_35reg2183);
-if (True == _35reg2184) {
-Obj _35reg2185 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2186 = PRIM_CDR(_35reg2185);
-Obj _35reg2187 = PRIM_CDR(_35reg2186);
-Obj _35reg2188 = PRIM_CAR(_35reg2187);
-Obj c = _35reg2188;
-Obj _35reg2189 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2190 = PRIM_CDR(_35reg2189);
-Obj _35reg2191 = PRIM_CDR(_35reg2190);
-Obj _35reg2192 = PRIM_CDR(_35reg2191);
-Obj _35reg2193 = PRIM_EQ(Nil, _35reg2192);
-if (True == _35reg2193) {
+Obj v0x7f1f24154500 = makeNative(30, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f24128c80 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24128c80) {
+Obj v0x7f1f24128ea0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f24128ec0 = PRIM_EQ(symlet, v0x7f1f24128ea0);
+if (True == v0x7f1f24128ec0) {
+Obj v0x7f1f240f9160 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f9180 = PRIM_ISCONS(v0x7f1f240f9160);
+if (True == v0x7f1f240f9180) {
+Obj v0x7f1f240f93a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f93c0 = PRIM_CAR(v0x7f1f240f93a0);
+Obj a = v0x7f1f240f93c0;
+Obj v0x7f1f240f9760 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f9780 = PRIM_CDR(v0x7f1f240f9760);
+Obj v0x7f1f240f97a0 = PRIM_ISCONS(v0x7f1f240f9780);
+if (True == v0x7f1f240f97a0) {
+Obj v0x7f1f240f9a60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f9a80 = PRIM_CDR(v0x7f1f240f9a60);
+Obj v0x7f1f240f9aa0 = PRIM_CAR(v0x7f1f240f9a80);
+Obj b = v0x7f1f240f9aa0;
+Obj v0x7f1f240f9e00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f9e20 = PRIM_CDR(v0x7f1f240f9e00);
+Obj v0x7f1f240f9e40 = PRIM_CDR(v0x7f1f240f9e20);
+Obj v0x7f1f240f9e60 = PRIM_ISCONS(v0x7f1f240f9e40);
+if (True == v0x7f1f240f9e60) {
+Obj v0x7f1f240f8200 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f8220 = PRIM_CDR(v0x7f1f240f8200);
+Obj v0x7f1f240f8240 = PRIM_CDR(v0x7f1f240f8220);
+Obj v0x7f1f240f8260 = PRIM_CAR(v0x7f1f240f8240);
+Obj c = v0x7f1f240f8260;
+Obj v0x7f1f240f86c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f240f86e0 = PRIM_CDR(v0x7f1f240f86c0);
+Obj v0x7f1f240f8720 = PRIM_CDR(v0x7f1f240f86e0);
+Obj v0x7f1f240f8740 = PRIM_CDR(v0x7f1f240f8720);
+Obj v0x7f1f240f87c0 = PRIM_EQ(Nil, v0x7f1f240f8740);
+if (True == v0x7f1f240f87c0) {
 pushCont(co, 27, clofun7, 2, c, a);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
@@ -10072,7 +10072,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1531;
+__arg0 = v0x7f1f24154500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10081,7 +10081,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1531;
+__arg0 = v0x7f1f24154500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10090,7 +10090,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1531;
+__arg0 = v0x7f1f24154500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10099,7 +10099,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1531;
+__arg0 = v0x7f1f24154500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10108,7 +10108,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1531;
+__arg0 = v0x7f1f24154500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10117,7 +10117,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1531;
+__arg0 = v0x7f1f24154500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10128,10 +10128,10 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj _35val2194 = __arg1;
+Obj v0x7f1f240f8960 = __arg1;
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 28, clofun7, 2, a, _35val2194);
+pushCont(co, 28, clofun7, 2, a, v0x7f1f240f8960);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
 __arg1 = c;
@@ -10144,15 +10144,15 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj _35val2195 = __arg1;
+Obj v0x7f1f240f8b80 = __arg1;
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35val2194= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg2196 = makeCons(a, Nil);
-pushCont(co, 29, clofun7, 1, _35val2194);
+Obj v0x7f1f240f8960= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f240f8c80 = makeCons(a, Nil);
+pushCont(co, 29, clofun7, 1, v0x7f1f240f8960);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = _35val2195;
-__arg2 = _35reg2196;
+__arg1 = v0x7f1f240f8b80;
+__arg2 = v0x7f1f240f8c80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10162,12 +10162,12 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj _35val2197 = __arg1;
-Obj _35val2194= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f240f8ca0 = __arg1;
+Obj v0x7f1f240f8960= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35union);
-__arg1 = _35val2194;
-__arg2 = _35val2197;
+__arg1 = v0x7f1f240f8960;
+__arg2 = v0x7f1f240f8ca0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10177,25 +10177,25 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj _35cc1532 = makeNative(31, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2158 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2158) {
-Obj _35reg2159 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2160 = PRIM_EQ(sym_37closure, _35reg2159);
-if (True == _35reg2160) {
-Obj _35reg2161 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2162 = PRIM_ISCONS(_35reg2161);
-if (True == _35reg2162) {
-Obj _35reg2163 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2164 = PRIM_CAR(_35reg2163);
-Obj lam = _35reg2164;
-Obj _35reg2165 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2166 = PRIM_CDR(_35reg2165);
-Obj more = _35reg2166;
-Obj _35reg2167 = makeCons(lam, more);
+Obj v0x7f1f241547e0 = makeNative(31, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f2412cca0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2412cca0) {
+Obj v0x7f1f2412ce60 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2412ce80 = PRIM_EQ(sym_37closure, v0x7f1f2412ce60);
+if (True == v0x7f1f2412ce80) {
+Obj v0x7f1f24128180 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f241281a0 = PRIM_ISCONS(v0x7f1f24128180);
+if (True == v0x7f1f241281a0) {
+Obj v0x7f1f24128440 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24128460 = PRIM_CAR(v0x7f1f24128440);
+Obj lam = v0x7f1f24128460;
+Obj v0x7f1f24128660 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24128680 = PRIM_CDR(v0x7f1f24128660);
+Obj more = v0x7f1f24128680;
+Obj v0x7f1f241288e0 = makeCons(lam, more);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg1 = _35reg2167;
+__arg1 = v0x7f1f241288e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10203,16 +10203,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1532;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1532;
+__arg0 = v0x7f1f241547e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10221,7 +10212,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1532;
+__arg0 = v0x7f1f241547e0;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = v0x7f1f241547e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10232,22 +10232,22 @@ goto *jumpTable[ps.label];
 
 label31:
 {
-Obj _35cc1533 = makeNative(32, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2148 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2148) {
-Obj _35reg2149 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2150 = PRIM_EQ(symreturn, _35reg2149);
-if (True == _35reg2150) {
-Obj _35reg2151 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2152 = PRIM_ISCONS(_35reg2151);
-if (True == _35reg2152) {
-Obj _35reg2153 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2154 = PRIM_CAR(_35reg2153);
-Obj x = _35reg2154;
-Obj _35reg2155 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2156 = PRIM_CDR(_35reg2155);
-Obj _35reg2157 = PRIM_EQ(Nil, _35reg2156);
-if (True == _35reg2157) {
+Obj v0x7f1f241549a0 = makeNative(32, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f2412fb00 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2412fb00) {
+Obj v0x7f1f2412fce0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2412fd00 = PRIM_EQ(symreturn, v0x7f1f2412fce0);
+if (True == v0x7f1f2412fd00) {
+Obj v0x7f1f2412ff20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2412ff40 = PRIM_ISCONS(v0x7f1f2412ff20);
+if (True == v0x7f1f2412ff40) {
+Obj v0x7f1f2412c160 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2412c1a0 = PRIM_CAR(v0x7f1f2412c160);
+Obj x = v0x7f1f2412c1a0;
+Obj v0x7f1f2412c7c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2412c7e0 = PRIM_CDR(v0x7f1f2412c7c0);
+Obj v0x7f1f2412c800 = PRIM_EQ(Nil, v0x7f1f2412c7e0);
+if (True == v0x7f1f2412c800) {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
 __arg1 = x;
@@ -10258,7 +10258,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1533;
+__arg0 = v0x7f1f241549a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10267,7 +10267,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1533;
+__arg0 = v0x7f1f241549a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10276,7 +10276,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1533;
+__arg0 = v0x7f1f241549a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10285,7 +10285,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1533;
+__arg0 = v0x7f1f241549a0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10296,38 +10296,38 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj _35cc1534 = makeNative(34, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2128 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2128) {
-Obj _35reg2129 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2130 = PRIM_EQ(symcall, _35reg2129);
-if (True == _35reg2130) {
-Obj _35reg2131 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2132 = PRIM_ISCONS(_35reg2131);
-if (True == _35reg2132) {
-Obj _35reg2133 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2134 = PRIM_CAR(_35reg2133);
-Obj exp = _35reg2134;
-Obj _35reg2135 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2136 = PRIM_CDR(_35reg2135);
-Obj _35reg2137 = PRIM_ISCONS(_35reg2136);
-if (True == _35reg2137) {
-Obj _35reg2138 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2139 = PRIM_CDR(_35reg2138);
-Obj _35reg2140 = PRIM_CAR(_35reg2139);
-Obj cont = _35reg2140;
-Obj _35reg2141 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2142 = PRIM_CDR(_35reg2141);
-Obj _35reg2143 = PRIM_CDR(_35reg2142);
-Obj _35reg2144 = PRIM_EQ(Nil, _35reg2143);
-if (True == _35reg2144) {
-Obj _35reg2145 = makeCons(cont, Nil);
-Obj _35reg2146 = makeCons(exp, _35reg2145);
+Obj v0x7f1f24154b80 = makeNative(34, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f24133160 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24133160) {
+Obj v0x7f1f241333c0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f241333e0 = PRIM_EQ(symcall, v0x7f1f241333c0);
+if (True == v0x7f1f241333e0) {
+Obj v0x7f1f241335c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f241335e0 = PRIM_ISCONS(v0x7f1f241335c0);
+if (True == v0x7f1f241335e0) {
+Obj v0x7f1f24133800 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24133820 = PRIM_CAR(v0x7f1f24133800);
+Obj exp = v0x7f1f24133820;
+Obj v0x7f1f24133b00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24133b20 = PRIM_CDR(v0x7f1f24133b00);
+Obj v0x7f1f24133b40 = PRIM_ISCONS(v0x7f1f24133b20);
+if (True == v0x7f1f24133b40) {
+Obj v0x7f1f24133e00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24133e20 = PRIM_CDR(v0x7f1f24133e00);
+Obj v0x7f1f24133e40 = PRIM_CAR(v0x7f1f24133e20);
+Obj cont = v0x7f1f24133e40;
+Obj v0x7f1f2412f240 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2412f260 = PRIM_CDR(v0x7f1f2412f240);
+Obj v0x7f1f2412f2a0 = PRIM_CDR(v0x7f1f2412f260);
+Obj v0x7f1f2412f2c0 = PRIM_EQ(Nil, v0x7f1f2412f2a0);
+if (True == v0x7f1f2412f2c0) {
+Obj v0x7f1f2412f640 = makeCons(cont, Nil);
+Obj v0x7f1f2412f660 = makeCons(exp, v0x7f1f2412f640);
 PUSH_CONT_0(co, 33, clofun7);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = _35reg2146;
+__arg2 = v0x7f1f2412f660;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10335,16 +10335,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1534;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1534;
+__arg0 = v0x7f1f24154b80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10353,7 +10344,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1534;
+__arg0 = v0x7f1f24154b80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10362,7 +10353,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1534;
+__arg0 = v0x7f1f24154b80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10371,7 +10362,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1534;
+__arg0 = v0x7f1f24154b80;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = v0x7f1f24154b80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10382,12 +10382,12 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj _35val2147 = __arg1;
+Obj v0x7f1f2412f680 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = globalRef(symcora_47lib_47toc_35union);
 __arg2 = Nil;
-__arg3 = _35val2147;
+__arg3 = v0x7f1f2412f680;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10397,22 +10397,22 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj _35cc1535 = makeNative(35, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2118 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2118) {
-Obj _35reg2119 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2120 = PRIM_EQ(symtailcall, _35reg2119);
-if (True == _35reg2120) {
-Obj _35reg2121 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2122 = PRIM_ISCONS(_35reg2121);
-if (True == _35reg2122) {
-Obj _35reg2123 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2124 = PRIM_CAR(_35reg2123);
-Obj exp = _35reg2124;
-Obj _35reg2125 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2126 = PRIM_CDR(_35reg2125);
-Obj _35reg2127 = PRIM_EQ(Nil, _35reg2126);
-if (True == _35reg2127) {
+Obj v0x7f1f24154dc0 = makeNative(35, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f24135300 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24135300) {
+Obj v0x7f1f24135500 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f24135560 = PRIM_EQ(symtailcall, v0x7f1f24135500);
+if (True == v0x7f1f24135560) {
+Obj v0x7f1f24135760 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f241357a0 = PRIM_ISCONS(v0x7f1f24135760);
+if (True == v0x7f1f241357a0) {
+Obj v0x7f1f24135a20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24135a40 = PRIM_CAR(v0x7f1f24135a20);
+Obj exp = v0x7f1f24135a40;
+Obj v0x7f1f24135ce0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24135d00 = PRIM_CDR(v0x7f1f24135ce0);
+Obj v0x7f1f24135d20 = PRIM_EQ(Nil, v0x7f1f24135d00);
+if (True == v0x7f1f24135d20) {
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
 __arg1 = exp;
@@ -10423,7 +10423,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1535;
+__arg0 = v0x7f1f24154dc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10432,7 +10432,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1535;
+__arg0 = v0x7f1f24154dc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10441,7 +10441,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1535;
+__arg0 = v0x7f1f24154dc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10450,7 +10450,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1535;
+__arg0 = v0x7f1f24154dc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10461,31 +10461,31 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj _35cc1536 = makeNative(37, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2100 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2100) {
-Obj _35reg2101 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2102 = PRIM_EQ(symcontinuation, _35reg2101);
-if (True == _35reg2102) {
-Obj _35reg2103 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2104 = PRIM_ISCONS(_35reg2103);
-if (True == _35reg2104) {
-Obj _35reg2105 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2106 = PRIM_CAR(_35reg2105);
-Obj arg = _35reg2106;
-Obj _35reg2107 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2108 = PRIM_CDR(_35reg2107);
-Obj _35reg2109 = PRIM_ISCONS(_35reg2108);
-if (True == _35reg2109) {
-Obj _35reg2110 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2111 = PRIM_CDR(_35reg2110);
-Obj _35reg2112 = PRIM_CAR(_35reg2111);
-Obj body = _35reg2112;
-Obj _35reg2113 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2114 = PRIM_CDR(_35reg2113);
-Obj _35reg2115 = PRIM_CDR(_35reg2114);
-Obj _35reg2116 = PRIM_EQ(Nil, _35reg2115);
-if (True == _35reg2116) {
+Obj v0x7f1f24154fa0 = makeNative(37, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f2413fc20 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2413fc20) {
+Obj v0x7f1f2413fe60 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2413fe80 = PRIM_EQ(symcontinuation, v0x7f1f2413fe60);
+if (True == v0x7f1f2413fe80) {
+Obj v0x7f1f24138060 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24138080 = PRIM_ISCONS(v0x7f1f24138060);
+if (True == v0x7f1f24138080) {
+Obj v0x7f1f24138220 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f241382a0 = PRIM_CAR(v0x7f1f24138220);
+Obj arg = v0x7f1f241382a0;
+Obj v0x7f1f24138540 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24138560 = PRIM_CDR(v0x7f1f24138540);
+Obj v0x7f1f24138580 = PRIM_ISCONS(v0x7f1f24138560);
+if (True == v0x7f1f24138580) {
+Obj v0x7f1f241387e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f241388a0 = PRIM_CDR(v0x7f1f241387e0);
+Obj v0x7f1f241388c0 = PRIM_CAR(v0x7f1f241388a0);
+Obj body = v0x7f1f241388c0;
+Obj v0x7f1f24138c80 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24138ca0 = PRIM_CDR(v0x7f1f24138c80);
+Obj v0x7f1f24138cc0 = PRIM_CDR(v0x7f1f24138ca0);
+Obj v0x7f1f24138ce0 = PRIM_EQ(Nil, v0x7f1f24138cc0);
+if (True == v0x7f1f24138ce0) {
 pushCont(co, 36, clofun7, 1, arg);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35free_45vars);
@@ -10497,7 +10497,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1536;
+__arg0 = v0x7f1f24154fa0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10506,7 +10506,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1536;
+__arg0 = v0x7f1f24154fa0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10515,7 +10515,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1536;
+__arg0 = v0x7f1f24154fa0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10524,7 +10524,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1536;
+__arg0 = v0x7f1f24154fa0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10533,7 +10533,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1536;
+__arg0 = v0x7f1f24154fa0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10544,11 +10544,11 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj _35val2117 = __arg1;
+Obj v0x7f1f24138e60 = __arg1;
 Obj arg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
-__arg1 = _35val2117;
+__arg1 = v0x7f1f24138e60;
 __arg2 = arg;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -10559,19 +10559,19 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj _35cc1537 = makeNative(39, clofun7, 0, 0);
-Obj _35reg2095 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2095) {
-Obj _35reg2096 = PRIM_CAR(closureRef(co, 0));
-Obj f = _35reg2096;
-Obj _35reg2097 = PRIM_CDR(closureRef(co, 0));
-Obj args = _35reg2097;
-Obj _35reg2098 = makeCons(f, args);
+Obj v0x7f1f2414d1e0 = makeNative(39, clofun7, 0, 0);
+Obj v0x7f1f2413f5e0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2413f5e0) {
+Obj v0x7f1f2413f6e0 = PRIM_CAR(closureRef(co, 0));
+Obj f = v0x7f1f2413f6e0;
+Obj v0x7f1f2413f7e0 = PRIM_CDR(closureRef(co, 0));
+Obj args = v0x7f1f2413f7e0;
+Obj v0x7f1f2413fa60 = makeCons(f, args);
 PUSH_CONT_0(co, 38, clofun7);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
 __arg1 = globalRef(symcora_47lib_47toc_35free_45vars);
-__arg2 = _35reg2098;
+__arg2 = v0x7f1f2413fa60;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10579,7 +10579,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1537;
+__arg0 = v0x7f1f2414d1e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10590,12 +10590,12 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj _35val2099 = __arg1;
+Obj v0x7f1f2413fa80 = __arg1;
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = globalRef(symcora_47lib_47toc_35union);
 __arg2 = Nil;
-__arg3 = _35val2099;
+__arg3 = v0x7f1f2413fa80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10617,23 +10617,23 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj _35p1518 = __arg1;
-Obj _35cc1519 = makeNative(41, clofun7, 0, 1, _35p1518);
-Obj _35reg2084 = PRIM_ISCONS(_35p1518);
-if (True == _35reg2084) {
-Obj _35reg2085 = PRIM_CAR(_35p1518);
-Obj _35reg2086 = PRIM_EQ(sym_37const, _35reg2085);
-if (True == _35reg2086) {
-Obj _35reg2087 = PRIM_CDR(_35p1518);
-Obj _35reg2088 = PRIM_ISCONS(_35reg2087);
-if (True == _35reg2088) {
-Obj _35reg2089 = PRIM_CDR(_35p1518);
-Obj _35reg2090 = PRIM_CAR(_35reg2089);
-Obj x = _35reg2090;
-Obj _35reg2091 = PRIM_CDR(_35p1518);
-Obj _35reg2092 = PRIM_CDR(_35reg2091);
-Obj _35reg2093 = PRIM_EQ(Nil, _35reg2092);
-if (True == _35reg2093) {
+Obj v0x7f1f24161e80 = __arg1;
+Obj v0x7f1f24161f00 = makeNative(41, clofun7, 0, 1, v0x7f1f24161e80);
+Obj v0x7f1f2414df60 = PRIM_ISCONS(v0x7f1f24161e80);
+if (True == v0x7f1f2414df60) {
+Obj v0x7f1f24146180 = PRIM_CAR(v0x7f1f24161e80);
+Obj v0x7f1f241461a0 = PRIM_EQ(sym_37const, v0x7f1f24146180);
+if (True == v0x7f1f241461a0) {
+Obj v0x7f1f24146380 = PRIM_CDR(v0x7f1f24161e80);
+Obj v0x7f1f241463a0 = PRIM_ISCONS(v0x7f1f24146380);
+if (True == v0x7f1f241463a0) {
+Obj v0x7f1f241465c0 = PRIM_CDR(v0x7f1f24161e80);
+Obj v0x7f1f241465e0 = PRIM_CAR(v0x7f1f241465c0);
+Obj x = v0x7f1f241465e0;
+Obj v0x7f1f241468a0 = PRIM_CDR(v0x7f1f24161e80);
+Obj v0x7f1f241468c0 = PRIM_CDR(v0x7f1f241468a0);
+Obj v0x7f1f241468e0 = PRIM_EQ(Nil, v0x7f1f241468c0);
+if (True == v0x7f1f241468e0) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10641,7 +10641,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1519;
+__arg0 = v0x7f1f24161f00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10650,7 +10650,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1519;
+__arg0 = v0x7f1f24161f00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10659,7 +10659,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1519;
+__arg0 = v0x7f1f24161f00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10668,7 +10668,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1519;
+__arg0 = v0x7f1f24161f00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10679,22 +10679,22 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj _35cc1520 = makeNative(42, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2074 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2074) {
-Obj _35reg2075 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2076 = PRIM_EQ(sym_37global, _35reg2075);
-if (True == _35reg2076) {
-Obj _35reg2077 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2078 = PRIM_ISCONS(_35reg2077);
-if (True == _35reg2078) {
-Obj _35reg2079 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2080 = PRIM_CAR(_35reg2079);
-Obj x = _35reg2080;
-Obj _35reg2081 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2082 = PRIM_CDR(_35reg2081);
-Obj _35reg2083 = PRIM_EQ(Nil, _35reg2082);
-if (True == _35reg2083) {
+Obj v0x7f1f2415b0c0 = makeNative(42, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f2414d140 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2414d140) {
+Obj v0x7f1f2414d360 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f2414d3a0 = PRIM_EQ(sym_37global, v0x7f1f2414d360);
+if (True == v0x7f1f2414d3a0) {
+Obj v0x7f1f2414d600 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2414d620 = PRIM_ISCONS(v0x7f1f2414d600);
+if (True == v0x7f1f2414d620) {
+Obj v0x7f1f2414d820 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2414d860 = PRIM_CAR(v0x7f1f2414d820);
+Obj x = v0x7f1f2414d860;
+Obj v0x7f1f2414dba0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2414dbc0 = PRIM_CDR(v0x7f1f2414dba0);
+Obj v0x7f1f2414dbe0 = PRIM_EQ(Nil, v0x7f1f2414dbc0);
+if (True == v0x7f1f2414dbe0) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10702,7 +10702,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1520;
+__arg0 = v0x7f1f2415b0c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10711,7 +10711,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1520;
+__arg0 = v0x7f1f2415b0c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10720,7 +10720,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1520;
+__arg0 = v0x7f1f2415b0c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10729,7 +10729,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1520;
+__arg0 = v0x7f1f2415b0c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10740,22 +10740,22 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj _35cc1521 = makeNative(43, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2064 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2064) {
-Obj _35reg2065 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2066 = PRIM_EQ(sym_37builtin, _35reg2065);
-if (True == _35reg2066) {
-Obj _35reg2067 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2068 = PRIM_ISCONS(_35reg2067);
-if (True == _35reg2068) {
-Obj _35reg2069 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2070 = PRIM_CAR(_35reg2069);
-Obj op = _35reg2070;
-Obj _35reg2071 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2072 = PRIM_CDR(_35reg2071);
-Obj _35reg2073 = PRIM_EQ(Nil, _35reg2072);
-if (True == _35reg2073) {
+Obj v0x7f1f2415b320 = makeNative(43, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f2415bf00 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2415bf00) {
+Obj v0x7f1f241541a0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f241541c0 = PRIM_EQ(sym_37builtin, v0x7f1f241541a0);
+if (True == v0x7f1f241541c0) {
+Obj v0x7f1f24154480 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f241544a0 = PRIM_ISCONS(v0x7f1f24154480);
+if (True == v0x7f1f241544a0) {
+Obj v0x7f1f24154800 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24154860 = PRIM_CAR(v0x7f1f24154800);
+Obj op = v0x7f1f24154860;
+Obj v0x7f1f24154c00 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24154c20 = PRIM_CDR(v0x7f1f24154c00);
+Obj v0x7f1f24154c40 = PRIM_EQ(Nil, v0x7f1f24154c20);
+if (True == v0x7f1f24154c40) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10763,7 +10763,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1521;
+__arg0 = v0x7f1f2415b320;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10772,7 +10772,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1521;
+__arg0 = v0x7f1f2415b320;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10781,7 +10781,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1521;
+__arg0 = v0x7f1f2415b320;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10790,7 +10790,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1521;
+__arg0 = v0x7f1f2415b320;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10801,22 +10801,22 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj _35cc1522 = makeNative(44, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2054 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2054) {
-Obj _35reg2055 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2056 = PRIM_EQ(symquote, _35reg2055);
-if (True == _35reg2056) {
-Obj _35reg2057 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2058 = PRIM_ISCONS(_35reg2057);
-if (True == _35reg2058) {
-Obj _35reg2059 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2060 = PRIM_CAR(_35reg2059);
-Obj x = _35reg2060;
-Obj _35reg2061 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2062 = PRIM_CDR(_35reg2061);
-Obj _35reg2063 = PRIM_EQ(Nil, _35reg2062);
-if (True == _35reg2063) {
+Obj v0x7f1f2415b500 = makeNative(44, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f24161b60 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f24161b60) {
+Obj v0x7f1f24161f20 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f24161f60 = PRIM_EQ(symquote, v0x7f1f24161f20);
+if (True == v0x7f1f24161f60) {
+Obj v0x7f1f2415b140 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2415b180 = PRIM_ISCONS(v0x7f1f2415b140);
+if (True == v0x7f1f2415b180) {
+Obj v0x7f1f2415b4c0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2415b4e0 = PRIM_CAR(v0x7f1f2415b4c0);
+Obj x = v0x7f1f2415b4e0;
+Obj v0x7f1f2415b8e0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f2415b900 = PRIM_CDR(v0x7f1f2415b8e0);
+Obj v0x7f1f2415b980 = PRIM_EQ(Nil, v0x7f1f2415b900);
+if (True == v0x7f1f2415b980) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10824,7 +10824,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1522;
+__arg0 = v0x7f1f2415b500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10833,7 +10833,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1522;
+__arg0 = v0x7f1f2415b500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10842,7 +10842,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1522;
+__arg0 = v0x7f1f2415b500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10851,7 +10851,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1522;
+__arg0 = v0x7f1f2415b500;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10862,22 +10862,22 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj _35cc1523 = makeNative(45, clofun7, 0, 1, closureRef(co, 0));
-Obj _35reg2044 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2044) {
-Obj _35reg2045 = PRIM_CAR(closureRef(co, 0));
-Obj _35reg2046 = PRIM_EQ(sym_37closure_45ref, _35reg2045);
-if (True == _35reg2046) {
-Obj _35reg2047 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2048 = PRIM_ISCONS(_35reg2047);
-if (True == _35reg2048) {
-Obj _35reg2049 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2050 = PRIM_CAR(_35reg2049);
-Obj __ = _35reg2050;
-Obj _35reg2051 = PRIM_CDR(closureRef(co, 0));
-Obj _35reg2052 = PRIM_CDR(_35reg2051);
-Obj _35reg2053 = PRIM_EQ(Nil, _35reg2052);
-if (True == _35reg2053) {
+Obj v0x7f1f2415b6c0 = makeNative(45, clofun7, 0, 1, closureRef(co, 0));
+Obj v0x7f1f240487e0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f240487e0) {
+Obj v0x7f1f240489a0 = PRIM_CAR(closureRef(co, 0));
+Obj v0x7f1f240489c0 = PRIM_EQ(sym_37closure_45ref, v0x7f1f240489a0);
+if (True == v0x7f1f240489c0) {
+Obj v0x7f1f24048b60 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24048b80 = PRIM_ISCONS(v0x7f1f24048b60);
+if (True == v0x7f1f24048b80) {
+Obj v0x7f1f24048d20 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f24161000 = PRIM_CAR(v0x7f1f24048d20);
+Obj __ = v0x7f1f24161000;
+Obj v0x7f1f241615a0 = PRIM_CDR(closureRef(co, 0));
+Obj v0x7f1f241615c0 = PRIM_CDR(v0x7f1f241615a0);
+Obj v0x7f1f241615e0 = PRIM_EQ(Nil, v0x7f1f241615c0);
+if (True == v0x7f1f241615e0) {
 __nargs = 2;
 __arg1 = True;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10885,7 +10885,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1523;
+__arg0 = v0x7f1f2415b6c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10894,7 +10894,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1523;
+__arg0 = v0x7f1f2415b6c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10903,7 +10903,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1523;
+__arg0 = v0x7f1f2415b6c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10912,7 +10912,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1523;
+__arg0 = v0x7f1f2415b6c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10923,7 +10923,7 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj _35cc1524 = makeNative(46, clofun7, 0, 0);
+Obj v0x7f1f2415b8a0 = makeNative(46, clofun7, 0, 0);
 Obj x = closureRef(co, 0);
 __nargs = 2;
 __arg1 = False;
@@ -10946,12 +10946,12 @@ goto *jumpTable[ps.label];
 
 label47:
 {
-Obj _35p1513 = __arg1;
-Obj _35p1514 = __arg2;
-Obj _35cc1515 = makeNative(48, clofun7, 0, 2, _35p1513, _35p1514);
-Obj _35reg2042 = PRIM_EQ(Nil, _35p1513);
-if (True == _35reg2042) {
-Obj __ = _35p1514;
+Obj v0x7f1f24161780 = __arg1;
+Obj v0x7f1f241617a0 = __arg2;
+Obj v0x7f1f24161880 = makeNative(48, clofun7, 0, 2, v0x7f1f24161780, v0x7f1f241617a0);
+Obj v0x7f1f240480e0 = PRIM_EQ(Nil, v0x7f1f24161780);
+if (True == v0x7f1f240480e0) {
+Obj __ = v0x7f1f241617a0;
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -10959,7 +10959,7 @@ if (co->ctx.pc.func != clofun7) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1515;
+__arg0 = v0x7f1f24161880;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -10970,15 +10970,15 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj _35cc1516 = makeNative(0, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2038 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2038) {
-Obj _35reg2039 = PRIM_CAR(closureRef(co, 0));
-Obj x = _35reg2039;
-Obj _35reg2040 = PRIM_CDR(closureRef(co, 0));
-Obj y = _35reg2040;
+Obj v0x7f1f241619e0 = makeNative(0, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f2404daa0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2404daa0) {
+Obj v0x7f1f2404dba0 = PRIM_CAR(closureRef(co, 0));
+Obj x = v0x7f1f2404dba0;
+Obj v0x7f1f2404dca0 = PRIM_CDR(closureRef(co, 0));
+Obj y = v0x7f1f2404dca0;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 49, clofun7, 3, y, s2, _35cc1516);
+pushCont(co, 49, clofun7, 3, y, s2, v0x7f1f241619e0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
 __arg1 = x;
@@ -10990,7 +10990,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1516;
+__arg0 = v0x7f1f241619e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11001,11 +11001,11 @@ goto *jumpTable[ps.label];
 
 label49:
 {
-Obj _35val2041 = __arg1;
+Obj v0x7f1f2404de00 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35cc1516= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == _35val2041) {
+Obj v0x7f1f241619e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == v0x7f1f2404de00) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35diff);
 __arg1 = y;
@@ -11017,7 +11017,7 @@ if (ps.func != clofun7) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1516;
+__arg0 = v0x7f1f241619e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11048,13 +11048,13 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35cc1517 = makeNative(2, clofun8, 0, 0);
-Obj _35reg2033 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2033) {
-Obj _35reg2034 = PRIM_CAR(closureRef(co, 0));
-Obj x = _35reg2034;
-Obj _35reg2035 = PRIM_CDR(closureRef(co, 0));
-Obj y = _35reg2035;
+Obj v0x7f1f24161bc0 = makeNative(2, clofun8, 0, 0);
+Obj v0x7f1f2404d520 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2404d520) {
+Obj v0x7f1f2404d620 = PRIM_CAR(closureRef(co, 0));
+Obj x = v0x7f1f2404d620;
+Obj v0x7f1f2404d720 = PRIM_CDR(closureRef(co, 0));
+Obj y = v0x7f1f2404d720;
 Obj s2 = closureRef(co, 1);
 pushCont(co, 1, clofun8, 1, x);
 __nargs = 3;
@@ -11068,7 +11068,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1517;
+__arg0 = v0x7f1f24161bc0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11079,11 +11079,11 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj _35val2036 = __arg1;
+Obj v0x7f1f2404d900 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg2037 = makeCons(x, _35val2036);
+Obj v0x7f1f2404d920 = makeCons(x, v0x7f1f2404d900);
 __nargs = 2;
-__arg1 = _35reg2037;
+__arg1 = v0x7f1f2404d920;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11103,12 +11103,12 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj _35p1508 = __arg1;
-Obj _35p1509 = __arg2;
-Obj _35cc1510 = makeNative(4, clofun8, 0, 2, _35p1508, _35p1509);
-Obj _35reg2031 = PRIM_EQ(Nil, _35p1508);
-if (True == _35reg2031) {
-Obj s2 = _35p1509;
+Obj v0x7f1f241463c0 = __arg1;
+Obj v0x7f1f241463e0 = __arg2;
+Obj v0x7f1f24161060 = makeNative(4, clofun8, 0, 2, v0x7f1f241463c0, v0x7f1f241463e0);
+Obj v0x7f1f2404ffe0 = PRIM_EQ(Nil, v0x7f1f241463c0);
+if (True == v0x7f1f2404ffe0) {
+Obj s2 = v0x7f1f241463e0;
 __nargs = 2;
 __arg1 = s2;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -11116,7 +11116,7 @@ if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1510;
+__arg0 = v0x7f1f24161060;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11127,15 +11127,15 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35cc1511 = makeNative(6, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
-Obj _35reg2027 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2027) {
-Obj _35reg2028 = PRIM_CAR(closureRef(co, 0));
-Obj x = _35reg2028;
-Obj _35reg2029 = PRIM_CDR(closureRef(co, 0));
-Obj y = _35reg2029;
+Obj v0x7f1f24161220 = makeNative(6, clofun8, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f2404f660 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2404f660) {
+Obj v0x7f1f2404f760 = PRIM_CAR(closureRef(co, 0));
+Obj x = v0x7f1f2404f760;
+Obj v0x7f1f2404f880 = PRIM_CDR(closureRef(co, 0));
+Obj y = v0x7f1f2404f880;
 Obj s2 = closureRef(co, 1);
-pushCont(co, 5, clofun8, 3, y, s2, _35cc1511);
+pushCont(co, 5, clofun8, 3, y, s2, v0x7f1f24161220);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
 __arg1 = x;
@@ -11147,7 +11147,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1511;
+__arg0 = v0x7f1f24161220;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11158,11 +11158,11 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35val2030 = __arg1;
+Obj v0x7f1f2404fa00 = __arg1;
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s2= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35cc1511= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
-if (True == _35val2030) {
+Obj v0x7f1f24161220= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
+if (True == v0x7f1f2404fa00) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35union);
 __arg1 = y;
@@ -11174,7 +11174,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1511;
+__arg0 = v0x7f1f24161220;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11185,13 +11185,13 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj _35cc1512 = makeNative(8, clofun8, 0, 0);
-Obj _35reg2022 = PRIM_ISCONS(closureRef(co, 0));
-if (True == _35reg2022) {
-Obj _35reg2023 = PRIM_CAR(closureRef(co, 0));
-Obj x = _35reg2023;
-Obj _35reg2024 = PRIM_CDR(closureRef(co, 0));
-Obj y = _35reg2024;
+Obj v0x7f1f24161420 = makeNative(8, clofun8, 0, 0);
+Obj v0x7f1f2404f0c0 = PRIM_ISCONS(closureRef(co, 0));
+if (True == v0x7f1f2404f0c0) {
+Obj v0x7f1f2404f1c0 = PRIM_CAR(closureRef(co, 0));
+Obj x = v0x7f1f2404f1c0;
+Obj v0x7f1f2404f2c0 = PRIM_CDR(closureRef(co, 0));
+Obj y = v0x7f1f2404f2c0;
 Obj s2 = closureRef(co, 1);
 pushCont(co, 7, clofun8, 1, x);
 __nargs = 3;
@@ -11205,7 +11205,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1512;
+__arg0 = v0x7f1f24161420;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11216,11 +11216,11 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35val2025 = __arg1;
+Obj v0x7f1f2404f4a0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg2026 = makeCons(x, _35val2025);
+Obj v0x7f1f2404f4c0 = makeCons(x, v0x7f1f2404f4a0);
 __nargs = 2;
-__arg1 = _35reg2026;
+__arg1 = v0x7f1f2404f4c0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11240,18 +11240,18 @@ goto *jumpTable[ps.label];
 
 label9:
 {
-Obj _35p1491 = __arg1;
-Obj _35p1492 = __arg2;
-Obj _35p1493 = __arg3;
-Obj _35p1494 = co->args[4];
-Obj _35p1495 = co->args[5];
-Obj _35cc1496 = makeNative(13, clofun8, 0, 5, _35p1491, _35p1492, _35p1493, _35p1494, _35p1495);
-Obj __ = _35p1491;
-__ = _35p1492;
-__ = _35p1493;
-Obj globals = _35p1494;
-Obj x = _35p1495;
-pushCont(co, 10, clofun8, 2, x, _35cc1496);
+Obj v0x7f1f2415b260 = __arg1;
+Obj v0x7f1f2415b280 = __arg2;
+Obj v0x7f1f2415b2a0 = __arg3;
+Obj v0x7f1f2415b2c0 = co->args[4];
+Obj v0x7f1f2415b2e0 = co->args[5];
+Obj v0x7f1f2415b460 = makeNative(13, clofun8, 0, 5, v0x7f1f2415b260, v0x7f1f2415b280, v0x7f1f2415b2a0, v0x7f1f2415b2c0, v0x7f1f2415b2e0);
+Obj __ = v0x7f1f2415b260;
+__ = v0x7f1f2415b280;
+__ = v0x7f1f2415b2a0;
+Obj globals = v0x7f1f2415b2c0;
+Obj x = v0x7f1f2415b2e0;
+pushCont(co, 10, clofun8, 2, x, v0x7f1f2415b460);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35number_63);
 __arg1 = x;
@@ -11264,21 +11264,21 @@ goto *jumpTable[ps.label];
 
 label10:
 {
-Obj _35val2007 = __arg1;
+Obj v0x7f1f2406bce0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35cc1496= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val2007) {
+Obj v0x7f1f2415b460= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == v0x7f1f2406bce0) {
 if (True == True) {
-Obj _35reg2008 = makeCons(x, Nil);
-Obj _35reg2009 = makeCons(sym_37const, _35reg2008);
+Obj v0x7f1f2406be80 = makeCons(x, Nil);
+Obj v0x7f1f2406bea0 = makeCons(sym_37const, v0x7f1f2406be80);
 __nargs = 2;
-__arg1 = _35reg2009;
+__arg1 = v0x7f1f2406bea0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1496;
+__arg0 = v0x7f1f2415b460;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11286,19 +11286,19 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-Obj _35reg2010 = primIsString(x);
-if (True == _35reg2010) {
+Obj v0x7f1f240690a0 = primIsString(x);
+if (True == v0x7f1f240690a0) {
 if (True == True) {
-Obj _35reg2011 = makeCons(x, Nil);
-Obj _35reg2012 = makeCons(sym_37const, _35reg2011);
+Obj v0x7f1f24069240 = makeCons(x, Nil);
+Obj v0x7f1f24069260 = makeCons(sym_37const, v0x7f1f24069240);
 __nargs = 2;
-__arg1 = _35reg2012;
+__arg1 = v0x7f1f24069260;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1496;
+__arg0 = v0x7f1f2415b460;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11306,7 +11306,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 11, clofun8, 2, x, _35cc1496);
+pushCont(co, 11, clofun8, 2, x, v0x7f1f2415b460);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35boolean_63);
 __arg1 = x;
@@ -11321,21 +11321,21 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj _35val2013 = __arg1;
+Obj v0x7f1f24069440 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35cc1496= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val2013) {
+Obj v0x7f1f2415b460= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == v0x7f1f24069440) {
 if (True == True) {
-Obj _35reg2014 = makeCons(x, Nil);
-Obj _35reg2015 = makeCons(sym_37const, _35reg2014);
+Obj v0x7f1f240695e0 = makeCons(x, Nil);
+Obj v0x7f1f24069600 = makeCons(sym_37const, v0x7f1f240695e0);
 __nargs = 2;
-__arg1 = _35reg2015;
+__arg1 = v0x7f1f24069600;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1496;
+__arg0 = v0x7f1f2415b460;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11343,7 +11343,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 }
 } else {
-pushCont(co, 12, clofun8, 2, x, _35cc1496);
+pushCont(co, 12, clofun8, 2, x, v0x7f1f2415b460);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
 __arg1 = x;
@@ -11357,21 +11357,21 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj _35val2016 = __arg1;
+Obj v0x7f1f240697a0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35cc1496= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val2016) {
+Obj v0x7f1f2415b460= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+if (True == v0x7f1f240697a0) {
 if (True == True) {
-Obj _35reg2017 = makeCons(x, Nil);
-Obj _35reg2018 = makeCons(sym_37const, _35reg2017);
+Obj v0x7f1f24069960 = makeCons(x, Nil);
+Obj v0x7f1f24069980 = makeCons(sym_37const, v0x7f1f24069960);
 __nargs = 2;
-__arg1 = _35reg2018;
+__arg1 = v0x7f1f24069980;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1496;
+__arg0 = v0x7f1f2415b460;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11380,16 +11380,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 if (True == False) {
-Obj _35reg2019 = makeCons(x, Nil);
-Obj _35reg2020 = makeCons(sym_37const, _35reg2019);
+Obj v0x7f1f24069ba0 = makeCons(x, Nil);
+Obj v0x7f1f24069bc0 = makeCons(sym_37const, v0x7f1f24069ba0);
 __nargs = 2;
-__arg1 = _35reg2020;
+__arg1 = v0x7f1f24069bc0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1496;
+__arg0 = v0x7f1f2415b460;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11401,26 +11401,26 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35cc1497 = makeNative(15, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj v0x7f1f2415b740 = makeNative(15, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj __ = closureRef(co, 0);
 __ = closureRef(co, 1);
 __ = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj _35reg1994 = PRIM_ISCONS(closureRef(co, 4));
-if (True == _35reg1994) {
-Obj _35reg1995 = PRIM_CAR(closureRef(co, 4));
-Obj _35reg1996 = PRIM_EQ(symquote, _35reg1995);
-if (True == _35reg1996) {
-Obj _35reg1997 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1998 = PRIM_ISCONS(_35reg1997);
-if (True == _35reg1998) {
-Obj _35reg1999 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg2000 = PRIM_CAR(_35reg1999);
-Obj x = _35reg2000;
-Obj _35reg2001 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg2002 = PRIM_CDR(_35reg2001);
-Obj _35reg2003 = PRIM_EQ(Nil, _35reg2002);
-if (True == _35reg2003) {
+Obj v0x7f1f24072be0 = PRIM_ISCONS(closureRef(co, 4));
+if (True == v0x7f1f24072be0) {
+Obj v0x7f1f24072de0 = PRIM_CAR(closureRef(co, 4));
+Obj v0x7f1f24072e00 = PRIM_EQ(symquote, v0x7f1f24072de0);
+if (True == v0x7f1f24072e00) {
+Obj v0x7f1f24072fe0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2406b000 = PRIM_ISCONS(v0x7f1f24072fe0);
+if (True == v0x7f1f2406b000) {
+Obj v0x7f1f2406b1a0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2406b1c0 = PRIM_CAR(v0x7f1f2406b1a0);
+Obj x = v0x7f1f2406b1c0;
+Obj v0x7f1f2406b460 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2406b480 = PRIM_CDR(v0x7f1f2406b460);
+Obj v0x7f1f2406b4a0 = PRIM_EQ(Nil, v0x7f1f2406b480);
+if (True == v0x7f1f2406b4a0) {
 pushCont(co, 14, clofun8, 1, x);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
@@ -11433,7 +11433,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1497;
+__arg0 = v0x7f1f2415b740;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11442,7 +11442,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1497;
+__arg0 = v0x7f1f2415b740;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11451,7 +11451,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1497;
+__arg0 = v0x7f1f2415b740;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11460,7 +11460,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1497;
+__arg0 = v0x7f1f2415b740;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11471,12 +11471,12 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj _35val2004 = __arg1;
+Obj v0x7f1f2406b640 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg2005 = makeCons(x, Nil);
-Obj _35reg2006 = makeCons(sym_37const, _35reg2005);
+Obj v0x7f1f2406b7e0 = makeCons(x, Nil);
+Obj v0x7f1f2406b800 = makeCons(sym_37const, v0x7f1f2406b7e0);
 __nargs = 2;
-__arg1 = _35reg2006;
+__arg1 = v0x7f1f2406b800;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11484,14 +11484,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label15:
 {
-Obj _35cc1498 = makeNative(19, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj v0x7f1f2415bb00 = makeNative(19, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
 Obj x = closureRef(co, 4);
-Obj _35reg1988 = primIsSymbol(x);
-if (True == _35reg1988) {
+Obj v0x7f1f240723a0 = primIsSymbol(x);
+if (True == v0x7f1f240723a0) {
 pushCont(co, 16, clofun8, 4, x, ns, import, globals);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
@@ -11504,7 +11504,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1498;
+__arg0 = v0x7f1f2415bb00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11515,12 +11515,12 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35val1989 = __arg1;
+Obj v0x7f1f240724c0 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == _35val1989) {
+if (True == v0x7f1f240724c0) {
 __nargs = 2;
 __arg1 = x;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -11543,9 +11543,9 @@ goto *jumpTable[ps.label];
 
 label17:
 {
-Obj _35val1990 = __arg1;
+Obj v0x7f1f24072640 = __arg1;
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj v = _35val1990;
+Obj v = v0x7f1f24072640;
 pushCont(co, 18, clofun8, 1, v);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
@@ -11560,12 +11560,12 @@ goto *jumpTable[ps.label];
 
 label18:
 {
-Obj _35val1991 = __arg1;
+Obj v0x7f1f24072780 = __arg1;
 Obj v= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg1992 = makeCons(v, Nil);
-Obj _35reg1993 = makeCons(sym_37global, _35reg1992);
+Obj v0x7f1f24072920 = makeCons(v, Nil);
+Obj v0x7f1f24072940 = makeCons(sym_37global, v0x7f1f24072920);
 __nargs = 2;
-__arg1 = _35reg1993;
+__arg1 = v0x7f1f24072940;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11573,35 +11573,35 @@ goto *jumpTable[co->ctx.pc.label];
 
 label19:
 {
-Obj _35cc1499 = makeNative(22, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj v0x7f1f2415bde0 = makeNative(22, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj _35reg1966 = PRIM_ISCONS(closureRef(co, 4));
-if (True == _35reg1966) {
-Obj _35reg1967 = PRIM_CAR(closureRef(co, 4));
-Obj _35reg1968 = PRIM_EQ(symlambda, _35reg1967);
-if (True == _35reg1968) {
-Obj _35reg1969 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1970 = PRIM_ISCONS(_35reg1969);
-if (True == _35reg1970) {
-Obj _35reg1971 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1972 = PRIM_CAR(_35reg1971);
-Obj args = _35reg1972;
-Obj _35reg1973 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1974 = PRIM_CDR(_35reg1973);
-Obj _35reg1975 = PRIM_ISCONS(_35reg1974);
-if (True == _35reg1975) {
-Obj _35reg1976 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1977 = PRIM_CDR(_35reg1976);
-Obj _35reg1978 = PRIM_CAR(_35reg1977);
-Obj body = _35reg1978;
-Obj _35reg1979 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1980 = PRIM_CDR(_35reg1979);
-Obj _35reg1981 = PRIM_CDR(_35reg1980);
-Obj _35reg1982 = PRIM_EQ(Nil, _35reg1981);
-if (True == _35reg1982) {
+Obj v0x7f1f240f8700 = PRIM_ISCONS(closureRef(co, 4));
+if (True == v0x7f1f240f8700) {
+Obj v0x7f1f240f8920 = PRIM_CAR(closureRef(co, 4));
+Obj v0x7f1f240f8940 = PRIM_EQ(symlambda, v0x7f1f240f8920);
+if (True == v0x7f1f240f8940) {
+Obj v0x7f1f240f8b40 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f240f8b60 = PRIM_ISCONS(v0x7f1f240f8b40);
+if (True == v0x7f1f240f8b60) {
+Obj v0x7f1f240f8d00 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f240f8d20 = PRIM_CAR(v0x7f1f240f8d00);
+Obj args = v0x7f1f240f8d20;
+Obj v0x7f1f240f8fc0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f240f8fe0 = PRIM_CDR(v0x7f1f240f8fc0);
+Obj v0x7f1f240f6000 = PRIM_ISCONS(v0x7f1f240f8fe0);
+if (True == v0x7f1f240f6000) {
+Obj v0x7f1f240f62a0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f240f62c0 = PRIM_CDR(v0x7f1f240f62a0);
+Obj v0x7f1f240f62e0 = PRIM_CAR(v0x7f1f240f62c0);
+Obj body = v0x7f1f240f62e0;
+Obj v0x7f1f240f6640 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f240f6660 = PRIM_CDR(v0x7f1f240f6640);
+Obj v0x7f1f240f6680 = PRIM_CDR(v0x7f1f240f6660);
+Obj v0x7f1f240f66a0 = PRIM_EQ(Nil, v0x7f1f240f6680);
+if (True == v0x7f1f240f66a0) {
 pushCont(co, 20, clofun8, 5, ns, import, globals, body, args);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35append);
@@ -11614,7 +11614,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1499;
+__arg0 = v0x7f1f2415bde0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11623,7 +11623,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1499;
+__arg0 = v0x7f1f2415bde0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11632,7 +11632,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1499;
+__arg0 = v0x7f1f2415bde0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11641,7 +11641,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1499;
+__arg0 = v0x7f1f2415bde0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11650,7 +11650,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1499;
+__arg0 = v0x7f1f2415bde0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11661,7 +11661,7 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj _35val1983 = __arg1;
+Obj v0x7f1f240f6ce0 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -11670,7 +11670,7 @@ Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 pushCont(co, 21, clofun8, 1, args);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = _35val1983;
+__arg1 = v0x7f1f240f6ce0;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = globals;
@@ -11684,13 +11684,13 @@ goto *jumpTable[ps.label];
 
 label21:
 {
-Obj _35val1984 = __arg1;
+Obj v0x7f1f240f6d80 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg1985 = makeCons(_35val1984, Nil);
-Obj _35reg1986 = makeCons(args, _35reg1985);
-Obj _35reg1987 = makeCons(symlambda, _35reg1986);
+Obj v0x7f1f240f6dc0 = makeCons(v0x7f1f240f6d80, Nil);
+Obj v0x7f1f240f6de0 = makeCons(args, v0x7f1f240f6dc0);
+Obj v0x7f1f240f6e00 = makeCons(symlambda, v0x7f1f240f6de0);
 __nargs = 2;
-__arg1 = _35reg1987;
+__arg1 = v0x7f1f240f6e00;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11698,18 +11698,18 @@ goto *jumpTable[co->ctx.pc.label];
 
 label22:
 {
-Obj _35cc1500 = makeNative(25, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj v0x7f1f24154220 = makeNative(25, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj _35reg1959 = PRIM_ISCONS(closureRef(co, 4));
-if (True == _35reg1959) {
-Obj _35reg1960 = PRIM_CAR(closureRef(co, 4));
-Obj _35reg1961 = PRIM_EQ(symif, _35reg1960);
-if (True == _35reg1961) {
-Obj _35reg1962 = PRIM_CDR(closureRef(co, 4));
-Obj args = _35reg1962;
+Obj v0x7f1f240f9d20 = PRIM_ISCONS(closureRef(co, 4));
+if (True == v0x7f1f240f9d20) {
+Obj v0x7f1f240f9f40 = PRIM_CAR(closureRef(co, 4));
+Obj v0x7f1f240f9f60 = PRIM_EQ(symif, v0x7f1f240f9f40);
+if (True == v0x7f1f240f9f60) {
+Obj v0x7f1f240f8060 = PRIM_CDR(closureRef(co, 4));
+Obj args = v0x7f1f240f8060;
 pushCont(co, 23, clofun8, 1, args);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
@@ -11724,7 +11724,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1500;
+__arg0 = v0x7f1f24154220;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11733,7 +11733,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1500;
+__arg0 = v0x7f1f24154220;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11744,12 +11744,12 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj _35val1963 = __arg1;
+Obj v0x7f1f240f8340 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 24, clofun8);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = _35val1963;
+__arg1 = v0x7f1f240f8340;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -11760,10 +11760,10 @@ goto *jumpTable[ps.label];
 
 label24:
 {
-Obj _35val1964 = __arg1;
-Obj _35reg1965 = makeCons(symif, _35val1964);
+Obj v0x7f1f240f8380 = __arg1;
+Obj v0x7f1f240f83a0 = makeCons(symif, v0x7f1f240f8380);
 __nargs = 2;
-__arg1 = _35reg1965;
+__arg1 = v0x7f1f240f83a0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11771,61 +11771,61 @@ goto *jumpTable[co->ctx.pc.label];
 
 label25:
 {
-Obj _35cc1501 = makeNative(28, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj v0x7f1f24154560 = makeNative(28, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj _35reg1915 = PRIM_ISCONS(closureRef(co, 4));
-if (True == _35reg1915) {
-Obj _35reg1916 = PRIM_CAR(closureRef(co, 4));
-Obj _35reg1917 = PRIM_EQ(symdo, _35reg1916);
-if (True == _35reg1917) {
-Obj _35reg1918 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1919 = PRIM_ISCONS(_35reg1918);
-if (True == _35reg1919) {
-Obj _35reg1920 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1921 = PRIM_CAR(_35reg1920);
-Obj _35reg1922 = PRIM_ISCONS(_35reg1921);
-if (True == _35reg1922) {
-Obj _35reg1923 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1924 = PRIM_CAR(_35reg1923);
-Obj _35reg1925 = PRIM_CAR(_35reg1924);
-Obj _35reg1926 = PRIM_EQ(symimport, _35reg1925);
-if (True == _35reg1926) {
-Obj _35reg1927 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1928 = PRIM_CAR(_35reg1927);
-Obj _35reg1929 = PRIM_CDR(_35reg1928);
-Obj _35reg1930 = PRIM_ISCONS(_35reg1929);
-if (True == _35reg1930) {
-Obj _35reg1931 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1932 = PRIM_CAR(_35reg1931);
-Obj _35reg1933 = PRIM_CDR(_35reg1932);
-Obj _35reg1934 = PRIM_CAR(_35reg1933);
-Obj pkg = _35reg1934;
-Obj _35reg1935 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1936 = PRIM_CAR(_35reg1935);
-Obj _35reg1937 = PRIM_CDR(_35reg1936);
-Obj _35reg1938 = PRIM_CDR(_35reg1937);
-Obj _35reg1939 = PRIM_EQ(Nil, _35reg1938);
-if (True == _35reg1939) {
-Obj _35reg1940 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1941 = PRIM_CDR(_35reg1940);
-Obj _35reg1942 = PRIM_ISCONS(_35reg1941);
-if (True == _35reg1942) {
-Obj _35reg1943 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1944 = PRIM_CDR(_35reg1943);
-Obj _35reg1945 = PRIM_CAR(_35reg1944);
-Obj y = _35reg1945;
-Obj _35reg1946 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1947 = PRIM_CDR(_35reg1946);
-Obj _35reg1948 = PRIM_CDR(_35reg1947);
-Obj _35reg1949 = PRIM_EQ(Nil, _35reg1948);
-if (True == _35reg1949) {
-Obj _35reg1950 = primIsString(pkg);
-if (True == _35reg1950) {
-Obj _35reg1951 = makeCons(pkg, Nil);
-Obj _35reg1952 = makeCons(symimport, _35reg1951);
+Obj v0x7f1f2412f700 = PRIM_ISCONS(closureRef(co, 4));
+if (True == v0x7f1f2412f700) {
+Obj v0x7f1f2412f8e0 = PRIM_CAR(closureRef(co, 4));
+Obj v0x7f1f2412f900 = PRIM_EQ(symdo, v0x7f1f2412f8e0);
+if (True == v0x7f1f2412f900) {
+Obj v0x7f1f2412fac0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2412fae0 = PRIM_ISCONS(v0x7f1f2412fac0);
+if (True == v0x7f1f2412fae0) {
+Obj v0x7f1f2412fd40 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2412fd80 = PRIM_CAR(v0x7f1f2412fd40);
+Obj v0x7f1f2412fda0 = PRIM_ISCONS(v0x7f1f2412fd80);
+if (True == v0x7f1f2412fda0) {
+Obj v0x7f1f2412c0a0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2412c0c0 = PRIM_CAR(v0x7f1f2412c0a0);
+Obj v0x7f1f2412c0e0 = PRIM_CAR(v0x7f1f2412c0c0);
+Obj v0x7f1f2412c100 = PRIM_EQ(symimport, v0x7f1f2412c0e0);
+if (True == v0x7f1f2412c100) {
+Obj v0x7f1f2412c740 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2412c760 = PRIM_CAR(v0x7f1f2412c740);
+Obj v0x7f1f2412c780 = PRIM_CDR(v0x7f1f2412c760);
+Obj v0x7f1f2412c7a0 = PRIM_ISCONS(v0x7f1f2412c780);
+if (True == v0x7f1f2412c7a0) {
+Obj v0x7f1f2412cac0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2412cae0 = PRIM_CAR(v0x7f1f2412cac0);
+Obj v0x7f1f2412cb00 = PRIM_CDR(v0x7f1f2412cae0);
+Obj v0x7f1f2412cb40 = PRIM_CAR(v0x7f1f2412cb00);
+Obj pkg = v0x7f1f2412cb40;
+Obj v0x7f1f2412cf00 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2412cf20 = PRIM_CAR(v0x7f1f2412cf00);
+Obj v0x7f1f2412cf40 = PRIM_CDR(v0x7f1f2412cf20);
+Obj v0x7f1f2412cf60 = PRIM_CDR(v0x7f1f2412cf40);
+Obj v0x7f1f2412cfc0 = PRIM_EQ(Nil, v0x7f1f2412cf60);
+if (True == v0x7f1f2412cfc0) {
+Obj v0x7f1f241282a0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f241282c0 = PRIM_CDR(v0x7f1f241282a0);
+Obj v0x7f1f241282e0 = PRIM_ISCONS(v0x7f1f241282c0);
+if (True == v0x7f1f241282e0) {
+Obj v0x7f1f241285a0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f241285c0 = PRIM_CDR(v0x7f1f241285a0);
+Obj v0x7f1f241285e0 = PRIM_CAR(v0x7f1f241285c0);
+Obj y = v0x7f1f241285e0;
+Obj v0x7f1f241289c0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f241289e0 = PRIM_CDR(v0x7f1f241289c0);
+Obj v0x7f1f24128a20 = PRIM_CDR(v0x7f1f241289e0);
+Obj v0x7f1f24128a40 = PRIM_EQ(Nil, v0x7f1f24128a20);
+if (True == v0x7f1f24128a40) {
+Obj v0x7f1f24128ba0 = primIsString(pkg);
+if (True == v0x7f1f24128ba0) {
+Obj v0x7f1f240f90a0 = makeCons(pkg, Nil);
+Obj v0x7f1f240f90e0 = makeCons(symimport, v0x7f1f240f90a0);
 pushCont(co, 26, clofun8, 6, pkg, import, env, ns, globals, y);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
@@ -11833,7 +11833,7 @@ __arg1 = env;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = globals;
-co->args[5] = _35reg1952;
+co->args[5] = v0x7f1f240f90e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11841,16 +11841,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1501;
-co->ctx.frees = __arg0;
-struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
-if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
-if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
-goto *jumpTable[ps.label];
-}
-} else {
-__nargs = 1;
-__arg0 = _35cc1501;
+__arg0 = v0x7f1f24154560;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11859,7 +11850,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1501;
+__arg0 = v0x7f1f24154560;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11868,7 +11859,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1501;
+__arg0 = v0x7f1f24154560;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11877,7 +11868,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1501;
+__arg0 = v0x7f1f24154560;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11886,7 +11877,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1501;
+__arg0 = v0x7f1f24154560;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11895,7 +11886,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1501;
+__arg0 = v0x7f1f24154560;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11904,7 +11895,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1501;
+__arg0 = v0x7f1f24154560;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11913,7 +11904,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1501;
+__arg0 = v0x7f1f24154560;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11922,7 +11913,16 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1501;
+__arg0 = v0x7f1f24154560;
+co->ctx.frees = __arg0;
+struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
+if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
+if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
+goto *jumpTable[ps.label];
+}
+} else {
+__nargs = 1;
+__arg0 = v0x7f1f24154560;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -11933,20 +11933,20 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35val1953 = __arg1;
+Obj v0x7f1f240f9100 = __arg1;
 Obj pkg= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj _35reg1954 = makeCons(pkg, import);
-pushCont(co, 27, clofun8, 1, _35val1953);
+Obj v0x7f1f240f9400 = makeCons(pkg, import);
+pushCont(co, 27, clofun8, 1, v0x7f1f240f9100);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
 __arg2 = ns;
-__arg3 = _35reg1954;
+__arg3 = v0x7f1f240f9400;
 co->args[4] = globals;
 co->args[5] = y;
 co->ctx.frees = __arg0;
@@ -11958,13 +11958,13 @@ goto *jumpTable[ps.label];
 
 label27:
 {
-Obj _35val1955 = __arg1;
-Obj _35val1953= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg1956 = makeCons(_35val1955, Nil);
-Obj _35reg1957 = makeCons(_35val1953, _35reg1956);
-Obj _35reg1958 = makeCons(symdo, _35reg1957);
+Obj v0x7f1f240f9460 = __arg1;
+Obj v0x7f1f240f9100= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f240f94a0 = makeCons(v0x7f1f240f9460, Nil);
+Obj v0x7f1f240f94c0 = makeCons(v0x7f1f240f9100, v0x7f1f240f94a0);
+Obj v0x7f1f240f94e0 = makeCons(symdo, v0x7f1f240f94c0);
 __nargs = 2;
-__arg1 = _35reg1958;
+__arg1 = v0x7f1f240f94e0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -11972,35 +11972,35 @@ goto *jumpTable[co->ctx.pc.label];
 
 label28:
 {
-Obj _35cc1502 = makeNative(31, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj v0x7f1f24154a80 = makeNative(31, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj _35reg1893 = PRIM_ISCONS(closureRef(co, 4));
-if (True == _35reg1893) {
-Obj _35reg1894 = PRIM_CAR(closureRef(co, 4));
-Obj _35reg1895 = PRIM_EQ(symdo, _35reg1894);
-if (True == _35reg1895) {
-Obj _35reg1896 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1897 = PRIM_ISCONS(_35reg1896);
-if (True == _35reg1897) {
-Obj _35reg1898 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1899 = PRIM_CAR(_35reg1898);
-Obj x = _35reg1899;
-Obj _35reg1900 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1901 = PRIM_CDR(_35reg1900);
-Obj _35reg1902 = PRIM_ISCONS(_35reg1901);
-if (True == _35reg1902) {
-Obj _35reg1903 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1904 = PRIM_CDR(_35reg1903);
-Obj _35reg1905 = PRIM_CAR(_35reg1904);
-Obj y = _35reg1905;
-Obj _35reg1906 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1907 = PRIM_CDR(_35reg1906);
-Obj _35reg1908 = PRIM_CDR(_35reg1907);
-Obj _35reg1909 = PRIM_EQ(Nil, _35reg1908);
-if (True == _35reg1909) {
+Obj v0x7f1f24135dc0 = PRIM_ISCONS(closureRef(co, 4));
+if (True == v0x7f1f24135dc0) {
+Obj v0x7f1f24135fc0 = PRIM_CAR(closureRef(co, 4));
+Obj v0x7f1f24135fe0 = PRIM_EQ(symdo, v0x7f1f24135fc0);
+if (True == v0x7f1f24135fe0) {
+Obj v0x7f1f24133180 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f241331a0 = PRIM_ISCONS(v0x7f1f24133180);
+if (True == v0x7f1f241331a0) {
+Obj v0x7f1f24133340 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24133360 = PRIM_CAR(v0x7f1f24133340);
+Obj x = v0x7f1f24133360;
+Obj v0x7f1f24133600 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24133620 = PRIM_CDR(v0x7f1f24133600);
+Obj v0x7f1f24133640 = PRIM_ISCONS(v0x7f1f24133620);
+if (True == v0x7f1f24133640) {
+Obj v0x7f1f241338a0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f241338c0 = PRIM_CDR(v0x7f1f241338a0);
+Obj v0x7f1f241338e0 = PRIM_CAR(v0x7f1f241338c0);
+Obj y = v0x7f1f241338e0;
+Obj v0x7f1f24133c20 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24133c40 = PRIM_CDR(v0x7f1f24133c20);
+Obj v0x7f1f24133c60 = PRIM_CDR(v0x7f1f24133c40);
+Obj v0x7f1f24133c80 = PRIM_EQ(Nil, v0x7f1f24133c60);
+if (True == v0x7f1f24133c80) {
 pushCont(co, 29, clofun8, 5, env, ns, import, globals, y);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
@@ -12016,7 +12016,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1502;
+__arg0 = v0x7f1f24154a80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12025,7 +12025,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1502;
+__arg0 = v0x7f1f24154a80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12034,7 +12034,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1502;
+__arg0 = v0x7f1f24154a80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12043,7 +12043,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1502;
+__arg0 = v0x7f1f24154a80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12052,7 +12052,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1502;
+__arg0 = v0x7f1f24154a80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12063,13 +12063,13 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj _35val1910 = __arg1;
+Obj v0x7f1f24133f40 = __arg1;
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-pushCont(co, 30, clofun8, 1, _35val1910);
+pushCont(co, 30, clofun8, 1, v0x7f1f24133f40);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
@@ -12086,13 +12086,13 @@ goto *jumpTable[ps.label];
 
 label30:
 {
-Obj _35val1911 = __arg1;
-Obj _35val1910= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg1912 = makeCons(_35val1911, Nil);
-Obj _35reg1913 = makeCons(_35val1910, _35reg1912);
-Obj _35reg1914 = makeCons(symdo, _35reg1913);
+Obj v0x7f1f2412f180 = __arg1;
+Obj v0x7f1f24133f40= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f2412f1c0 = makeCons(v0x7f1f2412f180, Nil);
+Obj v0x7f1f2412f1e0 = makeCons(v0x7f1f24133f40, v0x7f1f2412f1c0);
+Obj v0x7f1f2412f200 = makeCons(symdo, v0x7f1f2412f1e0);
 __nargs = 2;
-__arg1 = _35reg1914;
+__arg1 = v0x7f1f2412f200;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -12100,46 +12100,46 @@ goto *jumpTable[co->ctx.pc.label];
 
 label31:
 {
-Obj _35cc1503 = makeNative(34, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj v0x7f1f24154ec0 = makeNative(34, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj _35reg1860 = PRIM_ISCONS(closureRef(co, 4));
-if (True == _35reg1860) {
-Obj _35reg1861 = PRIM_CAR(closureRef(co, 4));
-Obj _35reg1862 = PRIM_EQ(symlet, _35reg1861);
-if (True == _35reg1862) {
-Obj _35reg1863 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1864 = PRIM_ISCONS(_35reg1863);
-if (True == _35reg1864) {
-Obj _35reg1865 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1866 = PRIM_CAR(_35reg1865);
-Obj a = _35reg1866;
-Obj _35reg1867 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1868 = PRIM_CDR(_35reg1867);
-Obj _35reg1869 = PRIM_ISCONS(_35reg1868);
-if (True == _35reg1869) {
-Obj _35reg1870 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1871 = PRIM_CDR(_35reg1870);
-Obj _35reg1872 = PRIM_CAR(_35reg1871);
-Obj b = _35reg1872;
-Obj _35reg1873 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1874 = PRIM_CDR(_35reg1873);
-Obj _35reg1875 = PRIM_CDR(_35reg1874);
-Obj _35reg1876 = PRIM_ISCONS(_35reg1875);
-if (True == _35reg1876) {
-Obj _35reg1877 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1878 = PRIM_CDR(_35reg1877);
-Obj _35reg1879 = PRIM_CDR(_35reg1878);
-Obj _35reg1880 = PRIM_CAR(_35reg1879);
-Obj c = _35reg1880;
-Obj _35reg1881 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1882 = PRIM_CDR(_35reg1881);
-Obj _35reg1883 = PRIM_CDR(_35reg1882);
-Obj _35reg1884 = PRIM_CDR(_35reg1883);
-Obj _35reg1885 = PRIM_EQ(Nil, _35reg1884);
-if (True == _35reg1885) {
+Obj v0x7f1f2413faa0 = PRIM_ISCONS(closureRef(co, 4));
+if (True == v0x7f1f2413faa0) {
+Obj v0x7f1f2413fc60 = PRIM_CAR(closureRef(co, 4));
+Obj v0x7f1f2413fc80 = PRIM_EQ(symlet, v0x7f1f2413fc60);
+if (True == v0x7f1f2413fc80) {
+Obj v0x7f1f2413fe20 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2413fe40 = PRIM_ISCONS(v0x7f1f2413fe20);
+if (True == v0x7f1f2413fe40) {
+Obj v0x7f1f2413ffe0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24138000 = PRIM_CAR(v0x7f1f2413ffe0);
+Obj a = v0x7f1f24138000;
+Obj v0x7f1f24138240 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24138260 = PRIM_CDR(v0x7f1f24138240);
+Obj v0x7f1f24138280 = PRIM_ISCONS(v0x7f1f24138260);
+if (True == v0x7f1f24138280) {
+Obj v0x7f1f241384c0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f241384e0 = PRIM_CDR(v0x7f1f241384c0);
+Obj v0x7f1f24138500 = PRIM_CAR(v0x7f1f241384e0);
+Obj b = v0x7f1f24138500;
+Obj v0x7f1f24138800 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24138840 = PRIM_CDR(v0x7f1f24138800);
+Obj v0x7f1f24138860 = PRIM_CDR(v0x7f1f24138840);
+Obj v0x7f1f24138880 = PRIM_ISCONS(v0x7f1f24138860);
+if (True == v0x7f1f24138880) {
+Obj v0x7f1f24138ba0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24138bc0 = PRIM_CDR(v0x7f1f24138ba0);
+Obj v0x7f1f24138be0 = PRIM_CDR(v0x7f1f24138bc0);
+Obj v0x7f1f24138c00 = PRIM_CAR(v0x7f1f24138be0);
+Obj c = v0x7f1f24138c00;
+Obj v0x7f1f24138fe0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24135020 = PRIM_CDR(v0x7f1f24138fe0);
+Obj v0x7f1f24135040 = PRIM_CDR(v0x7f1f24135020);
+Obj v0x7f1f24135060 = PRIM_CDR(v0x7f1f24135040);
+Obj v0x7f1f24135080 = PRIM_EQ(Nil, v0x7f1f24135060);
+if (True == v0x7f1f24135080) {
 pushCont(co, 32, clofun8, 6, env, ns, import, globals, c, a);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
@@ -12155,7 +12155,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1503;
+__arg0 = v0x7f1f24154ec0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12164,7 +12164,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1503;
+__arg0 = v0x7f1f24154ec0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12173,7 +12173,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1503;
+__arg0 = v0x7f1f24154ec0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12182,7 +12182,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1503;
+__arg0 = v0x7f1f24154ec0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12191,7 +12191,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1503;
+__arg0 = v0x7f1f24154ec0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12200,7 +12200,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1503;
+__arg0 = v0x7f1f24154ec0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12211,18 +12211,18 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj _35val1886 = __arg1;
+Obj v0x7f1f24135420 = __arg1;
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj c= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj _35reg1887 = makeCons(a, env);
-pushCont(co, 33, clofun8, 2, _35val1886, a);
+Obj v0x7f1f241356a0 = makeCons(a, env);
+pushCont(co, 33, clofun8, 2, v0x7f1f24135420, a);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
-__arg1 = _35reg1887;
+__arg1 = v0x7f1f241356a0;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = globals;
@@ -12236,15 +12236,15 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj _35val1888 = __arg1;
-Obj _35val1886= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f24135780 = __arg1;
+Obj v0x7f1f24135420= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj a= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg1889 = makeCons(_35val1888, Nil);
-Obj _35reg1890 = makeCons(_35val1886, _35reg1889);
-Obj _35reg1891 = makeCons(a, _35reg1890);
-Obj _35reg1892 = makeCons(symlet, _35reg1891);
+Obj v0x7f1f241357c0 = makeCons(v0x7f1f24135780, Nil);
+Obj v0x7f1f241357e0 = makeCons(v0x7f1f24135420, v0x7f1f241357c0);
+Obj v0x7f1f24135800 = makeCons(a, v0x7f1f241357e0);
+Obj v0x7f1f24135820 = makeCons(symlet, v0x7f1f24135800);
 __nargs = 2;
-__arg1 = _35reg1892;
+__arg1 = v0x7f1f24135820;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -12252,46 +12252,46 @@ goto *jumpTable[co->ctx.pc.label];
 
 label34:
 {
-Obj _35cc1504 = makeNative(35, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj v0x7f1f2414d380 = makeNative(35, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj __ = closureRef(co, 1);
 __ = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj _35reg1834 = PRIM_ISCONS(closureRef(co, 4));
-if (True == _35reg1834) {
-Obj _35reg1835 = PRIM_CAR(closureRef(co, 4));
-Obj _35reg1836 = PRIM_EQ(symns, _35reg1835);
-if (True == _35reg1836) {
-Obj _35reg1837 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1838 = PRIM_ISCONS(_35reg1837);
-if (True == _35reg1838) {
-Obj _35reg1839 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1840 = PRIM_CAR(_35reg1839);
-Obj path = _35reg1840;
-Obj _35reg1841 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1842 = PRIM_CDR(_35reg1841);
-Obj _35reg1843 = PRIM_ISCONS(_35reg1842);
-if (True == _35reg1843) {
-Obj _35reg1844 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1845 = PRIM_CDR(_35reg1844);
-Obj _35reg1846 = PRIM_CAR(_35reg1845);
-Obj import = _35reg1846;
-Obj _35reg1847 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1848 = PRIM_CDR(_35reg1847);
-Obj _35reg1849 = PRIM_CDR(_35reg1848);
-Obj _35reg1850 = PRIM_ISCONS(_35reg1849);
-if (True == _35reg1850) {
-Obj _35reg1851 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1852 = PRIM_CDR(_35reg1851);
-Obj _35reg1853 = PRIM_CDR(_35reg1852);
-Obj _35reg1854 = PRIM_CAR(_35reg1853);
-Obj body = _35reg1854;
-Obj _35reg1855 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1856 = PRIM_CDR(_35reg1855);
-Obj _35reg1857 = PRIM_CDR(_35reg1856);
-Obj _35reg1858 = PRIM_CDR(_35reg1857);
-Obj _35reg1859 = PRIM_EQ(Nil, _35reg1858);
-if (True == _35reg1859) {
+Obj v0x7f1f2414df20 = PRIM_ISCONS(closureRef(co, 4));
+if (True == v0x7f1f2414df20) {
+Obj v0x7f1f24146100 = PRIM_CAR(closureRef(co, 4));
+Obj v0x7f1f24146120 = PRIM_EQ(symns, v0x7f1f24146100);
+if (True == v0x7f1f24146120) {
+Obj v0x7f1f241462c0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f241462e0 = PRIM_ISCONS(v0x7f1f241462c0);
+if (True == v0x7f1f241462e0) {
+Obj v0x7f1f241464c0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f241464e0 = PRIM_CAR(v0x7f1f241464c0);
+Obj path = v0x7f1f241464e0;
+Obj v0x7f1f24146720 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24146740 = PRIM_CDR(v0x7f1f24146720);
+Obj v0x7f1f24146760 = PRIM_ISCONS(v0x7f1f24146740);
+if (True == v0x7f1f24146760) {
+Obj v0x7f1f241469a0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f241469c0 = PRIM_CDR(v0x7f1f241469a0);
+Obj v0x7f1f241469e0 = PRIM_CAR(v0x7f1f241469c0);
+Obj import = v0x7f1f241469e0;
+Obj v0x7f1f24146cc0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24146ce0 = PRIM_CDR(v0x7f1f24146cc0);
+Obj v0x7f1f24146d00 = PRIM_CDR(v0x7f1f24146ce0);
+Obj v0x7f1f24146d20 = PRIM_ISCONS(v0x7f1f24146d00);
+if (True == v0x7f1f24146d20) {
+Obj v0x7f1f2413f000 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2413f020 = PRIM_CDR(v0x7f1f2413f000);
+Obj v0x7f1f2413f040 = PRIM_CDR(v0x7f1f2413f020);
+Obj v0x7f1f2413f060 = PRIM_CAR(v0x7f1f2413f040);
+Obj body = v0x7f1f2413f060;
+Obj v0x7f1f2413f400 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2413f420 = PRIM_CDR(v0x7f1f2413f400);
+Obj v0x7f1f2413f440 = PRIM_CDR(v0x7f1f2413f420);
+Obj v0x7f1f2413f460 = PRIM_CDR(v0x7f1f2413f440);
+Obj v0x7f1f2413f480 = PRIM_EQ(Nil, v0x7f1f2413f460);
+if (True == v0x7f1f2413f480) {
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
@@ -12306,7 +12306,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1504;
+__arg0 = v0x7f1f2414d380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12315,7 +12315,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1504;
+__arg0 = v0x7f1f2414d380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12324,7 +12324,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1504;
+__arg0 = v0x7f1f2414d380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12333,7 +12333,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1504;
+__arg0 = v0x7f1f2414d380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12342,7 +12342,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1504;
+__arg0 = v0x7f1f2414d380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12351,7 +12351,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1504;
+__arg0 = v0x7f1f2414d380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12362,35 +12362,35 @@ goto *jumpTable[ps.label];
 
 label35:
 {
-Obj _35cc1505 = makeNative(39, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj v0x7f1f2414d840 = makeNative(39, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj _35reg1807 = PRIM_ISCONS(closureRef(co, 4));
-if (True == _35reg1807) {
-Obj _35reg1808 = PRIM_CAR(closureRef(co, 4));
-Obj _35reg1809 = PRIM_EQ(symdef, _35reg1808);
-if (True == _35reg1809) {
-Obj _35reg1810 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1811 = PRIM_ISCONS(_35reg1810);
-if (True == _35reg1811) {
-Obj _35reg1812 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1813 = PRIM_CAR(_35reg1812);
-Obj var = _35reg1813;
-Obj _35reg1814 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1815 = PRIM_CDR(_35reg1814);
-Obj _35reg1816 = PRIM_ISCONS(_35reg1815);
-if (True == _35reg1816) {
-Obj _35reg1817 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1818 = PRIM_CDR(_35reg1817);
-Obj _35reg1819 = PRIM_CAR(_35reg1818);
-Obj val = _35reg1819;
-Obj _35reg1820 = PRIM_CDR(closureRef(co, 4));
-Obj _35reg1821 = PRIM_CDR(_35reg1820);
-Obj _35reg1822 = PRIM_CDR(_35reg1821);
-Obj _35reg1823 = PRIM_EQ(Nil, _35reg1822);
-if (True == _35reg1823) {
+Obj v0x7f1f2415b9e0 = PRIM_ISCONS(closureRef(co, 4));
+if (True == v0x7f1f2415b9e0) {
+Obj v0x7f1f2415bd60 = PRIM_CAR(closureRef(co, 4));
+Obj v0x7f1f2415bda0 = PRIM_EQ(symdef, v0x7f1f2415bd60);
+if (True == v0x7f1f2415bda0) {
+Obj v0x7f1f2415bf80 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f2415bfa0 = PRIM_ISCONS(v0x7f1f2415bf80);
+if (True == v0x7f1f2415bfa0) {
+Obj v0x7f1f241541e0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24154200 = PRIM_CAR(v0x7f1f241541e0);
+Obj var = v0x7f1f24154200;
+Obj v0x7f1f24154600 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24154620 = PRIM_CDR(v0x7f1f24154600);
+Obj v0x7f1f24154640 = PRIM_ISCONS(v0x7f1f24154620);
+if (True == v0x7f1f24154640) {
+Obj v0x7f1f24154960 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24154980 = PRIM_CDR(v0x7f1f24154960);
+Obj v0x7f1f241549c0 = PRIM_CAR(v0x7f1f24154980);
+Obj val = v0x7f1f241549c0;
+Obj v0x7f1f24154de0 = PRIM_CDR(closureRef(co, 4));
+Obj v0x7f1f24154e00 = PRIM_CDR(v0x7f1f24154de0);
+Obj v0x7f1f24154e20 = PRIM_CDR(v0x7f1f24154e00);
+Obj v0x7f1f24154e60 = PRIM_EQ(Nil, v0x7f1f24154e20);
+if (True == v0x7f1f24154e60) {
 pushCont(co, 36, clofun8, 5, env, ns, import, globals, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35var_45with_45ns);
@@ -12403,7 +12403,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1505;
+__arg0 = v0x7f1f2414d840;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12412,7 +12412,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1505;
+__arg0 = v0x7f1f2414d840;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12421,7 +12421,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1505;
+__arg0 = v0x7f1f2414d840;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12430,7 +12430,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1505;
+__arg0 = v0x7f1f2414d840;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12439,7 +12439,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1505;
+__arg0 = v0x7f1f2414d840;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12450,13 +12450,13 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj _35val1824 = __arg1;
+Obj v0x7f1f24154fc0 = __arg1;
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj var1 = _35val1824;
+Obj var1 = v0x7f1f24154fc0;
 pushCont(co, 37, clofun8, 6, var1, env, ns, import, globals, val);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35add_45symbol_45to_45list);
@@ -12471,18 +12471,18 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj _35val1825 = __arg1;
+Obj v0x7f1f2414d160 = __arg1;
 Obj var1= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj val= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj _35reg1826 = makeCons(symset, Nil);
-Obj _35reg1827 = makeCons(sym_37builtin, _35reg1826);
-Obj _35reg1828 = makeCons(var1, Nil);
-Obj _35reg1829 = makeCons(sym_37const, _35reg1828);
-pushCont(co, 38, clofun8, 2, _35reg1829, _35reg1827);
+Obj v0x7f1f2414d400 = makeCons(symset, Nil);
+Obj v0x7f1f2414d420 = makeCons(sym_37builtin, v0x7f1f2414d400);
+Obj v0x7f1f2414d720 = makeCons(var1, Nil);
+Obj v0x7f1f2414d740 = makeCons(sym_37const, v0x7f1f2414d720);
+pushCont(co, 38, clofun8, 2, v0x7f1f2414d740, v0x7f1f2414d420);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
@@ -12499,14 +12499,14 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj _35val1830 = __arg1;
-Obj _35reg1829= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg1827= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg1831 = makeCons(_35val1830, Nil);
-Obj _35reg1832 = makeCons(_35reg1829, _35reg1831);
-Obj _35reg1833 = makeCons(_35reg1827, _35reg1832);
+Obj v0x7f1f2414d9a0 = __arg1;
+Obj v0x7f1f2414d740= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f2414d420= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+Obj v0x7f1f2414d9e0 = makeCons(v0x7f1f2414d9a0, Nil);
+Obj v0x7f1f2414da00 = makeCons(v0x7f1f2414d740, v0x7f1f2414d9e0);
+Obj v0x7f1f2414da20 = makeCons(v0x7f1f2414d420, v0x7f1f2414da00);
 __nargs = 2;
-__arg1 = _35reg1833;
+__arg1 = v0x7f1f2414da20;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -12514,18 +12514,18 @@ goto *jumpTable[co->ctx.pc.label];
 
 label39:
 {
-Obj _35cc1506 = makeNative(47, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
+Obj v0x7f1f2414dc80 = makeNative(47, clofun8, 0, 5, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2), closureRef(co, 3), closureRef(co, 4));
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
 Obj globals = closureRef(co, 3);
-Obj _35reg1787 = PRIM_ISCONS(closureRef(co, 4));
-if (True == _35reg1787) {
-Obj _35reg1788 = PRIM_CAR(closureRef(co, 4));
-Obj op = _35reg1788;
-Obj _35reg1789 = PRIM_CDR(closureRef(co, 4));
-Obj args = _35reg1789;
-pushCont(co, 40, clofun8, 7, op, args, env, ns, import, globals, _35cc1506);
+Obj v0x7f1f2404f820 = PRIM_ISCONS(closureRef(co, 4));
+if (True == v0x7f1f2404f820) {
+Obj v0x7f1f2404f920 = PRIM_CAR(closureRef(co, 4));
+Obj op = v0x7f1f2404f920;
+Obj v0x7f1f2404fa20 = PRIM_CDR(closureRef(co, 4));
+Obj args = v0x7f1f2404fa20;
+pushCont(co, 40, clofun8, 7, op, args, env, ns, import, globals, v0x7f1f2414dc80);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35builtin_63);
 __arg1 = op;
@@ -12536,7 +12536,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1506;
+__arg0 = v0x7f1f2414dc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12547,15 +12547,15 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj _35val1790 = __arg1;
+Obj v0x7f1f2404fb20 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj _35cc1506= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
-if (True == _35val1790) {
+Obj v0x7f1f2414dc80= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
+if (True == v0x7f1f2404fb20) {
 pushCont(co, 41, clofun8, 6, op, args, env, ns, import, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47lib_47toc_35builtin_45_62args);
@@ -12567,7 +12567,7 @@ if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1506;
+__arg0 = v0x7f1f2414dc80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12578,14 +12578,14 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj _35val1791 = __arg1;
+Obj v0x7f1f2404fc20 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj required = _35val1791;
+Obj required = v0x7f1f2404fc20;
 pushCont(co, 42, clofun8, 7, required, op, args, env, ns, import, globals);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35length);
@@ -12599,7 +12599,7 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj _35val1792 = __arg1;
+Obj v0x7f1f2404fd20 = __arg1;
 Obj required= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -12607,12 +12607,12 @@ Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 6];
-Obj provided = _35val1792;
-Obj _35reg1793 = PRIM_EQ(required, provided);
-if (True == _35reg1793) {
-Obj _35reg1794 = makeCons(op, Nil);
-Obj _35reg1795 = makeCons(sym_37builtin, _35reg1794);
-pushCont(co, 45, clofun8, 2, args, _35reg1795);
+Obj provided = v0x7f1f2404fd20;
+Obj v0x7f1f2404fe40 = PRIM_EQ(required, provided);
+if (True == v0x7f1f2404fe40) {
+Obj v0x7f1f241611c0 = makeCons(op, Nil);
+Obj v0x7f1f241611e0 = makeCons(sym_37builtin, v0x7f1f241611c0);
+pushCont(co, 45, clofun8, 2, args, v0x7f1f241611e0);
 __nargs = 5;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
@@ -12625,13 +12625,13 @@ if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = cor
 if (ps.func != clofun8) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
-Obj _35reg1799 = PRIM_GT(required, provided);
-if (True == _35reg1799) {
-Obj _35reg1800 = PRIM_SUB(required, provided);
+Obj v0x7f1f241618a0 = PRIM_GT(required, provided);
+if (True == v0x7f1f241618a0) {
+Obj v0x7f1f24161aa0 = PRIM_SUB(required, provided);
 pushCont(co, 43, clofun8, 6, op, args, env, ns, import, globals);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
-__arg1 = _35reg1800;
+__arg1 = v0x7f1f24161aa0;
 __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12653,19 +12653,19 @@ goto *jumpTable[ps.label];
 
 label43:
 {
-Obj _35val1801 = __arg1;
+Obj v0x7f1f24161b40 = __arg1;
 Obj op= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 5];
-Obj tmp = _35val1801;
-Obj _35reg1802 = makeCons(op, args);
+Obj tmp = v0x7f1f24161b40;
+Obj v0x7f1f2415b360 = makeCons(op, args);
 pushCont(co, 44, clofun8, 5, tmp, env, ns, import, globals);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35append);
-__arg1 = _35reg1802;
+__arg1 = v0x7f1f2415b360;
 __arg2 = tmp;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12676,22 +12676,22 @@ goto *jumpTable[ps.label];
 
 label44:
 {
-Obj _35val1803 = __arg1;
+Obj v0x7f1f2415b3a0 = __arg1;
 Obj tmp= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj env= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 Obj globals= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 4];
-Obj _35reg1804 = makeCons(_35val1803, Nil);
-Obj _35reg1805 = makeCons(tmp, _35reg1804);
-Obj _35reg1806 = makeCons(symlambda, _35reg1805);
+Obj v0x7f1f2415b3e0 = makeCons(v0x7f1f2415b3a0, Nil);
+Obj v0x7f1f2415b400 = makeCons(tmp, v0x7f1f2415b3e0);
+Obj v0x7f1f2415b420 = makeCons(symlambda, v0x7f1f2415b400);
 __nargs = 6;
 __arg0 = globalRef(symcora_47lib_47toc_35parse);
 __arg1 = env;
 __arg2 = ns;
 __arg3 = import;
 co->args[4] = globals;
-co->args[5] = _35reg1806;
+co->args[5] = v0x7f1f2415b420;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12701,13 +12701,13 @@ goto *jumpTable[ps.label];
 
 label45:
 {
-Obj _35val1796 = __arg1;
+Obj v0x7f1f24161600 = __arg1;
 Obj args= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg1795= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-pushCont(co, 46, clofun8, 1, _35reg1795);
+Obj v0x7f1f241611e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
+pushCont(co, 46, clofun8, 1, v0x7f1f241611e0);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = _35val1796;
+__arg1 = v0x7f1f24161600;
 __arg2 = args;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12718,11 +12718,11 @@ goto *jumpTable[ps.label];
 
 label46:
 {
-Obj _35val1797 = __arg1;
-Obj _35reg1795= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-Obj _35reg1798 = makeCons(_35reg1795, _35val1797);
+Obj v0x7f1f24161660 = __arg1;
+Obj v0x7f1f241611e0= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
+Obj v0x7f1f241616c0 = makeCons(v0x7f1f241611e0, v0x7f1f24161660);
 __nargs = 2;
-__arg1 = _35reg1798;
+__arg1 = v0x7f1f241616c0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun8) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -12730,7 +12730,7 @@ goto *jumpTable[co->ctx.pc.label];
 
 label47:
 {
-Obj _35cc1507 = makeNative(49, clofun8, 0, 0);
+Obj v0x7f1f2414dfe0 = makeNative(49, clofun8, 0, 0);
 Obj env = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
 Obj import = closureRef(co, 2);
@@ -12752,11 +12752,11 @@ goto *jumpTable[ps.label];
 
 label48:
 {
-Obj _35val1786 = __arg1;
+Obj v0x7f1f2404f600 = __arg1;
 Obj ls= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35map);
-__arg1 = _35val1786;
+__arg1 = v0x7f1f2404f600;
 __arg2 = ls;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12799,14 +12799,14 @@ goto *jumpTable[co->ctx.pc.label];
 
 label0:
 {
-Obj _35p1486 = __arg1;
-Obj _35p1487 = __arg2;
-Obj _35p1488 = __arg3;
-Obj _35cc1489 = makeNative(1, clofun9, 0, 3, _35p1486, _35p1487, _35p1488);
-Obj s = _35p1486;
-Obj ns = _35p1487;
-Obj _35reg1784 = PRIM_EQ(Nil, _35p1488);
-if (True == _35reg1784) {
+Obj v0x7f1f24161540 = __arg1;
+Obj v0x7f1f24161560 = __arg2;
+Obj v0x7f1f24161580 = __arg3;
+Obj v0x7f1f24161680 = makeNative(1, clofun9, 0, 3, v0x7f1f24161540, v0x7f1f24161560, v0x7f1f24161580);
+Obj s = v0x7f1f24161540;
+Obj ns = v0x7f1f24161560;
+Obj v0x7f1f24069680 = PRIM_EQ(Nil, v0x7f1f24161580);
+if (True == v0x7f1f24069680) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35var_45with_45ns);
 __arg1 = s;
@@ -12818,7 +12818,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1489;
+__arg0 = v0x7f1f24161680;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12829,15 +12829,15 @@ goto *jumpTable[ps.label];
 
 label1:
 {
-Obj _35cc1490 = makeNative(9, clofun9, 0, 0);
+Obj v0x7f1f24161860 = makeNative(9, clofun9, 0, 0);
 Obj s = closureRef(co, 0);
 Obj ns = closureRef(co, 1);
-Obj _35reg1774 = PRIM_ISCONS(closureRef(co, 2));
-if (True == _35reg1774) {
-Obj _35reg1775 = PRIM_CAR(closureRef(co, 2));
-Obj import = _35reg1775;
-Obj _35reg1776 = PRIM_CDR(closureRef(co, 2));
-Obj more = _35reg1776;
+Obj v0x7f1f2406ba80 = PRIM_ISCONS(closureRef(co, 2));
+if (True == v0x7f1f2406ba80) {
+Obj v0x7f1f2406bb80 = PRIM_CAR(closureRef(co, 2));
+Obj import = v0x7f1f2406bb80;
+Obj v0x7f1f2406bc80 = PRIM_CDR(closureRef(co, 2));
+Obj more = v0x7f1f2406bc80;
 pushCont(co, 2, clofun9, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35string_45append);
@@ -12850,7 +12850,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1490;
+__arg0 = v0x7f1f24161860;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12861,7 +12861,7 @@ goto *jumpTable[ps.label];
 
 label2:
 {
-Obj _35val1777 = __arg1;
+Obj v0x7f1f2406bee0 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -12869,7 +12869,7 @@ Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 3, clofun9, 4, import, s, ns, more);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35intern);
-__arg1 = _35val1777;
+__arg1 = v0x7f1f2406bee0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12879,7 +12879,7 @@ goto *jumpTable[ps.label];
 
 label3:
 {
-Obj _35val1778 = __arg1;
+Obj v0x7f1f2406bf00 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
@@ -12887,7 +12887,7 @@ Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
 pushCont(co, 4, clofun9, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35value_45or);
-__arg1 = _35val1778;
+__arg1 = v0x7f1f2406bf00;
 __arg2 = Nil;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -12898,12 +12898,12 @@ goto *jumpTable[ps.label];
 
 label4:
 {
-Obj _35val1779 = __arg1;
+Obj v0x7f1f2406bf40 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-Obj export = _35val1779;
+Obj export = v0x7f1f2406bf40;
 pushCont(co, 5, clofun9, 4, import, s, ns, more);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35elem_63);
@@ -12918,12 +12918,12 @@ goto *jumpTable[ps.label];
 
 label5:
 {
-Obj _35val1780 = __arg1;
+Obj v0x7f1f24069060 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj s= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 2];
 Obj more= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 3];
-if (True == _35val1780) {
+if (True == v0x7f1f24069060) {
 pushCont(co, 6, clofun9, 1, import);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35symbol_45_62string);
@@ -12949,13 +12949,13 @@ goto *jumpTable[ps.label];
 
 label6:
 {
-Obj _35val1781 = __arg1;
+Obj v0x7f1f24069340 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 7, clofun9, 1, import);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35string_45append);
 __arg1 = makeCString("#");
-__arg2 = _35val1781;
+__arg2 = v0x7f1f24069340;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12965,13 +12965,13 @@ goto *jumpTable[ps.label];
 
 label7:
 {
-Obj _35val1782 = __arg1;
+Obj v0x7f1f24069360 = __arg1;
 Obj import= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 8, clofun9);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35string_45append);
 __arg1 = import;
-__arg2 = _35val1782;
+__arg2 = v0x7f1f24069360;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -12981,10 +12981,10 @@ goto *jumpTable[ps.label];
 
 label8:
 {
-Obj _35val1783 = __arg1;
+Obj v0x7f1f24069380 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35intern);
-__arg1 = _35val1783;
+__arg1 = v0x7f1f24069380;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13008,8 +13008,8 @@ label10:
 {
 Obj var = __arg1;
 Obj ns = __arg2;
-Obj _35reg1768 = PRIM_EQ(ns, makeCString(""));
-if (True == _35reg1768) {
+Obj v0x7f1f2406b1e0 = PRIM_EQ(ns, makeCString(""));
+if (True == v0x7f1f2406b1e0) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13030,10 +13030,10 @@ goto *jumpTable[ps.label];
 
 label11:
 {
-Obj _35val1769 = __arg1;
+Obj v0x7f1f2406b2e0 = __arg1;
 Obj var= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-if (True == _35val1769) {
+if (True == v0x7f1f2406b2e0) {
 __nargs = 2;
 __arg1 = var;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13054,13 +13054,13 @@ goto *jumpTable[ps.label];
 
 label12:
 {
-Obj _35val1770 = __arg1;
+Obj v0x7f1f2406b5c0 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 pushCont(co, 13, clofun9, 1, ns);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35string_45append);
 __arg1 = makeCString("#");
-__arg2 = _35val1770;
+__arg2 = v0x7f1f2406b5c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13070,13 +13070,13 @@ goto *jumpTable[ps.label];
 
 label13:
 {
-Obj _35val1771 = __arg1;
+Obj v0x7f1f2406b5e0 = __arg1;
 Obj ns= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 PUSH_CONT_0(co, 14, clofun9);
 __nargs = 3;
 __arg0 = globalRef(symcora_47init_35string_45append);
 __arg1 = ns;
-__arg2 = _35val1771;
+__arg2 = v0x7f1f2406b5e0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13086,10 +13086,10 @@ goto *jumpTable[ps.label];
 
 label14:
 {
-Obj _35val1772 = __arg1;
+Obj v0x7f1f2406b600 = __arg1;
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35intern);
-__arg1 = _35val1772;
+__arg1 = v0x7f1f2406b600;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13099,12 +13099,12 @@ goto *jumpTable[ps.label];
 
 label15:
 {
-Obj _35p1482 = __arg1;
-Obj _35p1483 = __arg2;
-Obj _35cc1484 = makeNative(16, clofun9, 0, 2, _35p1482, _35p1483);
-Obj _35reg1766 = PRIM_EQ(MAKE_NUMBER(0), _35p1482);
-if (True == _35reg1766) {
-Obj res = _35p1483;
+Obj v0x7f1f241610a0 = __arg1;
+Obj v0x7f1f241610c0 = __arg2;
+Obj v0x7f1f24161180 = makeNative(16, clofun9, 0, 2, v0x7f1f241610a0, v0x7f1f241610c0);
+Obj v0x7f1f24072ea0 = PRIM_EQ(MAKE_NUMBER(0), v0x7f1f241610a0);
+if (True == v0x7f1f24072ea0) {
+Obj res = v0x7f1f241610c0;
 __nargs = 2;
 __arg1 = res;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13112,7 +13112,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1484;
+__arg0 = v0x7f1f24161180;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13123,16 +13123,16 @@ goto *jumpTable[ps.label];
 
 label16:
 {
-Obj _35cc1485 = makeNative(17, clofun9, 0, 0);
+Obj v0x7f1f241612e0 = makeNative(17, clofun9, 0, 0);
 Obj n = closureRef(co, 0);
 Obj res = closureRef(co, 1);
-Obj _35reg1763 = PRIM_SUB(n, MAKE_NUMBER(1));
-Obj _35reg1764 = primGenSym(symtmp);
-Obj _35reg1765 = makeCons(_35reg1764, res);
+Obj v0x7f1f24072bc0 = PRIM_SUB(n, MAKE_NUMBER(1));
+Obj v0x7f1f24072d40 = primGenSym(symtmp);
+Obj v0x7f1f24072d80 = makeCons(v0x7f1f24072d40, res);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35temp_45list);
-__arg1 = _35reg1763;
-__arg2 = _35reg1765;
+__arg1 = v0x7f1f24072bc0;
+__arg2 = v0x7f1f24072d80;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13169,8 +13169,8 @@ goto *jumpTable[ps.label];
 
 label19:
 {
-Obj _35val1760 = __arg1;
-Obj find = _35val1760;
+Obj v0x7f1f24072520 = __arg1;
+Obj find = v0x7f1f24072520;
 pushCont(co, 20, clofun9, 1, find);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
@@ -13184,9 +13184,9 @@ goto *jumpTable[ps.label];
 
 label20:
 {
-Obj _35val1761 = __arg1;
+Obj v0x7f1f24072620 = __arg1;
 Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == _35val1761) {
+if (True == v0x7f1f24072620) {
 __nargs = 2;
 __arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13221,8 +13221,8 @@ goto *jumpTable[ps.label];
 
 label22:
 {
-Obj _35val1757 = __arg1;
-Obj find = _35val1757;
+Obj v0x7f1f24072100 = __arg1;
+Obj find = v0x7f1f24072100;
 pushCont(co, 23, clofun9, 1, find);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
@@ -13236,9 +13236,9 @@ goto *jumpTable[ps.label];
 
 label23:
 {
-Obj _35val1758 = __arg1;
+Obj v0x7f1f24072200 = __arg1;
 Obj find= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
-if (True == _35val1758) {
+if (True == v0x7f1f24072200) {
 __nargs = 2;
 __arg1 = makeCString("ERROR");
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13273,11 +13273,11 @@ goto *jumpTable[ps.label];
 
 label25:
 {
-Obj _35val1753 = __arg1;
+Obj v0x7f1f240f6e40 = __arg1;
 PUSH_CONT_0(co, 26, clofun9);
 __nargs = 2;
 __arg0 = globalRef(symcora_47init_35null_63);
-__arg1 = _35val1753;
+__arg1 = v0x7f1f240f6e40;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13287,10 +13287,10 @@ goto *jumpTable[ps.label];
 
 label26:
 {
-Obj _35val1754 = __arg1;
-Obj _35reg1755 = primNot(_35val1754);
+Obj v0x7f1f240f6e60 = __arg1;
+Obj v0x7f1f240f6e80 = primNot(v0x7f1f240f6e60);
 __nargs = 2;
-__arg1 = _35reg1755;
+__arg1 = v0x7f1f240f6e80;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
@@ -13298,12 +13298,12 @@ goto *jumpTable[co->ctx.pc.label];
 
 label27:
 {
-Obj _35p1478 = __arg1;
-Obj _35p1479 = __arg2;
-Obj _35cc1480 = makeNative(28, clofun9, 0, 2, _35p1478, _35p1479);
-Obj x = _35p1478;
-Obj _35reg1682 = PRIM_EQ(Nil, _35p1479);
-if (True == _35reg1682) {
+Obj v0x7f1f240f9620 = __arg1;
+Obj v0x7f1f240f9640 = __arg2;
+Obj v0x7f1f240f9700 = makeNative(28, clofun9, 0, 2, v0x7f1f240f9620, v0x7f1f240f9640);
+Obj x = v0x7f1f240f9620;
+Obj v0x7f1f2412cb20 = PRIM_EQ(Nil, v0x7f1f240f9640);
+if (True == v0x7f1f2412cb20) {
 __nargs = 2;
 __arg1 = False;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13311,7 +13311,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1480;
+__arg0 = v0x7f1f240f9700;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13322,14 +13322,14 @@ goto *jumpTable[ps.label];
 
 label28:
 {
-Obj _35cc1481 = makeNative(30, clofun9, 0, 0);
+Obj v0x7f1f240f9860 = makeNative(30, clofun9, 0, 0);
 Obj x = closureRef(co, 0);
-Obj _35reg1677 = PRIM_ISCONS(closureRef(co, 1));
-if (True == _35reg1677) {
-Obj _35reg1678 = PRIM_CAR(closureRef(co, 1));
-Obj hd = _35reg1678;
-Obj _35reg1679 = PRIM_CDR(closureRef(co, 1));
-Obj tl = _35reg1679;
+Obj v0x7f1f2412c180 = PRIM_ISCONS(closureRef(co, 1));
+if (True == v0x7f1f2412c180) {
+Obj v0x7f1f2412c280 = PRIM_CAR(closureRef(co, 1));
+Obj hd = v0x7f1f2412c280;
+Obj v0x7f1f2412c380 = PRIM_CDR(closureRef(co, 1));
+Obj tl = v0x7f1f2412c380;
 pushCont(co, 29, clofun9, 2, x, tl);
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35index);
@@ -13342,7 +13342,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1481;
+__arg0 = v0x7f1f240f9860;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13353,11 +13353,11 @@ goto *jumpTable[ps.label];
 
 label29:
 {
-Obj _35val1680 = __arg1;
+Obj v0x7f1f2412c840 = __arg1;
 Obj x= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj tl= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
-Obj _35reg1681 = PRIM_LT(_35val1680, MAKE_NUMBER(0));
-if (True == _35reg1681) {
+Obj v0x7f1f2412c880 = PRIM_LT(v0x7f1f2412c840, MAKE_NUMBER(0));
+if (True == v0x7f1f2412c880) {
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35exist_45in_45env);
 __arg1 = x;
@@ -13406,14 +13406,14 @@ goto *jumpTable[ps.label];
 
 label32:
 {
-Obj _35p1472 = __arg1;
-Obj _35p1473 = __arg2;
-Obj _35p1474 = __arg3;
-Obj _35cc1475 = makeNative(33, clofun9, 0, 3, _35p1472, _35p1473, _35p1474);
-Obj __ = _35p1472;
-Obj x = _35p1473;
-Obj _35reg1674 = PRIM_EQ(Nil, _35p1474);
-if (True == _35reg1674) {
+Obj v0x7f1f24128da0 = __arg1;
+Obj v0x7f1f24128dc0 = __arg2;
+Obj v0x7f1f24128de0 = __arg3;
+Obj v0x7f1f24128ee0 = makeNative(33, clofun9, 0, 3, v0x7f1f24128da0, v0x7f1f24128dc0, v0x7f1f24128de0);
+Obj __ = v0x7f1f24128da0;
+Obj x = v0x7f1f24128dc0;
+Obj v0x7f1f2412fa80 = PRIM_EQ(Nil, v0x7f1f24128de0);
+if (True == v0x7f1f2412fa80) {
 __nargs = 2;
 __arg1 = MAKE_NUMBER(-1);
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13421,7 +13421,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1475;
+__arg0 = v0x7f1f24128ee0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13432,17 +13432,17 @@ goto *jumpTable[ps.label];
 
 label33:
 {
-Obj _35cc1476 = makeNative(34, clofun9, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
+Obj v0x7f1f240f90c0 = makeNative(34, clofun9, 0, 3, closureRef(co, 0), closureRef(co, 1), closureRef(co, 2));
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1670 = PRIM_ISCONS(closureRef(co, 2));
-if (True == _35reg1670) {
-Obj _35reg1671 = PRIM_CAR(closureRef(co, 2));
-Obj a = _35reg1671;
-Obj _35reg1672 = PRIM_CDR(closureRef(co, 2));
-Obj b = _35reg1672;
-Obj _35reg1673 = PRIM_EQ(x, a);
-if (True == _35reg1673) {
+Obj v0x7f1f2412f4c0 = PRIM_ISCONS(closureRef(co, 2));
+if (True == v0x7f1f2412f4c0) {
+Obj v0x7f1f2412f5c0 = PRIM_CAR(closureRef(co, 2));
+Obj a = v0x7f1f2412f5c0;
+Obj v0x7f1f2412f6c0 = PRIM_CDR(closureRef(co, 2));
+Obj b = v0x7f1f2412f6c0;
+Obj v0x7f1f2412f7e0 = PRIM_EQ(x, a);
+if (True == v0x7f1f2412f7e0) {
 __nargs = 2;
 __arg1 = pos;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13450,7 +13450,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1476;
+__arg0 = v0x7f1f240f90c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13459,7 +13459,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1476;
+__arg0 = v0x7f1f240f90c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13470,19 +13470,19 @@ goto *jumpTable[ps.label];
 
 label34:
 {
-Obj _35cc1477 = makeNative(35, clofun9, 0, 0);
+Obj v0x7f1f240f9320 = makeNative(35, clofun9, 0, 0);
 Obj pos = closureRef(co, 0);
 Obj x = closureRef(co, 1);
-Obj _35reg1666 = PRIM_ISCONS(closureRef(co, 2));
-if (True == _35reg1666) {
-Obj _35reg1667 = PRIM_CAR(closureRef(co, 2));
-Obj a = _35reg1667;
-Obj _35reg1668 = PRIM_CDR(closureRef(co, 2));
-Obj b = _35reg1668;
-Obj _35reg1669 = PRIM_ADD(pos, MAKE_NUMBER(1));
+Obj v0x7f1f24133f00 = PRIM_ISCONS(closureRef(co, 2));
+if (True == v0x7f1f24133f00) {
+Obj v0x7f1f2412f000 = PRIM_CAR(closureRef(co, 2));
+Obj a = v0x7f1f2412f000;
+Obj v0x7f1f2412f100 = PRIM_CDR(closureRef(co, 2));
+Obj b = v0x7f1f2412f100;
+Obj v0x7f1f2412f280 = PRIM_ADD(pos, MAKE_NUMBER(1));
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35pos_45in_45list0);
-__arg1 = _35reg1669;
+__arg1 = v0x7f1f2412f280;
 __arg2 = x;
 __arg3 = b;
 co->ctx.frees = __arg0;
@@ -13492,7 +13492,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1477;
+__arg0 = v0x7f1f240f9320;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13515,14 +13515,14 @@ goto *jumpTable[ps.label];
 
 label36:
 {
-Obj _35p1467 = __arg1;
-Obj _35p1468 = __arg2;
-Obj _35p1469 = __arg3;
-Obj _35cc1470 = makeNative(37, clofun9, 0, 3, _35p1467, _35p1468, _35p1469);
-Obj f = _35p1467;
-Obj acc = _35p1468;
-Obj _35reg1664 = PRIM_EQ(Nil, _35p1469);
-if (True == _35reg1664) {
+Obj v0x7f1f241286e0 = __arg1;
+Obj v0x7f1f24128700 = __arg2;
+Obj v0x7f1f24128720 = __arg3;
+Obj v0x7f1f24128820 = makeNative(37, clofun9, 0, 3, v0x7f1f241286e0, v0x7f1f24128700, v0x7f1f24128720);
+Obj f = v0x7f1f241286e0;
+Obj acc = v0x7f1f24128700;
+Obj v0x7f1f24133980 = PRIM_EQ(Nil, v0x7f1f24128720);
+if (True == v0x7f1f24133980) {
 __nargs = 2;
 __arg1 = acc;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13530,7 +13530,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1470;
+__arg0 = v0x7f1f24128820;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13541,15 +13541,15 @@ goto *jumpTable[ps.label];
 
 label37:
 {
-Obj _35cc1471 = makeNative(39, clofun9, 0, 0);
+Obj v0x7f1f24128a00 = makeNative(39, clofun9, 0, 0);
 Obj f = closureRef(co, 0);
 Obj acc = closureRef(co, 1);
-Obj _35reg1660 = PRIM_ISCONS(closureRef(co, 2));
-if (True == _35reg1660) {
-Obj _35reg1661 = PRIM_CAR(closureRef(co, 2));
-Obj x = _35reg1661;
-Obj _35reg1662 = PRIM_CDR(closureRef(co, 2));
-Obj y = _35reg1662;
+Obj v0x7f1f241333a0 = PRIM_ISCONS(closureRef(co, 2));
+if (True == v0x7f1f241333a0) {
+Obj v0x7f1f241334a0 = PRIM_CAR(closureRef(co, 2));
+Obj x = v0x7f1f241334a0;
+Obj v0x7f1f241335a0 = PRIM_CDR(closureRef(co, 2));
+Obj y = v0x7f1f241335a0;
 pushCont(co, 38, clofun9, 2, f, y);
 __nargs = 3;
 __arg0 = f;
@@ -13562,7 +13562,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1471;
+__arg0 = v0x7f1f24128a00;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13573,13 +13573,13 @@ goto *jumpTable[ps.label];
 
 label38:
 {
-Obj _35val1663 = __arg1;
+Obj v0x7f1f24133740 = __arg1;
 Obj f= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 0];
 Obj y= ((Obj*)bytesData(co->ctx.stk.stack))[co->ctx.stk.base + 1];
 __nargs = 4;
 __arg0 = globalRef(symcora_47lib_47toc_35foldl);
 __arg1 = f;
-__arg2 = _35val1663;
+__arg2 = v0x7f1f24133740;
 __arg3 = y;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
@@ -13602,12 +13602,12 @@ goto *jumpTable[ps.label];
 
 label40:
 {
-Obj _35p1462 = __arg1;
-Obj _35p1463 = __arg2;
-Obj _35cc1464 = makeNative(41, clofun9, 0, 2, _35p1462, _35p1463);
-Obj var = _35p1462;
-Obj _35reg1658 = PRIM_EQ(Nil, _35p1463);
-if (True == _35reg1658) {
+Obj v0x7f1f2412cf80 = __arg1;
+Obj v0x7f1f2412cfa0 = __arg2;
+Obj v0x7f1f24128060 = makeNative(41, clofun9, 0, 2, v0x7f1f2412cf80, v0x7f1f2412cfa0);
+Obj var = v0x7f1f2412cf80;
+Obj v0x7f1f24135ea0 = PRIM_EQ(Nil, v0x7f1f2412cfa0);
+if (True == v0x7f1f24135ea0) {
 __nargs = 2;
 __arg1 = Nil;
 co->ctx = co->callstack.data[--co->callstack.len];
@@ -13615,7 +13615,7 @@ if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1464;
+__arg0 = v0x7f1f24128060;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13626,32 +13626,32 @@ goto *jumpTable[ps.label];
 
 label41:
 {
-Obj _35cc1465 = makeNative(42, clofun9, 0, 2, closureRef(co, 0), closureRef(co, 1));
+Obj v0x7f1f241281c0 = makeNative(42, clofun9, 0, 2, closureRef(co, 0), closureRef(co, 1));
 Obj var = closureRef(co, 0);
-Obj _35reg1648 = PRIM_ISCONS(closureRef(co, 1));
-if (True == _35reg1648) {
-Obj _35reg1649 = PRIM_CAR(closureRef(co, 1));
-Obj _35reg1650 = PRIM_ISCONS(_35reg1649);
-if (True == _35reg1650) {
-Obj _35reg1651 = PRIM_CAR(closureRef(co, 1));
-Obj _35reg1652 = PRIM_CAR(_35reg1651);
-Obj x = _35reg1652;
-Obj _35reg1653 = PRIM_CAR(closureRef(co, 1));
-Obj _35reg1654 = PRIM_CDR(_35reg1653);
-Obj y = _35reg1654;
-Obj _35reg1655 = PRIM_CDR(closureRef(co, 1));
-Obj __ = _35reg1655;
-Obj _35reg1656 = PRIM_EQ(var, x);
-if (True == _35reg1656) {
-Obj _35reg1657 = makeCons(x, y);
+Obj v0x7f1f24135380 = PRIM_ISCONS(closureRef(co, 1));
+if (True == v0x7f1f24135380) {
+Obj v0x7f1f24135520 = PRIM_CAR(closureRef(co, 1));
+Obj v0x7f1f24135540 = PRIM_ISCONS(v0x7f1f24135520);
+if (True == v0x7f1f24135540) {
+Obj v0x7f1f241356e0 = PRIM_CAR(closureRef(co, 1));
+Obj v0x7f1f24135700 = PRIM_CAR(v0x7f1f241356e0);
+Obj x = v0x7f1f24135700;
+Obj v0x7f1f241358a0 = PRIM_CAR(closureRef(co, 1));
+Obj v0x7f1f241358c0 = PRIM_CDR(v0x7f1f241358a0);
+Obj y = v0x7f1f241358c0;
+Obj v0x7f1f241359c0 = PRIM_CDR(closureRef(co, 1));
+Obj __ = v0x7f1f241359c0;
+Obj v0x7f1f24135ae0 = PRIM_EQ(var, x);
+if (True == v0x7f1f24135ae0) {
+Obj v0x7f1f24135bc0 = makeCons(x, y);
 __nargs = 2;
-__arg1 = _35reg1657;
+__arg1 = v0x7f1f24135bc0;
 co->ctx = co->callstack.data[--co->callstack.len];
 if (co->ctx.pc.func != clofun9) { goto fail; }
 goto *jumpTable[co->ctx.pc.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1465;
+__arg0 = v0x7f1f241281c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13660,7 +13660,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1465;
+__arg0 = v0x7f1f241281c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13669,7 +13669,7 @@ goto *jumpTable[ps.label];
 }
 } else {
 __nargs = 1;
-__arg0 = _35cc1465;
+__arg0 = v0x7f1f241281c0;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };
@@ -13680,14 +13680,14 @@ goto *jumpTable[ps.label];
 
 label42:
 {
-Obj _35cc1466 = makeNative(43, clofun9, 0, 0);
+Obj v0x7f1f24128420 = makeNative(43, clofun9, 0, 0);
 Obj var = closureRef(co, 0);
-Obj _35reg1645 = PRIM_ISCONS(closureRef(co, 1));
-if (True == _35reg1645) {
-Obj _35reg1646 = PRIM_CAR(closureRef(co, 1));
-Obj __ = _35reg1646;
-Obj _35reg1647 = PRIM_CDR(closureRef(co, 1));
-Obj y = _35reg1647;
+Obj v0x7f1f24138f00 = PRIM_ISCONS(closureRef(co, 1));
+if (True == v0x7f1f24138f00) {
+Obj v0x7f1f24135000 = PRIM_CAR(closureRef(co, 1));
+Obj __ = v0x7f1f24135000;
+Obj v0x7f1f24135100 = PRIM_CDR(closureRef(co, 1));
+Obj y = v0x7f1f24135100;
 __nargs = 3;
 __arg0 = globalRef(symcora_47lib_47toc_35assq);
 __arg1 = var;
@@ -13699,7 +13699,7 @@ if (ps.func != clofun9) { co->ctx.pc = ps; goto fail; };
 goto *jumpTable[ps.label];
 } else {
 __nargs = 1;
-__arg0 = _35cc1466;
+__arg0 = v0x7f1f24128420;
 co->ctx.frees = __arg0;
 struct pcState ps = OBJ_FIELD(__arg0, scmNative, code);
 if (OBJ_FIELD(__arg0, scmNative, required)+1 != __nargs) { co->ctx.pc.func = coraDispatch; goto fail; };

--- a/lib/toc/internal.c
+++ b/lib/toc/internal.c
@@ -17,7 +17,11 @@ builtinGenerateSym(struct Cora *co) {
 	Obj to = co->args[1];
 	FILE *out = mustCObj(to);
 	Obj exp = co->args[2];
-	const char *s = symbolStr(exp);
+	char s[256];
+	symbolStr(exp, s, 256);
+	if (s[0] >= '0' && s[0] <= '9') {
+		fprintf(out, "v");
+	}
 	for (const char *p = s; *p != 0; p++) {
 		if ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
 		    (*p >= '0' && *p <= '9')) {
@@ -71,8 +75,9 @@ builtinEscapeStr(struct Cora *co) {
 static void
 builtinSymbolCooked(struct Cora *co) {
 	Obj sym = co->args[1];
-	char *s = symbolStr(sym);
-	for (; *s != 0; s++) {
+	char dst[256];
+	symbolStr(sym, dst, 256);
+	for (char *s=dst; *s != 0; s++) {
 		if (*s == '#') {
 			coraReturn(co, True);
 			return;

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -25,7 +25,8 @@ traceWrap(struct Cora *co) {
 	assert(isNative(origin));
 	co->args[0] = origin;
 
-	char *name = symbolStr(sym);
+	char name[256];
+	symbolStr(sym, name, 256);
 	TRACE_BEGIN(name);
 	trampoline(co, 0, coraDispatch);
 	TRACE_END(name);

--- a/src/gc.c
+++ b/src/gc.c
@@ -234,7 +234,7 @@ struct GC {
 	struct GCStats stats;
 
 	// remember set for generationGC.
-	struct scmVector *rset;
+	scmHeadEx *rset;
 };
 
 static void
@@ -876,18 +876,22 @@ gcFlip(struct GC *gc) {
 	}
 
 	// GC Statistics
+	char *gen = "";
 	if (gc->version % 24 == 0) {
 		gc->stats.oldGenSize = gc->stats.markSize;
+		gen = "***";
 	} else if (gc->version % 8 == 0) {
 		gc->stats.middleGenSize = gc->stats.markSize;
+		gen = "**";
 	} else if (gc->version % 4 == 0) {
 		gc->stats.youngGenSize = gc->stats.markSize;
+		gen = "*";
 	}
 	char *coraDebug = getenv("CORADEBUG");
 	if (coraDebug != NULL) {
 		printf("gc%" PRIu64
-		       ", trigger=%dsz, mark=%dsz %dcnt, skip=%dcnt, incremental=%dsz, sys=%zusz\n",
-		       gc->version, gc->stats.nextSize, gc->stats.markSize,
+		       "%s, trigger=%zusz, mark=%zusz %dcnt, skip=%dcnt, incremental=%zusz, sys=%zusz\n",
+		       gc->version, gen, gc->stats.nextSize, gc->stats.markSize,
 		       gc->stats.markCount, gc->stats.markSkip,
 		       gc->stats.allocated, sysSize, gc->stats.youngGenSize,
 		       gc->stats.middleGenSize, gc->stats.oldGenSize);
@@ -1075,14 +1079,14 @@ writeBarrierForIncremental(struct GC *gc, uintptr_t *slot, uintptr_t val) {
 }
 
 void
-writeBarrierForGeneration(struct GC *gc, struct scmVector *v, uintptr_t val) {
+writeBarrierForGeneration(struct GC *gc, scmHeadEx *v, uintptr_t val) {
 	// skip if not a pointer
 	if (tag(val) != TAG_PTR) {
 		return;
 	}
 
 	scmHead *h = ptr(val);
-	if (versionCmp(v->head.version % 64, h->version % 64) <= 0) {
+	if (versionCmp(v->version % 64, h->version % 64) <= 0) {
 		return;
 	}
 
@@ -1098,8 +1102,8 @@ writeBarrierForGeneration(struct GC *gc, struct scmVector *v, uintptr_t val) {
 		}
 		break;
 	case gcStateIncremental:
-		if (((v->head.version & 1) == 1) &&
-		    ((h->version + 1) % 64) == (v->head.version % 64)) {
+		if (((v->version & 1) == 1) &&
+		    ((h->version + 1) % 64) == (v->version % 64)) {
 			return;
 		}
 		// add vec to rset and enqueue val
@@ -1119,8 +1123,8 @@ gcRSet(struct GC *gc) {
 		return;
 	}
 
-	struct scmVector *prev = NULL;
-	struct scmVector *p = gc->rset;
+	scmHeadEx *prev = NULL;
+	scmHeadEx *p = gc->rset;
 	while (p != NULL) {
 		scmHead *h = (scmHead *) p;
 		if (versionCmp
@@ -1133,13 +1137,26 @@ gcRSet(struct GC *gc) {
 				prev->rset = p->rset;
 			}
 
-			struct scmVector *tmp = p;
+			scmHeadEx *tmp = p;
 			p = p->rset;
 			tmp->rset = NULL;
 			tmp->inRSet = false;
 		} else {
-			for (int i = 0; i < p->size; i++) {
-				gcMark(gc, p->data[i], 0);
+			switch(p->type) {
+			case scmHeadVector:
+				{
+					struct scmVector *pv = (struct scmVector*)p;
+					for (int i = 0; i < pv->size; i++) {
+						gcMark(gc, pv->data[i], 0);
+					}
+					break;
+				}
+			case scmHeadSymbol:
+				{
+					struct scmSymbol *pv = (struct scmSymbol*)p;
+					gcMark(gc, pv->value, 0);
+					break;
+				}
 			}
 			prev = p;
 			p = p->rset;

--- a/src/gc.c
+++ b/src/gc.c
@@ -891,9 +891,9 @@ gcFlip(struct GC *gc) {
 	if (coraDebug != NULL) {
 		printf("gc%" PRIu64
 		       "%s, trigger=%zusz, mark=%zusz %dcnt, skip=%dcnt, incremental=%zusz, sys=%zusz\n",
-		       gc->version, gen, gc->stats.nextSize, gc->stats.markSize,
-		       gc->stats.markCount, gc->stats.markSkip,
-		       gc->stats.allocated, sysSize);
+		       gc->version, gen, gc->stats.nextSize,
+		       gc->stats.markSize, gc->stats.markCount,
+		       gc->stats.markSkip, gc->stats.allocated, sysSize);
 	}
 
 	gc->version = gc->version + 2;
@@ -1137,10 +1137,11 @@ gcRSet(struct GC *gc) {
 			tmp->rset = NULL;
 			tmp->inRSet = false;
 		} else {
-			switch(p->type) {
+			switch (p->type) {
 			case scmHeadVector:
 				{
-					struct scmVector *pv = (struct scmVector*)p;
+					struct scmVector *pv =
+						(struct scmVector *) p;
 					for (int i = 0; i < pv->size; i++) {
 						gcMark(gc, pv->data[i], 0);
 					}
@@ -1148,7 +1149,8 @@ gcRSet(struct GC *gc) {
 				}
 			case scmHeadSymbol:
 				{
-					struct scmSymbol *pv = (struct scmSymbol*)p;
+					struct scmSymbol *pv =
+						(struct scmSymbol *) p;
 					gcMark(gc, pv->value, 0);
 					break;
 				}

--- a/src/gc.c
+++ b/src/gc.c
@@ -893,8 +893,7 @@ gcFlip(struct GC *gc) {
 		       "%s, trigger=%zusz, mark=%zusz %dcnt, skip=%dcnt, incremental=%zusz, sys=%zusz\n",
 		       gc->version, gen, gc->stats.nextSize, gc->stats.markSize,
 		       gc->stats.markCount, gc->stats.markSkip,
-		       gc->stats.allocated, sysSize, gc->stats.youngGenSize,
-		       gc->stats.middleGenSize, gc->stats.oldGenSize);
+		       gc->stats.allocated, sysSize);
 	}
 
 	gc->version = gc->version + 2;
@@ -979,10 +978,6 @@ sweepSizeClass(struct GC *gc, struct runDoneProgress *pg) {
 			if (!inuse(gc, p)) {
 				p->type = scmHeadUnused;
 			}
-			/* if ((p->version & VERSION_MASK) == */
-			/*     ((gc->version - 2) & VERSION_MASK)) { */
-			/*      p->type = scmHeadUnused; */
-			/* } */
 		}
 		pg->b = pg->b->next;
 		return;

--- a/src/reader.c
+++ b/src/reader.c
@@ -258,7 +258,9 @@ printObj(FILE *to, Obj o) {
 	} else if (iscons(o)) {
 		printCons(to, o, true);
 	} else if (issymbol(o)) {
-		fprintf(to, "%s", symbolStr(o));
+		char dest[256];
+		symbolStr(o, dest, 256);
+		fprintf(to, "%s", dest);
 	} else if (isboolean(o)) {
 		if (o == True) {
 			fprintf(to, "true");

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -294,7 +294,8 @@ primSet(struct Cora *co, Obj key, Obj val) {
 		} else {
 			assert(s->owner == co);
 		}
-	} else if (tag(key) == TAG_PTR && ((scmHead *)ptr(key))->type == scmHeadSymbol) {
+	} else if (tag(key) == TAG_PTR &&
+		   ((scmHead *) ptr(key))->type == scmHeadSymbol) {
 		struct scmSymbol *s = ptr(key);
 		writeBarrierForIncremental(getGC(), &s->value, val);
 		writeBarrierForGeneration(getGC(), &s->head, val);
@@ -531,7 +532,8 @@ builtinValue(struct Cora *co) {
 			printf("undefined value: %s\n", s->sym);
 			assert(false);
 		}
-	} else if (tag(sym) == TAG_PTR && ((scmHead *)ptr(sym))->type == scmHeadSymbol) {
+	} else if (tag(sym) == TAG_PTR &&
+		   ((scmHead *) ptr(sym))->type == scmHeadSymbol) {
 		struct scmSymbol *s = ptr(sym);
 		ret = s->value;
 		assert(ret != Undef);
@@ -548,7 +550,8 @@ builtinValueOr(struct Cora *co) {
 	if (tag(sym) == TAG_SYMBOL) {
 		struct trieNode *s = ptr(sym);
 		ret = s->value;
-	} else if (tag(sym) == TAG_PTR && ((scmHead *)ptr(sym))->type == scmHeadSymbol) {
+	} else if (tag(sym) == TAG_PTR &&
+		   ((scmHead *) ptr(sym))->type == scmHeadSymbol) {
 		struct scmSymbol *s = ptr(sym);
 		ret = s->value;
 	} else {

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -162,12 +162,9 @@ static void
 coraGCFunc(struct GC *gc, struct Cora *co) {
 	TRACE_SCOPE("coraGCFunc");
 	// The globals
-	int n = 0;
 	for (struct trieNode * p = co->globals; p != &gRoot; p = p->next) {
-		n++;
 		gcMark(gc, p->value, 0);
 	}
-	printf("gc globals count=%d\n", n);
 
 	// The stack.
 	gcMark(gc, co->ctx.stk.stack, 0);

--- a/src/types.c
+++ b/src/types.c
@@ -172,7 +172,6 @@ static void
 bytesGCFunc(struct GC *gc, void *f) {
 }
 
-
 struct trieNode gRoot = { };
 
 Obj
@@ -206,11 +205,20 @@ symbolGet(Obj sym) {
 	return s->value;
 }
 
-char *
-symbolStr(Obj sym) {
+int
+symbolStr(Obj sym, char *dest, size_t sz) {
 	assert(issymbol(sym));
-	struct trieNode *s = ptr(sym);
-	return s->sym;
+	if (tag(sym) == TAG_SYMBOL) {
+		struct trieNode *s = ptr(sym);
+		int l = strlen(s->sym) + 1;
+		assert(l < sz);
+		memcpy(dest, s->sym, l);
+		return 0;
+	} else if (tag(sym) == TAG_PTR && ((scmHead *)ptr(sym))->type == scmHeadSymbol) {
+		snprintf(dest, sz, "%p", ptr(sym));
+		return 0;
+	}
+	assert(false);
 }
 
 Obj
@@ -296,8 +304,8 @@ makeVector(int size, int cap) {
 	struct scmVector *vec = newObj(scmHeadVector,
 				       sizeof(struct scmVector) +
 				       sizeof(Obj) * cap);
-	vec->rset = NULL;
-	vec->inRSet = false;
+	vec->head.rset = NULL;
+	vec->head.inRSet = false;
 	vec->size = size;
 	vec->cap = cap;
 	for (int i = 0; i < vec->size; i++) {
@@ -325,7 +333,7 @@ vectorSet(Obj vec, int idx, Obj val) {
 	assert(v->head.type == scmHeadVector);
 	assert(idx >= 0 && idx < v->size);
 	writeBarrierForIncremental(getGC(), &v->data[idx], val);
-	writeBarrierForGeneration(getGC(), v, val);
+	writeBarrierForGeneration(getGC(), &v->head, val);
 	return vec;
 }
 
@@ -428,6 +436,13 @@ continuationGCFunc(struct GC *gc, void *f) {
 	gcMarkCallStack(gc, &from->cs, minv);
 }
 
+static void
+symbolGCFunc(struct GC *gc, void *f) {
+	struct scmSymbol *from = f;
+	version_t minv = from->head.version;
+	gcMark(gc, from->value, minv);
+}
+
 void
 typesInit() {
 	gcRegistForType(scmHeadCons, consGCFunc);
@@ -435,4 +450,5 @@ typesInit() {
 	gcRegistForType(scmHeadVector, vectorGCFunc);
 	gcRegistForType(scmHeadNative, nativeGCFunc);
 	gcRegistForType(scmHeadContinuation, continuationGCFunc);
+	gcRegistForType(scmHeadSymbol, symbolGCFunc);
 }

--- a/src/types.c
+++ b/src/types.c
@@ -214,7 +214,8 @@ symbolStr(Obj sym, char *dest, size_t sz) {
 		assert(l < sz);
 		memcpy(dest, s->sym, l);
 		return 0;
-	} else if (tag(sym) == TAG_PTR && ((scmHead *)ptr(sym))->type == scmHeadSymbol) {
+	} else if (tag(sym) == TAG_PTR &&
+		   ((scmHead *) ptr(sym))->type == scmHeadSymbol) {
 		snprintf(dest, sz, "%p", ptr(sym));
 		return 0;
 	}

--- a/src/types.h
+++ b/src/types.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include "gc.h"
 #include "str.h"
 
@@ -36,7 +37,7 @@ typedef uintptr_t Obj;
 #define TAG_BOOLEAN 0xd
 
 #define iscobj(x) (tag(x) == TAG_COBJ)
-#define issymbol(x) (tag(x) == TAG_SYMBOL)
+#define issymbol(x) ((tag(x) == TAG_SYMBOL) || (tag(x) == TAG_PTR && ((scmHead *)ptr(x))->type == scmHeadSymbol))
 #define isfixnum(x) (((x) & 1) == 0)
 #define isboolean(x) (((x) & 0xf) == TAG_BOOLEAN)
 
@@ -66,7 +67,7 @@ void* mustCObj(Obj o);
 #define intern(x) makeSymbol(x)
 Obj makeSymbol(const char *s);
 Obj symbolGet(Obj sym);
-char* symbolStr(Obj sym);
+int symbolStr(Obj sym, char* dest, size_t sz);
 
 #define cons(x, y) makeCons(x, y)
 #define iscons(o) (((o) & TAG_MASK) == TAG_PTR && ((scmHead *)ptr(o))->type == scmHeadCons)


### PR DESCRIPTION
Now cora have two kinds of symbols: intern and gensym
The interned symbol are used as global variable, never GC
While gensym generate temporary symbol, should be GC
This division can avoid the memory leak of temporary symbol