### PR TITLE
runtime: fix continuation object memory leak

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -954,9 +954,8 @@ gcRunIncremental(struct GC *gc) {
 			assert((curr->version & 1) == 1);
 			fn(gc, curr);
 			curr->version =
-				(curr->
-				 version & (3 << 6)) | ((curr->version +
-							 1) % 64);
+				(curr->version & (3 << 6)) |
+				((curr->version + 1) % 64);
 			gcInuseSizeInc(gc, curr->size);
 		}
 		steps--;

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -443,13 +443,12 @@ continuationAsClosure(struct Cora *co) {
 
 	// Replace the current stack with the delimited continuation.
 	struct callStack *to = &co->callstack;
-	struct callStack *cs = contCallStack(cont);
-	for (int i = 0; i < cs->len; i++) {
-		struct frame *addr = &cs->data[i];
+	struct callStack cs = contCallStack(cont);
+	for (int i = 0; i < cs.len; i++) {
 		if (to->len + 1 >= to->cap) {
 			growCallStack(to);
 		}
-		to->data[to->len++] = *addr;
+		to->data[to->len++] = cs.data[i];
 	}
 	Obj val = co->args[1];
 	coraReturn(co, val);
@@ -466,15 +465,7 @@ builtinThrow(struct Cora *co) {
 	assert(try->stk.base == 0);
 
 	// Capture the call stack as continuation.
-	Obj cont = makeContinuation();
-	struct callStack *stack = contCallStack(cont);
-	for (int i = p; i < co->callstack.len; i++) {
-		struct frame *addr = &co->callstack.data[i];
-		if (stack->len + 1 >= stack->cap) {
-			growCallStack(stack);
-		}
-		stack->data[stack->len++] = *addr;
-	}
+	Obj cont = makeContinuation(&co->callstack.data[p], co->callstack.len - p);
 
 	// Now that we get the current continuation, disguise as a closure.
 	Obj clo = makeNative(0, continuationAsClosure, 1, 1, cont);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -465,7 +465,9 @@ builtinThrow(struct Cora *co) {
 	assert(try->stk.base == 0);
 
 	// Capture the call stack as continuation.
-	Obj cont = makeContinuation(&co->callstack.data[p], co->callstack.len - p);
+	Obj cont =
+		makeContinuation(&co->callstack.data[p],
+				 co->callstack.len - p);
 
 	// Now that we get the current continuation, disguise as a closure.
 	Obj clo = makeNative(0, continuationAsClosure, 1, 1, cont);

--- a/src/types.c
+++ b/src/types.c
@@ -402,8 +402,9 @@ vectorGCFunc(struct GC *gc, void *f) {
 Obj
 makeContinuation(struct frame *data, int len) {
 	struct scmContinuation *cont = newObj(scmHeadContinuation,
-					      sizeof(struct scmContinuation) + len*sizeof(struct frame));
-	for (int i=0; i<len; i++) {
+					      sizeof(struct scmContinuation) +
+					      len * sizeof(struct frame));
+	for (int i = 0; i < len; i++) {
 		cont->data[i] = data[i];
 	}
 	cont->len = len;

--- a/src/types.c
+++ b/src/types.c
@@ -325,7 +325,8 @@ vectorRef(Obj v, int idx) {
 
 struct scmContinuation {
 	scmHead head;
-	struct callStack cs;
+	int len;
+	struct frame data[];
 };
 
 Obj
@@ -399,21 +400,25 @@ vectorGCFunc(struct GC *gc, void *f) {
 }
 
 Obj
-makeContinuation() {
-	struct scmContinuation *cont =
-		newObj(scmHeadContinuation, sizeof(struct scmContinuation));
-	struct callStack *stack = &cont->cs;
-	stack->data = malloc(64 * sizeof(struct frame));
-	stack->len = 0;
-	stack->cap = 64;
+makeContinuation(struct frame *data, int len) {
+	struct scmContinuation *cont = newObj(scmHeadContinuation,
+					      sizeof(struct scmContinuation) + len*sizeof(struct frame));
+	for (int i=0; i<len; i++) {
+		cont->data[i] = data[i];
+	}
+	cont->len = len;
 	return ((Obj) (&cont->head) | TAG_PTR);
 }
 
-struct callStack *
+struct callStack
 contCallStack(Obj cont) {
 	struct scmContinuation *v = ptr(cont);
 	assert(v->head.type == scmHeadContinuation);
-	return &v->cs;
+	struct callStack cs;
+	cs.data = v->data;
+	cs.len = v->len;
+	cs.cap = v->len;
+	return cs;
 }
 
 void
@@ -434,7 +439,8 @@ static void
 continuationGCFunc(struct GC *gc, void *f) {
 	struct scmContinuation *from = f;
 	version_t minv = from->head.version;
-	gcMarkCallStack(gc, &from->cs, minv);
+	struct callStack cs = contCallStack((Obj) (&from->head) | TAG_PTR);
+	gcMarkCallStack(gc, &cs, minv);
 }
 
 static void

--- a/src/types.h
+++ b/src/types.h
@@ -164,8 +164,8 @@ struct callStack {
   int cap;
 };
 
-Obj makeContinuation();
-struct callStack* contCallStack(Obj cont);
+Obj makeContinuation(struct frame *data, int len);
+struct callStack contCallStack(Obj cont);
 
 void gcMarkCallStack(struct GC *gc, struct callStack *stack, int minv);
 


### PR DESCRIPTION
The old continuation object use malloc and never free.
Before this fix, coroutine1m test takes 5.1G memory, and now 2.6G after the fix.